### PR TITLE
cli: do not serialize empty workspace

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -190,7 +190,8 @@ impl ToString for Config {
                 false => Some(self.scripts.clone()),
             },
             clusters,
-            workspace: Some(self.workspace.clone()),
+            workspace: (!self.workspace.members.is_empty() || !self.workspace.exclude.is_empty())
+                .then(|| self.workspace.clone()),
         };
 
         toml::to_string(&cfg).expect("Must be well formed")


### PR DESCRIPTION
Did not catch this in https://github.com/project-serum/anchor/pull/546

Without this fix empty `[workspace]` created on `anchor init`.