### PR TITLE
spl: add token `close_account` instruction

### DIFF
--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -128,6 +128,28 @@ pub fn initialize_account<'a, 'b, 'c, 'info>(
     )
 }
 
+pub fn close_account<'a, 'b, 'c, 'info>(
+    ctx: CpiContext<'a, 'b, 'c, 'info, CloseAccount<'info>>,
+) -> ProgramResult {
+    let ix = spl_token::instruction::close_account(
+        &spl_token::ID,
+        ctx.accounts.account.key,
+        ctx.accounts.destination.key,
+        ctx.accounts.authority.key,
+        &[], // TODO: support multisig
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.account.clone(),
+            ctx.accounts.destination.clone(),
+            ctx.accounts.authority.clone(),
+            ctx.program.clone(),
+        ],
+        ctx.signer_seeds,
+    )
+}
+
 pub fn initialize_mint<'a, 'b, 'c, 'info>(
     ctx: CpiContext<'a, 'b, 'c, 'info, InitializeMint<'info>>,
     decimals: u8,
@@ -215,6 +237,13 @@ pub struct InitializeAccount<'info> {
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
     pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CloseAccount<'info> {
+    pub account: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -144,7 +144,6 @@ pub fn close_account<'a, 'b, 'c, 'info>(
             ctx.accounts.account.clone(),
             ctx.accounts.destination.clone(),
             ctx.accounts.authority.clone(),
-            ctx.program.clone(),
         ],
         ctx.signer_seeds,
     )


### PR DESCRIPTION
Adding another missing instruction for the SPL token program.