### PR TITLE
Add array to ts IdlType

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -83,21 +83,26 @@ export type IdlType =
   | "bytes"
   | "string"
   | "publicKey"
-  | IdlTypeVec
+  | IdlTypeDefined
   | IdlTypeOption
-  | IdlTypeDefined;
+  | IdlTypeVec
+  | IdlTypeArray;
 
-export type IdlTypeVec = {
-  vec: IdlType;
+// User defined type.
+export type IdlTypeDefined = {
+  defined: string;
 };
 
 export type IdlTypeOption = {
   option: IdlType;
 };
 
-// User defined type.
-export type IdlTypeDefined = {
-  defined: string;
+export type IdlTypeVec = {
+  vec: IdlType;
+};
+
+export type IdlTypeArray = {
+  array: [idlType: IdlType, size: number];
 };
 
 export type IdlEnumVariant = {


### PR DESCRIPTION
I had an issue where trying to type with https://github.com/saber-hq/saber-common/tree/master/packages/anchor-contrib
wasn't possible because it does not have array.
Turns out array is also missing from anchor