### PR TITLE
feature = "debug-log"

### DIFF
--- a/lang/syn/src/codegen/accounts.rs
+++ b/lang/syn/src/codegen/accounts.rs
@@ -21,6 +21,8 @@ pub fn generate(accs: AccountsStruct) -> proc_macro2::TokenStream {
                     let name = &s.ident;
                     let ty = &s.raw_field.ty;
                     quote! {
+                        #[cfg(feature = "debug-log")]
+                        ::solana_program::log::sol_log(stringify!(#name));
                         let #name: #ty = anchor_lang::Accounts::try_accounts(program_id, accounts)?;
                     }
                 }
@@ -38,9 +40,13 @@ pub fn generate(accs: AccountsStruct) -> proc_macro2::TokenStream {
                         let name = &f.typed_ident();
                         match f.is_init {
                             false => quote! {
+                                #[cfg(feature = "debug-log")]
+                                ::solana_program::log::sol_log(stringify!(#name));
                                 let #name = anchor_lang::Accounts::try_accounts(program_id, accounts)?;
                             },
                             true => quote! {
+                                #[cfg(feature = "debug-log")]
+                                ::solana_program::log::sol_log(stringify!(#name));
                                 let #name = anchor_lang::AccountsInit::try_accounts_init(program_id, accounts)?;
                             },
                         }


### PR DESCRIPTION
Small addition
Add logs (controlled by a feature)
It allows you to know which account is wrong.
Example:
Before:
```
Transaction simulation failed: Error processing Instruction 0: invalid account data for instruction 
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt invoke [1]
    Program log: **An account's data contents was invalid** <--- Which one? I'm sending 11 accounts!
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt consumed 17026 of 200000 compute units
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt failed: invalid account data for instruction
```

After:
```
Transaction simulation failed: Error processing Instruction 0: invalid account data for instruction 
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt invoke [1]
    Program log: dispatch [112, 225, 192, 69, 163, 214, 226, 252]
    Program log: state : ProgramAccount < State >
    Program log: st_sol_mint : CpiAccount < Mint >    <-----+
    Program log: An account's data contents was invalid  <--| Way better! it's the st_sol_mint : CpiAccount < Mint >!!!
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt consumed 17026 of 200000 compute units
    Program 5HeJRkxvJdYCnZuGnKrUuekFSoH1HKcrJVNPS1zZUXCt failed: invalid account data for instruction
```