### PR TITLE
cli: Add --skip-build flag to anchor test resolve #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incremented for features.
 
 * ts: Add `program.simulate` namespace ([#266](https://github.com/project-serum/anchor/pull/266)).
 * cli: Add yarn flag to test command ([#267](https://github.com/project-serum/anchor/pull/267)).
+* cli: Add `--skip-build` flag to test command ([301](https://github.com/project-serum/anchor/pull/301)).
 
 ## Breaking Changes
 


### PR DESCRIPTION
This PR adds another flag called `--skip-build` to the command `anchor test` to skip the building of Solana program in the workspace. This would save time when working on a large workspace where building would take time. 

Previously, if the users would like to alter their tests and run `anchor test` again, the cli would build everything again. With, `--skip-build`, tests could be run right away without going through the building of source code again.

Example usage:
```
anchor test --skip-build

workspace % anchor test --skip-build


  someProgram
    ✓ Should initialize (59397ms)
    ✓ Should pass the test (4472ms)
```