### PR TITLE
lang: ignore unnamed structs instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Features
+
+* lang: Ignore `Unnamed` structs instead of panic ([#605](https://github.com/project-serum/anchor/pull/605)).
+
 ## [0.13.2] - 2021-08-11
 
 ### Fixes

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -384,7 +384,8 @@ fn parse_ty_defs(ctx: &CrateContext) -> Result<Vec<IdlTypeDefinition>> {
                         })
                     })
                     .collect::<Result<Vec<IdlField>>>(),
-                _ => panic!("Only named structs are allowed."),
+                syn::Fields::Unnamed(_) => return None,
+                _ => panic!("Empty structs are allowed."),
             };
 
             Some(fields.map(|fields| IdlTypeDefinition {


### PR DESCRIPTION
Motivation: I wanted safer math in the project in which I working on and added unnamed structs for this, like:
```rust
#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd, AnchorDeserialize, AnchorSerialize)]
pub struct TokenAmount(u64);
```
but I can't use IDL right now because anything except named structs causes `panic`.

It would be cool to support unnamed structs (like arrays or maybe we can add attributes to struct and use it as an object in JS), but this will require much more effort. With this simple change `idl parse` does not fail at least and can be used in JS with small IDL patching =\