### PR TITLE
cli, docker: Version verifiable builder with cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ incremented for features.
 
 ## [Unreleased]
 
+* cli: Version verifiable docker builder ([#145](https://github.com/project-serum/anchor/pull/145)).
+
 ## [0.4.0] - 2021-04-04
 
 ## Features

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,6 +31,9 @@ use std::string::ToString;
 mod config;
 mod template;
 
+// Version of the docker image.
+const DOCKER_BUILDER_VER: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Clap)]
 pub struct Opts {
     #[clap(subcommand)]
@@ -380,7 +383,7 @@ fn build_cwd(
 fn build_cwd_verifiable(workspace_dir: &Path) -> Result<()> {
     // Docker vars.
     let container_name = "anchor-program";
-    let image_name = "projectserum/build";
+    let image_name = format!("projectserum/build:v{}", DOCKER_BUILDER_VER);
     let volume_mount = format!(
         "{}:/workdir",
         workspace_dir.canonicalize()?.display().to_string()

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,14 +1,27 @@
-IMG_ORG ?= projectserum
-IMG_VER ?= latest
-
 WORKDIR=$(PWD)
+#
+# Extract anchor version from it's Cargo.toml.
+#
+ANCHOR_CLI=v$(shell awk -F ' = ' '$$1 ~ /version/ { gsub(/[\"]/, "", $$2); printf("%s",$$2) }' ../cli/Cargo.toml)
+#
+# Solana toolchain.
+#
+SOLANA_CLI=v1.6.3
+#
+# Build version should match the Anchor cli version.
+#
+IMG_ORG ?= projectserum
+IMG_VER ?= $(ANCHOR_CLI)
 
 .PHONY: build build-push build-shell
 
 default:
 
 build: build/Dockerfile
-	@docker build $@ -t $(IMG_ORG)/$@:$(IMG_VER)
+	@docker build \
+	--build-arg ANCHOR_CLI=$(ANCHOR_CLI) \
+	--build-arg SOLANA_CLI=$(SOLANA_CLI) \
+	$@ -t $(IMG_ORG)/$@:$(IMG_VER)
 
 build-push:
 	@docker push $(IMG_ORG)/anchorbuild:$(IMG_VER)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 WORKDIR=$(PWD)
 #
-# Extract anchor version from it's Cargo.toml.
+# Extract anchor version from the Cargo.toml.
 #
 ANCHOR_CLI=v$(shell awk -F ' = ' '$$1 ~ /version/ { gsub(/[\"]/, "", $$2); printf("%s",$$2) }' ../cli/Cargo.toml)
 #

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,9 +1,15 @@
+#
+# Docker image to generate deterministic, verifiable builds of Anchor programs.
+# This must be run *after* a given ANCHOR_CLI version is published and a git tag
+# is released on GitHub.
+#
+
 FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG SOLANA_CHANNEL=v1.2.17
-ARG SOLANA_CLI=v1.5.6
+ARG SOLANA_CLI
+ARG ANCHOR_CLI
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
@@ -21,16 +27,10 @@ RUN curl "https://sh.rustup.rs" -sfo rustup.sh && \
     rustup component add rustfmt clippy
 
 # Install Solana tools.
-RUN curl -sSf https://raw.githubusercontent.com/solana-labs/solana/${SOLANA_CLI}/install/solana-install-init.sh | sh -s - ${SOLANA_CLI} && \
-  # BPF sdk.
-  curl -L --retry 5 --retry-delay 2 -o bpf-sdk.tar.bz2 http://solana-sdk.s3.amazonaws.com/${SOLANA_CHANNEL}/bpf-sdk.tar.bz2 && \
-  rm -rf bpf-sdk && \
-  mkdir -p bpf-sdk && \
-  tar jxf bpf-sdk.tar.bz2 && \
-  rm -f bpf-sdk.tar.bz2
+RUN sh -c "$(curl -sSfL https://release.solana.com/${SOLANA_CLI}/install)"
 
 # Install anchor.
-RUN cargo install --git https://github.com/project-serum/anchor anchor-cli --locked
+RUN cargo install --git https://github.com/project-serum/anchor --tag ${ANCHOR_CLI} anchor-cli --locked
 
 # Build a dummy program to bootstrap the BPF SDK (doing this speeds up builds).
 RUN mkdir -p /tmp && cd tmp && anchor init dummy && cd dummy && anchor build


### PR DESCRIPTION
Addresses https://github.com/project-serum/anchor/issues/133.

Ties the verifiable docker image builder version to the anchor cli version. Before building the docker image, one must

* bump the `anchor-cli` version
* merge changes + cut a release with a tag matching the version, e.g. `v0.4.0`
* build the docker image
* push to docker hub

Then the corresponding `anchor-cli` will work with the new image. 