### PR TITLE
cli: allow execute custom test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         - pushd examples/chat && yarn && anchor test && popd
         - pushd examples/ido-pool && yarn && anchor test && popd
         - pushd examples/swap/deps/serum-dex/dex && cargo build-bpf && cd ../../../ && anchor test && popd
-        - pushd examples/cfo && anchor run test && popd
+        - pushd examples/cfo && anchor run test-with-build && popd
     - <<: *examples
       name: Runs the examples 3
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ incremented for features.
 ### Features
 
 * cli: Add keys `members` / `exclude` in config `programs` section ([#546](https://github.com/project-serum/anchor/pull/546)).
+* cli: Allow to use custom command for test instead mocha runner ([#550](https://github.com/project-serum/anchor/pull/550)).
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ incremented for features.
 ### Features
 
 * cli: Add keys `members` / `exclude` in config `programs` section ([#546](https://github.com/project-serum/anchor/pull/546)).
-* cli: Allow to use custom command for test instead mocha runner ([#550](https://github.com/project-serum/anchor/pull/550)).
+* cli: Allow to use custom command for test through scripts instead mocha runner ([#550](https://github.com/project-serum/anchor/pull/550)).
 
 ### Breaking Changes
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -96,6 +96,8 @@ pub enum Command {
         /// use this to save time when running test and the program code is not altered.
         #[clap(long)]
         skip_build: bool,
+        #[clap(multiple = true)]
+        args: Vec<String>,
     },
     /// Creates a new program.
     New { name: String },
@@ -254,11 +256,13 @@ fn main() -> Result<()> {
             skip_deploy,
             skip_local_validator,
             skip_build,
+            args,
         } => test(
             &opts.cfg_override,
             skip_deploy,
             skip_local_validator,
             skip_build,
+            args,
         ),
         #[cfg(feature = "dev")]
         Command::Airdrop => airdrop(cfg_override),
@@ -978,6 +982,7 @@ fn test(
     skip_deploy: bool,
     skip_local_validator: bool,
     skip_build: bool,
+    extra_args: Vec<String>,
 ) -> Result<()> {
     with_workspace(cfg_override, |cfg, _path, _cargo| {
         // Build if needed.
@@ -1015,7 +1020,10 @@ fn test(
                 .get("test")
                 .expect("Not able to find command for `test`")
                 .clone();
-            let mut args: Vec<&str> = cmd.split(' ').collect();
+            let mut args: Vec<&str> = cmd
+                .split(' ')
+                .chain(extra_args.iter().map(|arg| arg.as_str()))
+                .collect();
             let program = args.remove(0);
 
             std::process::Command::new(program)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -96,9 +96,6 @@ pub enum Command {
         /// use this to save time when running test and the program code is not altered.
         #[clap(long)]
         skip_build: bool,
-        /// Custom command for executing tests instead of mocha runner.
-        #[clap(long)]
-        cmd: Option<String>,
         file: Option<String>,
     },
     /// Creates a new program.
@@ -258,14 +255,12 @@ fn main() -> Result<()> {
             skip_deploy,
             skip_local_validator,
             skip_build,
-            cmd,
             file,
         } => test(
             &opts.cfg_override,
             skip_deploy,
             skip_local_validator,
             skip_build,
-            cmd,
             file,
         ),
         #[cfg(feature = "dev")]
@@ -977,7 +972,6 @@ fn test(
     skip_deploy: bool,
     skip_local_validator: bool,
     skip_build: bool,
-    cmd: Option<String>,
     file: Option<String>,
 ) -> Result<()> {
     with_workspace(cfg_override, |cfg, _path, _cargo| {
@@ -1011,7 +1005,7 @@ fn test(
 
         // Run the tests.
         let test_result: Result<_> = {
-            let (cmd, program, args) = if let Some(ref cmd) = cmd {
+            let (cmd, program, args) = if let Some(cmd) = cfg.scripts.get("test") {
                 let mut args: Vec<&str> = cmd.split(' ').collect();
                 (cmd.clone(), args.remove(0), args)
             } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -279,7 +279,16 @@ fn init(cfg_override: &ConfigOverride, name: String, typescript: bool) -> Result
     std::env::set_current_dir(&name)?;
     fs::create_dir("app")?;
 
-    let cfg = Config::default();
+    let mut cfg = Config::default();
+    cfg.scripts.insert(
+        "test".to_owned(),
+        if typescript {
+            "ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+        } else {
+            "mocha -t 1000000 tests/"
+        }
+        .to_owned(),
+    );
     let toml = cfg.to_string();
     let mut file = File::create("Anchor.toml")?;
     file.write_all(toml.as_bytes())?;

--- a/examples/cashiers-check/Anchor.toml
+++ b/examples/cashiers-check/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/cfo/Anchor.toml
+++ b/examples/cfo/Anchor.toml
@@ -10,6 +10,7 @@ lockup = { address = "6ebQNeTPZ1j7k3TtkCCtEPRvG7GQsucQrZ7sSEDQi9Ks", idl = "./de
 #
 # Testing.
 #
+test = "mocha -t 1000000 tests/"
 test-with-build = "anchor run build && anchor test --skip-build"
 #
 # Build the program and all CPI dependencies.

--- a/examples/cfo/Anchor.toml
+++ b/examples/cfo/Anchor.toml
@@ -10,7 +10,7 @@ lockup = { address = "6ebQNeTPZ1j7k3TtkCCtEPRvG7GQsucQrZ7sSEDQi9Ks", idl = "./de
 #
 # Testing.
 #
-test = "anchor run build && anchor test --skip-build"
+test-with-build = "anchor run build && anchor test --skip-build"
 #
 # Build the program and all CPI dependencies.
 #

--- a/examples/chat/Anchor.toml
+++ b/examples/chat/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/composite/Anchor.toml
+++ b/examples/composite/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/errors/Anchor.toml
+++ b/examples/errors/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/escrow/Anchor.toml
+++ b/examples/escrow/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/events/Anchor.toml
+++ b/examples/events/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/ido-pool/Anchor.toml
+++ b/examples/ido-pool/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/interface/Anchor.toml
+++ b/examples/interface/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/lockup/Anchor.toml
+++ b/examples/lockup/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/misc/Anchor.toml
+++ b/examples/misc/Anchor.toml
@@ -8,3 +8,6 @@ program = "./target/deploy/misc.so"
 
 [workspace]
 exclude = ["shared"]
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/multisig/Anchor.toml
+++ b/examples/multisig/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/pyth/Anchor.toml
+++ b/examples/pyth/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/examples/spl/token-proxy/Anchor.toml
+++ b/examples/spl/token-proxy/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/swap/Anchor.toml
+++ b/examples/swap/Anchor.toml
@@ -5,3 +5,6 @@ wallet = "~/.config/solana/id.json"
 [[test.genesis]]
 address = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
 program = "./deps/serum-dex/dex/target/deploy/serum_dex.so"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/sysvars/Anchor.toml
+++ b/examples/sysvars/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-0/Anchor.toml
+++ b/examples/tutorial/basic-0/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-1/Anchor.toml
+++ b/examples/tutorial/basic-1/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-2/Anchor.toml
+++ b/examples/tutorial/basic-2/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-3/Anchor.toml
+++ b/examples/tutorial/basic-3/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-4/Anchor.toml
+++ b/examples/tutorial/basic-4/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-5/Anchor.toml
+++ b/examples/tutorial/basic-5/Anchor.toml
@@ -1,3 +1,6 @@
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "mocha -t 1000000 tests/"

--- a/examples/typescript/Anchor.toml
+++ b/examples/typescript/Anchor.toml
@@ -5,3 +5,6 @@ wallet = "~/.config/solana/id.json"
 [workspace]
 members = ["typescript"]
 exclude = ["typescript"]
+
+[scripts]
+test = "ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/examples/zero-copy/Anchor.toml
+++ b/examples/zero-copy/Anchor.toml
@@ -4,3 +4,6 @@ wallet = "~/.config/solana/id.json"
 
 [workspace]
 members = ["zero-copy"]
+
+[scripts]
+test = "mocha -t 1000000 tests/"


### PR DESCRIPTION
Closes #426 

Usage example:
```bash
anchor test --cmd "npx ts-node node_modules/.bin/tape tests/*.ts"
```