### PR TITLE
Update solana endpoints

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1582,7 +1582,7 @@ fn set_workspace_dir_or_exit() {
 fn airdrop(cfg_override: &ConfigOverride) -> Result<()> {
     let url = cfg_override
         .cluster
-        .unwrap_or_else(|| "https://devnet.solana.com".to_string());
+        .unwrap_or_else(|| "https://api.devnet.solana.com".to_string());
     loop {
         let exit = std::process::Command::new("solana")
             .arg("airdrop")
@@ -1605,8 +1605,8 @@ fn cluster(_cmd: ClusterCommand) -> Result<()> {
     println!("Cluster Endpoints:\n");
     println!("* Mainnet - https://solana-api.projectserum.com");
     println!("* Mainnet - https://api.mainnet-beta.solana.com");
-    println!("* Devnet  - https://devnet.solana.com");
-    println!("* Testnet - https://testnet.solana.com");
+    println!("* Devnet  - https://api.devnet.solana.com");
+    println!("* Testnet - https://api.testnet.solana.com");
     Ok(())
 }
 

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -54,8 +54,8 @@ impl std::fmt::Display for Cluster {
 impl Cluster {
     pub fn url(&self) -> &str {
         match self {
-            Cluster::Devnet => "https://devnet.solana.com",
-            Cluster::Testnet => "https://testnet.solana.com",
+            Cluster::Devnet => "https://api.devnet.solana.com",
+            Cluster::Testnet => "https://api.testnet.solana.com",
             Cluster::Mainnet => "https://api.mainnet-beta.solana.com",
             Cluster::VipMainnet => "https://vip-api.mainnet-beta.solana.com",
             Cluster::Localnet => "http://127.0.0.1:8899",
@@ -65,8 +65,8 @@ impl Cluster {
     }
     pub fn ws_url(&self) -> &str {
         match self {
-            Cluster::Devnet => "wss://devnet.solana.com",
-            Cluster::Testnet => "wss://testnet.solana.com",
+            Cluster::Devnet => "wss://api.devnet.solana.com",
+            Cluster::Testnet => "wss://api.testnet.solana.com",
             Cluster::Mainnet => "wss://api.mainnet-beta.solana.com",
             Cluster::VipMainnet => "wss://vip-api.mainnet-beta.solana.com",
             Cluster::Localnet => "ws://127.0.0.1:9000",

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 pub enum Cluster {
     Testnet,
     Mainnet,
-    VipMainnet,
     Devnet,
     Localnet,
     Debug,
@@ -25,7 +24,6 @@ impl FromStr for Cluster {
         match s.to_lowercase().as_str() {
             "t" | "testnet" => Ok(Cluster::Testnet),
             "m" | "mainnet" => Ok(Cluster::Mainnet),
-            "v" | "vipmainnet" => Ok(Cluster::VipMainnet),
             "d" | "devnet" => Ok(Cluster::Devnet),
             "l" | "localnet" => Ok(Cluster::Localnet),
             "g" | "debug" => Ok(Cluster::Debug),
@@ -41,7 +39,6 @@ impl std::fmt::Display for Cluster {
         let clust_str = match self {
             Cluster::Testnet => "testnet",
             Cluster::Mainnet => "mainnet",
-            Cluster::VipMainnet => "vipmainnet",
             Cluster::Devnet => "devnet",
             Cluster::Localnet => "localnet",
             Cluster::Debug => "debug",
@@ -57,7 +54,6 @@ impl Cluster {
             Cluster::Devnet => "https://api.devnet.solana.com",
             Cluster::Testnet => "https://api.testnet.solana.com",
             Cluster::Mainnet => "https://api.mainnet-beta.solana.com",
-            Cluster::VipMainnet => "https://vip-api.mainnet-beta.solana.com",
             Cluster::Localnet => "http://127.0.0.1:8899",
             Cluster::Debug => "http://34.90.18.145:8899",
             Cluster::Custom(url, _ws_url) => url,
@@ -68,7 +64,6 @@ impl Cluster {
             Cluster::Devnet => "wss://api.devnet.solana.com",
             Cluster::Testnet => "wss://api.testnet.solana.com",
             Cluster::Mainnet => "wss://api.mainnet-beta.solana.com",
-            Cluster::VipMainnet => "wss://vip-api.mainnet-beta.solana.com",
             Cluster::Localnet => "ws://127.0.0.1:9000",
             Cluster::Debug => "ws://34.90.18.145:9000",
             Cluster::Custom(_url, ws_url) => ws_url,
@@ -88,7 +83,6 @@ mod tests {
     fn test_cluster_parse() {
         test_cluster("testnet", Cluster::Testnet);
         test_cluster("mainnet", Cluster::Mainnet);
-        test_cluster("vipmainnet", Cluster::VipMainnet);
         test_cluster("devnet", Cluster::Devnet);
         test_cluster("localnet", Cluster::Localnet);
         test_cluster("debug", Cluster::Debug);

--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -215,8 +215,8 @@ Cluster Endpoints:
 
 * Mainnet - https://solana-api.projectserum.com
 * Mainnet - https://api.mainnet-beta.solana.com
-* Devnet  - https://devnet.solana.com
-* Testnet - https://testnet.solana.com
+* Devnet  - https://api.devnet.solana.com
+* Testnet - https://api.testnet.solana.com
 ```
 
 ## Verify


### PR DESCRIPTION
Devs have been running into issues with the default (devnet) cluster; the devnet.solana.com endpoint is deprecated, and does not offer the same stability and performance of api.devnet.solana.com 
This pr updates the devnet and testnet endpoints, and also removes the vip cluster endpoint, which no longer exists.