### PR TITLE
cli: Use pascal case for anchor shell workspace

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -228,7 +228,7 @@ anchor.setProvider(provider);
             r#"
 anchor.workspace.{} = new anchor.Program({}, new PublicKey("{}"), provider);
 "#,
-            program.name,
+            program.name.to_camel_case(),
             serde_json::to_string(&program.idl)?,
             program.program_id.to_string()
         ));


### PR DESCRIPTION
Changes the api to be consistent with the default client api.