### PR TITLE
Add message for base Error message property

### DIFF
--- a/ts/src/error.ts
+++ b/ts/src/error.ts
@@ -32,13 +32,13 @@ export class ProgramError extends Error {
     // Parse user error.
     let errorMsg = idlErrors.get(errorCode);
     if (errorMsg !== undefined) {
-      return new ProgramError(errorCode, errorMsg);
+      return new ProgramError(errorCode, errorMsg, errorCode + ': ' + errorMsg);
     }
 
     // Parse framework internal error.
     errorMsg = LangErrorMessage.get(errorCode);
     if (errorMsg !== undefined) {
-      return new ProgramError(errorCode, errorMsg);
+      return new ProgramError(errorCode, errorMsg, errorCode + ': ' + errorMsg);
     }
 
     // Unable to parse the error. Just return the untranslated error.


### PR DESCRIPTION
When Mocha tests run, they output the error's `message` property, which currently is empty.  Our `toString` override doesn't get used.

Alternatively can do this in the constructor for `ProgramError` and ditch the `toString`.  Wasn't sure if this is designed this way on purpose.