### PR TITLE
lang: add `AsRef` conversions for accounts to `AccountInfo`

### DIFF
--- a/lang/src/cpi_account.rs
+++ b/lang/src/cpi_account.rs
@@ -87,6 +87,12 @@ impl<'info, T: AccountDeserialize + Clone> ToAccountInfo<'info> for CpiAccount<'
     }
 }
 
+impl<'info, T: AccountDeserialize + Clone> AsRef<AccountInfo<'info>> for CpiAccount<'info, T> {
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.info
+    }
+}
+
 impl<'a, T: AccountDeserialize + Clone> Deref for CpiAccount<'a, T> {
     type Target = T;
 

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -162,6 +162,14 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfo<'inf
     }
 }
 
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for ProgramAccount<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAccount<'a, T> {
     type Target = T;
 


### PR DESCRIPTION
Allow for cheaper conversions to get the account info from `ProgramAccount` and `CpiAccount`