### PR TITLE
ts: use accounts with types in InstructionCoder

### DIFF
--- a/ts/src/coder/instruction.ts
+++ b/ts/src/coder/instruction.ts
@@ -88,7 +88,10 @@ export class InstructionCoder {
     const ixLayouts = stateMethods
       .map((m: IdlStateMethod) => {
         let fieldLayouts = m.args.map((arg: IdlField) => {
-          return IdlCoder.fieldLayout(arg, Array.from([...idl.accounts, ...idl.types]));
+          return IdlCoder.fieldLayout(
+            arg,
+            Array.from([...idl.accounts, ...idl.types])
+          );
         });
         const name = camelCase(m.name);
         return [name, borsh.struct(fieldLayouts, name)];
@@ -96,7 +99,10 @@ export class InstructionCoder {
       .concat(
         idl.instructions.map((ix) => {
           let fieldLayouts = ix.args.map((arg: IdlField) =>
-            IdlCoder.fieldLayout(arg, Array.from([...idl.accounts, ...idl.types]))
+            IdlCoder.fieldLayout(
+              arg,
+              Array.from([...idl.accounts, ...idl.types])
+            )
           );
           const name = camelCase(ix.name);
           return [name, borsh.struct(fieldLayouts, name)];

--- a/ts/src/coder/instruction.ts
+++ b/ts/src/coder/instruction.ts
@@ -88,7 +88,7 @@ export class InstructionCoder {
     const ixLayouts = stateMethods
       .map((m: IdlStateMethod) => {
         let fieldLayouts = m.args.map((arg: IdlField) => {
-          return IdlCoder.fieldLayout(arg, idl.types);
+          return IdlCoder.fieldLayout(arg, Array.from([...idl.accounts, ...idl.types]));
         });
         const name = camelCase(m.name);
         return [name, borsh.struct(fieldLayouts, name)];
@@ -96,7 +96,7 @@ export class InstructionCoder {
       .concat(
         idl.instructions.map((ix) => {
           let fieldLayouts = ix.args.map((arg: IdlField) =>
-            IdlCoder.fieldLayout(arg, idl.types)
+            IdlCoder.fieldLayout(arg, Array.from([...idl.accounts, ...idl.types]))
           );
           const name = camelCase(ix.name);
           return [name, borsh.struct(fieldLayouts, name)];


### PR DESCRIPTION
Simplified example:
```rust
use anchor_lang::prelude::*;
use std::ops::DerefMut;

pub mod error;

use error::GovernanceResult;

#[program]
pub mod governance {
    use super::*;

    pub fn initialize_governance(
        ctx: Context<InitializeGovernance>,
        governance: Governance,
    ) -> GovernanceResult<()> {
        *ctx.accounts.governance.deref_mut() = governance;
        Ok(())
    }
}

#[account]
pub struct Governance {
    factor: u128,
}

#[derive(Accounts)]
pub struct InitializeGovernance<'info> {
    #[account(init)]
    governance: ProgramAccount<'info, Governance>,

    rent: Sysvar<'info, Rent>,
}
```

It's will not be possible to call `initialize_governance` from JS because IDL loading will fail with error: `User defined types not provided`