### PR TITLE
Include git ignore in init template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 test-ledger
 examples/*/Cargo.lock
 examples/**/Cargo.lock
+.DS_Store

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -194,6 +194,10 @@ fn init(name: String, typescript: bool) -> Result<()> {
     let mut virt_manifest = File::create("Cargo.toml")?;
     virt_manifest.write_all(template::virtual_manifest().as_bytes())?;
 
+    // Initialize .gitignore file
+    let mut virt_manifest = File::create(".gitignore")?;
+    virt_manifest.write_all(template::git_ignore().as_bytes())?;
+
     // Build the program.
     fs::create_dir("programs")?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -210,7 +210,7 @@ fn init(name: String, typescript: bool) -> Result<()> {
         let mut ts_config = File::create("tsconfig.json")?;
         ts_config.write_all(template::ts_config().as_bytes())?;
 
-        let mut mocha = File::create(&format!("tests/{}.ts", name))?;
+        let mut mocha = File::create(&format!("tests/{}.spec.ts", name))?;
         mocha.write_all(template::ts_mocha(&name).as_bytes())?;
     } else {
         let mut mocha = File::create(&format!("tests/{}.js", name))?;

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1,13 +1,12 @@
 use heck::CamelCase;
 use heck::SnakeCase;
 
-pub fn virtual_manifest() -> String {
+pub fn virtual_manifest() -> &'static str {
     r#"[workspace]
 members = [
     "programs/*"
 ]
 "#
-    .to_string()
 }
 
 pub fn cargo_toml(name: &str) -> String {
@@ -64,7 +63,7 @@ main();
     )
 }
 
-pub fn deploy_script() -> String {
+pub fn deploy_script() -> &'static str {
     r#"
 // Migrations are an early feature. Currently, they're nothing more than this
 // single deploy script that's invoked from the CLI, injecting a provider
@@ -79,12 +78,10 @@ module.exports = async function (provider) {
   // Add your deploy script here.
 }
 "#
-    .to_string()
 }
-pub fn xargo_toml() -> String {
+pub fn xargo_toml() -> &'static str {
     r#"[target.bpfel-unknown-unknown.dependencies.std]
 features = []"#
-        .to_string()
 }
 
 pub fn lib_rs(name: &str) -> String {
@@ -151,7 +148,7 @@ describe('{}', () => {{
     )
 }
 
-pub fn ts_config() -> String {
+pub fn ts_config() -> &'static str {
     r#"{
   "compilerOptions": {
     "types": ["mocha", "chai"],
@@ -163,5 +160,16 @@ pub fn ts_config() -> String {
   }
 }
 "#
-    .to_string()
+}
+
+pub fn git_ignore() -> &'static str {
+    r#"# ignore Mac OS noise
+.DS_Store
+
+# ignore the build directory for Rust/Anchor
+target
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+    "#
 }


### PR DESCRIPTION
- A little weird to initialize git ignore manually, so I added a template for it
- Changed template functions without a parameter to not allocate unnecessarily
- Fixed the typescript test file default (missing `.spec`)