### PR TITLE
lang: add deprecation warning for constraint

### DIFF
--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -15,6 +15,7 @@ anchor-debug = []
 
 [dependencies]
 proc-macro2 = "1.0"
+proc-macro2-diagnostics = "0.9"
 quote = "1.0"
 syn = { version = "1.0.60", features = ["full", "extra-traits", "parsing"] }
 anyhow = "1.0.32"


### PR DESCRIPTION
The warning will be shown only when nightly Rust is used.
(require nightly-only experimental API: [proc_macro_diagnostic](https://github.com/rust-lang/rust/issues/54140))

https://doc.rust-lang.org/proc_macro/struct.Span.html#method.warning
Use additional crate for diagnostic emulation: [proc_macro2_diagnostics](https://crates.io/crates/proc_macro2_diagnostics).

Message example:
```bash
warning: Deprecated. Should be used with constraint: #[account(constraint = pool_lendable.owner == *reserve_signer.key)]
  --> programs/reserve/src/lib.rs:45:15
   |
45 |     #[account("pool_lendable.owner == *reserve_signer.key")]
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: 1 warning emitted
```