### PR TITLE
only import node modules if !isBrowser

### DIFF
--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -11,7 +11,7 @@ import {
   SimulatedTransactionResponse,
   Commitment,
 } from "@solana/web3.js";
-import { isBrowser } from "./utils/helpers";
+import { isBrowser } from "./utils/common";
 
 /**
  * The network and wallet context used to send transactions paid for and signed

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -11,6 +11,7 @@ import {
   SimulatedTransactionResponse,
   Commitment,
 } from "@solana/web3.js";
+import { isBrowser } from "./utils/helpers";
 
 /**
  * The network and wallet context used to send transactions paid for and signed
@@ -54,12 +55,14 @@ export default class Provider {
   }
 
   /**
-   * Returns a `Provider` read from the `ANCHOR_PROVIDER_URL` envirnment
+   * Returns a `Provider` read from the `ANCHOR_PROVIDER_URL` environment
    * variable
    *
    * (This api is for Node only.)
    */
   static env(): Provider {
+    if (isBrowser) return;
+
     const process = require("process");
     const url = process.env.ANCHOR_PROVIDER_URL;
     if (url === undefined) {

--- a/ts/src/utils/common.ts
+++ b/ts/src/utils/common.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns true if being run inside a web browser,
+ * false if in a Node process or electron app.
+ */
+export const isBrowser =
+  typeof window !== "undefined" && !window.process?.hasOwnProperty("type");

--- a/ts/src/utils/helpers.ts
+++ b/ts/src/utils/helpers.ts
@@ -1,0 +1,6 @@
+/**
+ * returns true if being run inside a web browser,
+ * false if in a Node process or electron app
+ */
+export const isBrowser =
+  typeof window !== "undefined" && !window.process?.hasOwnProperty("type");

--- a/ts/src/utils/helpers.ts
+++ b/ts/src/utils/helpers.ts
@@ -1,6 +1,0 @@
-/**
- * returns true if being run inside a web browser,
- * false if in a Node process or electron app
- */
-export const isBrowser =
-  typeof window !== "undefined" && !window.process?.hasOwnProperty("type");

--- a/ts/src/workspace.ts
+++ b/ts/src/workspace.ts
@@ -3,7 +3,7 @@ import * as toml from "toml";
 import { PublicKey } from "@solana/web3.js";
 import { Program } from "./program";
 import { Idl } from "./idl";
-import { isBrowser } from "./utils/helpers";
+import { isBrowser } from "./utils/common";
 
 let _populatedWorkspace = false;
 
@@ -16,18 +16,13 @@ let _populatedWorkspace = false;
  */
 const workspace = new Proxy({} as any, {
   get(workspaceCache: { [key: string]: Program }, programName: string) {
-    if (isBrowser) return;
+    if (isBrowser) {
+      console.log("Workspaces aren't available in the browser");
+      return undefined;
+    }
 
     const fs = require("fs");
     const process = require("process");
-
-    if (
-      typeof window !== "undefined" &&
-      !window.process?.hasOwnProperty("type")
-    ) {
-      // Workspaces are available in electron, but not in the browser, yet.
-      return undefined;
-    }
 
     if (!_populatedWorkspace) {
       const path = require("path");

--- a/ts/src/workspace.ts
+++ b/ts/src/workspace.ts
@@ -3,6 +3,7 @@ import * as toml from "toml";
 import { PublicKey } from "@solana/web3.js";
 import { Program } from "./program";
 import { Idl } from "./idl";
+import { isBrowser } from "./utils/helpers";
 
 let _populatedWorkspace = false;
 
@@ -15,6 +16,8 @@ let _populatedWorkspace = false;
  */
 const workspace = new Proxy({} as any, {
   get(workspaceCache: { [key: string]: Program }, programName: string) {
+    if (isBrowser) return;
+
     const fs = require("fs");
     const process = require("process");
 


### PR DESCRIPTION
I didn't mean to publish this to the main repo sorry.

It's just a proposal as a simpler follow up to https://github.com/johnrees/anchor/pull/2

I've got too much other stuff going on atm to continue working on this issue but perhaps it will be helpful as a starting point. I can verify that `import * as anchor from "@project-serum/anchor";` works without crashing a react app I created with this template https://github.com/johnrees/cra

Feel free to take over this PR or remove it. Thanks