### PR TITLE
ts: check if execution context stack is empty in event parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
         - cargo fmt -- --check
         - cargo clippy --all-targets -- -D warnings
         - cargo test
+        - pushd ts && yarn && yarn test && popd
     - <<: *examples
       name: Runs the examples 1
       script:

--- a/ts/package.json
+++ b/ts/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "prettier src/** -w",
     "watch": "tsc -p tsconfig.cjs.json --watch",
     "prepublishOnly": "yarn build",
-    "docs": "typedoc --excludePrivate --includeVersion --out ../docs/src/.vuepress/dist/ts/ --readme none src/index.ts"
+    "docs": "typedoc --excludePrivate --includeVersion --out ../docs/src/.vuepress/dist/ts/ --readme none src/index.ts",
+    "test": "jest tests --detectOpenHandles"
   },
   "dependencies": {
     "@project-serum/borsh": "^0.2.2",

--- a/ts/src/program/event.ts
+++ b/ts/src/program/event.ts
@@ -58,7 +58,7 @@ export class EventParser {
     log: string
   ): [Event | null, string | null, boolean] {
     // Executing program is this program.
-    if (execution.program() === this.programId.toString()) {
+    if (execution.stack.length > 0 && execution.program() === this.programId.toString()) {
       return this.handleProgramLog(log);
     }
     // Executing program is not this program.

--- a/ts/tests/events.spec.ts
+++ b/ts/tests/events.spec.ts
@@ -1,33 +1,33 @@
-import { PublicKey } from '@solana/web3.js';
-import { EventParser } from '../src/program/event';
-import { Coder } from '../src';
+import { PublicKey } from "@solana/web3.js";
+import { EventParser } from "../src/program/event";
+import { Coder } from "../src";
 
-describe('Events', () => {
-  it('Parses multiple instructions', async () => {
-		const logs = [
-			'Program 11111111111111111111111111111111 invoke [1]',
-			'Program 11111111111111111111111111111111 success',
-			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 invoke [1]',
-			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 consumed 17867 of 200000 compute units',
-			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 success'
-		];
-		const idl = {
-			"version": "0.0.0",
-			"name": "basic_0",
-			"instructions": [
-				{
-					"name": "initialize",
-					"accounts": [],
-					"args": []
-				}
-			]
-		};
-		const coder = new Coder(idl);
-		const programId = PublicKey.default;
-		const eventParser = new EventParser(coder, programId);
+describe("Events", () => {
+  it("Parses multiple instructions", async () => {
+    const logs = [
+      "Program 11111111111111111111111111111111 invoke [1]",
+      "Program 11111111111111111111111111111111 success",
+      "Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 invoke [1]",
+      "Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 consumed 17867 of 200000 compute units",
+      "Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 success",
+    ];
+    const idl = {
+      version: "0.0.0",
+      name: "basic_0",
+      instructions: [
+        {
+          name: "initialize",
+          accounts: [],
+          args: [],
+        },
+      ],
+    };
+    const coder = new Coder(idl);
+    const programId = PublicKey.default;
+    const eventParser = new EventParser(coder, programId);
 
-		eventParser.parseLogs(logs, () => {
-			throw new Error('Should never find logs');
-		});
-	});
+    eventParser.parseLogs(logs, () => {
+      throw new Error("Should never find logs");
+    });
+  });
 });

--- a/ts/tests/events.spec.ts
+++ b/ts/tests/events.spec.ts
@@ -1,0 +1,33 @@
+import { PublicKey } from '@solana/web3.js';
+import { EventParser } from '../src/program/event';
+import { Coder } from '../src';
+
+describe('Events', () => {
+  it('Parses multiple instructions', async () => {
+		const logs = [
+			'Program 11111111111111111111111111111111 invoke [1]',
+			'Program 11111111111111111111111111111111 success',
+			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 invoke [1]',
+			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 consumed 17867 of 200000 compute units',
+			'Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 success'
+		];
+		const idl = {
+			"version": "0.0.0",
+			"name": "basic_0",
+			"instructions": [
+				{
+					"name": "initialize",
+					"accounts": [],
+					"args": []
+				}
+			]
+		};
+		const coder = new Coder(idl);
+		const programId = PublicKey.default;
+		const eventParser = new EventParser(coder, programId);
+
+		eventParser.parseLogs(logs, () => {
+			throw new Error('Should never find logs');
+		});
+	});
+});


### PR DESCRIPTION
* Fixes #523

`handleSystemLog` would return a new program that is pushed back onto the stack, allowing the parsing to function as expected.