### PR TITLE
lang: fix remaining_accounts for interface attribute CPIs

### DIFF
--- a/lang/attribute/interface/src/lib.rs
+++ b/lang/attribute/interface/src/lib.rs
@@ -211,14 +211,14 @@ pub fn interface(
                             .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotSerialize)?;
                         let mut data = #sighash_tts.to_vec();
                         data.append(&mut ix_data);
-                        let accounts = ctx.accounts.to_account_metas(None);
+                        let accounts = ctx.to_account_metas(None);
                         anchor_lang::solana_program::instruction::Instruction {
                             program_id: *ctx.program.key,
                             accounts,
                             data,
                         }
                     };
-                    let mut acc_infos = ctx.accounts.to_account_infos();
+                    let mut acc_infos = ctx.to_account_infos();
                     acc_infos.push(ctx.program.clone());
                     anchor_lang::solana_program::program::invoke_signed(
                         &ix,

--- a/lang/attribute/interface/src/lib.rs
+++ b/lang/attribute/interface/src/lib.rs
@@ -197,7 +197,7 @@ pub fn interface(
             let sighash_tts: proc_macro2::TokenStream =
                 format!("{:?}", sighash_arr).parse().unwrap();
             quote! {
-                pub fn #method_name<'a,'b, 'c, 'info, T: anchor_lang::ToAccountMetas + anchor_lang::ToAccountInfos<'info>>(
+                pub fn #method_name<'a,'b, 'c, 'info, T: anchor_lang::Accounts<'info> + anchor_lang::ToAccountMetas + anchor_lang::ToAccountInfos<'info>>(
                     ctx: anchor_lang::CpiContext<'a, 'b, 'c, 'info, T>,
                     #(#args),*
                 ) -> anchor_lang::solana_program::entrypoint::ProgramResult {


### PR DESCRIPTION
Remaining accounts are not getting copied over in CPI calls for instructions that implement an interface.


```
    'Program log: cpi_ctx.remaining_accounts: [AccountInfo { key: H4JnrkjQGBWsbKxEDk4Dhqs2uudeRX3y1rnnx6LYdBij owner: 8txEX4TVedVDgxRcY3iDVQJ8yfbkkqLTuZaPRbZEcwm2 is_signer: false is_writable: false executable: false rent_epoch: 0 lamports: 2415120 data.len: 219  data: 5a5ad99306208704d1e2df2446715c99a6c5b14477d703cb2228cfa4fca28de8d9676b8fd70ca76bff66fa5f1ce7636068e98e70d2c7bf2696603dffb6c5621a ... }]',
      'Program 8txEX4TVedVDgxRcY3iDVQJ8yfbkkqLTuZaPRbZEcwm2 invoke [2]',
      'Program log: ctx.remining_accounts: []',
```

I referenced:
https://github.com/project-serum/anchor/commit/c23a5dfa29b1b4393e9e6a68d4b4c5189faf9f5c#diff-81fba76fcb828ad92cb05fbcba9147847b7f9a888dda8bf2052b68b5f08ac99eR83