### PR TITLE
lang/syn: fix module path resolution in crate parsing

### DIFF
--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -97,7 +97,7 @@ impl ParsedModule {
                 item: item.clone(),
                 file: module.file.clone(),
                 path: module.path.clone(),
-                name: name.clone(),
+                name: item.ident.to_string(),
             }));
             modules.insert(name.clone(), module);
         }
@@ -112,12 +112,15 @@ impl ParsedModule {
         parent_path: &str,
         item: syn::ItemMod,
     ) -> ParseResult<Self> {
-        let path = format!("{}::{}", parent_path, item.ident);
-
         Ok(match item.content {
             Some((_, items)) => {
                 // The module content is within the parent file being parsed
-                Self::new(path, parent_file.to_owned(), item.ident.to_string(), items)
+                Self::new(
+                    parent_path.to_owned(),
+                    parent_file.to_owned(),
+                    item.ident.to_string(),
+                    items,
+                )
             }
             None => {
                 // The module is referencing some other file, so we need to load that
@@ -141,7 +144,12 @@ impl ParsedModule {
                     .map_err(|_| ParseError::new_spanned(&item, "could not read file"))?;
                 let mod_file = syn::parse_file(&mod_file_content)?;
 
-                Self::new(path, mod_file_path, item.ident.to_string(), mod_file.items)
+                Self::new(
+                    parent_path.to_owned(),
+                    mod_file_path,
+                    item.ident.to_string(),
+                    mod_file.items,
+                )
             }
         })
     }


### PR DESCRIPTION
Fixes a bug in generating the module path, which causes
nested modules to have the wrong path.

E.g. 

```
mod foo {
    mod bar;
}
```

resolves to two modules:

```
::foo
::foo::foo::foo
```

but should actually resolve to:

```
::foo
::foo::bar
```