### PR TITLE
Fix #733: Use an Expr for payer rather than an Ident.

### DIFF
--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -611,7 +611,7 @@ pub enum ConstraintRentExempt {
 #[derive(Debug, Clone)]
 pub struct ConstraintInitGroup {
     pub seeds: Option<ConstraintSeedsGroup>,
-    pub payer: Option<Ident>,
+    pub payer: Option<Expr>,
     pub space: Option<Expr>,
     pub kind: InitKind,
 }
@@ -638,7 +638,7 @@ pub struct ConstraintState {
 
 #[derive(Debug, Clone)]
 pub struct ConstraintPayer {
-    pub target: Ident,
+    pub target: Expr,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -185,3 +185,11 @@ pub struct TestInitToken<'info> {
     pub system_program: AccountInfo<'info>,
     pub token_program: AccountInfo<'info>,
 }
+
+#[derive(Accounts)]
+pub struct TestCompositePayer<'info> {
+    pub composite: TestInit<'info>,
+    #[account(init, payer = composite.payer, space = 8 + size_of::<Data>())]
+    pub data: Account<'info, Data>,
+    pub system_program: AccountInfo<'info>,
+}

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -191,5 +191,5 @@ pub struct TestCompositePayer<'info> {
     pub composite: TestInit<'info>,
     #[account(init, payer = composite.payer, space = 8 + size_of::<Data>())]
     pub data: Account<'info, Data>,
-    pub system_program: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
 }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -152,4 +152,11 @@ pub mod misc {
         assert!(ctx.accounts.token.mint == ctx.accounts.mint.key());
         Ok(())
     }
+
+    pub fn test_composite_payer(ctx: Context<TestCompositePayer>) -> ProgramResult {
+        ctx.accounts.composite.data.data = 1;
+        ctx.accounts.data.udata = 2;
+        ctx.accounts.data.idata = 3;
+        Ok(())
+    }
 }

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -578,4 +578,29 @@ describe("misc", () => {
     assert.ok(account.owner.equals(program.provider.wallet.publicKey));
     assert.ok(account.mint.equals(mint.publicKey));
   });
+
+  it("Can initialize multiple accounts via a composite payer", async () => {
+    const data1 = anchor.web3.Keypair.generate();
+    const data2 = anchor.web3.Keypair.generate();
+
+    const tx = await program.rpc.testCompositePayer({
+      accounts: {
+        composite: {
+          data: data1.publicKey,
+          payer: program.provider.wallet.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        },
+        data: data2.publicKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      },
+      signers: [data1, data2]
+    });
+
+    const account1 = await program.account.dataI8.fetch(data1.publicKey);
+    assert.equal(account1.data, 1);
+
+    const account2 = await program.account.data.fetch(data2.publicKey);
+    assert.equal(account2.udata, 2);
+    assert.equal(account2.idata, 3);
+  });
 });


### PR DESCRIPTION
I believe this fixes #733, although I'm getting started with Rust macros/anchor so let me know if this issue is subtler than I thought!

cc @Aadhinana

One question that came up while pairing on this: is there a recommended way to test macro changes? We ended up just making a scratch project and then verified that everything compiled + the `payer`-related outputs of `cargo expand` looked correct.