### PR TITLE
Prune ix and solana version pinning

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,9 +23,9 @@ serde_json = "1.0"
 shellexpand = "2.1.0"
 toml = "0.5.8"
 serde = { version = "1.0.122", features = ["derive"] }
-solana-sdk = "1.7.4"
-solana-program = "1.7.4"
-solana-client = "1.7.4"
+solana-sdk = "=1.7.8"
+solana-program = "=1.7.8"
+solana-client = "=1.7.8"
 serum-common = { git = "https://github.com/project-serum/serum-dex", features = ["client"] }
 dirs = "3.0"
 heck = "0.3.1"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ ANCHOR_CLI=v$(shell awk -F ' = ' '$$1 ~ /version/ { gsub(/[\"]/, "", $$2); print
 #
 # Solana toolchain.
 #
-SOLANA_CLI=v1.7.4
+SOLANA_CLI=v1.7.8
 #
 # Build version should match the Anchor cli version.
 #

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -18,7 +18,7 @@ rustup component add rustfmt
 See the solana [docs](https://docs.solana.com/cli/install-solana-cli-tools) for installation instructions. On macOS and Linux,
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.7.4/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
 ```
 
 ## Install Mocha

--- a/examples/permissioned-markets/programs/permissioned-markets-middleware/Cargo.toml
+++ b/examples/permissioned-markets/programs/permissioned-markets-middleware/Cargo.toml
@@ -17,4 +17,4 @@ default = []
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
 anchor-spl = { path = "../../../../spl" }
-solana-program = "1.7.4"
+solana-program = "=1.7.8"

--- a/examples/permissioned-markets/programs/permissioned-markets/Cargo.toml
+++ b/examples/permissioned-markets/programs/permissioned-markets/Cargo.toml
@@ -18,5 +18,5 @@ default = []
 anchor-lang = { path = "../../../../lang" }
 anchor-spl = { path = "../../../../spl" }
 serum_dex = { path = "../../deps/serum-dex/dex", features = ["no-entrypoint"] }
-solana-program = "1.7.4"
+solana-program = "=1.7.8"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -34,7 +34,7 @@ anchor-derive-accounts = { path = "./derive/accounts", version = "0.11.1" }
 base64 = "0.13.0"
 borsh = "0.9"
 bytemuck = "1.4.0"
-solana-program = "1.7.4"
+solana-program = "=1.7.8"
 thiserror = "1.0.20"
 
 #

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -13,5 +13,5 @@ devnet = []
 anchor-lang = { path = "../lang", version = "0.11.1", features = ["derive"] }
 lazy_static = "1.4.0"
 serum_dex = { git = "https://github.com/project-serum/serum-dex", version = "0.3.1", features = ["no-entrypoint"] }
-solana-program = "1.7.4"
+solana-program = "=1.7.8"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -12,6 +12,6 @@ devnet = []
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.11.1", features = ["derive"] }
 lazy_static = "1.4.0"
-serum_dex = { git = "https://github.com/project-serum/serum-dex", branch = "armani/auth", version = "0.3.1", features = ["no-entrypoint"] }
+serum_dex = { git = "https://github.com/project-serum/serum-dex", version = "0.3.1", features = ["no-entrypoint"] }
 solana-program = "1.7.4"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/spl/src/dex/middleware.rs
+++ b/spl/src/dex/middleware.rs
@@ -75,7 +75,7 @@ pub trait MarketMiddleware {
         Ok(())
     }
 
-    fn prune(&self, _ctx: &mut Context) -> ProgramResult {
+    fn prune(&self, _ctx: &mut Context, limit: u16) -> ProgramResult {
         Ok(())
     }
 
@@ -357,7 +357,7 @@ impl MarketMiddleware for OpenOrdersPda {
     ///
     /// 0.   Discriminant.
     /// ..
-    fn prune(&self, ctx: &mut Context) -> ProgramResult {
+    fn prune(&self, ctx: &mut Context, limit: u16) -> ProgramResult {
         // Set owner of open orders to be itself.
         ctx.accounts[5] = ctx.accounts[4].clone();
         Ok(())
@@ -394,6 +394,11 @@ impl MarketMiddleware for Logger {
 
     fn close_open_orders(&self, _ctx: &mut Context) -> ProgramResult {
         msg!("proxying close open orders");
+        Ok(())
+    }
+
+    fn prune(&self, _ctx: &mut Context, limit: u16) -> ProgramResult {
+        msg!("proxying prune {:?}", limit);
         Ok(())
     }
 }

--- a/spl/src/dex/middleware.rs
+++ b/spl/src/dex/middleware.rs
@@ -75,7 +75,7 @@ pub trait MarketMiddleware {
         Ok(())
     }
 
-    fn prune(&self, _ctx: &mut Context, limit: u16) -> ProgramResult {
+    fn prune(&self, _ctx: &mut Context, _limit: u16) -> ProgramResult {
         Ok(())
     }
 
@@ -357,7 +357,7 @@ impl MarketMiddleware for OpenOrdersPda {
     ///
     /// 0.   Discriminant.
     /// ..
-    fn prune(&self, ctx: &mut Context, limit: u16) -> ProgramResult {
+    fn prune(&self, ctx: &mut Context, _limit: u16) -> ProgramResult {
         // Set owner of open orders to be itself.
         ctx.accounts[5] = ctx.accounts[4].clone();
         Ok(())

--- a/spl/src/dex/proxy.rs
+++ b/spl/src/dex/proxy.rs
@@ -95,10 +95,10 @@ impl<'a> MarketProxy<'a> {
                     mw.close_open_orders(&mut ctx)?;
                 }
             }
-            Some(MarketInstruction::Prune) => {
+            Some(MarketInstruction::Prune(limit)) => {
                 require!(ctx.accounts.len() >= 7, ErrorCode::NotEnoughAccounts);
                 for mw in &self.middlewares {
-                    mw.prune(&mut ctx)?;
+                    mw.prune(&mut ctx, limit)?;
                 }
             }
             _ => {


### PR DESCRIPTION
Two changes:

* Updates the dex's `prune` instruction to use the new limit parameter.
* Pins solana crates to 1.7.8 (this should fix the build).