### PR TITLE
Clarify docs for anchor test

### DIFF
--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -93,7 +93,11 @@ of all workspace programs before running them.
 If the configured network is a localnet, then automatically starts the localnetwork and runs
 the test.
 
-When running tests we stream program logs to .anchor/program-logs/<address>.<program-name>.log
+::: tip Note
+Be sure to shutdown any other local validators, otherwise `anchor test` will fail to run.
+:::
+
+When running tests we stream program logs to `.anchor/program-logs/<address>.<program-name>.log`
 
 ::: tip Note
 The Anchor workflow [recommends](https://www.parity.io/paritys-checklist-for-secure-smart-contract-development/)


### PR DESCRIPTION
A small update to the docs to clarify that `solana-test-validator` needs to be turned off, otherwise `anchor test` will fail.

Includes a format fix where markdown was interpreting the three dots in a code string as an ellipses.