### PR TITLE
Add EscrowAccount type extraction and make package.json sufficient

### DIFF
--- a/tests/escrow/Anchor.toml
+++ b/tests/escrow/Anchor.toml
@@ -6,4 +6,4 @@ wallet = "~/.config/solana/id.json"
 escrow = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
-test = "ts-mocha -t 1000000 tests/*.ts"
+test = "yarn run ts-mocha -t 1000000 tests/*.ts"

--- a/tests/escrow/package.json
+++ b/tests/escrow/package.json
@@ -4,10 +4,14 @@
     "@project-serum/serum": "latest",
     "@solana/spl-token": "latest",
     "@solana/web3.js": "latest",
+    "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "@types/node": "^14.14.37",
     "bn.js": "^5.2.0",
     "camelcase": "^6.2.0",
-    "chai": "^4.3.4"
+    "chai": "^4.3.4",
+    "mocha": "^9.1.2",
+    "ts-mocha": "^8.0.0",
+    "typescript": "^4.4.3"
   }
 }

--- a/tests/escrow/tests/escrow.ts
+++ b/tests/escrow/tests/escrow.ts
@@ -1,14 +1,15 @@
 import * as anchor from "../../../ts";
-import  { Program, BN } from "../../../ts";
+import  { Program, BN, IdlAccounts } from "../../../ts";
 import {
-	SYSVAR_RENT_PUBKEY,
 	PublicKey,
 	Keypair,
 	SystemProgram,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID, Token } from "@solana/spl-token";
 import { assert } from "chai";
-import { Escrow } from '../target/types/escrow';
+import { Escrow } from "../target/types/escrow";
+
+type EscrowAccount = IdlAccounts<Escrow>["escrowAccount"];
 
 describe("escrow", () => {
   const provider = anchor.Provider.env();
@@ -101,7 +102,6 @@ describe("escrow", () => {
           escrowAccount: escrowAccount.publicKey,
           systemProgram: SystemProgram.programId,
           tokenProgram: TOKEN_PROGRAM_ID,
-          rent: SYSVAR_RENT_PUBKEY,
         },
         signers: [escrowAccount],
       }
@@ -119,7 +119,7 @@ describe("escrow", () => {
       initializerTokenAccountA
     );
 
-    let _escrowAccount = await program.account.escrowAccount.fetch(
+    let _escrowAccount: EscrowAccount = await program.account.escrowAccount.fetch(
       escrowAccount.publicKey
     );
 
@@ -197,7 +197,6 @@ describe("escrow", () => {
           escrowAccount: newEscrow.publicKey,
           systemProgram: SystemProgram.programId,
           tokenProgram: TOKEN_PROGRAM_ID,
-          rent: SYSVAR_RENT_PUBKEY,
         },
         signers: [newEscrow],
       }


### PR DESCRIPTION
The example is not terribly useful, but it shows how to manipulate `EscrowAccount` on its own, for instance if typing on another interface is required.

It shows that it typechecks with the returned type of fetch.

Also add whatever is required to make this test actually able to run from its package.json alone, no global install other that yarn