### PR TITLE
Feat/migrations typescript support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
         - pushd examples/misc && anchor test && popd
         - pushd examples/events && anchor test && popd
         - pushd examples/cashiers-check && anchor test && popd
+        - pushd examples/typescript && yarn && anchor test && popd
     - <<: *examples
       name: Runs the examples 2
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ incremented for features.
 * cli: Specify test files to run ([#118](https://github.com/project-serum/anchor/pull/118)).
 * lang: Allow overriding the `#[state]` account's size ([#121](https://github.com/project-serum/anchor/pull/121)).
 * lang, client, ts: Add event emission and subscriptions ([#89](https://github.com/project-serum/anchor/pull/89)).
+* cli: TypeScript migrations ([#132](https://github.com/project-serum/anchor/pull/132)).
 
 ## Breaking Changes
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -252,22 +252,26 @@ fn init(name: String, typescript: bool) -> Result<()> {
 
     // Build the test suite.
     fs::create_dir("tests")?;
+    // Build the migrations directory.
+    fs::create_dir("migrations")?;
+
     if typescript {
         // Build typescript config
         let mut ts_config = File::create("tsconfig.json")?;
         ts_config.write_all(template::ts_config().as_bytes())?;
+
+        let mut deploy = File::create("migrations/deploy.ts")?;
+        deploy.write_all(&template::ts_deploy_script().as_bytes())?;
 
         let mut mocha = File::create(&format!("tests/{}.spec.ts", name))?;
         mocha.write_all(template::ts_mocha(&name).as_bytes())?;
     } else {
         let mut mocha = File::create(&format!("tests/{}.js", name))?;
         mocha.write_all(template::mocha(&name).as_bytes())?;
-    }
 
-    // Build the migrations directory.
-    fs::create_dir("migrations")?;
-    let mut deploy = File::create("migrations/deploy.js")?;
-    deploy.write_all(&template::deploy_script().as_bytes())?;
+        let mut deploy = File::create("migrations/deploy.js")?;
+        deploy.write_all(&template::deploy_script().as_bytes())?;
+    }
 
     println!("{} initialized", name);
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1373,24 +1373,25 @@ fn migrate(url: Option<String>) -> Result<()> {
 
         let url = url.unwrap_or_else(|| cfg.cluster.url().to_string());
         let cur_dir = std::env::current_dir()?;
-        let module_path = format!("{}/migrations/deploy.js", cur_dir.display());
+        let module_path = cur_dir.join("migrations/deploy.js");
 
         let ts_config_exist = Path::new("tsconfig.json").exists();
         let ts_deploy_file_exists = Path::new("migrations/deploy.ts").exists();
 
         if ts_config_exist && ts_deploy_file_exists {
             let ts_module_path = cur_dir.join("migrations/deploy.ts");
-            if let Err(_e) = std::process::Command::new("tsc")
-                .arg(&ts_module_path.canonicalize()?)
+            let exit = std::process::Command::new("tsc")
+                .arg(&ts_module_path)
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
-                .output()
-            {
-                std::process::exit(1);
+                .output()?;
+            if !exit.status.success() {
+                std::process::exit(exit.status.code().unwrap());
             }
         };
 
-        let deploy_script_host_str = template::deploy_script_host(&url, &module_path);
+        let deploy_script_host_str =
+            template::deploy_script_host(&url, &module_path.display().to_string());
 
         if !Path::new(".anchor").exists() {
             fs::create_dir(".anchor")?;
@@ -1406,7 +1407,7 @@ fn migrate(url: Option<String>) -> Result<()> {
 
         if ts_config_exist && ts_deploy_file_exists {
             std::fs::remove_file(&module_path)
-                .map_err(|_| anyhow!("Unable to remove file {}", module_path))?;
+                .map_err(|_| anyhow!("Unable to remove file {}", module_path.display()))?;
         }
 
         if !exit.status.success() {

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -79,6 +79,34 @@ module.exports = async function (provider) {
 }
 "#
 }
+
+pub fn ts_deploy_script() -> &'static str {
+    r#"
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@project-serum/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+  async function deployAsync(exampleString: string): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        console.log(exampleString);
+        resolve();
+      }, 2000);
+    });
+  }
+
+  await deployAsync("Typescript migration example complete.");
+}
+"#
+}
+
 pub fn xargo_toml() -> &'static str {
     r#"[target.bpfel-unknown-unknown.dependencies.std]
 features = []"#

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -93,16 +93,6 @@ module.exports = async function (provider) {
   anchor.setProvider(provider);
 
   // Add your deploy script here.
-  async function deployAsync(exampleString: string): Promise<void> {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        console.log(exampleString);
-        resolve();
-      }, 2000);
-    });
-  }
-
-  await deployAsync("Typescript migration example complete.");
 }
 "#
 }

