### PR TITLE
Docs: add reference for `anchor test --skip-local-validator`

### DIFF
--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -93,7 +93,11 @@ of all workspace programs before running them.
 If the configured network is a localnet, then automatically starts the localnetwork and runs
 the test.
 
-When running tests we stream program logs to .anchor/program-logs/<address>.<program-name>.log
+::: tip Note
+Be sure to shutdown any other local validators, otherwise `anchor test` will fail to run.
+:::
+
+When running tests we stream program logs to `.anchor/program-logs/<address>.<program-name>.log`
 
 ::: tip Note
 The Anchor workflow [recommends](https://www.parity.io/paritys-checklist-for-secure-smart-contract-development/)

--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -95,6 +95,8 @@ the test.
 
 ::: tip Note
 Be sure to shutdown any other local validators, otherwise `anchor test` will fail to run.
+
+If you'd prefer to run the program against your local validator use `anchor test --skip-local-validator`.
 :::
 
 When running tests we stream program logs to `.anchor/program-logs/<address>.<program-name>.log`


### PR DESCRIPTION
I've forgotten this too many times for it not to be mentioned in the docs.