### PR TITLE
cli: Fund configured wallet when testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+## Features
+
+* cli: Fund Anchor.toml configured wallet when testing ([#164](https://github.com/project-serum/anchor/pull/164)).
+
 ## [0.4.1] - 2021-04-06
 
 * cli: Version verifiable docker builder ([#145](https://github.com/project-serum/anchor/pull/145)).

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,6 +2,7 @@ use anchor_syn::idl::Idl;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
 use serum_common::client::Cluster;
+use solana_sdk::signature::Keypair;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
@@ -57,6 +58,11 @@ impl Config {
         }
 
         Ok(None)
+    }
+
+    pub fn wallet_kp(&self) -> Result<Keypair> {
+        solana_sdk::signature::read_keypair_file(&self.wallet.to_string())
+            .map_err(|_| anyhow!("Unable to read keypair file"))
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -909,7 +909,7 @@ fn test(skip_deploy: bool, skip_local_validator: bool, file: Option<String>) -> 
                 };
                 match skip_local_validator {
                     true => None,
-                    false => Some(start_test_validator(flags)?),
+                    false => Some(start_test_validator(cfg, flags)?),
                 }
             }
             _ => {
@@ -1058,7 +1058,7 @@ pub struct IdlTestMetadata {
     address: String,
 }
 
-fn start_test_validator(flags: Option<Vec<String>>) -> Result<Child> {
+fn start_test_validator(cfg: &Config, flags: Option<Vec<String>>) -> Result<Child> {
     fs::create_dir_all(".anchor")?;
     let test_ledger_filename = ".anchor/test-ledger";
     let test_ledger_log_filename = ".anchor/test-ledger-log.txt";
@@ -1076,6 +1076,8 @@ fn start_test_validator(flags: Option<Vec<String>>) -> Result<Child> {
     let validator_handle = std::process::Command::new("solana-test-validator")
         .arg("--ledger")
         .arg(test_ledger_filename)
+        .arg("--mint")
+        .arg(cfg.wallet_kp()?.pubkey().to_string())
         .args(flags.unwrap_or_default())
         .stdout(Stdio::from(test_validator_stdout))
         .stderr(Stdio::from(test_validator_stderr))


### PR DESCRIPTION
Addresses https://github.com/project-serum/anchor/issues/162. Previously, only the default `~/.config/solana/id.json` would be funded. Now the wallet in the Anchor.toml will be.