### PR TITLE
cli: Generate ts idl in addition to type

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -41,7 +41,12 @@ pub fn idl_ts(idl: &Idl) -> Result<String> {
         .collect();
     let idl_json = serde_json::to_string_pretty(&idl)?;
     Ok(format!(
-        "export type {} = {}",
+        r#"export type {} = {};
+
+export const IDL: {} = {};
+"#,
+        idl.name.to_camel_case(),
+        idl_json,
         idl.name.to_camel_case(),
         idl_json
     ))


### PR DESCRIPTION
Generates the IDL value in addition to the type for type script clients. This allows one to create a ts program via 

```
import { ProgramName, IDL } from './target/types/program-name';
new Program<ProgramName>(IDL, programId, provider)
```