### PR TITLE
Add `anchor-debug` feature to optionally inject log statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ incremented for features.
 ## Features
 
 * client: Adds support for state instructions ([#248](https://github.com/project-serum/anchor/pull/248)).
+* lang: Add `anchor-debug` feature flag for logging ([#253](https://github.com/project-serum/anchor/pull/253)).
 
 ## Breaking
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -10,6 +10,17 @@ description = "Solana Sealevel eDSL"
 [features]
 derive = []
 default = []
+anchor-debug = [
+    "anchor-attribute-access-control/anchor-debug",
+    "anchor-attribute-account/anchor-debug",
+    "anchor-attribute-error/anchor-debug",
+    "anchor-attribute-event/anchor-debug",
+    "anchor-attribute-interface/anchor-debug",
+    "anchor-attribute-program/anchor-debug",
+    "anchor-attribute-program/anchor-debug",
+    "anchor-attribute-state/anchor-debug",
+    "anchor-derive-accounts/anchor-debug"
+]
 
 [dependencies]
 anchor-attribute-access-control = { path = "./attribute/access-control", version = "0.4.5" }

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/interface/Cargo.toml
+++ b/lang/attribute/interface/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/attribute/state/Cargo.toml
+++ b/lang/attribute/state/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+default = []
+anchor-debug = ["anchor-syn/anchor-debug"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 idl = []
 hash = []
 default = []
+anchor-debug = []
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/lang/syn/src/codegen/accounts.rs
+++ b/lang/syn/src/codegen/accounts.rs
@@ -21,7 +21,7 @@ pub fn generate(accs: AccountsStruct) -> proc_macro2::TokenStream {
                     let name = &s.ident;
                     let ty = &s.raw_field.ty;
                     quote! {
-                        #[cfg(feature = "debug-log")]
+                        #[cfg(feature = "anchor-debug")]
                         ::solana_program::log::sol_log(stringify!(#name));
                         let #name: #ty = anchor_lang::Accounts::try_accounts(program_id, accounts)?;
                     }
@@ -40,12 +40,12 @@ pub fn generate(accs: AccountsStruct) -> proc_macro2::TokenStream {
                         let name = &f.typed_ident();
                         match f.is_init {
                             false => quote! {
-                                #[cfg(feature = "debug-log")]
+                                #[cfg(feature = "anchor-debug")]
                                 ::solana_program::log::sol_log(stringify!(#name));
                                 let #name = anchor_lang::Accounts::try_accounts(program_id, accounts)?;
                             },
                             true => quote! {
-                                #[cfg(feature = "debug-log")]
+                                #[cfg(feature = "anchor-debug")]
                                 ::solana_program::log::sol_log(stringify!(#name));
                                 let #name = anchor_lang::AccountsInit::try_accounts_init(program_id, accounts)?;
                             },

--- a/lang/syn/src/codegen/program.rs
+++ b/lang/syn/src/codegen/program.rs
@@ -67,6 +67,10 @@ pub fn generate(program: Program) -> proc_macro2::TokenStream {
         /// program, where execution begins.
         #[cfg(not(feature = "no-entrypoint"))]
         fn entry(program_id: &Pubkey, accounts: &[AccountInfo], ix_data: &[u8]) -> ProgramResult {
+            #[cfg(feature = "anchor-debug")]
+            {
+                msg!("anchor-debug is active");
+            }
             if ix_data.len() < 8 {
                 return Err(ProgramError::Custom(99));
             }


### PR DESCRIPTION
This makes `anchor-lang` print a log first thing in `fn entry()` conditionally using a feature. It helped me see that I need to work on something anchor-specific and not Solana-specific and it might help others. I'd love to grow this in the future.