### PR TITLE
spl: Fix Rent required on InitializeAccount

### DIFF
--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -120,6 +120,7 @@ pub fn initialize_account<'a, 'b, 'c, 'info>(
             ctx.accounts.account.clone(),
             ctx.accounts.mint.clone(),
             ctx.accounts.authority.clone(),
+            ctx.accounts.rent.clone(),
             ctx.program.clone(),
         ],
         ctx.signer_seeds,
@@ -188,6 +189,7 @@ pub struct InitializeAccount<'info> {
     pub account: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
+    pub rent: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
CPI calls to Token InitializeAccount currently error under all conditions:
```
    Instruction references an unknown account SysvarRent111111111111111111111111111111111
    Program F6HCxvZMaCFFjXaceSwnH8GNdneADrBZCjdnC6GzQje1 consumed 200000 of 200000 compute units
    Program F6HCxvZMaCFFjXaceSwnH8GNdneADrBZCjdnC6GzQje1 failed: An account required by the instruction is missing
Translating error Error: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: An account required by the instruction is missing
```

This change simply adds `Rent` to the list of accounts being provided to the invoke call.

NOTE: additional use cases involving the optional owner field are also currently not covered in this instruction. 