### PR TITLE
cli: option to specify program to launch/deploy in workspace

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,6 +94,8 @@ pub enum Command {
         url: Option<String>,
         #[clap(short, long)]
         keypair: Option<String>,
+        #[clap(short, long)]
+        program_name: Option<String>,
     },
     /// Runs the deploy migration script.
     Migrate {
@@ -110,6 +112,8 @@ pub enum Command {
         /// this should almost always be set.
         #[clap(short, long)]
         verifiable: bool,
+        #[clap(short, long)]
+        program_name: Option<String>,
     },
     /// Upgrades a single program. The configured wallet must be the upgrade
     /// authority.
@@ -118,6 +122,7 @@ pub enum Command {
         #[clap(short, long)]
         program_id: Pubkey,
         /// Filepath to the new program binary.
+        #[clap(short, long)]
         program_filepath: String,
     },
     #[cfg(feature = "dev")]
@@ -218,7 +223,7 @@ fn main() -> Result<()> {
         Command::New { name } => new(name),
         Command::Build { idl, verifiable } => build(idl, verifiable),
         Command::Verify { program_id } => verify(program_id),
-        Command::Deploy { url, keypair } => deploy(url, keypair),
+        Command::Deploy { url, keypair, program_name } => deploy(url, keypair, program_name),
         Command::Upgrade {
             program_id,
             program_filepath,
@@ -229,7 +234,8 @@ fn main() -> Result<()> {
             url,
             keypair,
             verifiable,
-        } => launch(url, keypair, verifiable),
+            program_name,
+        } => launch(url, keypair, verifiable, program_name),
         Command::Test {
             skip_deploy,
             skip_local_validator,
@@ -936,7 +942,7 @@ fn test(
             _ => {
                 if !skip_deploy {
                     build(None, false)?;
-                    deploy(None, None)?;
+                    deploy(None, None, None)?;
                 }
                 None
             }
@@ -1151,11 +1157,11 @@ fn start_test_validator(cfg: &Config, flags: Option<Vec<String>>) -> Result<Chil
 
 // TODO: Testing and deploys should use separate sections of metadata.
 //       Similarly, each network should have separate metadata.
-fn deploy(url: Option<String>, keypair: Option<String>) -> Result<()> {
-    _deploy(url, keypair).map(|_| ())
+fn deploy(url: Option<String>, keypair: Option<String>, program_name: Option<String>) -> Result<()> {
+    _deploy(url, keypair, program_name).map(|_| ())
 }
 
-fn _deploy(url: Option<String>, keypair: Option<String>) -> Result<Vec<(Pubkey, Program)>> {
+fn _deploy(url: Option<String>, keypair: Option<String>, program_str: Option<String>) -> Result<Vec<(Pubkey, Program)>> {
     with_workspace(|cfg, _path, _cargo| {
         // Fallback to config vars if not provided via CLI.
         let url = url.unwrap_or_else(|| cfg.cluster.url().to_string());
@@ -1168,9 +1174,16 @@ fn _deploy(url: Option<String>, keypair: Option<String>) -> Result<Vec<(Pubkey, 
         let mut programs = Vec::new();
 
         for mut program in read_all_programs()? {
+            if let Some(single_prog_str) = &program_str {
+                let program_name = program.path.file_name().unwrap().to_str().unwrap();
+                if single_prog_str.as_str() != program_name {
+                    continue
+                }
+            }
             let binary_path = program.binary_path().display().to_string();
 
-            println!("Deploying {}...", binary_path);
+            println!("Deploying program {:?}...", program.path.file_name().unwrap().to_str().unwrap());
+            println!("Program path: {}...", binary_path);
 
             // Write the program's keypair filepath. This forces a new deploy
             // address.
@@ -1245,10 +1258,10 @@ fn upgrade(program_id: Pubkey, program_filepath: String) -> Result<()> {
     })
 }
 
-fn launch(url: Option<String>, keypair: Option<String>, verifiable: bool) -> Result<()> {
+fn launch(url: Option<String>, keypair: Option<String>, verifiable: bool, program_name: Option<String>) -> Result<()> {
     // Build and deploy.
     build(None, verifiable)?;
-    let programs = _deploy(url.clone(), keypair.clone())?;
+    let programs = _deploy(url.clone(), keypair.clone(), program_name)?;
 
     with_workspace(|cfg, _path, _cargo| {
         let url = url.unwrap_or_else(|| cfg.cluster.url().to_string());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,6 @@ pub enum Command {
         #[clap(short, long)]
         program_id: Pubkey,
         /// Filepath to the new program binary.
-        #[clap(short, long)]
         program_filepath: String,
     },
     #[cfg(feature = "dev")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1280,7 +1280,7 @@ fn launch(
 ) -> Result<()> {
     // Build and deploy.
     build(None, verifiable)?;
-    let programs = _deploy(url.clone(), keypair.clone(), program_name)?;
+    let programs = _deploy(url.clone(), keypair.clone(), program_name.clone())?;
 
     with_workspace(|cfg, _path, _cargo| {
         let url = url.unwrap_or_else(|| cfg.cluster.url().to_string());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -223,7 +223,11 @@ fn main() -> Result<()> {
         Command::New { name } => new(name),
         Command::Build { idl, verifiable } => build(idl, verifiable),
         Command::Verify { program_id } => verify(program_id),
-        Command::Deploy { url, keypair, program_name } => deploy(url, keypair, program_name),
+        Command::Deploy {
+            url,
+            keypair,
+            program_name,
+        } => deploy(url, keypair, program_name),
         Command::Upgrade {
             program_id,
             program_filepath,
@@ -1157,11 +1161,19 @@ fn start_test_validator(cfg: &Config, flags: Option<Vec<String>>) -> Result<Chil
 
 // TODO: Testing and deploys should use separate sections of metadata.
 //       Similarly, each network should have separate metadata.
-fn deploy(url: Option<String>, keypair: Option<String>, program_name: Option<String>) -> Result<()> {
+fn deploy(
+    url: Option<String>,
+    keypair: Option<String>,
+    program_name: Option<String>,
+) -> Result<()> {
     _deploy(url, keypair, program_name).map(|_| ())
 }
 
-fn _deploy(url: Option<String>, keypair: Option<String>, program_str: Option<String>) -> Result<Vec<(Pubkey, Program)>> {
+fn _deploy(
+    url: Option<String>,
+    keypair: Option<String>,
+    program_str: Option<String>,
+) -> Result<Vec<(Pubkey, Program)>> {
     with_workspace(|cfg, _path, _cargo| {
         // Fallback to config vars if not provided via CLI.
         let url = url.unwrap_or_else(|| cfg.cluster.url().to_string());
@@ -1177,12 +1189,15 @@ fn _deploy(url: Option<String>, keypair: Option<String>, program_str: Option<Str
             if let Some(single_prog_str) = &program_str {
                 let program_name = program.path.file_name().unwrap().to_str().unwrap();
                 if single_prog_str.as_str() != program_name {
-                    continue
+                    continue;
                 }
             }
             let binary_path = program.binary_path().display().to_string();
 
-            println!("Deploying program {:?}...", program.path.file_name().unwrap().to_str().unwrap());
+            println!(
+                "Deploying program {:?}...",
+                program.path.file_name().unwrap().to_str().unwrap()
+            );
             println!("Program path: {}...", binary_path);
 
             // Write the program's keypair filepath. This forces a new deploy
@@ -1258,7 +1273,12 @@ fn upgrade(program_id: Pubkey, program_filepath: String) -> Result<()> {
     })
 }
 
-fn launch(url: Option<String>, keypair: Option<String>, verifiable: bool, program_name: Option<String>) -> Result<()> {
+fn launch(
+    url: Option<String>,
+    keypair: Option<String>,
+    verifiable: bool,
+    program_name: Option<String>,
+) -> Result<()> {
     // Build and deploy.
     build(None, verifiable)?;
     let programs = _deploy(url.clone(), keypair.clone(), program_name)?;


### PR DESCRIPTION
Example usage:
```
jonch@RASK-Legion:~/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3$ ../../../target/debug/anchor deploy -p puppet-master
Deploying workspace: http://127.0.0.1:8899
Upgrade authority: /home/jonch/.config/solana/id.json
Deploying program "puppet-master"...
Program path: /home/jonch/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3/target/deploy/puppet_master.so...
Program Id: AHa1ZTcXRvFFKwuVDv2yvCXxhj1TWfD6kUgKLJ817Pid

Deploy success
jonch@RASK-Legion:~/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3$ ../../../target/debug/anchor deploy -p puppet
Deploying workspace: http://127.0.0.1:8899
Upgrade authority: /home/jonch/.config/solana/id.json
Deploying program "puppet"...
Program path: /home/jonch/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3/target/deploy/puppet.so...
Program Id: 4GcsYTfRXtGggwp6q4vYmFTfGfkEpCzURdPqa4LJtjd1

Deploy success
```
After relaunching the `solana-test-validator`:
```
jonch@RASK-Legion:~/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3$ ../../../target/debug/anchor deploy 
Deploying workspace: http://127.0.0.1:8899
Upgrade authority: /home/jonch/.config/solana/id.json
Deploying program "puppet-master"...
Program path: /home/jonch/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3/target/deploy/puppet_master.so...
Program Id: 3jBh3yWw8bCanai4RoYbd6Vrv5Hvnzi8qvGKoZjNEGRU

Deploying program "puppet"...
Program path: /home/jonch/Desktop/Programming/blockchain/anchor/examples/tutorial/basic-3/target/deploy/puppet.so...
Program Id: 8CEAaQYHpp3GkTnVfqaar6Z1JffAfNSwBPwcBPs4gYyo

Deploy success
```

closes: https://github.com/project-serum/anchor/issues/280