### PR TITLE
cli: add npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ examples/**/Cargo.lock
 .DS_Store
 docs/yarn.lock
 ts/docs/
+cli/npm-package/anchor
+cli/npm-package/*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build-cli
-build-anchor-cli:
+build-cli:
 	cargo build -p anchor-cli --release
 	cp target/release/anchor cli/npm-package/anchor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build-anchor-cli
+build-anchor-cli:
+	cargo build -p anchor-cli --release
+	cp target/release/anchor cli/npm-package/anchor

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-anchor-cli
+.PHONY: build-cli
 build-anchor-cli:
 	cargo build -p anchor-cli --release
 	cp target/release/anchor cli/npm-package/anchor

--- a/cli/npm-package/package.json
+++ b/cli/npm-package/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@project-serum/anchor-cli",
+  "version": "0.10.0",
+  "description": "Anchor CLI tool",
+  "homepage": "https://github.com/project-serum/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/project-serum/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/project-serum/anchor.git"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "bin": {
+    "anchor": "anchor"
+  },
+  "scripts": {
+    "prepack": "[ \"$(uname -op)\" != \"x86_64 GNU/Linux\" ] && (echo Only for x86_64 GNU/Linux && exit 1) || ([ \"$(./anchor --version)\" != \"anchor-cli $(jq -r .version package.json)\" ] && (echo Check anchor binary version && exit 2) || exit 0)"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Resolve #427 

This pull request adds npm package for `anchor-cli` but only for linux/x64. This should good for CI and for most of developers.

Steps for publishing:
```shell
$ make build-anchor-cli
$ cd cli/npm-package && npm publish
```

Possible improvements:
1) Add js file as entrypoint which runs distributed binary in case of linux/x64 and global installed anchor otherwise (with version check).
2) Try to build wasm module (not sure, is it possible with the current wasi state or not).