### PR TITLE
ts: Enable declaration map

### DIFF
--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -11,6 +11,7 @@
 
     "sourceMap": true,
     "declaration": true,
+    "declarationMap": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
In VSCode clicking on anchor exported types go to their interface file in dist instead of implementation. Would like to jump to typescript source instead. 

Solution: Enable declaration map in tsconfig.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#new---declarationmap