--- a/examples/tutorial/basic-2/migrations/deploy.ts
+++ b/examples/tutorial/basic-2/migrations/deploy.ts
@@ -1,0 +1,22 @@
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@project-serum/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+  async function saySomethingAsync(withString: string): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        console.log(withString);
+        resolve();
+      }, 2000);
+    });
+  }
+
+  await saySomethingAsync("I like Anchor Ts migrations !");
+};

--- a/examples/typescript/Anchor.toml
+++ b/examples/typescript/Anchor.toml
@@ -1,0 +1,2 @@
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"

--- a/examples/typescript/Cargo.toml
+++ b/examples/typescript/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "programs/*"
+]

--- a/examples/typescript/migrations/deploy.ts
+++ b/examples/typescript/migrations/deploy.ts
@@ -9,14 +9,14 @@ module.exports = async function (provider) {
   anchor.setProvider(provider);
 
   // Add your deploy script here.
-  async function saySomethingAsync(withString: string): Promise<void> {
+  async function deployAsync(exampleString: string): Promise<void> {
     return new Promise((resolve) => {
       setTimeout(() => {
-        console.log(withString);
+        console.log(exampleString);
         resolve();
       }, 2000);
     });
   }
 
-  await saySomethingAsync("I like Anchor Ts migrations !");
-};
+  await deployAsync("Typescript migration example complete.");
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "typescript",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^14.14.37"
+  }
+}

--- a/examples/typescript/programs/typescript/Cargo.toml
+++ b/examples/typescript/programs/typescript/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "typescript"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "typescript"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/examples/typescript/programs/typescript/Xargo.toml
+++ b/examples/typescript/programs/typescript/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/examples/typescript/programs/typescript/src/lib.rs
+++ b/examples/typescript/programs/typescript/src/lib.rs
@@ -1,3 +1,6 @@
+//! The typescript example serves to show how one would setup an Anchor
+//! workspace with TypeScript tests and migrations.
+
 #![feature(proc_macro_hygiene)]
 
 use anchor_lang::prelude::*;

--- a/examples/typescript/programs/typescript/src/lib.rs
+++ b/examples/typescript/programs/typescript/src/lib.rs
@@ -1,0 +1,14 @@
+#![feature(proc_macro_hygiene)]
+
+use anchor_lang::prelude::*;
+
+#[program]
+pub mod typescript {
+    use super::*;
+    pub fn initialize(ctx: Context<Initialize>) -> ProgramResult {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}

--- a/examples/typescript/tests/typescript.spec.ts
+++ b/examples/typescript/tests/typescript.spec.ts
@@ -1,0 +1,14 @@
+import * as anchor from '@project-serum/anchor';
+
+describe('typescript', () => {
+
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.Provider.env());
+
+  it('Is initialized!', async () => {
+    // Add your test here.
+    const program = anchor.workspace.Typescript;
+    const tx = await program.rpc.initialize();
+    console.log("Your transaction signature", tx);
+  });
+});

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Below code adds support for Ts migration files.
Things to know:
• The script will transpile the `deploy.ts` file using `tsc` to the migrations dir. The  resulting `deploy.js` will be deleted upon successful script completion.

• There are some conflicts when using `import * as anchor from "..."` with a 3rd party lib. Hence the script sticking with commonjs require. Intellisense raises a missing @types/node.

• I added a different template in ts_deploy_script with an example ts async function although it was not absolutely necessary. I thought this template was bound to evolve in the future and that it provided clearer intent to readers.

