### PR TITLE
cli: Add keys include/exclude in programs section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Features
+
+* cli: Add keys `include` / `exclude` in config `programs` section ([#546](https://github.com/project-serum/anchor/pull/546)).
+
 ### Breaking Changes
 
 * lang: `CpiAccount::reload` mutates the existing struct instead of returning a new one ([#526](https://github.com/project-serum/anchor/pull/526)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ incremented for features.
 
 ### Features
 
-* cli: Add keys `include` / `exclude` in config `programs` section ([#546](https://github.com/project-serum/anchor/pull/546)).
+* cli: Add keys `members` / `exclude` in config `programs` section ([#546](https://github.com/project-serum/anchor/pull/546)).
 
 ### Breaking Changes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -34,7 +34,9 @@ pub type ClustersConfig = BTreeMap<Cluster, BTreeMap<String, ProgramDeployment>>
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ProgramsConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -35,7 +35,7 @@ pub type ClustersConfig = BTreeMap<Cluster, BTreeMap<String, ProgramDeployment>>
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub include: Vec<String>,
+    pub members: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
 }
@@ -117,7 +117,7 @@ impl Config {
                 .expect("failed to get program from path");
 
             match (
-                self.workspace.include.is_empty(),
+                self.workspace.members.is_empty(),
                 self.workspace.exclude.is_empty(),
             ) {
                 (true, true) => programs.push(path),
@@ -127,7 +127,7 @@ impl Config {
                     }
                 }
                 (false, _) => {
-                    if self.workspace.include.contains(&program) {
+                    if self.workspace.members.contains(&program) {
                         programs.push(path);
                     }
                 }
@@ -212,17 +212,17 @@ impl FromStr for Config {
             test: cfg.test,
             clusters: cfg.clusters.map_or(Ok(BTreeMap::new()), deser_clusters)?,
             workspace: cfg.workspace.map(|workspace| {
-                let (include, exclude) = match (workspace.include.is_empty(), workspace.exclude.is_empty()) {
+                let (members, exclude) = match (workspace.members.is_empty(), workspace.exclude.is_empty()) {
                     (true, true) => (vec![], vec![]),
                     (true, false) => (vec![], workspace.exclude),
                     (false, is_empty) => {
                         if !is_empty {
-                            println!("Fields `include` and `exclude` in `[workspace]` section are not compatible, only `include` will be used.");
+                            println!("Fields `members` and `exclude` in `[workspace]` section are not compatible, only `members` will be used.");
                         }
-                        (workspace.include, vec![])
+                        (workspace.members, vec![])
                     }
                 };
-                WorkspaceConfig { include, exclude }
+                WorkspaceConfig { members, exclude }
             }).unwrap_or_default()
         })
     }

--- a/examples/misc/Anchor.toml
+++ b/examples/misc/Anchor.toml
@@ -5,3 +5,6 @@ wallet = "~/.config/solana/id.json"
 [[test.genesis]]
 address = "FtMNMKp9DZHKWUyVAsj3Q5QV8ow4P3fUPP7ZrWEQJzKr"
 program = "./target/deploy/misc.so"
+
+[programs]
+exclude = ["shared"]

--- a/examples/misc/Anchor.toml
+++ b/examples/misc/Anchor.toml
@@ -6,5 +6,5 @@ wallet = "~/.config/solana/id.json"
 address = "FtMNMKp9DZHKWUyVAsj3Q5QV8ow4P3fUPP7ZrWEQJzKr"
 program = "./target/deploy/misc.so"
 
-[programs]
+[workspace]
 exclude = ["shared"]

--- a/examples/misc/programs/shared/Cargo.toml
+++ b/examples/misc/programs/shared/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/misc/programs/shared/src/lib.rs
+++ b/examples/misc/programs/shared/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/examples/typescript/Anchor.toml
+++ b/examples/typescript/Anchor.toml
@@ -3,5 +3,5 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [workspace]
-include = ["typescript"]
+members = ["typescript"]
 exclude = ["typescript"]

--- a/examples/typescript/Anchor.toml
+++ b/examples/typescript/Anchor.toml
@@ -1,3 +1,7 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[programs]
+include = ["typescript"]
+exclude = ["typescript"]

--- a/examples/typescript/Anchor.toml
+++ b/examples/typescript/Anchor.toml
@@ -2,6 +2,6 @@
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
-[programs]
+[workspace]
 include = ["typescript"]
 exclude = ["typescript"]

--- a/examples/typescript/programs/shared/Cargo.toml
+++ b/examples/typescript/programs/shared/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/typescript/programs/shared/src/lib.rs
+++ b/examples/typescript/programs/shared/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/examples/zero-copy/Anchor.toml
+++ b/examples/zero-copy/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[programs]
+include = ["zero-copy"]

--- a/examples/zero-copy/Anchor.toml
+++ b/examples/zero-copy/Anchor.toml
@@ -3,4 +3,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [workspace]
-include = ["zero-copy"]
+members = ["zero-copy"]

--- a/examples/zero-copy/Anchor.toml
+++ b/examples/zero-copy/Anchor.toml
@@ -2,5 +2,5 @@
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
-[programs]
+[workspace]
 include = ["zero-copy"]

--- a/examples/zero-copy/programs/shared/Cargo.toml
+++ b/examples/zero-copy/programs/shared/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/zero-copy/programs/shared/src/lib.rs
+++ b/examples/zero-copy/programs/shared/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Not sure that this is correct but I think it would be good if `programs` directory would be able to contain shared code (crate) between programs. Right now `anchor` cli consider all directories in in `programs` as program and trying to compile / generate IDL. This PR allows to include / exclude directories.