### PR TITLE
ANCHOR_WALLET is required when running `anchor migrate`

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1792,6 +1792,7 @@ fn migrate(cfg_override: &ConfigOverride) -> Result<()> {
             std::fs::write("deploy.js", deploy_script_host_str)?;
             std::process::Command::new("node")
                 .arg("deploy.js")
+                .env("ANCHOR_WALLET", cfg.provider.wallet.to_string())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()?


### PR DESCRIPTION
Reference:
* https://github.com/project-serum/anchor/blob/master/cli/src/template.rs#L57-L83
* https://github.com/project-serum/anchor/blob/master/ts/src/provider.ts#L231-L243