### PR TITLE
Add fetchMultiple to compliment rpc getMultiple

### DIFF
--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -152,9 +152,9 @@ export class AccountClient<T = any> {
     }
     return data;
   }
-  
+
   /**
-   * Returns multiple deserialized accounts. 
+   * Returns multiple deserialized accounts.
    * Accounts not found or with wrong discriminator are returned as null.
    *
    * @param addresses The addresses of the accounts to fetch.
@@ -162,19 +162,22 @@ export class AccountClient<T = any> {
   async fetchMultiple(addresses: Address[]): Promise<(Object | null)[]> {
     const accounts = await rpcUtil.getMultipleAccounts(
       this._provider.connection,
-      addresses.map(address => translateAddress(address))
+      addresses.map((address) => translateAddress(address))
     );
 
     const discriminator = await accountDiscriminator(this._idlAccount.name);
     // Decode accounts where discriminator is correct, null otherwise
-    return accounts.map(account => {
-        if (account == null) {
-          return null;
-        }
-        if (discriminator.compare(account?.account.data.slice(0, 8))) {
-          return null;
-        }
-        return this._coder.accounts.decode(this._idlAccount.name, account?.account.data);
+    return accounts.map((account) => {
+      if (account == null) {
+        return null;
+      }
+      if (discriminator.compare(account?.account.data.slice(0, 8))) {
+        return null;
+      }
+      return this._coder.accounts.decode(
+        this._idlAccount.name,
+        account?.account.data
+      );
     });
   }
 


### PR DESCRIPTION
## Notes
- Added `fetchMultiple` to `AccountClient` to handle fetching multiple program accounts at once.

## Discussion
- Also created (but didn't commit) test in the tests/misc project, but it requires depending on local built ts. Not sure how ts tests are being handled, please advise.
- getMultipleAccountsInfo is now in solana web3, but only (stable) as of `1.24.1`. Currently anchor is using `1.17.0`. Advise upgrading this reference and reworking `utils/rpc` to use it.  ~~I could do this and #364 at the same time.~~ Already did that one.