### PR TITLE
lang: Namespaceable account discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ incremented for features.
 * cli: Specify test files to run ([#118](https://github.com/project-serum/anchor/pull/118)).
 * lang: Allow overriding the `#[state]` account's size ([#121](https://github.com/project-serum/anchor/pull/121)).
 * lang, client, ts: Add event emission and subscriptions ([#89](https://github.com/project-serum/anchor/pull/89)).
+* lang/account: Allow namespacing account discriminators ([#128](https://github.com/project-serum/anchor/pull/128)).
 
 ## Breaking Changes
 
 * client: Replace url str with `Cluster` struct when constructing clients ([#89](https://github.com/project-serum/anchor/pull/89)).
+* lang: Changes the account discriminator of `IdlAccount` to be namespaced by `"internal"` ([#128](https://github.com/project-serum/anchor/pull/128)).
 
 ## [0.3.0] - 2021-03-12
 

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -19,15 +19,24 @@ use syn::parse_macro_input;
 /// and the account deserialization will exit with an error.
 #[proc_macro_attribute]
 pub fn account(
-    _args: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
+    let namespace = args.to_string().replace("\"", "");
+
     let account_strct = parse_macro_input!(input as syn::ItemStruct);
     let account_name = &account_strct.ident;
 
     let discriminator: proc_macro2::TokenStream = {
         // Namespace the discriminator to prevent collisions.
-        let discriminator_preimage = format!("account:{}", account_name.to_string());
+        let discriminator_preimage = {
+            if namespace.is_empty() {
+                format!("account:{}", account_name.to_string())
+            } else {
+                format!("{}:{}", namespace, account_name.to_string())
+            }
+        };
+
         let mut discriminator = [0u8; 8];
         discriminator.copy_from_slice(
             &anchor_syn::hash::hash(discriminator_preimage.as_bytes()).to_bytes()[..8],

--- a/lang/src/idl.rs
+++ b/lang/src/idl.rs
@@ -81,7 +81,7 @@ pub struct IdlSetBuffer<'info> {
 //
 // Note: we use the same account for the "write buffer", similar to the
 //       bpf upgradeable loader's mechanism.
-#[account]
+#[account("internal")]
 #[derive(Debug)]
 pub struct IdlAccount {
     // Address that can modify the IDL.


### PR DESCRIPTION
Addresses https://github.com/project-serum/anchor/issues/127.

Allows the ability to namespace the account discriminator pre-image, e.g.,

```rust
#[account("internal")]
pub struct IdlAccount {
...
}
```