### PR TITLE
ts: Support empty account structs

### DIFF
--- a/ts/src/coder/common.ts
+++ b/ts/src/coder/common.ts
@@ -35,7 +35,7 @@ export function accountSize(
   }
   return idlAccount.type.fields
     .map((f) => typeSize(idl, f.type))
-    .reduce((a, b) => a + b);
+    .reduce((a, b) => a + b, 0);
 }
 
 // Returns the size of the type in bytes. For variable length types, just return


### PR DESCRIPTION
i may be a usecase of one, but if you declare a struct like 

```
#[account]
#[derive(Debug, Default)]
pub struct Post {}
```

then the program builds and deploys fine, idl outputs fine, but when you load the idl in js it does this

```
/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/coder/common.js:32
        .reduce((a, b) => a + b);
         ^

TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at Object.accountSize (/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/coder/common.js:32:10)
    at new AccountClient (/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/program/namespace/account.js:51:67)
    at /home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/program/namespace/account.js:39:32
    at Array.forEach (<anonymous>)
    at Function.build (/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/program/namespace/account.js:37:22)
    at Function.build (/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/program/namespace/index.js:43:33)
    at new Program (/home/hana/work/hana/circuit/scratch/node_modules/@project-serum/anchor/dist/cjs/program/index.js:57:96)
    at Object.<anonymous> (/home/hana/work/hana/circuit/scratch/index.js:14:17)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
```