### PR TITLE
cli: any arch/platform in npm package

### DIFF
--- a/cli/npm-package/anchor.js
+++ b/cli/npm-package/anchor.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+const { spawn, spawnSync } = require("child_process");
+const path = require("path");
+const { arch, platform } = require("os");
+const { version } = require("./package.json");
+
+const PACKAGE_VERSION = `anchor-cli ${version}`;
+const PACKAGE_ANCHOR_PATH = path.join(__dirname, "anchor");
+
+function getBinaryVersion(location) {
+  const result = spawnSync(location, ["--version"]);
+  const error =
+    (result.error && result.error.toString()) ||
+    (result.stderr.length > 0 && result.stderr.toString().trim()) ||
+    null;
+  return [error, result.stdout && result.stdout.toString().trim()];
+}
+
+function runAnchor(location) {
+  const args = process.argv.slice(2);
+  const anchor = spawn(location, args, { stdio: "inherit" });
+  anchor.on("exit", (code, signal) => {
+    process.on("exit", () => {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code);
+      }
+    });
+  });
+
+  process.on("SIGINT", function () {
+    anchor.kill("SIGINT");
+    anchor.kill("SIGTERM");
+  });
+}
+
+function tryPackageAnchor() {
+  if (arch() !== "x64" || platform() !== "linux") {
+    console.error(`Only x86_64 / Linux distributed in NPM package right now.`);
+    return false;
+  }
+
+  const [error, binaryVersion] = getBinaryVersion(PACKAGE_ANCHOR_PATH);
+  if (error !== null) {
+    console.error(`Failed to get version of local binary: ${error}`);
+    return false;
+  }
+  if (binaryVersion !== PACKAGE_VERSION) {
+    console.error(
+      `Package binary version is not correct. Expected "${PACKAGE_VERSION}", found "${binaryVersion}".`
+    );
+    return false;
+  }
+
+  runAnchor(PACKAGE_ANCHOR_PATH);
+  return true;
+}
+
+function trySystemAnchor() {
+  console.error("Trying globally installed anchor.");
+
+  const added = path.dirname(process.argv[1]);
+  const directories = process.env.PATH.split(":").filter(
+    (dir) => dir !== added
+  );
+  process.env.PATH = directories.join(":");
+
+  const [error, binaryVersion] = getBinaryVersion("anchor");
+  if (error !== null) {
+    console.error(`Failed to get version of global binary: ${error}`);
+    return;
+  }
+  if (binaryVersion !== PACKAGE_VERSION) {
+    console.error(
+      `Globally installed anchor version is not correct. Expected "${PACKAGE_VERSION}", found "${binaryVersion}".`
+    );
+    return;
+  }
+
+  runAnchor("anchor");
+}
+
+tryPackageAnchor() || trySystemAnchor();

--- a/cli/npm-package/package.json
+++ b/cli/npm-package/package.json
@@ -12,17 +12,11 @@
   },
   "license": "(MIT OR Apache-2.0)",
   "bin": {
-    "anchor": "anchor"
+    "anchor": "./anchor.js"
   },
   "scripts": {
-    "prepack": "[ \"$(uname -op)\" != \"x86_64 GNU/Linux\" ] && (echo Only for x86_64 GNU/Linux && exit 1) || ([ \"$(./anchor --version)\" != \"anchor-cli $(jq -r .version package.json)\" ] && (echo Check anchor binary version && exit 2) || exit 0)"
+    "prepack": "[ \"$(uname -op)\" != \"x86_64 GNU/Linux\" ] && (echo Can be packed only on x86_64 GNU/Linux && exit 1) || ([ \"$(./anchor --version)\" != \"anchor-cli $(jq -r .version package.json)\" ] && (echo Check anchor binary version && exit 2) || exit 0)"
   },
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
This PR improves https://github.com/project-serum/anchor/pull/438 by allowing install package on any arch/platform by using the globally installed anchor as a fallback. 