### PR TITLE
Provides ANCHOR_WALLET env var to anchor test and use it in NodeWallet

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1355,6 +1355,7 @@ fn test(
             std::process::Command::new(program)
                 .args(args)
                 .env("ANCHOR_PROVIDER_URL", cfg.provider.cluster.url())
+                .env("ANCHOR_WALLET", cfg.provider.wallet.to_string())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -230,11 +230,12 @@ export class NodeWallet implements Wallet {
   constructor(readonly payer: Keypair) {}
 
   static local(): NodeWallet {
+    const process = require("process");
     const payer = Keypair.fromSecretKey(
       Buffer.from(
         JSON.parse(
           require("fs").readFileSync(
-            require("os").homedir() + "/.config/solana/id.json",
+            process.env.ANCHOR_WALLET,
             {
               encoding: "utf-8",
             }


### PR DESCRIPTION
#701 
Tested and works fine, `anchor test` is happy