### PR TITLE
docs: add copy button for code blocks

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@xiaopanda/vuepress-plugin-code-copy": "^1.0.3",
     "gh-pages": "^3.1.0",
     "vuepress": "^1.5.3",
     "vuepress-plugin-dehydrate": "^1.1.5",

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -97,5 +97,6 @@ module.exports = {
     "dehydrate",
     "@vuepress/plugin-back-to-top",
     "@vuepress/plugin-medium-zoom",
+    "@xiaopanda/vuepress-plugin-code-copy",
   ],
 };


### PR DESCRIPTION
Add copy button to enable copy the code in code blocks.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/12815768/132970638-b5a5f3db-908a-4cce-9509-3f9335b71379.gif)
