### PR TITLE
Add "slop" when anchor build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incremented for features.
 
 * lang: Add `--detach` flag to `anchor test` ([#770](https://github.com/project-serum/anchor/pull/770)).
 * lang: Add `associated_token` keyword for initializing associated token accounts within `#[derive(Accounts)]` ([#790](https://github.com/project-serum/anchor/pull/790)).
+* cli: Allow passing through cargo flags for build command ([#719](https://github.com/project-serum/anchor/pull/719)).
 
 ## [0.16.1] - 2021-09-17
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -799,7 +799,6 @@ fn docker_build(
 fn _build_cwd(idl_out: Option<PathBuf>, slop: Option<Vec<String>>) -> Result<()> {
     let exit = std::process::Command::new("cargo")
         .arg("build-bpf")
-        //.arg("--")
         .args(slop.unwrap_or(vec![]))
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -2040,18 +2039,6 @@ fn publish(cfg_override: &ConfigOverride, program_name: String) -> Result<()> {
 
     let anchor_package = AnchorPackage::from(program_name.clone(), &cfg)?;
     let anchor_package_bytes = serde_json::to_vec(&anchor_package)?;
-
-    // Build the program before sending it to the server.
-    build(
-        cfg_override,
-        None,
-        true,
-        Some(program_name.clone()),
-        cfg.solana_version.clone(),
-        None,
-        None,
-        None,
-    )?;
 
     // Set directory to top of the workspace.
     let workspace_dir = cfg.path().parent().unwrap();


### PR DESCRIPTION
#642

https://github.com/clap-rs/clap/blob/44ae55fa4e33a2952f66e7d4f73782cff7c8f1f0/examples/22_stop_parsing_with_--.rs

```
arowana:~/the-best-projects-in-the-universe/anchor/tests/events$ ../../target/debug/anchor build -- --help
solana-cargo-build-bpf 1.7.10
Compile a local package and all of its dependencies using the Solana BPF SDK

USAGE:
    cargo-build-bpf [FLAGS] [OPTIONS]

FLAGS:
        --dump                   Dump ELF information to a text file on success
    -h, --help                   Prints help information
        --no-default-features    Do not activate the `default` feature
        --offline                Run without accessing the network
    -V, --version                Prints version information
    -v, --verbose                Use verbose output
        --workspace              Build all BPF packages in the workspace

OPTIONS:
        --bpf-out-dir <DIRECTORY>    Place final BPF build artifacts in this directory
        --bpf-sdk <PATH>             Path to the Solana BPF SDK [default:
                                     /home/<yolo>/.local/share/solana/install/releases/1.7.10/solana-
                                     release/bin/sdk/bpf]
        --features <FEATURES>...     Space-separated list of features to activate
        --manifest-path <PATH>       Path to Cargo.toml
  ```
        
Thoughts?
