### PR TITLE
Update solana tooling to v1.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ _examples: &examples
   - npm install -g @project-serum/common
   - npm install -g @solana/spl-token
   - sudo apt-get install -y pkg-config build-essential libudev-dev
-  - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
+  - sh -c "$(curl -sSfL https://release.solana.com/v1.6.3/install)"
   - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
   - export NODE_PATH="/home/travis/.nvm/versions/node/v$NODE_VERSION/lib/node_modules/:$NODE_PATH"
   - yes | solana-keygen new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ incremented for features.
 
 * client: Replace url str with `Cluster` struct when constructing clients ([#89](https://github.com/project-serum/anchor/pull/89)).
 * lang: Changes the account discriminator of `IdlAccount` to be namespaced by `"internal"` ([#128](https://github.com/project-serum/anchor/pull/128)).
+* lang, spl, cli: Upgrade solana toolchain to 1.6.3, a major version upgrade even though only the minor version is incremented. ([#]()).
 
 ## [0.3.0] - 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ incremented for features.
 
 * client: Replace url str with `Cluster` struct when constructing clients ([#89](https://github.com/project-serum/anchor/pull/89)).
 * lang: Changes the account discriminator of `IdlAccount` to be namespaced by `"internal"` ([#128](https://github.com/project-serum/anchor/pull/128)).
-* lang, spl, cli: Upgrade solana toolchain to 1.6.3, a major version upgrade even though only the minor version is incremented. ([#139](https://github.com/project-serum/anchor/pull/139)).
+* lang, spl, cli: Upgrade solana toolchain to 1.6.3, a major version upgrade even though only the minor version is incremented. This allows for the removal of `-#![feature(proc_macro_hygiene)]`. ([#139](https://github.com/project-serum/anchor/pull/139)).
 
 ## [0.3.0] - 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ incremented for features.
 
 * client: Replace url str with `Cluster` struct when constructing clients ([#89](https://github.com/project-serum/anchor/pull/89)).
 * lang: Changes the account discriminator of `IdlAccount` to be namespaced by `"internal"` ([#128](https://github.com/project-serum/anchor/pull/128)).
-* lang, spl, cli: Upgrade solana toolchain to 1.6.3, a major version upgrade even though only the minor version is incremented. ([#]()).
+* lang, spl, cli: Upgrade solana toolchain to 1.6.3, a major version upgrade even though only the minor version is incremented. ([#139](https://github.com/project-serum/anchor/pull/139)).
 
 ## [0.3.0] - 2021-03-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "regex",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ dependencies = [
  "anyhow",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -72,7 +72,7 @@ dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -83,7 +83,7 @@ dependencies = [
  "anyhow",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ dependencies = [
  "anyhow",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ dependencies = [
  "anyhow",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ dependencies = [
  "solana-client",
  "solana-program",
  "solana-sdk",
- "syn 1.0.57",
+ "syn 1.0.67",
  "toml",
 ]
 
@@ -164,7 +164,7 @@ dependencies = [
  "anyhow",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.3",
- "syn 1.0.57",
+ "syn 1.0.67",
  "thiserror",
 ]
 
@@ -398,7 +398,7 @@ dependencies = [
  "borsh-schema-derive-internal",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -409,7 +409,7 @@ checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -473,12 +473,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "bytes"
@@ -587,7 +581,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -821,6 +815,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle 2.4.0",
+ "zeroize",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,7 +846,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -939,15 +946,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.0.2",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.8.2",
+ "serde_bytes",
+ "sha2 0.9.3",
  "zeroize",
 ]
 
@@ -983,28 +991,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.57",
- "synstructure",
 ]
 
 [[package]]
@@ -1103,12 +1089,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
+name = "futures"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1116,6 +1118,17 @@ name = "futures-core"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1132,7 +1145,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1153,12 +1166,14 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1231,11 +1246,11 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1243,10 +1258,9 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.25",
+ "tokio 1.4.0",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1305,6 +1319,16 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
@@ -1337,12 +1361,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1365,11 +1390,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1380,8 +1405,8 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project",
- "socket2",
- "tokio 0.2.25",
+ "socket2 0.4.0",
+ "tokio 1.4.0",
  "tower-service",
  "tracing",
  "want",
@@ -1389,16 +1414,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes 0.5.6",
  "futures-util",
  "hyper",
  "log",
  "rustls",
- "tokio 0.2.25",
+ "tokio 1.4.0",
  "tokio-rustls",
  "webpki",
 ]
@@ -1536,11 +1560,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "15.1.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
+checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
 dependencies = [
- "futures",
+ "futures 0.3.13",
  "log",
  "serde",
  "serde_derive",
@@ -1689,16 +1713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,7 +1783,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -1831,7 +1845,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1882,7 +1896,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1976,7 +1990,7 @@ dependencies = [
  "Inflector",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2075,12 +2089,11 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "byteorder",
- "crypto-mac 0.7.0",
+ "crypto-mac 0.8.0",
 ]
 
 [[package]]
@@ -2124,14 +2137,8 @@ checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -2175,7 +2182,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
  "version_check",
 ]
 
@@ -2408,12 +2415,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2426,14 +2433,13 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.25",
+ "tokio 1.4.0",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -2503,11 +2509,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -2619,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -2637,13 +2643,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2816,10 +2822,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account-decoder"
-version = "1.5.15"
+name = "socket2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37959d9f3ca64df39491bf3cedbf512f2240c17a26222813b4f91a5181fdd367"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "solana-account-decoder"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498dfa42765cdff0a0fbeb2cdcd8a06f2b61ea40fdac81a55ff33117099b8b57"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2841,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05d59dac62190a2531540f8bed46d85178d5dd03c0b028dbf6ef7751c2385e8"
+checksum = "40bb0d03ae8149f4a9dcb1e8e37ce60dae4fdd9d1b4293e087ad1db6004be527"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -2857,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12e6ba3606e6197e3a698b805215272a32b83d63e7f17f95efc3640a9ad0086"
+checksum = "b933b24bbc46329eaa6cbed374c3069b6692c19e242015bc25cb4820c0d889ed"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2889,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0742db5b1ba5cff328180b9640e974d5be685a6e124cb076e93a2dbb37920bb"
+checksum = "70e4522c98c9c60ea5eb6a5757993c96badd5183d4762a1ade2828d4eea5dabd"
 dependencies = [
  "bincode",
  "chrono",
@@ -2904,14 +2920,14 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fc7598a8cd6c06ef61ff26fd21040cf66e165a9a87815112ee29a11d49fbbe"
+checksum = "77229d3a6911ceeb7f6b9d5ec481f76d33eda6dd60566e6ad36b501e2c99598c"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
  "cc",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.2",
  "ed25519-dalek",
  "either",
  "lazy_static",
@@ -2921,16 +2937,16 @@ dependencies = [
  "reqwest",
  "serde",
  "syn 0.15.44",
- "syn 1.0.57",
+ "syn 1.0.67",
  "tokio 0.1.22",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfc5fc18839f3f246918605fe7c73fcb77f38f409c1b5bd94ac2bc7dbed8af1"
+checksum = "e3960501855c86deff7b846cb2398ad1f6d375f4b69700a8b227a7d7973db18c"
 dependencies = [
  "bs58",
  "bv",
@@ -2948,22 +2964,22 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad15b641518fd06ec7c7340bc7084452a3df41db010e7336daacc71982419286"
+checksum = "e80259d94cebfe38e1eff976900ad3fc1c91e9b7c72c8c2fa123f6ea259a99f0"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "rustc_version",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43574788d590dd391adb95dd4e5c77d6b7a34643f87ce3def53c88609411f82"
+checksum = "bc65a5c5e7446c2ac77a3fd31fb80158daa76e9f48512e7909660a8af1b71cad"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2972,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d08db83bc404770b2c71683a8ac82362191adf93a43f7b477d8790e9813bac"
+checksum = "ee6bd5e526b09d5b5619b302a9070705d2291c2ec548cc2639a3f2b01326f076"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
@@ -2985,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75e71e51ad934f7c009b9f91bf38ba2c4fdcc5067309143a44ca8a9132e4cc5"
+checksum = "5e4e2649578dd2a65fc09909d027463faa95c2ca9d63d63a93f48579f1d99b96"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2999,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27783cd7fcada6274b404a0c8005a2840ad727f1416e785eede817b84c00ed5e"
+checksum = "91c212ebe74c5453f4b14c7f83bece629ac32c21bc57dac1aa8906e09c3aa6e1"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -3010,26 +3026,26 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_derive",
- "socket2",
+ "socket2 0.3.19",
  "solana-clap-utils",
  "solana-logger",
  "solana-version",
- "tokio 0.3.7",
+ "tokio 1.4.0",
  "url",
 ]
 
 [[package]]
 name = "solana-program"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0611108a184bb2b8dd99915ced4aa0066a9aecaabba634608a95ff869a2fd5f6"
+checksum = "9c01edd2ce0ca37499bea84569b064d99ce37e883a636a8639bc73b722eb1e6b"
 dependencies = [
  "bincode",
  "borsh",
  "borsh-derive",
  "bs58",
  "bv",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.2",
  "hex",
  "itertools",
  "lazy_static",
@@ -3052,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d41402ff03aa6eb1bb16ee264f6f630cdd4cdbe788c1445a2ce5d56029892c"
+checksum = "4026b2e597b1a81b32790bf416f8f83fdd421a4868bf50a957298280242c3e97"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3062,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5cf03edc09ad4ffb8e0b00cb233357fa3cd09ff762047e905f24faa331f1ca0"
+checksum = "9db67e3681bc3d7de5e59eb907e1398b82fab2b1e121594ec105e71bfd6c524b"
 dependencies = [
  "base32",
  "console 0.11.3",
@@ -3082,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42076f62f0680ca4f8ab54e9a09183cb2f2f08b3e97fef1f271077dc2cdae37"
+checksum = "730f00ad48d68e7bb1aa690ec62021209613dc0f5519d1749cf19fb488a22349"
 dependencies = [
  "bincode",
  "blake3",
@@ -3096,7 +3112,6 @@ dependencies = [
  "dir-diff",
  "flate2",
  "fnv",
- "fs_extra",
  "itertools",
  "lazy_static",
  "libc",
@@ -3133,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13a1da30516b20542a09d56880173e2dc10913014273064ee0a2cbff2663097"
+checksum = "c192f20cc1b227b12464bdb2dcd1f532cf5a44b78aacda9358f617d2996aa702"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3158,6 +3173,7 @@ dependencies = [
  "pbkdf2 0.6.0",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
+ "rand_core 0.6.2",
  "rustc_version",
  "rustversion",
  "serde",
@@ -3177,22 +3193,22 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26120921bf5b5956cc8d557c2b43328824c83d530dd30f0eb6fe9bff8480b0b"
+checksum = "ae3e3cc2e6c8c5c8ecf44e060f0347ad7a1ab0c6f8338a4a5d3afa575b36e68b"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "rustversion",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be88a66e79697851f23ccec6f6b58363735f65a214159eee0f1c9ad692155592"
+checksum = "640a17c68f6cf4664bc35bf8de68059aa7eb4a1620e5b12b59e357bc95e55b1c"
 dependencies = [
  "bincode",
  "digest 0.9.0",
@@ -3205,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75dfb5494f40481a6c2e5becb8f5ed24040ef7b8181ff7ab6b7ba147b2b5890"
+checksum = "3edcd1d31c7a84652c6df1aa6400f9482ac4ee45b90aeb9342255b7352e905b0"
 dependencies = [
  "bincode",
  "log",
@@ -3227,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11b0c6b26c5b1be8e00f8c71eb302a210ca32ab3475dd94d37c55cc471adb7f"
+checksum = "5adbd94985e7d1572aeae2dd83eeaa54ab10fd7b25dd3ecdbebba169ff025bae"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3252,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be26db630d4cf041afdb7d949f6f68fc988e17c6a91a81f165cb5263ef59cadb"
+checksum = "78ae0e7436e2d80bf7dbc7a946b9516678d6e880cff97d9dba0a77d0e42eaccb"
 dependencies = [
  "log",
  "rustc_version",
@@ -3268,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.5.15"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a77972988927f5ec7e7108b508d9b89859a0e71baeac57941168102d1869d"
+checksum = "f7f28d592f0f82f67bbd68ba6c49ddedea35e1b36a99385065f383568edf612e"
 dependencies = [
  "bincode",
  "log",
@@ -3389,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -3406,7 +3422,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
  "unicode-xid 0.2.1",
 ]
 
@@ -3498,7 +3514,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3513,18 +3529,20 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
+checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
 dependencies = [
- "failure",
- "hmac 0.7.1",
+ "anyhow",
+ "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.3.0",
+ "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.8.2",
+ "sha2 0.9.3",
+ "thiserror",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -3549,7 +3567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
@@ -3568,40 +3586,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.23",
- "num_cpus",
- "pin-project-lite 0.1.12",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46409491c9375a693ce7032101970a54f8a2010efb77e13f70788f0d84489e39"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
- "bytes 0.6.0",
- "futures-core",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio 0.7.9",
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
  "winapi 0.3.9",
 ]
@@ -3613,7 +3611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "tokio-io",
 ]
 
@@ -3623,7 +3621,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures",
+ "futures 0.1.31",
  "tokio-executor",
 ]
 
@@ -3634,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -3643,7 +3641,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 dependencies = [
- "futures",
+ "futures 0.1.31",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -3655,19 +3653,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "log",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3677,7 +3675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "lazy_static",
  "log",
  "mio 0.6.23",
@@ -3691,13 +3689,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "futures-core",
  "rustls",
- "tokio 0.2.25",
+ "tokio 1.4.0",
  "webpki",
 ]
 
@@ -3708,7 +3705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -3718,7 +3715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "iovec",
  "mio 0.6.23",
  "tokio-io",
@@ -3734,7 +3731,7 @@ dependencies = [
  "crossbeam-deque 0.7.3",
  "crossbeam-queue",
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "lazy_static",
  "log",
  "num_cpus",
@@ -3749,7 +3746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.31",
  "slab",
  "tokio-executor",
 ]
@@ -3761,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "log",
  "mio 0.6.23",
  "tokio-codec",
@@ -3776,7 +3773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.31",
  "iovec",
  "libc",
  "log",
@@ -3789,16 +3786,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
+ "pin-project-lite",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -3823,8 +3820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "tracing-core",
 ]
 
@@ -3835,16 +3831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -3884,15 +3870,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -4034,7 +4011,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -4068,7 +4045,7 @@ checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4101,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]
@@ -4205,7 +4182,7 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.57",
+ "syn 1.0.67",
  "synstructure",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,17 +15,17 @@ default = []
 [dependencies]
 clap = "3.0.0-beta.1"
 anyhow = "1.0.32"
-syn = { version = "1.0.54", features = ["full", "extra-traits"] }
+syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 anchor-lang = { path = "../lang" }
 anchor-syn = { path = "../lang/syn", features = ["idl"] }
 serde_json = "1.0"
 shellexpand = "2.1.0"
 serde_yaml = "0.8"
 toml = "0.5.8"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.122", features = ["derive"] }
 solana-sdk = "1.5.8"
-solana-program = "=1.5.15"
-solana-client = "=1.5.15"
+solana-program = "1.6.3"
+solana-client = "1.6.3"
 serum-common = { git = "https://github.com/project-serum/serum-dex", features = ["client"] }
 dirs = "3.0"
 heck = "0.3.1"

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -104,9 +104,7 @@ features = []"#
 
 pub fn lib_rs(name: &str) -> String {
     format!(
-        r#"#![feature(proc_macro_hygiene)]
-
-use anchor_lang::prelude::*;
+        r#"use anchor_lang::prelude::*;
 
 #[program]
 pub mod {} {{

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,6 +10,6 @@ description = "Rust client for Anchor programs"
 anchor-lang = { path = "../lang", version = "0.3.0" }
 anyhow = "1.0.32"
 regex = "1.4.5"
-solana-client = "=1.5.15"
-solana-sdk = "=1.5.15"
+solana-client = "1.6.3"
+solana-sdk = "1.6.3"
 thiserror = "1.0.20"

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -18,7 +18,7 @@ rustup component add rustfmt
 See the solana [docs](https://docs.solana.com/cli/install-solana-cli-tools) for installation instructions. Version 1.5.5 is required. On macOS and Linux,
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.6.3/install)"
 ```
 
 ## Install Mocha

--- a/examples/cashiers-check/programs/cashiers-check/src/lib.rs
+++ b/examples/cashiers-check/programs/cashiers-check/src/lib.rs
@@ -3,8 +3,6 @@
 //! reside until they are "cashed" by the intended recipient. The creator of
 //! the check can cancel the check at any time to get back the funds.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, TokenAccount, Transfer};
 use std::convert::Into;

--- a/examples/composite/programs/composite/src/lib.rs
+++ b/examples/composite/programs/composite/src/lib.rs
@@ -1,8 +1,6 @@
 //! This example demonstrates the ability to compose together multiple
 //! structs deriving `Accounts`. See `CompositeUpdate`, below.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/errors/programs/errors/src/lib.rs
+++ b/examples/errors/programs/errors/src/lib.rs
@@ -1,8 +1,6 @@
 //! This example demonstrates how custom errors and associated error messsages
 //! can be defined and transparently propagated to clients.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/events/programs/events/src/lib.rs
+++ b/examples/events/programs/events/src/lib.rs
@@ -1,4 +1,5 @@
-#![feature(proc_macro_hygiene)]
+//! This example demonstrates how to emit an event, which can be
+//! subscribed to by a client.
 
 use anchor_lang::prelude::*;
 

--- a/examples/interface/programs/counter-auth/src/lib.rs
+++ b/examples/interface/programs/counter-auth/src/lib.rs
@@ -3,8 +3,6 @@
 //! to be incremented if it changes the counter from odd -> even or even -> odd.
 //! Creative, I know. :P.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use counter::Auth;
 

--- a/examples/interface/programs/counter/src/lib.rs
+++ b/examples/interface/programs/counter/src/lib.rs
@@ -6,8 +6,6 @@
 //! Here, we have a counter, where, in order to set the count, the `Auth`
 //! program must first approve the transaction.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/lockup/programs/lockup/src/lib.rs
+++ b/examples/lockup/programs/lockup/src/lib.rs
@@ -1,8 +1,6 @@
 //! A relatively advanced example of a lockup program. If you're new to Anchor,
 //! it's suggested to start with the other examples.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::program;

--- a/examples/lockup/programs/registry/src/lib.rs
+++ b/examples/lockup/programs/registry/src/lib.rs
@@ -1,8 +1,6 @@
 //! A relatively advanced example of a staking program. If you're new to Anchor,
 //! it's suggested to start with the other examples.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program_option::COption;
 use anchor_spl::token::{self, Mint, TokenAccount, Transfer};

--- a/examples/misc/programs/misc/src/lib.rs
+++ b/examples/misc/programs/misc/src/lib.rs
@@ -1,8 +1,6 @@
 //! Misc example is a catchall program for testing unrelated features.
 //! It's not too instructive/coherent by itself, so please see other examples.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/multisig/programs/multisig/src/lib.rs
+++ b/examples/multisig/programs/multisig/src/lib.rs
@@ -17,8 +17,6 @@
 //! the `execute_transaction`, once enough (i.e. `threhsold`) of the owners have
 //! signed.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use anchor_lang::solana_program::instruction::Instruction;

--- a/examples/spl/token-proxy/programs/token-proxy/src/lib.rs
+++ b/examples/spl/token-proxy/programs/token-proxy/src/lib.rs
@@ -1,7 +1,5 @@
 //! This example demonstrates the use of the `anchor_spl::token` CPI client.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Burn, MintTo, Transfer};
 

--- a/examples/sysvars/programs/sysvars/src/lib.rs
+++ b/examples/sysvars/programs/sysvars/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/tutorial/basic-0/programs/basic-0/src/lib.rs
+++ b/examples/tutorial/basic-0/programs/basic-0/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/tutorial/basic-1/programs/basic-1/src/lib.rs
+++ b/examples/tutorial/basic-1/programs/basic-1/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/tutorial/basic-2/programs/basic-2/src/lib.rs
+++ b/examples/tutorial/basic-2/programs/basic-2/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 // Define the program's instruction handlers.

--- a/examples/tutorial/basic-3/programs/puppet-master/src/lib.rs
+++ b/examples/tutorial/basic-3/programs/puppet-master/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 // #region core
 use anchor_lang::prelude::*;
 use puppet::{Puppet, SetData};

--- a/examples/tutorial/basic-3/programs/puppet/src/lib.rs
+++ b/examples/tutorial/basic-3/programs/puppet/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/examples/tutorial/basic-4/programs/basic-4/src/lib.rs
+++ b/examples/tutorial/basic-4/programs/basic-4/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 // #region code
 use anchor_lang::prelude::*;
 

--- a/examples/typescript/programs/typescript/src/lib.rs
+++ b/examples/typescript/programs/typescript/src/lib.rs
@@ -1,8 +1,6 @@
 //! The typescript example serves to show how one would setup an Anchor
 //! workspace with TypeScript tests and migrations.
 
-#![feature(proc_macro_hygiene)]
-
 use anchor_lang::prelude::*;
 
 #[program]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -21,6 +21,6 @@ anchor-attribute-interface = { path = "./attribute/interface", version = "0.3.0"
 anchor-derive-accounts = { path = "./derive/accounts", version = "0.3.0" }
 anchor-attribute-event = { path = "./attribute/event", version = "0.3.0" }
 borsh = "0.8.2"
-solana-program = "=1.5.15"
+solana-program = "1.6.3"
 thiserror = "1.0.20"
 base64 = "0.13.0"

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0" }
 regex = "1.0"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0", features = ["hash"] }

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anchor-syn = { path = "../../syn", version = "0.3.0" }

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0", features = ["hash"] }

--- a/lang/attribute/interface/Cargo.toml
+++ b/lang/attribute/interface/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0" }
 heck = "0.3.2"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0" }

--- a/lang/attribute/state/Cargo.toml
+++ b/lang/attribute/state/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0" }

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full"] }
+syn = { version = "1.0.60", features = ["full"] }
 anyhow = "1.0.32"
 anchor-syn = { path = "../../syn", version = "0.3.0" }

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -15,10 +15,10 @@ default = []
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "=1.0.57", features = ["full", "extra-traits", "parsing"] }
+syn = { version = "1.0.60", features = ["full", "extra-traits", "parsing"] }
 anyhow = "1.0.32"
 heck = "0.3.1"
-serde = { version = "1.0.118", features = ["derive"] }
+serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.2"
 thiserror = "1.0"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -9,4 +9,4 @@ description = "CPI clients for SPL programs"
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.3.0", features = ["derive"] }
 spl-token = { version = "3.0.1", features = ["no-entrypoint"] }
-solana-program = "=1.5.15"
+solana-program = "1.6.3"


### PR DESCRIPTION
Addresses

* https://github.com/project-serum/anchor/issues/38
* https://github.com/project-serum/anchor/issues/112

Note that the change from solana 1.5.x -> 1.6.x is a major version upgrade even though only the minor version is incremented.