### PR TITLE
ts: replace deprecated web3.Account with web3.Keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ incremented for features.
 * ts: Add `program.simulate` namespace ([#266](https://github.com/project-serum/anchor/pull/266)).
 * cli: Add yarn flag to test command ([#267](https://github.com/project-serum/anchor/pull/267)).
 
+## Breaking Changes
+
+* ts: Replace deprecated `web3.Account` with `web3.Keypair` ([#274](https://github.com/project-serum/anchor/pull/274)).
+
 ## [0.5.0] - 2021-05-07
 
 ## Features

--- a/examples/cashiers-check/tests/cashiers-check.js
+++ b/examples/cashiers-check/tests/cashiers-check.js
@@ -28,8 +28,8 @@ describe("cashiers-check", () => {
     );
   });
 
-  const check = new anchor.web3.Account();
-  const vault = new anchor.web3.Account();
+  const check = anchor.web3.Keypair.generate();
+  const vault = anchor.web3.Keypair.generate();
 
   let checkSigner = null;
 

--- a/examples/chat/tests/chat.js
+++ b/examples/chat/tests/chat.js
@@ -9,7 +9,7 @@ describe("chat", () => {
   const program = anchor.workspace.Chat;
 
   // Chat room account.
-  const chatRoom = new anchor.web3.Account();
+  const chatRoom = anchor.web3.Keypair.generate();
 
   it("Creates a chat room", async () => {
     // Add your test here.

--- a/examples/composite/tests/composite.js
+++ b/examples/composite/tests/composite.js
@@ -10,8 +10,8 @@ describe("composite", () => {
   it("Is initialized!", async () => {
     const program = anchor.workspace.Composite;
 
-    const dummyA = new anchor.web3.Account();
-    const dummyB = new anchor.web3.Account();
+    const dummyA = anchor.web3.Keypair.generate();
+    const dummyB = anchor.web3.Keypair.generate();
 
     const tx = await program.rpc.initialize({
       accounts: {

--- a/examples/ido-pool/tests/ido-pool.js
+++ b/examples/ido-pool/tests/ido-pool.js
@@ -85,7 +85,7 @@ describe("ido-pool", () => {
     );
     poolUsdc = await createTokenAccount(provider, usdcMint, poolSigner);
 
-    poolAccount = new anchor.web3.Account();
+    poolAccount = anchor.web3.Keypair.generate();
     const nowBn = new anchor.BN(Date.now() / 1000);
     startIdoTs = nowBn.add(new anchor.BN(5));
     endDepositsTs = nowBn.add(new anchor.BN(10));

--- a/examples/ido-pool/tests/utils/index.js
+++ b/examples/ido-pool/tests/utils/index.js
@@ -23,7 +23,7 @@ async function createMint(provider, authority) {
   if (authority === undefined) {
     authority = provider.wallet.publicKey;
   }
-  const mint = new anchor.web3.Account();
+  const mint = anchor.web3.Keypair.generate();
   const instructions = await createMintInstructions(
     provider,
     authority,
@@ -57,7 +57,7 @@ async function createMintInstructions(provider, authority, mint) {
 }
 
 async function createTokenAccount(provider, mint, owner) {
-  const vault = new anchor.web3.Account();
+  const vault = anchor.web3.Keypair.generate();
   const tx = new anchor.web3.Transaction();
   tx.add(
     ...(await createTokenAccountInstrs(provider, vault.publicKey, mint, owner))

--- a/examples/lockup/migrations/deploy.js
+++ b/examples/lockup/migrations/deploy.js
@@ -139,8 +139,8 @@ async function registrarInit(
   rewardQLen,
   mint
 ) {
-  const registrar = new anchor.web3.Account();
-  const rewardQ = new anchor.web3.Account();
+  const registrar = anchor.web3.Keypair.generate();
+  const rewardQ = anchor.web3.Keypair.generate();
   const withdrawalTimelock = new anchor.BN(_withdrawalTimelock);
   const stakeRate = new anchor.BN(_stakeRate);
   const [

--- a/examples/lockup/tests/lockup.js
+++ b/examples/lockup/tests/lockup.js
@@ -56,7 +56,7 @@ describe("Lockup and Registry", () => {
   });
 
   it("Sets a new authority", async () => {
-    const newAuthority = new anchor.web3.Account();
+    const newAuthority = anchor.web3.Keypair.generate();
     await lockup.state.rpc.setAuthority(newAuthority.publicKey, {
       accounts: {
         authority: provider.wallet.publicKey,
@@ -81,7 +81,7 @@ describe("Lockup and Registry", () => {
 
   it("Adds to the whitelist", async () => {
     const generateEntry = async () => {
-      let programId = new anchor.web3.Account().publicKey;
+      let programId = anchor.web3.Keypair.generate().publicKey;
       return {
         programId,
       };
@@ -133,7 +133,7 @@ describe("Lockup and Registry", () => {
     assert.deepEqual(lockupAccount.whitelist, entries.slice(1));
   });
 
-  const vesting = new anchor.web3.Account();
+  const vesting = anchor.web3.Keypair.generate();
   let vestingAccount = null;
   let vestingSigner = null;
 
@@ -259,8 +259,8 @@ describe("Lockup and Registry", () => {
     assert.ok(tokenAccount.amount.eq(new anchor.BN(100)));
   });
 
-  const registrar = new anchor.web3.Account();
-  const rewardQ = new anchor.web3.Account();
+  const registrar = anchor.web3.Keypair.generate();
+  const rewardQ = anchor.web3.Keypair.generate();
   const withdrawalTimelock = new anchor.BN(4);
   const stakeRate = new anchor.BN(2);
   const rewardQLen = 170;
@@ -335,7 +335,7 @@ describe("Lockup and Registry", () => {
     assert.ok(registrarAccount.withdrawalTimelock.eq(withdrawalTimelock));
   });
 
-  const member = new anchor.web3.Account();
+  const member = anchor.web3.Keypair.generate();
   let memberAccount = null;
   let memberSigner = null;
   let balances = null;
@@ -462,8 +462,8 @@ describe("Lockup and Registry", () => {
     assert.ok(spt.amount.eq(new anchor.BN(10)));
   });
 
-  const unlockedVendor = new anchor.web3.Account();
-  const unlockedVendorVault = new anchor.web3.Account();
+  const unlockedVendor = anchor.web3.Keypair.generate();
+  const unlockedVendorVault = anchor.web3.Keypair.generate();
   let unlockedVendorSigner = null;
 
   it("Drops an unlocked reward", async () => {
@@ -575,8 +575,8 @@ describe("Lockup and Registry", () => {
     assert.ok(memberAccount.rewardsCursor == 1);
   });
 
-  const lockedVendor = new anchor.web3.Account();
-  const lockedVendorVault = new anchor.web3.Account();
+  const lockedVendor = anchor.web3.Keypair.generate();
+  const lockedVendorVault = anchor.web3.Keypair.generate();
   let lockedVendorSigner = null;
   let lockedRewardAmount = null;
   let lockedRewardKind = null;
@@ -788,7 +788,7 @@ describe("Lockup and Registry", () => {
     );
   });
 
-  const pendingWithdrawal = new anchor.web3.Account();
+  const pendingWithdrawal = anchor.web3.Keypair.generate();
 
   it("Unstakes (unlocked)", async () => {
     const unstakeAmount = new anchor.BN(10);

--- a/examples/lockup/tests/lockup.js
+++ b/examples/lockup/tests/lockup.js
@@ -144,7 +144,7 @@ describe("Lockup and Registry", () => {
     const beneficiary = provider.wallet.publicKey;
     const depositAmount = new anchor.BN(100);
 
-    const vault = new anchor.web3.Account();
+    const vault = anchor.web3.Keypair.generate();
     let [
       _vestingSigner,
       nonce,
@@ -668,8 +668,8 @@ describe("Lockup and Registry", () => {
   let vendoredVestingSigner = null;
 
   it("Claims a locked reward", async () => {
-    vendoredVesting = new anchor.web3.Account();
-    vendoredVestingVault = new anchor.web3.Account();
+    vendoredVesting = anchor.web3.Keypair.generate();
+    vendoredVestingVault = anchor.web3.Keypair.generate();
     let [
       _vendoredVestingSigner,
       nonce,

--- a/examples/lockup/tests/utils.js
+++ b/examples/lockup/tests/utils.js
@@ -2,10 +2,10 @@ const anchor = require("@project-serum/anchor");
 const serumCmn = require("@project-serum/common");
 
 async function createBalanceSandbox(provider, r, registrySigner) {
-  const spt = new anchor.web3.Account();
-  const vault = new anchor.web3.Account();
-  const vaultStake = new anchor.web3.Account();
-  const vaultPw = new anchor.web3.Account();
+  const spt = anchor.web3.Keypair.generate();
+  const vault = anchor.web3.Keypair.generate();
+  const vaultStake = anchor.web3.Keypair.generate();
+  const vaultPw = anchor.web3.Keypair.generate();
 
   const lamports = await provider.connection.getMinimumBalanceForRentExemption(
     165

--- a/examples/misc/tests/misc.js
+++ b/examples/misc/tests/misc.js
@@ -17,7 +17,7 @@ describe("misc", () => {
     assert.ok(accountInfo.data.length === 99);
   });
 
-  const data = new anchor.web3.Account();
+  const data = anchor.web3.Keypair.generate();
 
   it("Can use u128 and i128", async () => {
     const tx = await program.rpc.initialize(
@@ -38,7 +38,7 @@ describe("misc", () => {
   });
 
   it("Can use u16", async () => {
-    const data = new anchor.web3.Account();
+    const data = anchor.web3.Keypair.generate();
     const tx = await program.rpc.testU16(99, {
       accounts: {
         myAccount: data.publicKey,

--- a/examples/multisig/tests/multisig.js
+++ b/examples/multisig/tests/multisig.js
@@ -8,7 +8,7 @@ describe("multisig", () => {
   const program = anchor.workspace.Multisig;
 
   it("Tests the multisig program", async () => {
-    const multisig = new anchor.web3.Account();
+    const multisig = anchor.web3.Keypair.generate();
     const [
       multisigSigner,
       nonce,

--- a/examples/multisig/tests/multisig.js
+++ b/examples/multisig/tests/multisig.js
@@ -18,10 +18,10 @@ describe("multisig", () => {
     );
     const multisigSize = 200; // Big enough.
 
-    const ownerA = new anchor.web3.Account();
-    const ownerB = new anchor.web3.Account();
-    const ownerC = new anchor.web3.Account();
-    const ownerD = new anchor.web3.Account();
+    const ownerA = anchor.web3.Keypair.generate();
+    const ownerB = anchor.web3.Keypair.generate();
+    const ownerC = anchor.web3.Keypair.generate();
+    const ownerD = anchor.web3.Keypair.generate();
     const owners = [ownerA.publicKey, ownerB.publicKey, ownerC.publicKey];
 
     const threshold = new anchor.BN(2);
@@ -63,7 +63,7 @@ describe("multisig", () => {
         owners: newOwners,
     });
 
-    const transaction = new anchor.web3.Account();
+    const transaction = anchor.web3.Keypair.generate();
     const txSize = 1000; // Big enough, cuz I'm lazy.
     await program.rpc.createTransaction(pid, accounts, data, {
       accounts: {

--- a/examples/spl/token-proxy/tests/token-proxy.js
+++ b/examples/spl/token-proxy/tests/token-proxy.js
@@ -86,7 +86,7 @@ async function createMint(provider, authority) {
   if (authority === undefined) {
     authority = provider.wallet.publicKey;
   }
-  const mint = new anchor.web3.Account();
+  const mint = anchor.web3.Keypair.generate();
   const instructions = await createMintInstructions(
     provider,
     authority,
@@ -120,7 +120,7 @@ async function createMintInstructions(provider, authority, mint) {
 }
 
 async function createTokenAccount(provider, mint, owner) {
-  const vault = new anchor.web3.Account();
+  const vault = anchor.web3.Keypair.generate();
   const tx = new anchor.web3.Transaction();
   tx.add(
     ...(await createTokenAccountInstrs(provider, vault.publicKey, mint, owner))

--- a/examples/swap/tests/swap.js
+++ b/examples/swap/tests/swap.js
@@ -28,8 +28,8 @@ describe("swap", () => {
     marketBVaultSigner;
 
   // Open orders accounts on the two markets for the provider.
-  const openOrdersA = new anchor.web3.Account();
-  const openOrdersB = new anchor.web3.Account();
+  const openOrdersA = anchor.web3.Keypair.generate();
+  const openOrdersB = anchor.web3.Keypair.generate();
 
   it("BOILERPLATE: Sets up two markets with resting orders", async () => {
     ORDERBOOK_ENV = await utils.setupTwoMarkets({

--- a/examples/tutorial/basic-1/tests/basic-1.js
+++ b/examples/tutorial/basic-1/tests/basic-1.js
@@ -13,7 +13,7 @@ describe("basic-1", () => {
     const program = anchor.workspace.Basic1;
 
     // The Account to create.
-    const myAccount = new anchor.web3.Account();
+    const myAccount = anchor.web3.Keypair.generate();
 
     // Create account transaction.
     const tx = new anchor.web3.Transaction();
@@ -58,7 +58,7 @@ describe("basic-1", () => {
 
     // #region code
     // The Account to create.
-    const myAccount = new anchor.web3.Account();
+    const myAccount = anchor.web3.Keypair.generate();
 
     // Atomically create the new account and initialize it with the program.
     await program.rpc.initialize(new anchor.BN(1234), {
@@ -93,7 +93,7 @@ describe("basic-1", () => {
     const program = anchor.workspace.Basic1;
 
     // The Account to create.
-    const myAccount = new anchor.web3.Account();
+    const myAccount = anchor.web3.Keypair.generate();
 
     // Atomically create the new account and initialize it with the program.
     // #region code-simplified

--- a/examples/tutorial/basic-2/tests/basic-2.js
+++ b/examples/tutorial/basic-2/tests/basic-2.js
@@ -8,7 +8,7 @@ describe('basic-2', () => {
   anchor.setProvider(provider)
 
   // Counter for the tests.
-  const counter = new anchor.web3.Account()
+  const counter = anchor.web3.Keypair.generate()
 
   // Program for the tests.
   const program = anchor.workspace.Basic2

--- a/examples/tutorial/basic-3/tests/basic-3.js
+++ b/examples/tutorial/basic-3/tests/basic-3.js
@@ -12,7 +12,7 @@ describe("basic-3", () => {
     const puppet = anchor.workspace.Puppet;
 
     // Initialize a new puppet account.
-    const newPuppetAccount = new anchor.web3.Account();
+    const newPuppetAccount = anchor.web3.Keypair.generate();
     const tx = await puppet.rpc.initialize({
       accounts: {
         puppet: newPuppetAccount.publicKey,

--- a/examples/tutorial/basic-5/tests/basic-5.js
+++ b/examples/tutorial/basic-5/tests/basic-5.js
@@ -7,7 +7,7 @@ describe("basic-5", () => {
 
   const program = anchor.workspace.Basic5;
 
-  const mint = new anchor.web3.Account();
+  const mint = anchor.web3.Keypair.generate();
 
   // Setup. Not important for the point of the example.
   it("Sets up the test", async () => {

--- a/examples/zero-copy/tests/zero-copy.js
+++ b/examples/zero-copy/tests/zero-copy.js
@@ -7,7 +7,7 @@ describe("zero-copy", () => {
 
   const program = anchor.workspace.ZeroCopy;
 
-  const foo = new anchor.web3.Account();
+  const foo = anchor.web3.Keypair.generate();
 
   it("Creates zero copy state", async () => {
     await program.state.rpc.new({
@@ -155,7 +155,7 @@ describe("zero-copy", () => {
     assert.ok(bar.data.toNumber() === 99);
   });
 
-  const eventQ = new anchor.web3.Account();
+  const eventQ = anchor.web3.Keypair.generate();
   const size = 1000000 + 8; // Account size in bytes.
 
   it("Creates a large event queue", async () => {

--- a/ts/package.json
+++ b/ts/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@project-serum/borsh": "^0.2.1",
-    "@solana/web3.js": "^1.2.0",
+    "@solana/web3.js": "^1.10.1",
     "@types/bn.js": "^4.11.6",
     "@types/bs58": "^4.0.1",
     "@types/crypto-hash": "^1.1.2",

--- a/ts/package.json
+++ b/ts/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@project-serum/borsh": "^0.2.1",
-    "@solana/web3.js": "^1.10.1",
+    "@solana/web3.js": "^1.11.0",
     "@types/bn.js": "^4.11.6",
     "@types/bs58": "^4.0.1",
     "@types/crypto-hash": "^1.1.2",

--- a/ts/src/program/context.ts
+++ b/ts/src/program/context.ts
@@ -1,6 +1,6 @@
 import {
-  Account,
   AccountMeta,
+  Keypair,
   PublicKey,
   ConfirmOptions,
   TransactionInstruction,
@@ -25,7 +25,7 @@ export type Context = {
   /**
    * Accounts that must sign a given transaction.
    */
-  signers?: Array<Account>;
+  signers?: Array<Keypair>;
 
   /**
    * Instructions to run *before* a given method. Often this is used, for

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -38,7 +38,7 @@ type AccountProps = {
   all: (filter?: Buffer) => Promise<ProgramAccount<any>[]>;
   subscribe: (address: PublicKey, commitment?: Commitment) => EventEmitter;
   unsubscribe: (address: PublicKey) => void;
-  createInstruction: (account: Keypair) => Promise<TransactionInstruction>;
+  createInstruction: (keypair: Keypair) => Promise<TransactionInstruction>;
   associated: (...args: PublicKey[]) => Promise<any>;
   associatedAddress: (...args: PublicKey[]) => Promise<PublicKey>;
 };
@@ -93,7 +93,7 @@ export default class AccountFactory {
       // Returns an instruction for creating this account.
       // @ts-ignore
       accountsNamespace["createInstruction"] = async (
-        account: Keypair,
+        keypair: Keypair,
         sizeOverride?: number
       ): Promise<TransactionInstruction> => {
         // @ts-ignore
@@ -101,7 +101,7 @@ export default class AccountFactory {
 
         return SystemProgram.createAccount({
           fromPubkey: provider.wallet.publicKey,
-          newAccountPubkey: account.publicKey,
+          newAccountPubkey: keypair.publicKey,
           space: sizeOverride ?? size,
           lamports: await provider.connection.getMinimumBalanceForRentExemption(
             sizeOverride ?? size

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -2,7 +2,7 @@ import camelCase from "camelcase";
 import EventEmitter from "eventemitter3";
 import * as bs58 from "bs58";
 import {
-  Account,
+  Keypair,
   PublicKey,
   SystemProgram,
   TransactionInstruction,
@@ -38,7 +38,7 @@ type AccountProps = {
   all: (filter?: Buffer) => Promise<ProgramAccount<any>[]>;
   subscribe: (address: PublicKey, commitment?: Commitment) => EventEmitter;
   unsubscribe: (address: PublicKey) => void;
-  createInstruction: (account: Account) => Promise<TransactionInstruction>;
+  createInstruction: (account: Keypair) => Promise<TransactionInstruction>;
   associated: (...args: PublicKey[]) => Promise<any>;
   associatedAddress: (...args: PublicKey[]) => Promise<PublicKey>;
 };
@@ -93,7 +93,7 @@ export default class AccountFactory {
       // Returns an instruction for creating this account.
       // @ts-ignore
       accountsNamespace["createInstruction"] = async (
-        account: Account,
+        account: Keypair,
         sizeOverride?: number
       ): Promise<TransactionInstruction> => {
         // @ts-ignore

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -1,6 +1,6 @@
 import {
   Connection,
-  Account,
+  Keypair,
   PublicKey,
   Transaction,
   TransactionSignature,
@@ -81,7 +81,7 @@ export default class Provider {
    */
   async send(
     tx: Transaction,
-    signers?: Array<Account | undefined>,
+    signers?: Array<Keypair | undefined>,
     opts?: ConfirmOptions
   ): Promise<TransactionSignature> {
     if (signers === undefined) {
@@ -91,7 +91,7 @@ export default class Provider {
       opts = this.opts;
     }
 
-    const signerKps = signers.filter((s) => s !== undefined) as Array<Account>;
+    const signerKps = signers.filter((s) => s !== undefined) as Array<Keypair>;
     const signerPubkeys = [this.wallet.publicKey].concat(
       signerKps.map((s) => s.publicKey)
     );
@@ -141,7 +141,7 @@ export default class Provider {
 
       const signerKps = signers.filter(
         (s) => s !== undefined
-      ) as Array<Account>;
+      ) as Array<Keypair>;
       const signerPubkeys = [this.wallet.publicKey].concat(
         signerKps.map((s) => s.publicKey)
       );
@@ -180,7 +180,7 @@ export default class Provider {
    */
   async simulate(
     tx: Transaction,
-    signers?: Array<Account | undefined>,
+    signers?: Array<Keypair | undefined>,
     opts?: ConfirmOptions
   ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>> {
     if (signers === undefined) {
@@ -190,7 +190,7 @@ export default class Provider {
       opts = this.opts;
     }
 
-    const signerKps = signers.filter((s) => s !== undefined) as Array<Account>;
+    const signerKps = signers.filter((s) => s !== undefined) as Array<Keypair>;
     const signerPubkeys = [this.wallet.publicKey].concat(
       signerKps.map((s) => s.publicKey)
     );
@@ -210,7 +210,7 @@ export default class Provider {
 
 export type SendTxRequest = {
   tx: Transaction;
-  signers: Array<Account | undefined>;
+  signers: Array<Keypair | undefined>;
 };
 
 /**
@@ -226,10 +226,10 @@ export interface Wallet {
  * Node only wallet.
  */
 export class NodeWallet implements Wallet {
-  constructor(readonly payer: Account) {}
+  constructor(readonly payer: Keypair) {}
 
   static local(): NodeWallet {
-    const payer = new Account(
+    const payer = Keypair.fromSecretKey(
       Buffer.from(
         JSON.parse(
           require("fs").readFileSync(

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -676,7 +676,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@solana/web3.js@^1.2.0":
+"@solana/web3.js@^1.10.1":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.10.1.tgz#b3e7197a2628c26c54227963741b1788bb67f7ff"
   integrity sha512-5zepm+AaVfC6uao/WxKT7SlemqgGEp+x7XUv+018RURIx+XEcF+G2ZgjrIbjy5OoXJyfz+wGw8Or2fxsypderA==

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -242,9 +242,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
-  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -677,9 +677,9 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@solana/web3.js@^1.2.0":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.2.3.tgz#8d4c1f70b8c208c721eeca03c9624d3638ba3d7f"
-  integrity sha512-aDsFJhefIiKh9kb3xeWcX5rsAPdUqJtz61F9tplfp//mYVpzKZeWYZSUKB39PXo7c5ZrxVeBx7am4J7NB10Pcg==
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.10.1.tgz#b3e7197a2628c26c54227963741b1788bb67f7ff"
+  integrity sha512-5zepm+AaVfC6uao/WxKT7SlemqgGEp+x7XUv+018RURIx+XEcF+G2ZgjrIbjy5OoXJyfz+wGw8Or2fxsypderA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     bn.js "^5.0.0"
@@ -757,9 +757,9 @@
     crypto-hash "*"
 
 "@types/express-serve-static-core@^4.17.9":
-  version "4.17.18"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz#8371e260f40e0e1ca0c116a9afcd9426fa094c40"
-  integrity sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz#00acfc1632e729acac4f1530e9e16f6dd1508a1d"
+  integrity sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -815,14 +815,14 @@
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
 "@types/node@*":
-  version "14.14.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
-  integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
+  integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
 
 "@types/node@^12.12.54":
-  version "12.20.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.5.tgz#4ca82a766f05c359fd6c77505007e5a272f4bb9b"
-  integrity sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg==
+  version "12.20.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.12.tgz#fd9c1c2cfab536a2383ed1ef70f94adea743a226"
+  integrity sha512-KQZ1al2hKOONAs2MFv+yTQP1LkDWMrRJ9YCVRalXltOfXsBmH5IownLxQaiq0lnAHwAViLnh2aTYqrPcRGEbgg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2972,9 +2972,9 @@ istanbul-reports@^3.0.2:
     istanbul-lib-report "^3.0.0"
 
 jayson@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.4.4.tgz#dcedffba0c02785c4aa22dbff8c28966cae59773"
-  integrity sha512-fgQflh+Qnhdv9fjxTnpTsa2WUG/dgyeKQzIh5MJ77Qv2sqFyyAZn7mTUYgPjJMFjsKfb4HNsSBh6ktJeeQiAGQ==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.6.2.tgz#e551e25abf2efe333051a6ed88b10f08c5288f50"
+  integrity sha512-hbl+x2xH6FT7nckw+Pq3lKOIJaMBKOgNJEVfvloDBWB8iSfzn/1U2igj1A5rplqNMFN/OnnaTNw8qPKVmoq83Q==
   dependencies:
     "@types/connect" "^3.4.33"
     "@types/express-serve-static-core" "^4.17.9"
@@ -4523,9 +4523,9 @@ rimraf@^3.0.0, rimraf@^3.0.2:
     glob "^7.1.3"
 
 rpc-websockets@^7.4.2:
-  version "7.4.9"
-  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.4.9.tgz#7f66d343d92903a2ebe9911aa8c1ea4961e2785d"
-  integrity sha512-5MsJlPDzJkt3eqlUeYHg66A7mxXSSYRE11lKGfNmAXgcMBw4F3a7CLgviwqf6rb850qP3Q1BP8ygp+V+DDq1qQ==
+  version "7.4.11"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.4.11.tgz#ac8105116f1a888fbc3dd6b8394ea135ee59499c"
+  integrity sha512-/6yKCkRrEEb+TlJb6Q/pNBD4WdO/tFxE22rQYBl1YyIgz3SpzQDQ/0qAMWWksjFkDayiq3xVxmkP8e/tL422ZA==
   dependencies:
     "@babel/runtime" "^7.11.2"
     assert-args "^1.2.1"
@@ -5338,9 +5338,9 @@ use@^3.1.0:
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 utf-8-validate@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.4.tgz#72a1735983ddf7a05a43a9c6b67c5ce1c910f9b8"
-  integrity sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.5.tgz#dd32c2e82c72002dc9f02eb67ba6761f43456ca1"
+  integrity sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==
   dependencies:
     node-gyp-build "^4.2.0"
 
@@ -5511,9 +5511,9 @@ ws@^7.2.3:
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
 ws@^7.3.1:
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
-  integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
+  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -676,10 +676,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@solana/web3.js@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.10.1.tgz#b3e7197a2628c26c54227963741b1788bb67f7ff"
-  integrity sha512-5zepm+AaVfC6uao/WxKT7SlemqgGEp+x7XUv+018RURIx+XEcF+G2ZgjrIbjy5OoXJyfz+wGw8Or2fxsypderA==
+"@solana/web3.js@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.11.0.tgz#1cc9a25381687c82e444ad0633f028e050a06753"
+  integrity sha512-kmngWxntzp0HNhWInd7/3g2uqxdOrahvaHOyjilcRe+WCiC777gERz3+eIAbxIYx2zAZPjy02MZzLgoRHccZoQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     bn.js "^5.0.0"


### PR DESCRIPTION
I'm submitting this as a draft as I haven't yet tested every example, but it should work. It also not be needed yet? I'm running `@project-serum/anchor@0.5.1-beta.2`.

The `Account` class was [deprecated](https://github.com/solana-labs/solana-web3.js/blob/62513cdee2ca0c4f350e811a982ca13731201a9f/src/account.ts#L7-L11) in `@solana/web3.js@1.10.0` so I have changed all occurances of `new anchor.web3.Account()` to `anchor.web3.Keypair.generate()`