### PR TITLE
examples: Use path dep for all examples

### DIFF
--- a/examples/cashiers-check/programs/cashiers-check/Cargo.toml
+++ b/examples/cashiers-check/programs/cashiers-check/Cargo.toml
@@ -15,5 +15,5 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor" }
-anchor-spl = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../lang" }
+anchor-spl = { path = "../../../../spl" }

--- a/examples/errors/programs/errors/Cargo.toml
+++ b/examples/errors/programs/errors/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../lang" }

--- a/examples/interface/programs/counter-auth/Cargo.toml
+++ b/examples/interface/programs/counter-auth/Cargo.toml
@@ -15,5 +15,5 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../lang" }
 counter = { path = "../counter", features = ["cpi"] }

--- a/examples/interface/programs/counter/Cargo.toml
+++ b/examples/interface/programs/counter/Cargo.toml
@@ -15,4 +15,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../lang" }

--- a/examples/lockup/programs/lockup/Cargo.toml
+++ b/examples/lockup/programs/lockup/Cargo.toml
@@ -13,5 +13,5 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
-anchor-spl = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../lang" }
+anchor-spl = { path = "../../../../spl" }

--- a/examples/lockup/programs/registry/Cargo.toml
+++ b/examples/lockup/programs/registry/Cargo.toml
@@ -13,6 +13,6 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
-anchor-spl = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../lang" }
+anchor-spl = { path = "../../../../spl" }
 lockup = { path = "../lockup", features = ["cpi"] }

--- a/examples/misc/programs/misc/Cargo.toml
+++ b/examples/misc/programs/misc/Cargo.toml
@@ -15,4 +15,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../lang" }

--- a/examples/multisig/programs/multisig/Cargo.toml
+++ b/examples/multisig/programs/multisig/Cargo.toml
@@ -15,4 +15,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../lang" }

--- a/examples/spl/token-proxy/programs/token-proxy/Cargo.toml
+++ b/examples/spl/token-proxy/programs/token-proxy/Cargo.toml
@@ -13,5 +13,5 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
-anchor-spl = { git = "https://github.com/project-serum/anchor" }
+anchor-lang = { path = "../../../../../lang" }
+anchor-spl = { path = "../../../../../spl" }

--- a/examples/sysvars/programs/sysvars/Cargo.toml
+++ b/examples/sysvars/programs/sysvars/Cargo.toml
@@ -13,4 +13,5 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../lang" }
+anchor-spl = { path = "../../../../spl" }

--- a/examples/tutorial/basic-0/programs/basic-0/Cargo.toml
+++ b/examples/tutorial/basic-0/programs/basic-0/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../../lang" }

--- a/examples/tutorial/basic-1/programs/basic-1/Cargo.toml
+++ b/examples/tutorial/basic-1/programs/basic-1/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../../lang" }

--- a/examples/tutorial/basic-3/programs/puppet-master/Cargo.toml
+++ b/examples/tutorial/basic-3/programs/puppet-master/Cargo.toml
@@ -13,5 +13,5 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../../lang" }
 puppet = { path = "../puppet", features = ["cpi"] }

--- a/examples/tutorial/basic-3/programs/puppet/Cargo.toml
+++ b/examples/tutorial/basic-3/programs/puppet/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../../lang" }

--- a/examples/tutorial/basic-4/programs/basic-4/Cargo.toml
+++ b/examples/tutorial/basic-4/programs/basic-4/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { git = "https://github.com/project-serum/anchor", features = ["derive"] }
+anchor-lang = { path = "../../../../../lang" }


### PR DESCRIPTION
Switching to a path dependency so that any breakage can be caught before merge.