### PR TITLE
set `ANCHOR_WALLET` for `anchor migrate` in typescript mode

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1799,6 +1799,7 @@ fn migrate(cfg_override: &ConfigOverride) -> Result<()> {
             std::fs::write("deploy.ts", deploy_script_host_str)?;
             std::process::Command::new("ts-node")
                 .arg("deploy.ts")
+                .env("ANCHOR_WALLET", cfg.provider.wallet.to_string())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()?


### PR DESCRIPTION
This is a followup to #779 - that PR set `ANCHOR_WALLET` for the `anchor migrate` command but only for js: 

https://github.com/project-serum/anchor/blob/bde45c2985ae8e21a7c45156164da8e443773b98/cli/src/lib.rs#L1794-L1796

and it's missing in ts mode:

https://github.com/project-serum/anchor/blob/bde45c2985ae8e21a7c45156164da8e443773b98/cli/src/lib.rs#L1784-L1786