### PR TITLE
Properly build anchor.Wallet for shell template script

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -282,15 +282,18 @@ pub fn node_shell(
 const anchor = require('@project-serum/anchor');
 const web3 = anchor.web3;
 const PublicKey = anchor.web3.PublicKey;
+const Keypair = anchor.web3.Keypair;
 
 const __wallet = new anchor.Wallet(
-  Buffer.from(
-    JSON.parse(
-      require('fs').readFileSync(
-        "{}",
-        {{
-          encoding: "utf-8",
-        }},
+  Keypair.fromSecretKey(
+    Buffer.from(
+      JSON.parse(
+        require('fs').readFileSync(
+          "{}",
+          {{
+            encoding: "utf-8",
+          }},
+        ),
       ),
     ),
   ),


### PR DESCRIPTION
The provider wallet in the node shell template was not being created properly because the contents of the configured wallet were not being wrapped in a `Keypair`. 

This was causing problems when trying to run the escrow tests within the shell, such as the following error:

```
Translating error TypeError: Cannot read property 'toString' of undefined
    at Transaction.partialSign (/d/solarwind/node_modules/@project-serum/anchor/node_modules/@solana/web3.js/lib/index.cjs.js:1034:36)
    at NodeWallet.signTransaction (/d/solarwind/node_modules/@project-serum/anchor/dist/cjs/provider.js:160:12)
    at Provider.send (/d/solarwind/node_modules/@project-serum/anchor/dist/cjs/provider.js:78:27)
    ...
```
---

Example output using `anchor shell`

Old version:

```
> provider.wallet.payer
<Buffer d3 2b 2c 86 a2 ed ea ...

> provider.wallet.payer.publicKey
undefined
```

Fixed version:

```
> provider.wallet.payer
Keypair {
  _keypair: {
    publicKey: Uint8Array(32) [
      ...
    ],
    secretKey: Uint8Array(64) [
      ...
     ]
   }
}

> provider.wallet.payer.publicKey
PublicKey {
  _bn: <BN: ...>
}
```

cc @cqfd @nicholas-ewasiuk 🙌 