### PR TITLE
ts: enable the use of workspaces in electron projects

### DIFF
--- a/ts/src/workspace.ts
+++ b/ts/src/workspace.ts
@@ -19,8 +19,11 @@ const workspace = new Proxy({} as any, {
     const fs = require("fs");
     const process = require("process");
 
-    if (typeof window !== "undefined") {
-      // Workspaces aren't available in the browser, yet.
+    if (
+      typeof window !== "undefined" &&
+      !window.process?.hasOwnProperty("type")
+    ) {
+      // Workspaces are available in electron, but not in the browser, yet.
       return undefined;
     }
 


### PR DESCRIPTION
I'm not sure if you want to add this but it's a minor tweak that enables the use of anchor in [electron](https://www.electronjs.org) desktop apps.

If `window.process.type` exists then you know that you're inside an electron app. This code will bypass the workspace browser-check guard if that's the case.