### PR TITLE
simplifying test and fixing warning for puppet library not marked public

### DIFF
--- a/examples/tutorial/basic-3/programs/puppet/src/lib.rs
+++ b/examples/tutorial/basic-3/programs/puppet/src/lib.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 #[program]
-mod puppet {
+pub mod puppet {
     use super::*;
     pub fn initialize(ctx: Context<Initialize>) -> ProgramResult {
         Ok(())

--- a/examples/tutorial/basic-3/tests/basic-3.js
+++ b/examples/tutorial/basic-3/tests/basic-3.js
@@ -19,17 +19,7 @@ describe("basic-3", () => {
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       },
       signers: [newPuppetAccount],
-      instructions: [
-        anchor.web3.SystemProgram.createAccount({
-          fromPubkey: provider.wallet.publicKey,
-          newAccountPubkey: newPuppetAccount.publicKey,
-          space: 8 + 8, // Add 8 for the account discriminator.
-          lamports: await provider.connection.getMinimumBalanceForRentExemption(
-            8 + 8
-          ),
-          programId: puppet.programId,
-        }),
-      ],
+      instructions: [await puppet.account.puppet.createInstruction(newPuppetAccount)],
     });
 
     // Invoke the puppet master to perform a CPI to the puppet.


### PR DESCRIPTION
1. change example to use the simplified instruction format we learned in tutorial 1
2. get warnings for unused methods because `warning: function is never used: "initialize"`. I'm not sure why it only does it for the pupet and not the master perhaps something with the way it's imported with cpi flag (perhaps if something is getting a cpi feature it should mark the module public?)

maybe should add something to make modules get marked public if 