### PR TITLE
ts, cli: Overrideable workspace program addresses

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -33,7 +33,8 @@
     "find": "^0.3.0",
     "js-sha256": "^0.9.0",
     "pako": "^2.0.3",
-    "snake-case": "^3.0.4"
+    "snake-case": "^3.0.4",
+    "toml": "^3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/ts/src/workspace.ts
+++ b/ts/src/workspace.ts
@@ -1,6 +1,8 @@
 import camelCase from "camelcase";
+import * as toml from "toml";
 import { PublicKey } from "@solana/web3.js";
 import { Program } from "./program";
+import { getProvider } from "./";
 
 let _populatedWorkspace = false;
 
@@ -44,12 +46,23 @@ const workspace = new Proxy({} as any, {
           const idlStr = fs.readFileSync(path);
           const idl = JSON.parse(idlStr);
           const name = camelCase(idl.name, { pascalCase: true });
-          programs[name] = new Program(
-            idl,
-            new PublicKey(idl.metadata.address)
-          );
+          if (idl.metadata && idl.metadata.address) {
+            programs[name] = new Program(
+              idl,
+              new PublicKey(idl.metadata.address)
+            );
+          }
           return programs;
         }, workspaceCache);
+
+      // Override the workspace programs if the user put them in the config.
+      const anchorToml = toml.parse(
+        fs.readFileSync(path.join(projectRoot, "Anchor.toml"), "utf-8")
+      );
+      const clusterId = anchorToml.provider.cluster;
+      if (anchorToml.clusters && anchorToml.clusters[clusterId]) {
+        attachWorkspaceOverride(workspaceCache, anchorToml.clusters[clusterId]);
+      }
 
       _populatedWorkspace = true;
     }
@@ -57,5 +70,20 @@ const workspace = new Proxy({} as any, {
     return workspaceCache[programName];
   },
 });
+
+function attachWorkspaceOverride(
+  workspaceCache: { [key: string]: Program },
+  overrideConfig: { [key: string]: string }
+) {
+  Object.keys(overrideConfig).forEach((programName) => {
+    const wsProgramName = camelCase(programName, { pascalCase: true });
+    const oldProgram = workspaceCache[wsProgramName];
+    const overrideAddress = new PublicKey(overrideConfig[programName]);
+    workspaceCache[wsProgramName] = new Program(
+      oldProgram.idl,
+      overrideAddress
+    );
+  });
+}
 
 export default workspace;

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -5112,6 +5112,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"


### PR DESCRIPTION
This change allows one to easily run their tests against any cluster. Simply change the Anchor toml's `cluster` variable to the desired network slug. For example, the following config would run `anchor tests` against Devnet.

```toml
[provider]
cluster = "devnet"
wallet = "~/.config/solana/id.json"

[clusters.mainnet]
multisig = "A9HAbnCwoD6f2NkZobKFf6buJoN9gUVVvX5PoUnDHS6u"

[clusters.devnet]
multisig = "F3Uf5F61dmht1xuNNNkk3jnzj82TY56vVjVEhZALRkN"
```

To run against mainnet, change the `provider.cluster` setting to `mainnet`.