### PR TITLE
Expose ProgramError to the client

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -12,6 +12,8 @@ import Coder, {
   TypesCoder,
   AccountsCoder,
 } from "./coder";
+
+import { ProgramError } from "./error";
 import { Instruction } from "./coder/instruction";
 import { Idl } from "./idl";
 import workspace from "./workspace";
@@ -71,4 +73,5 @@ export {
   Wallet,
   Address,
   EventParser,
+  ProgramError,
 };


### PR DESCRIPTION
I would like to expose Program Error / or the consts inside programerror to use as a debugging tool so I dont have to see ugly hex decimals when I get an error