### PR TITLE
docs: add minimum Node.js version (v11)

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -51,3 +51,9 @@ npm install -g @project-serum/anchor
 
 Make sure your `NODE_PATH` is set properly so that globally installed modules
 can be resolved.
+
+## Minimum version requirements
+
+| Build tool  | Version        |
+|:------------|:---------------|
+| Node.js     | v11.0.0        |

--- a/ts/package.json
+++ b/ts/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=11"
   },
   "scripts": {
     "build": "rm -rf dist/ && yarn build:node",


### PR DESCRIPTION
Resolves: https://github.com/project-serum/anchor/issues/113

- Documents that Node.js v11.0.0 is the minimum required version for contributing to Anchor.
- Adds a table the could be easily extended for minimum version requirements of other build tools (Rust, etc...). 