### PR TITLE
Expose accountDiscriminator as static method of AccountsCoder

### DIFF
--- a/ts/src/coder/accounts.ts
+++ b/ts/src/coder/accounts.ts
@@ -37,7 +37,7 @@ export class AccountsCoder<A extends string = string> {
     }
     const len = layout.encode(account, buffer);
     let accountData = buffer.slice(0, len);
-    let discriminator = await accountDiscriminator(accountName);
+    let discriminator = AccountsCoder.accountDiscriminator(accountName);
     return Buffer.concat([discriminator, accountData]);
   }
 
@@ -50,9 +50,13 @@ export class AccountsCoder<A extends string = string> {
     }
     return layout.decode(data);
   }
-}
 
-// Calculates unique 8 byte discriminator prepended to all anchor accounts.
-export async function accountDiscriminator(name: string): Promise<Buffer> {
-  return Buffer.from(sha256.digest(`account:${name}`)).slice(0, 8);
+  /**
+   * Calculates and returns a unique 8 byte discriminator prepended to all anchor accounts.
+   *
+   * @param name The name of the account to calculate the discriminator.
+   */
+  public static accountDiscriminator(name: string): Buffer {
+    return Buffer.from(sha256.digest(`account:${name}`)).slice(0, 8);
+  }
 }

--- a/ts/src/coder/index.ts
+++ b/ts/src/coder/index.ts
@@ -9,11 +9,7 @@ import { sighash } from "./common";
 export { accountSize } from "./common";
 export { TypesCoder } from "./types";
 export { InstructionCoder } from "./instruction";
-export {
-  AccountsCoder,
-  accountDiscriminator,
-  ACCOUNT_DISCRIMINATOR_SIZE,
-} from "./accounts";
+export { AccountsCoder, ACCOUNT_DISCRIMINATOR_SIZE } from "./accounts";
 export { EventCoder, eventDiscriminator } from "./event";
 export { StateCoder, stateDiscriminator } from "./state";
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -12,8 +12,8 @@ import Provider from "../../provider";
 import { Idl, IdlTypeDef } from "../../idl";
 import Coder, {
   ACCOUNT_DISCRIMINATOR_SIZE,
-  accountDiscriminator,
   accountSize,
+  AccountsCoder,
 } from "../../coder";
 import { Subscription, Address, translateAddress } from "../common";
 import { getProvider } from "../../";
@@ -132,7 +132,9 @@ export class AccountClient<T = any> {
     }
 
     // Assert the account discriminator is correct.
-    const discriminator = await accountDiscriminator(this._idlAccount.name);
+    const discriminator = AccountsCoder.accountDiscriminator(
+      this._idlAccount.name
+    );
     if (discriminator.compare(accountInfo.data.slice(0, 8))) {
       throw new Error("Invalid account discriminator");
     }
@@ -165,7 +167,9 @@ export class AccountClient<T = any> {
       addresses.map((address) => translateAddress(address))
     );
 
-    const discriminator = await accountDiscriminator(this._idlAccount.name);
+    const discriminator = AccountsCoder.accountDiscriminator(
+      this._idlAccount.name
+    );
     // Decode accounts where discriminator is correct, null otherwise
     return accounts.map((account) => {
       if (account == null) {
@@ -185,7 +189,7 @@ export class AccountClient<T = any> {
    * Returns all instances of this account type for the program.
    */
   async all(filter?: Buffer): Promise<ProgramAccount<T>[]> {
-    let bytes = await accountDiscriminator(this._idlAccount.name);
+    let bytes = AccountsCoder.accountDiscriminator(this._idlAccount.name);
     if (filter !== undefined) {
       bytes = Buffer.concat([bytes, filter]);
     }


### PR DESCRIPTION
# Overview

The intention of this PR is to expose the `accountDiscriminator` as a static method of the class `AccountsCoder`.