### PR TITLE
Add mint::freeze_authority attribute when init-ing a mint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incremented for features.
 
 ### Features
 
+* lang: Add `mint::freeze_authority` keyword for mint initialization within `#[derive(Accounts)]` ([#835](https://github.com/project-serum/anchor/pull/835)).
 * cli: Add `localnet` command for starting a local `solana-test-validator` with the workspace deployed ([#820](https://github.com/project-serum/anchor/pull/820)).
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ incremented for features.
 
 * cli: `target/types` directory now created on build to store a TypeScript types file for each program's IDL ([#795](https://github.com/project-serum/anchor/pull/795)).
 * ts: `Program<T>` can now be typed with an IDL type ([#795](https://github.com/project-serum/anchor/pull/795)).
+* lang: Add `mint::freeze_authority` keyword for mint initialization within `#[derive(Accounts)]` ([#835](https://github.com/project-serum/anchor/pull/835)).
 
 ## [0.17.0] - 2021-10-03
 
 ### Features
 
-* lang: Add `mint::freeze_authority` keyword for mint initialization within `#[derive(Accounts)]` ([#835](https://github.com/project-serum/anchor/pull/835)).
 * cli: Add `localnet` command for starting a local `solana-test-validator` with the workspace deployed ([#820](https://github.com/project-serum/anchor/pull/820)).
 
 ### Breaking

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -433,13 +433,21 @@ pub fn generate_init(
                 };
             }
         }
-        InitKind::Mint { owner, decimals } => {
+        InitKind::Mint {
+            owner,
+            decimals,
+            freeze_authority,
+        } => {
             let create_account = generate_create_account(
                 field,
                 quote! {anchor_spl::token::Mint::LEN},
                 quote! {token_program.to_account_info().key},
                 seeds_with_nonce,
             );
+            let freeze_authority = match freeze_authority {
+                Some(fa) => quote! { Some(&#fa.key()) },
+                None => quote! { None },
+            };
             quote! {
                 let #field: #ty_decl = {
                     // Define payer variable.
@@ -455,7 +463,7 @@ pub fn generate_init(
                         rent: rent.to_account_info(),
                     };
                     let cpi_ctx = CpiContext::new(cpi_program, accounts);
-                    anchor_spl::token::initialize_mint(cpi_ctx, #decimals, &#owner.to_account_info().key, None)?;
+                    anchor_spl::token::initialize_mint(cpi_ctx, #decimals, &#owner.to_account_info().key, #freeze_authority)?;
                     let pa: #ty_decl = #from_account_info;
                     pa
                 };

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -659,7 +659,9 @@ pub struct ConstraintSpace {
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum InitKind {
-    Program { owner: Option<Expr> },
+    Program {
+        owner: Option<Expr>,
+    },
     // Owner for token and mint represents the authority. Not to be confused
     // with the owner of the AccountInfo.
     Token {

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -564,6 +564,7 @@ pub enum ConstraintToken {
     AssociatedTokenMint(Context<ConstraintTokenMint>),
     AssociatedTokenAuthority(Context<ConstraintTokenAuthority>),
     MintAuthority(Context<ConstraintMintAuthority>),
+    MintFreezeAuthority(Context<ConstraintMintFreezeAuthority>),
     MintDecimals(Context<ConstraintMintDecimals>),
     Bump(Context<ConstraintTokenBump>),
 }
@@ -661,9 +662,19 @@ pub enum InitKind {
     Program { owner: Option<Expr> },
     // Owner for token and mint represents the authority. Not to be confused
     // with the owner of the AccountInfo.
-    Token { owner: Expr, mint: Expr },
-    AssociatedToken { owner: Expr, mint: Expr },
-    Mint { owner: Expr, decimals: Expr },
+    Token {
+        owner: Expr,
+        mint: Expr,
+    },
+    AssociatedToken {
+        owner: Expr,
+        mint: Expr,
+    },
+    Mint {
+        owner: Expr,
+        freeze_authority: Option<Expr>,
+        decimals: Expr,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -684,6 +695,11 @@ pub struct ConstraintTokenAuthority {
 #[derive(Debug, Clone)]
 pub struct ConstraintMintAuthority {
     mint_auth: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintMintFreezeAuthority {
+    mint_freeze_auth: Expr,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -533,7 +533,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                 "authority must be provided to initialize a mint program derived address"
                             ))
                         },
-                        freeze_authority: mint_freeze_authority.map(|fa| fa.clone().into_inner().mint_freeze_auth)
+                        freeze_authority: mint_freeze_authority.map(|fa| fa.into_inner().mint_freeze_auth)
                     }
                 } else {
                     InitKind::Program {

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -183,7 +183,7 @@ pub struct TestInitZeroCopy<'info> {
 
 #[derive(Accounts)]
 pub struct TestInitMint<'info> {
-    #[account(init, mint::decimals = 6, mint::authority = payer, payer = payer)]
+    #[account(init, mint::decimals = 6, mint::authority = payer, mint::freeze_authority = payer, payer = payer)]
     pub mint: Account<'info, Mint>,
     #[account(signer)]
     pub payer: AccountInfo<'info>,

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -455,6 +455,9 @@ describe("misc", () => {
     assert.ok(
       mintAccount.mintAuthority.equals(program.provider.wallet.publicKey)
     );
+    assert.ok(
+      mintAccount.freezeAuthority.equals(program.provider.wallet.publicKey)
+    );
   });
 
   it("Can create a random mint account prefunded", async () => {


### PR DESCRIPTION
This came up in discord and I thought it would be a good excuse to learn some more macro stuff (no worries if this isn't actually a feature that needs to be included in anchor!).