### PR TITLE
docs: use light/dark theme based on user's preference

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "gh-pages": "^3.1.0",
     "vuepress": "^1.5.3",
-    "vuepress-plugin-dehydrate": "^1.1.5"
+    "vuepress-plugin-dehydrate": "^1.1.5",
+    "vuepress-theme-default-prefers-color-scheme": "^2.0.0"
   }
 }

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -25,6 +25,8 @@ module.exports = {
     ],
   ],
 
+  theme: "default-prefers-color-scheme",
+
   /**
    * Theme configuration, here is the default theme configuration for VuePress.
    *


### PR DESCRIPTION
I don't think anybody even asked for this but here it is in case it's useful!

This will respect your operating system's preference for dark/light themes in the same way that GitHub _(I think?)_ does and theme the docs accordingly. It doesn't add a theme switcher or anything fancy like that.

It uses this package https://github.com/tolking/vuepress-theme-default-prefers-color-scheme

**Anchor docs + dark theme =**

![Screenshot 2021-07-07 at 6 52 58 PM](https://user-images.githubusercontent.com/601961/124806627-d349ad00-df54-11eb-807c-88474cdb5ebe.png)

I also didn't add any sort of yarn/npm lockfiles to the repo as there wasn't anything there originally.

![dark side](https://user-images.githubusercontent.com/601961/124807153-61be2e80-df55-11eb-82b0-349e094bb2c0.gif)
