### PR TITLE
anchor configuration should use the right name.

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -10,6 +10,7 @@ use clap::Clap;
 use flate2::read::ZlibDecoder;
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
+use heck::SnakeCase;
 use rand::rngs::OsRng;
 use reqwest::blocking::multipart::{Form, Part};
 use reqwest::blocking::Client;
@@ -319,7 +320,7 @@ fn init(cfg_override: &ConfigOverride, name: String, typescript: bool) -> Result
     );
     let mut localnet = BTreeMap::new();
     localnet.insert(
-        name.to_string(),
+        name.to_string().to_snake_case(),
         ProgramDeployment {
             address: template::default_program_id(),
             path: None,


### PR DESCRIPTION
This will fix a bug where anyone who `anchor init` a new project with a name that isn't in `snake_case` will have problems running the `anchor test` command because the wrong name is used for the `Anchor.toml` configuration. So, when they run `anchor test` on a fresh project, they will get a `TypeError: Cannot read property 'state' of undefined` error.

This is caused by this particular line: https://github.com/project-serum/anchor/blob/master/cli/src/lib.rs#L1402. The `--bpf-program` is set using a name that is supposed to be in `snake_case` but the `Anchor.toml` configuration is created without being casted to `snake_case`.

So, without this fix, if you run `anchor init basic-0`, you will have problems running `anchor test`. If you run `anchor init basic_0`, you will be fine running `anchor test`.

This fix will make sure that the behavior is consistent for both.

Without this fix, `anchor init basic-0` will generate:

```toml
[programs.localnet]
basic-0 = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"

[registry]
url = "https://anchor.projectserum.com"

[provider]
cluster = "localnet"
wallet = "~/.config/solana/id.json"

[scripts]
test = "mocha -t 1000000 tests/"

```

With this fix, `anchor init basic-0` will generate:

```toml
[programs.localnet]
basic_0 = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"

[registry]
url = "https://anchor.projectserum.com"

[provider]
cluster = "localnet"
wallet = "~/.config/solana/id.json"

[scripts]
test = "mocha -t 1000000 tests/"
```