### PR TITLE
lang: check that ProgramAccount writable on deref_mut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Features
+
+* lang: Check that ProgramAccount writable before mut borrow ([#681](https://github.com/project-serum/anchor/pull/681)).
+
 ## [0.14.0] - 2021-09-02
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ incremented for features.
 
 ### Features
 
-* lang: Check that ProgramAccount writable before mut borrow ([#681](https://github.com/project-serum/anchor/pull/681)).
+* lang: Check that ProgramAccount writable before mut borrow (`anchor-debug` only) ([#681](https://github.com/project-serum/anchor/pull/681)).
 
 ## [0.14.0] - 2021-09-02
 

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -6,6 +6,7 @@ use crate::{
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
+use solana_program::msg;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use std::ops::{Deref, DerefMut};
@@ -156,6 +157,11 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAcco
 
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for ProgramAccount<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        if !self.inner.info.is_writable {
+            msg!("The given ProgramAccount is not mutable");
+            panic!();
+        }
+
         &mut DerefMut::deref_mut(&mut self.inner).account
     }
 }

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -6,7 +6,6 @@ use crate::{
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
-use solana_program::msg;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use std::ops::{Deref, DerefMut};
@@ -157,8 +156,9 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAcco
 
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for ProgramAccount<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        #[cfg(feature = "anchor-debug")]
         if !self.inner.info.is_writable {
-            msg!("The given ProgramAccount is not mutable");
+            solana_program::msg!("The given ProgramAccount is not mutable");
             panic!();
         }
 


### PR DESCRIPTION
It's easy to skip `mut` for ProgramAccount and later surprise in tests that account data is not changed while the program is finished successfully.