### PR TITLE
Do like saberhq anchor-contrib then it works for vec and array

### DIFF
--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -93,8 +93,10 @@ export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
   ? Defined[T["defined"]]
   : T extends { option: { defined: keyof Defined } }
   ? Defined[T["option"]["defined"]] | null
-  : T extends { vec: { defined: keyof Defined } }
-  ? Defined[T["vec"]["defined"]][]
+  : T extends { vec: keyof TypeMap }
+  ? TypeMap[T["vec"]][]
+  : T extends { array: [ defined: keyof TypeMap, size: number ] }
+  ? TypeMap[T["array"][0]][]
   : unknown;
 
 /**

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -95,7 +95,7 @@ export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
   ? Defined[T["option"]["defined"]] | null
   : T extends { vec: keyof TypeMap }
   ? TypeMap[T["vec"]][]
-  : T extends { array: [ defined: keyof TypeMap, size: number ] }
+  : T extends { array: [defined: keyof TypeMap, size: number] }
   ? TypeMap[T["array"][0]][]
   : unknown;
 


### PR DESCRIPTION
I don't know what i am doing but it works, inspired from @saberhq/anchor-contrib

https://github.com/Arrowana/saber-common/blob/b8f3825f8338807841cb6c3ab7a87efa5b4a9036/packages/anchor-contrib/src/index.ts#L115-L129

To test it, i hacked in `EscrowAccount` some more fields, until i got delicious typing going. Yes!
```#[account]
pub struct EscrowAccount {
    pub initializer_key: Pubkey,
    pub initializer_deposit_token_account: Pubkey,
    pub initializer_receive_token_account: Pubkey,
    pub initializer_amount: u64,
    pub taker_amount: u64,
    pub bla: [u8; 32],
    pub v: Vec<Pubkey>,
}
```

![image](https://user-images.githubusercontent.com/8245419/136681097-0e65c136-c629-4c49-b8e1-56b7a08f7d39.png)

Before they would show `unknown[]` and `unknown`, not what one would expect, 
