### PR TITLE
Remove mandatory init when using associated_token constraints.

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -56,6 +56,7 @@ pub fn linearize(c_group: &ConstraintGroup) -> Vec<Constraint> {
         state,
         close,
         address,
+        associated_token,
     } = c_group.clone();
 
     let mut constraints = Vec::new();
@@ -68,6 +69,9 @@ pub fn linearize(c_group: &ConstraintGroup) -> Vec<Constraint> {
     }
     if let Some(c) = seeds {
         constraints.push(Constraint::Seeds(c));
+    }
+    if let Some(c) = associated_token {
+        constraints.push(Constraint::AssociatedToken(c));
     }
     if let Some(c) = mutable {
         constraints.push(Constraint::Mut(c));
@@ -115,6 +119,7 @@ fn generate_constraint(f: &Field, c: &Constraint) -> proc_macro2::TokenStream {
         Constraint::State(c) => generate_constraint_state(f, c),
         Constraint::Close(c) => generate_constraint_close(f, c),
         Constraint::Address(c) => generate_constraint_address(f, c),
+        Constraint::AssociatedToken(c) => generate_constraint_associated_token(f, c),
     }
 }
 
@@ -366,6 +371,21 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
             if #name.to_account_info().key != &__program_signer {
                 return Err(anchor_lang::__private::ErrorCode::ConstraintSeeds.into());
             }
+        }
+    }
+}
+
+fn generate_constraint_associated_token(
+    f: &Field,
+    c: &ConstraintAssociatedToken,
+) -> proc_macro2::TokenStream {
+    let name = &f.ident;
+    let wallet_address = &c.wallet;
+    let spl_token_mint_address = &c.mint;
+    quote! {
+        let __associated_token_address = anchor_spl::associated_token::get_associated_token_address(&#wallet_address.key(), &#spl_token_mint_address.key());
+        if #name.to_account_info().key != &__associated_token_address {
+            return Err(anchor_lang::__private::ErrorCode::ConstraintAssociated.into());
         }
     }
 }

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -497,6 +497,7 @@ pub struct ConstraintGroup {
     raw: Vec<ConstraintRaw>,
     close: Option<ConstraintClose>,
     address: Option<ConstraintAddress>,
+    associated_token: Option<ConstraintAssociatedToken>,
 }
 
 impl ConstraintGroup {
@@ -533,6 +534,7 @@ pub enum Constraint {
     Owner(ConstraintOwner),
     RentExempt(ConstraintRentExempt),
     Seeds(ConstraintSeedsGroup),
+    AssociatedToken(ConstraintAssociatedToken),
     Executable(ConstraintExecutable),
     State(ConstraintState),
     Close(ConstraintClose),
@@ -712,6 +714,12 @@ pub struct ConstraintMintDecimals {
 #[derive(Debug, Clone)]
 pub struct ConstraintTokenBump {
     bump: Option<Expr>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintAssociatedToken {
+    pub wallet: Expr,
+    pub mint: Expr,
 }
 
 // Syntaxt context object for preserving metadata about the inner item.

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -4,7 +4,7 @@ use anchor_lang::solana_program::program_error::ProgramError;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::{Accounts, CpiContext};
 
-pub use spl_associated_token_account::ID;
+pub use spl_associated_token_account::{get_associated_token_address, ID};
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> ProgramResult {
     let ix = spl_associated_token_account::create_associated_token_account(

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -50,6 +50,17 @@ pub struct TestInitAssociatedToken<'info> {
 }
 
 #[derive(Accounts)]
+pub struct TestValidateAssociatedToken<'info> {
+    #[account(
+        associated_token::mint = mint,
+        associated_token::authority = wallet,
+    )]
+    pub token: Account<'info, TokenAccount>,
+    pub mint: Account<'info, Mint>,
+    pub wallet: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
 #[instruction(nonce: u8)]
 pub struct TestInstructionConstraint<'info> {
     #[account(

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -165,6 +165,12 @@ pub mod misc {
         Ok(())
     }
 
+    pub fn test_validate_associated_token(
+        _ctx: Context<TestValidateAssociatedToken>,
+    ) -> ProgramResult {
+        Ok(())
+    }
+
     pub fn test_fetch_all(ctx: Context<TestFetchAll>, filterable: Pubkey) -> ProgramResult {
         ctx.accounts.data.authority = ctx.accounts.authority.key();
         ctx.accounts.data.filterable = filterable;

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -647,7 +647,7 @@ describe("misc", () => {
     assert.ok(account.mint.equals(mint.publicKey));
   });
 
-  it("Can validate associated_token constrainst", async () => {
+  it("Can validate associated_token constraints", async () => {
     await program.rpc.testValidateAssociatedToken({
       accounts: {
         token: associatedToken,

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -612,8 +612,10 @@ describe("misc", () => {
     assert.equal(account2.idata, 3);
   });
 
+  let associatedToken = null;
+
   it("Can create an associated token account", async () => {
-    const token = await Token.getAssociatedTokenAddress(
+    associatedToken = await Token.getAssociatedTokenAddress(
       ASSOCIATED_TOKEN_PROGRAM_ID,
       TOKEN_PROGRAM_ID,
       mint.publicKey,
@@ -622,7 +624,7 @@ describe("misc", () => {
 
     await program.rpc.testInitAssociatedToken({
       accounts: {
-        token,
+        token: associatedToken,
         mint: mint.publicKey,
         payer: program.provider.wallet.publicKey,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
@@ -637,12 +639,38 @@ describe("misc", () => {
       TOKEN_PROGRAM_ID,
       program.provider.wallet.payer
     );
-    const account = await client.getAccountInfo(token);
+    const account = await client.getAccountInfo(associatedToken);
     assert.ok(account.state === 1);
     assert.ok(account.amount.toNumber() === 0);
     assert.ok(account.isInitialized);
     assert.ok(account.owner.equals(program.provider.wallet.publicKey));
     assert.ok(account.mint.equals(mint.publicKey));
+  });
+
+  it("Can validate associated_token constrainst", async () => {
+    await program.rpc.testValidateAssociatedToken({
+      accounts: {
+        token: associatedToken,
+        mint: mint.publicKey,
+        wallet: program.provider.wallet.publicKey
+      }
+    });
+
+    await assert.rejects(
+      async () => {
+        await program.rpc.testValidateAssociatedToken({
+          accounts: {
+            token: associatedToken,
+            mint: mint.publicKey,
+            wallet: anchor.web3.Keypair.generate().publicKey
+          }
+        });
+      },
+      (err) => {
+        assert.equal(err.code, 149);
+        return true;
+      }
+    );
   });
 
   it("Can fetch all accounts of a given type", async () => {


### PR DESCRIPTION
This is a first pass at fixing #814 while pairing with @davoclavo! I feel like some of the names/structure are a little iffy (happy to clean up) but things basically work.
