### PR TITLE
@project-serum/anchor-cli install instructions

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -31,6 +31,16 @@ npm install -g mocha
 
 ## Install Anchor
 
+### Install using pre-build binary on x86_64 Linux
+
+Anchor binaries are avalable via an NPM package [`@project-serum/anchor-cli`](https://www.npmjs.com/package/@project-serum/anchor-cli). Only x86_64 Linux is supported currently, you must build from source for other OS'.
+
+```bash
+npm i -g @project-serum/anchor-cli
+```
+
+### Build from source for other operating systems
+
 For now, we can use Cargo to install the CLI.
 
 ```bash


### PR DESCRIPTION
This NPM package allows users to install Anchor binaries directly on 64 bit Linux. Instructions are provided to build from  source for other operating systems.