### PR TITLE
cli: Add .anchor to .gitignore created by anchor init

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -183,6 +183,7 @@ pub fn ts_config() -> &'static str {
 
 pub fn git_ignore() -> &'static str {
     r#"
+.anchor
 .DS_Store
 target
 **/*.rs.bk


### PR DESCRIPTION
excludes the .anchor dir when new anchor projects are created outside this project's directory