### PR TITLE
lang: change client_accoutns visibility

### DIFF
--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -105,7 +105,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         ///
         /// To access the struct in this module, one should use the sibling
         /// `accounts` module (also generated), which re-exports this.
-        mod #account_mod_name {
+        pub(crate) mod #account_mod_name {
             use super::*;
             use anchor_lang::prelude::borsh;
             #(#re_exports)*


### PR DESCRIPTION
This will allow defining accounts structs in separate files. Usage is still complicated but at least make it possible (maybe mod scheme should be changed in the future?).

Usage example:
```rust
use serum::{__client_accounts_dex_accounts, DexAccounts};

#[derive(Accounts)]
pub struct Initialize<'info> {
    dex: DexAccounts<'info>,
}
```