### PR TITLE
cli: add program logs for genesis programs in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Features
+
+* cli: Programs embedded into genesis during tests will produce program logs.
+
 ## [0.13.0] - 2021-08-08
 
 ### Features

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1457,6 +1457,21 @@ fn stream_logs(config: &WithPath<Config>) -> Result<Vec<std::process::Child>> {
             .spawn()?;
         handles.push(child);
     }
+    if let Some(test) = config.test.as_ref() {
+        for entry in &test.genesis {
+            let log_file = File::create(format!("{}/{}.log", program_logs_dir, entry.address))?;
+            let stdio = std::process::Stdio::from(log_file);
+            let child = std::process::Command::new("solana")
+                .arg("logs")
+                .arg(entry.address.clone())
+                .arg("--url")
+                .arg(config.provider.cluster.url())
+                .stdout(stdio)
+                .spawn()?;
+            handles.push(child);
+        }
+    }
+
     Ok(handles)
 }
 


### PR DESCRIPTION
* Closes #585

I believe for tests, you would just want logs from these programs.