### PR TITLE
lang: use `pub(crate)` visibility for `__nonce` field

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro;
 
 use quote::quote;
-use syn::parse_macro_input;
+use syn::{parse_macro_input, parse_quote};
 
 /// A data structure representing a Solana account, implementing various traits:
 ///
@@ -218,7 +218,12 @@ pub fn associated(
             });
             fields.named.push(syn::Field {
                 attrs: Vec::new(),
-                vis: syn::Visibility::Inherited,
+                vis: syn::Visibility::Restricted(syn::VisRestricted {
+                    pub_token: syn::token::Pub::default(),
+                    paren_token: syn::token::Paren::default(),
+                    in_token: None,
+                    path: Box::new(parse_quote!(crate))
+                }),
                 ident: Some(syn::Ident::new("__nonce", proc_macro2::Span::call_site())),
                 colon_token: Some(syn::token::Colon {
                     spans: [proc_macro2::Span::call_site()],


### PR DESCRIPTION
This changes the visibility for the `__nonce` field on associated account states to be visible to the entire crate by default (instead of being private to the module its defined within).

Motivation for this is primarily to allow defining structs using the `#[associated]` macro in separate modules from the program handlers.