### PR TITLE
Support `cargo_args` on `test`, `verify` and `publish` commands

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -185,7 +185,7 @@ pub enum Command {
     Publish {
         /// The name of the program to publish.
         program: String,
-        /// Arguments to pass to the underlying `cargo build-bpf` command
+        /// Arguments to pass to the underlying `cargo build-bpf` command.
         #[clap(
             required = false,
             takes_value = true,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -95,7 +95,7 @@ pub enum Command {
         /// only.
         #[clap(short, long)]
         solana_version: Option<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command
+        /// Arguments to pass to the underlying `cargo build-bpf` command.
         #[clap(
             required = false,
             takes_value = true,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -124,7 +124,7 @@ pub enum Command {
         detach: bool,
         #[clap(multiple_values = true)]
         args: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command
+        /// Arguments to pass to the underlying `cargo build-bpf` command.
         #[clap(
             required = false,
             takes_value = true,


### PR DESCRIPTION
A follow-up to https://github.com/project-serum/anchor/pull/719 enabling passing arguments to the underlying `cargo build-bpf` for `anchor test`, `anchor verify` and `anchor publish`