### PR TITLE
cli: Allow Cargo.lock to in workspace subdirectories when publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ incremented for features.
 
 * cli: Programs embedded into genesis during tests will produce program logs.
 
+### Fixes
+
+* cli: Allows Cargo.lock to exist in workspace subdirectories when publishing ([#593](https://github.com/project-serum/anchor/pull/593)).
+
 ## [0.13.0] - 2021-08-08
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "tar",
  "tokio 1.4.0",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,3 +36,4 @@ reqwest = { version = "0.11.4", features = ["multipart", "blocking"] }
 tokio = "1.0"
 pathdiff = "0.2.0"
 cargo_toml = "0.9.2"
+walkdir = "2"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -55,7 +55,7 @@ pub struct Manifest(cargo_toml::Manifest);
 impl Manifest {
     pub fn from_path(p: impl AsRef<Path>) -> Result<Self> {
         cargo_toml::Manifest::from_path(p)
-            .map(|m| Manifest(m))
+            .map(Manifest)
             .map_err(Into::into)
     }
 
@@ -205,7 +205,7 @@ impl WithPath<Config> {
                 return Ok(Some(WithPath::new(program, path)));
             }
         }
-        return Ok(None);
+        Ok(None)
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -261,6 +261,7 @@ impl Config {
             // root workspace Cargo.toml.
             if cargo_toml.is_none() && cargo_toml_level.is_some() {
                 let toml = cargo_toml::Manifest::from_path(cargo_toml_level.as_ref().unwrap())?;
+                // TODO: this is what's causing failures.
                 if toml.workspace.is_none() {
                     cargo_toml = cargo_toml_level;
                 }
@@ -434,6 +435,7 @@ pub fn extract_lib_name(cargo_toml: impl AsRef<Path>) -> Result<String> {
 #[derive(Debug, Clone)]
 pub struct Program {
     pub lib_name: String,
+    // Canonicalized path to the program directory.
     pub path: PathBuf,
     pub idl: Option<Idl>,
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -97,13 +97,27 @@ impl WithPath<Config> {
             .workspace
             .members
             .iter()
-            .map(|m| PathBuf::from(m).canonicalize().unwrap())
+            .map(|m| {
+                self.path()
+                    .parent()
+                    .unwrap()
+                    .join(m)
+                    .canonicalize()
+                    .unwrap()
+            })
             .collect();
         let exclude = self
             .workspace
             .exclude
             .iter()
-            .map(|m| PathBuf::from(m).canonicalize().unwrap())
+            .map(|m| {
+                self.path()
+                    .parent()
+                    .unwrap()
+                    .join(m)
+                    .canonicalize()
+                    .unwrap()
+            })
             .collect();
         Ok((members, exclude))
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -107,6 +107,29 @@ impl WithPath<Config> {
             .collect();
         Ok((members, exclude))
     }
+
+    pub fn get_program(&self, name: &str) -> Result<Option<WithPath<Program>>> {
+        for program in self.read_all_programs()? {
+            let cargo_toml = program.path.join("Cargo.toml");
+            if !cargo_toml.exists() {
+                return Err(anyhow!(
+                    "Did not find Cargo.toml at the path: {}",
+                    program.path.display()
+                ));
+            }
+            let p_lib_name = extract_lib_name(&cargo_toml)?;
+            if name == p_lib_name {
+                let path = self
+                    .path()
+                    .parent()
+                    .unwrap()
+                    .canonicalize()?
+                    .join(&program.path);
+                return Ok(Some(WithPath::new(program, path)));
+            }
+        }
+        return Ok(None);
+    }
 }
 
 impl<T> std::ops::Deref for WithPath<T> {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -486,7 +486,6 @@ pub struct ProgramWorkspace {
 pub struct AnchorPackage {
     pub name: String,
     pub address: String,
-    pub path: String,
     pub idl: Option<String>,
 }
 
@@ -502,19 +501,9 @@ impl AnchorPackage {
             .ok_or_else(|| anyhow!("Program not provided in Anchor.toml"))?
             .get(&name)
             .ok_or_else(|| anyhow!("Program not provided in Anchor.toml"))?;
-        let path = program_details
-            .path
-            .clone()
-            // TODO: use a default path if one isn't provided?
-            .ok_or_else(|| anyhow!("Path to program binary not provided"))?;
         let idl = program_details.idl.clone();
         let address = program_details.address.to_string();
-        Ok(Self {
-            name,
-            path,
-            address,
-            idl,
-        })
+        Ok(Self { name, address, idl })
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -437,7 +437,15 @@ pub fn build(
             stderr,
         )?,
         // If the Cargo.toml is at the root, build the entire workspace.
-        Some(cargo) if cargo.path().parent() == cfg.path().parent() => {}
+        Some(cargo) if cargo.path().parent() == cfg.path().parent() => build_all(
+            &cfg,
+            cfg.path(),
+            idl_out,
+            verifiable,
+            solana_version,
+            stdout,
+            stderr,
+        )?,
         // Cargo.toml represents a single package. Build it.
         Some(cargo) => build_cwd(
             &cfg,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -502,13 +502,7 @@ fn build_cwd(
     };
     match verifiable {
         false => _build_cwd(idl_out),
-        true => build_cwd_verifiable(
-            cfg,
-            cargo_toml,
-            solana_version,
-            stdout.into(),
-            stderr.into(),
-        ),
+        true => build_cwd_verifiable(cfg, cargo_toml, solana_version, stdout, stderr),
     }
 }
 
@@ -822,7 +816,7 @@ fn verify(
     Ok(())
 }
 
-fn cd_member(cfg_override: &ConfigOverride, program_name: &String) -> Result<()> {
+fn cd_member(cfg_override: &ConfigOverride, program_name: &str) -> Result<()> {
     // Change directories to the given `program_name`, if given.
     let cfg = Config::discover(cfg_override)?.expect("Not in workspace.");
 
@@ -835,7 +829,7 @@ fn cd_member(cfg_override: &ConfigOverride, program_name: &String) -> Result<()>
             ));
         }
         let p_lib_name = Manifest::from_path(&cargo_toml)?.lib_name()?;
-        if program_name.as_str() == p_lib_name {
+        if program_name == p_lib_name {
             std::env::set_current_dir(&program.path)?;
             return Ok(());
         }
@@ -2183,6 +2177,6 @@ fn is_hidden(entry: &walkdir::DirEntry) -> bool {
     entry
         .file_name()
         .to_str()
-        .map(|s| s == "." || s.starts_with(".") || s == "target")
+        .map(|s| s == "." || s.starts_with('.') || s == "target")
         .unwrap_or(false)
 }

--- a/docs/src/getting-started/publishing.md
+++ b/docs/src/getting-started/publishing.md
@@ -40,7 +40,7 @@ cluster = "mainnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.mainnet]
-multisig = { address = "A9HAbnCwoD6f2NkZobKFf6buJoN9gUVVvX5PoUnDHS6u", path = "./target/deploy/multisig.so", idl = "./target/idl/multisig.json" }
+multisig = "A9HAbnCwoD6f2NkZobKFf6buJoN9gUVVvX5PoUnDHS6u"
 ```
 
 Here there are four sections.
@@ -53,8 +53,8 @@ Here there are four sections.
    standard Anchor workflow, this can be ommitted.  For programs not written in Anchor
    but still want to publish, this should be added.
 3. `[provider]` - configures the wallet and cluster settings. Here, `mainnet` is used because the registry only supports `mainnet` binary verification at the moment.
-3. `[programs.mainnet]` - configures each program in the workpace. Here the
-   `address` of the program to verify and the `path` to it's binary build artifact. For Anchor programs with an **IDL**, an `idl = "<path>"` field should also be provided.
+3. `[programs.mainnet]` - configures each program in the workpace, providing
+   the `address` of the program to verify.
 
 ::: tip
 When defining program in `[programs.mainnet]`, make sure the name provided


### PR DESCRIPTION
More robust workspace packaging for publishing.