### PR TITLE
Ts fixes

### DIFF
--- a/ts/src/program/event.ts
+++ b/ts/src/program/event.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
-import { IdlEvent, IdlEventField } from "src/idl";
+import { IdlEvent, IdlEventField } from "../idl";
 import Coder from "../coder";
 import { DecodeType } from "./namespace/types";
 import Provider from "../provider";

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
-import { Idl } from "src";
+import { Idl } from "../../";
 import {
   IdlField,
   IdlInstruction,

--- a/ts/types/buffer-layout/index.d.ts
+++ b/ts/types/buffer-layout/index.d.ts
@@ -7,7 +7,7 @@ declare module 'buffer-layout' {
 
     constructor(span: number, property?: string);
 
-    decode(b: Buffer, offset?: number): T;
+    decode(b: Buffer | string, offset?: number): T;
     encode(src: T, b: Buffer, offset?: number): number;
     getSpan(b: Buffer, offset?: number): number;
     replicate(name: string): this;


### PR DESCRIPTION
I got error during build 
```src/coder/instruction.ts:137:35 - error TS2345: Argument of type 'string | Buffer' is not assignable to parameter of type 'Buffer'.
  Type 'string' is not assignable to type 'Buffer'.

data: decoder.layout.decode(data),
```
so fixed type of `Layout`

Also changed paths using `src` to relative paths to avoid problems for other packages using Anchor package
```
../node_modules/@project-serum/anchor/dist/cjs/program/namespace/types.d.ts:3:21 - error TS2307: Cannot find module 'src' or its corresponding type declarations.
 import { Idl } from "src";
```