### PR TITLE
client: Fix websocket url parsing

### DIFF
--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -40,6 +40,8 @@ impl FromStr for Cluster {
                     ws_url.set_port(Some(8900))
                         .map_err(|_| anyhow!("Unable to set port"))?;
                 }
+                ws_url.set_scheme("ws")
+                    .map_err(|_| anyhow!("Unable to set scheme"))?;
 
                 Ok(Cluster::Custom(http_url.to_string(), ws_url.to_string()))
             }
@@ -116,7 +118,7 @@ mod tests {
         let url = "http://my-url.com:7000/";
         let cluster = Cluster::from_str(url).unwrap();
         assert_eq!(
-            Cluster::Custom(url.to_string(), "http://my-url.com:7001/".to_string()),
+            Cluster::Custom(url.to_string(), "ws://my-url.com:7001/".to_string()),
             cluster
         );
     }
@@ -126,7 +128,7 @@ mod tests {
         let url = "http://my-url.com/";
         let cluster = Cluster::from_str(url).unwrap();
         assert_eq!(
-            Cluster::Custom(url.to_string(), "http://my-url.com:8900/".to_string()),
+            Cluster::Custom(url.to_string(), "ws://my-url.com:8900/".to_string()),
             cluster
         );
     }

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -40,8 +40,14 @@ impl FromStr for Cluster {
                     ws_url.set_port(Some(8900))
                         .map_err(|_| anyhow!("Unable to set port"))?;
                 }
-                ws_url.set_scheme("ws")
-                    .map_err(|_| anyhow!("Unable to set scheme"))?;
+                if ws_url.scheme() == "https" {
+                    ws_url.set_scheme("wss")
+                        .map_err(|_| anyhow!("Unable to set scheme"))?;
+                } else {
+                    ws_url.set_scheme("ws")
+                        .map_err(|_| anyhow!("Unable to set scheme"))?;
+                }
+
 
                 Ok(Cluster::Custom(http_url.to_string(), ws_url.to_string()))
             }
@@ -129,6 +135,25 @@ mod tests {
         let cluster = Cluster::from_str(url).unwrap();
         assert_eq!(
             Cluster::Custom(url.to_string(), "ws://my-url.com:8900/".to_string()),
+            cluster
+        );
+    }
+
+    #[test]
+    fn test_https_port() {
+        let url = "https://my-url.com:7000/";
+        let cluster = Cluster::from_str(url).unwrap();
+        assert_eq!(
+            Cluster::Custom(url.to_string(), "wss://my-url.com:7001/".to_string()),
+            cluster
+        );
+    }
+    #[test]
+    fn test_https_no_port() {
+        let url = "https://my-url.com/";
+        let cluster = Cluster::from_str(url).unwrap();
+        assert_eq!(
+            Cluster::Custom(url.to_string(), "wss://my-url.com:8900/".to_string()),
             cluster
         );
     }


### PR DESCRIPTION
Should close #574 
Used set_scheme() from url package to change websocket url from http:// to ws://.