### PR TITLE
cli: Add shell command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ incremented for features.
 * ts: Add `program.simulate` namespace ([#266](https://github.com/project-serum/anchor/pull/266)).
 * cli: Add yarn flag to test command ([#267](https://github.com/project-serum/anchor/pull/267)).
 * cli: Add `--skip-build` flag to test command ([301](https://github.com/project-serum/anchor/pull/301)).
+* cli: Add `anchor shell` command to spawn a node shell populated with an Anchor.toml based environment ([#303](https://github.com/project-serum/anchor/pull/303)).
 
 ## Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
 name = "anchor-cli"
 version = "0.5.0"
 dependencies = [
+ "anchor-client",
  "anchor-lang",
  "anchor-syn",
  "anyhow",
@@ -158,6 +159,7 @@ dependencies = [
  "anchor-lang",
  "anyhow",
  "regex",
+ "serde",
  "solana-client",
  "solana-sdk",
  "thiserror",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = "3.0.0-beta.1"
 anyhow = "1.0.32"
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 anchor-lang = { path = "../lang" }
+anchor-client = { path = "../client" }
 anchor-syn = { path = "../lang/syn", features = ["idl"] }
 serde_json = "1.0"
 shellexpand = "2.1.0"

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1,4 +1,6 @@
+use crate::config::ProgramWorkspace;
 use crate::VERSION;
+use anyhow::Result;
 use heck::{CamelCase, SnakeCase};
 
 pub fn virtual_manifest() -> &'static str {
@@ -189,4 +191,51 @@ target
 # Ignore backup files creates by cargo fmt.
 **/*.rs.bk
     "#
+}
+
+pub fn node_shell(
+    cluster_url: &str,
+    wallet_path: &str,
+    programs: Vec<ProgramWorkspace>,
+) -> Result<String> {
+    let mut eval_string = format!(
+        r#"
+const anchor = require('@project-serum/anchor');
+const web3 = anchor.web3;
+const PublicKey = anchor.web3.PublicKey;
+
+const __wallet = new anchor.Wallet(
+  Buffer.from(
+    JSON.parse(
+      require('fs').readFileSync(
+        "{}",
+        {{
+          encoding: "utf-8",
+        }},
+      ),
+    ),
+  ),
+);
+const __connection = new web3.Connection("{}", "processed");
+const provider = new anchor.Provider(__connection, __wallet, {{
+  commitment: "processed",
+  preflightcommitment: "processed",
+}});
+anchor.setProvider(provider);
+"#,
+        wallet_path, cluster_url,
+    );
+
+    for program in programs {
+        eval_string.push_str(&format!(
+            r#"
+anchor.workspace.{} = new anchor.Program({}, new PublicKey("{}"), provider);
+"#,
+            program.name,
+            serde_json::to_string(&program.idl)?,
+            program.program_id.to_string()
+        ));
+    }
+
+    Ok(eval_string)
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,6 +10,7 @@ description = "Rust client for Anchor programs"
 anchor-lang = { path = "../lang", version = "0.5.0" }
 anyhow = "1.0.32"
 regex = "1.4.5"
+serde = { version = "1.0.122", features = ["derive"] }
 solana-client = "1.6.6"
 solana-sdk = "1.6.6"
 thiserror = "1.0.20"

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Cluster {
     Testnet,
     Mainnet,


### PR DESCRIPTION
Add a new `anchor shell` command that runs a node shell with generated clients ready to go, configured from the Anchor toml, for example,

```
cluster = "mainnet"
wallet = "<wallet>"

[clusters.mainnet]
lockup = "GrAkKfEpTKQuVHG2Y97Y2FF4i7y7Q5AHLK94JBy7Y5yv"
registry = "6ebQNeTPZ1j7k3TtkCCtEPRvG7GQsucQrZ7sSEDQi9Ks"

[clusters.devnet]
lockup = "<address-here>"
registry = "<address-here>"
```

Would allow one to run `anchor shell` to run a shell and communicate with the programs via `anchor.workspace.<program-name>` on mainnet. Or `anchor shell --cluster devnet` to do the same, but on devnet. 