### PR TITLE
lang: Optimize `trait Key` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ incremented for features.
 
 * lang: Ignore `Unnamed` structs instead of panic ([#605](https://github.com/project-serum/anchor/pull/605)).
 * lang: Add constraints for initializing mint accounts as pdas, `#[account(init, seeds = [...], mint::decimals = <expr>, mint::authority = <expr>)]` ([#562](https://github.com/project-serum/anchor/pull/562)).
+* lang: Add `AsRef<AccountInfo>` for `AccountInfo` wrappers ([#652](https://github.com/project-serum/anchor/pull/652)).
+* lang: Optimize `trait Key` by removing `AccountInfo` cloning ([#652](https://github.com/project-serum/anchor/pull/652)).
 
 ### Breaking Changes
 

--- a/lang/src/account_info.rs
+++ b/lang/src/account_info.rs
@@ -1,5 +1,5 @@
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, ToAccountInfo, ToAccountInfos, ToAccountMetas};
+use crate::{Accounts, AccountsExit, Key, ToAccountInfo, ToAccountInfos, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
@@ -48,5 +48,11 @@ impl<'info> AccountsExit<'info> for AccountInfo<'info> {
     fn exit(&self, _program_id: &Pubkey) -> ProgramResult {
         // no-op
         Ok(())
+    }
+}
+
+impl<'info> Key for AccountInfo<'info> {
+    fn key(&self) -> Pubkey {
+        *self.key
     }
 }

--- a/lang/src/cpi_account.rs
+++ b/lang/src/cpi_account.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
 use crate::{
-    AccountDeserialize, Accounts, AccountsExit, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    AccountDeserialize, Accounts, AccountsExit, Key, ToAccountInfo, ToAccountInfos, ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -111,5 +111,11 @@ impl<'info, T: AccountDeserialize + Clone> AccountsExit<'info> for CpiAccount<'i
     fn exit(&self, _program_id: &Pubkey) -> ProgramResult {
         // no-op
         Ok(())
+    }
+}
+
+impl<'info, T: AccountDeserialize + Clone> Key for CpiAccount<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.info.key
     }
 }

--- a/lang/src/cpi_state.rs
+++ b/lang/src/cpi_state.rs
@@ -110,6 +110,14 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfo<'inf
     }
 }
 
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for CpiState<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Deref for CpiState<'info, T> {
     type Target = T;
 

--- a/lang/src/cpi_state.rs
+++ b/lang/src/cpi_state.rs
@@ -1,7 +1,7 @@
 use crate::error::ErrorCode;
 use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, CpiStateContext, ProgramState,
-    ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, CpiStateContext, Key,
+    ProgramState, ToAccountInfo, ToAccountInfos, ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -138,5 +138,11 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info
     fn exit(&self, _program_id: &Pubkey) -> ProgramResult {
         // no-op
         Ok(())
+    }
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for CpiState<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -203,15 +203,6 @@ pub trait Key {
     fn key(&self) -> Pubkey;
 }
 
-impl<'info, T> Key for T
-where
-    T: ToAccountInfo<'info>,
-{
-    fn key(&self) -> Pubkey {
-        *self.to_account_info().key
-    }
-}
-
 impl Key for Pubkey {
     fn key(&self) -> Pubkey {
         *self

--- a/lang/src/loader.rs
+++ b/lang/src/loader.rs
@@ -166,6 +166,12 @@ impl<'info, T: ZeroCopy> ToAccountMetas for Loader<'info, T> {
     }
 }
 
+impl<'info, T: ZeroCopy> AsRef<AccountInfo<'info>> for Loader<'info, T> {
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.acc_info
+    }
+}
+
 impl<'info, T: ZeroCopy> ToAccountInfos<'info> for Loader<'info, T> {
     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
         vec![self.acc_info.clone()]

--- a/lang/src/loader.rs
+++ b/lang/src/loader.rs
@@ -1,6 +1,7 @@
 use crate::error::ErrorCode;
 use crate::{
-    Accounts, AccountsClose, AccountsExit, ToAccountInfo, ToAccountInfos, ToAccountMetas, ZeroCopy,
+    Accounts, AccountsClose, AccountsExit, Key, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    ZeroCopy,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -181,5 +182,11 @@ impl<'info, T: ZeroCopy> ToAccountInfos<'info> for Loader<'info, T> {
 impl<'info, T: ZeroCopy> ToAccountInfo<'info> for Loader<'info, T> {
     fn to_account_info(&self) -> AccountInfo<'info> {
         self.acc_info.clone()
+    }
+}
+
+impl<'info, T: ZeroCopy> Key for Loader<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.acc_info.key
     }
 }

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
 use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, CpiAccount,
+    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, CpiAccount, Key,
     ToAccountInfo, ToAccountInfos, ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
@@ -161,5 +161,11 @@ where
 {
     fn from(a: CpiAccount<'info, T>) -> Self {
         Self::new(a.to_account_info(), Deref::deref(&a).clone())
+    }
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for ProgramAccount<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
     }
 }

--- a/lang/src/state.rs
+++ b/lang/src/state.rs
@@ -109,6 +109,14 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfo<'inf
     }
 }
 
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for ProgramState<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramState<'a, T> {
     type Target = T;
 

--- a/lang/src/state.rs
+++ b/lang/src/state.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
 use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, CpiAccount, ToAccountInfo,
+    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, CpiAccount, Key, ToAccountInfo,
     ToAccountInfos, ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
@@ -158,4 +158,10 @@ pub fn address(program_id: &Pubkey) -> Pubkey {
     let seed = PROGRAM_STATE_SEED;
     let owner = program_id;
     Pubkey::create_with_seed(&base, seed, owner).unwrap()
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for ProgramState<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
+    }
 }

--- a/lang/src/sysvar.rs
+++ b/lang/src/sysvar.rs
@@ -1,5 +1,5 @@
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, ToAccountInfo, ToAccountInfos, ToAccountMetas};
+use crate::{Accounts, AccountsExit, Key, ToAccountInfo, ToAccountInfos, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
@@ -90,5 +90,11 @@ impl<'info, T: solana_program::sysvar::Sysvar> AccountsExit<'info> for Sysvar<'i
     fn exit(&self, _program_id: &Pubkey) -> ProgramResult {
         // no-op
         Ok(())
+    }
+}
+
+impl<'info, T: solana_program::sysvar::Sysvar> Key for Sysvar<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.info.key
     }
 }

--- a/lang/src/sysvar.rs
+++ b/lang/src/sysvar.rs
@@ -60,6 +60,12 @@ impl<'info, T: solana_program::sysvar::Sysvar> ToAccountInfos<'info> for Sysvar<
     }
 }
 
+impl<'info, T: solana_program::sysvar::Sysvar> AsRef<AccountInfo<'info>> for Sysvar<'info, T> {
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.info
+    }
+}
+
 impl<'a, T: solana_program::sysvar::Sysvar> Deref for Sysvar<'a, T> {
     type Target = T;
 


### PR DESCRIPTION
Closes #608 

While `AsRef<AccountInfo>` was added to `AccountInfo` in solana:1.7.11 it's still not possible to use for `trait Key` :cry: 

So I changed `trait Key` by removing `AccountInfo` cloning and also added an additional `AsRef<AccountInfo>` implementation which can be used in programs.