### PR TITLE
simulate.ts: add Event import

### DIFF
--- a/ts/src/program/namespace/simulate.ts
+++ b/ts/src/program/namespace/simulate.ts
@@ -3,7 +3,7 @@ import Provider from "../../provider";
 import { IdlInstruction } from "../../idl";
 import { splitArgsAndCtx } from "../context";
 import { TransactionFn } from "./transaction";
-import { EventParser } from "../event";
+import { EventParser, Event } from "../event";
 import Coder from "../../coder";
 import { Idl } from "../../idl";
 import { ProgramError } from "../../error";


### PR DESCRIPTION
When I try to compile `@project-serum/anchor` in my local project, I'm running into the following compilation error:
```
node_modules/@project-serum/anchor/dist/program/namespace/simulate.d.ts:55:13 - error TS2304: Cannot find name 'Event'.

55     events: Event[];
               ~~~~~

```

I needed to add `"skipLibCheck": true` to my `tsconfig.json` to fix it. Explicitly importing `Event` in `simulate.ts` also fixes it.

I'm not sure why `@project-serum/anchor` builds successfully builds without the explicit import but then fails in my local project. I'm assuming it has to do with `tsconfig.json` for `@project-serum/anchor`.
