### PR TITLE
lang: Remove cpi feature flag for account signer check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ incremented for features.
 * ts: `Program<T>` can now be typed with an IDL type ([#795](https://github.com/project-serum/anchor/pull/795)).
 * lang: Add `mint::freeze_authority` keyword for mint initialization within `#[derive(Accounts)]` ([#835](https://github.com/project-serum/anchor/pull/835)).
 
+### Breaking
+
+* lang: Accounts marked with the `#[account(signer)]` constraint now enforce signer when the `"cpi"` feature is enabled ([#849](https://github.com/project-serum/anchor/pull/849)).
+
 ## [0.17.0] - 2021-10-03
 
 ### Features

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -202,15 +202,8 @@ pub fn generate_constraint_signer(f: &Field, _c: &ConstraintSigner) -> proc_macr
         _ => panic!("Invalid syntax: signer cannot be specified."),
     };
     quote! {
-        // Don't enforce on CPI, since usually a program is signing and so
-        // the `try_accounts` deserializatoin will fail *if* the one
-        // tries to manually invoke it.
-        //
-        // This check will be performed on the other end of the invocation.
-        if cfg!(not(feature = "cpi")) {
-            if !#info.to_account_info().is_signer {
-                return Err(anchor_lang::__private::ErrorCode::ConstraintSigner.into());
-            }
+        if !#info.to_account_info().is_signer {
+            return Err(anchor_lang::__private::ErrorCode::ConstraintSigner.into());
         }
     }
 }

--- a/tests/lockup/programs/registry/src/lib.rs
+++ b/tests/lockup/programs/registry/src/lib.rs
@@ -2,6 +2,7 @@
 //! it's suggested to start with the other examples.
 
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::account_info::next_account_info;
 use anchor_lang::solana_program::program_option::COption;
 use anchor_spl::token::{self, Mint, TokenAccount, Transfer};
 use lockup::{CreateVesting, RealizeLock, Realizor, Vesting};
@@ -499,21 +500,17 @@ mod registry {
             &[ctx.accounts.cmn.vendor.nonce],
         ];
         let signer = &[&seeds[..]];
-        let mut remaining_accounts: &[AccountInfo] = ctx.remaining_accounts;
+        let remaining_accounts: &[AccountInfo] = ctx.remaining_accounts;
         let cpi_program = ctx.accounts.lockup_program.clone();
         let cpi_accounts = {
-            let accs = CreateVesting::try_accounts(
-                ctx.accounts.lockup_program.key,
-                &mut remaining_accounts,
-                &[],
-            )?;
+            let accs = &mut remaining_accounts.iter();
             lockup::cpi::accounts::CreateVesting {
-                vesting: accs.vesting.to_account_info(),
-                vault: accs.vault.to_account_info(),
-                depositor: accs.depositor.to_account_info(),
-                depositor_authority: accs.depositor_authority.to_account_info(),
-                token_program: accs.token_program.to_account_info(),
-                clock: accs.clock.to_account_info(),
+                vesting: next_account_info(accs)?.to_account_info(),
+                vault: next_account_info(accs)?.to_account_info(),
+                depositor: next_account_info(accs)?.to_account_info(),
+                depositor_authority: next_account_info(accs)?.to_account_info(),
+                token_program: next_account_info(accs)?.to_account_info(),
+                clock: next_account_info(accs)?.to_account_info(),
             }
         };
         let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, signer);


### PR DESCRIPTION
Closes https://github.com/project-serum/anchor/issues/97.

This check is no longer necessary now that CPI clients only use AccountInfo.