### PR TITLE
Instructions less pain please

### DIFF
--- a/ts/src/program/namespace/transaction.ts
+++ b/ts/src/program/namespace/transaction.ts
@@ -16,9 +16,7 @@ export default class TransactionFactory {
     const txFn: TransactionFn<IDL, I> = (...args): Transaction => {
       const [, ctx] = splitArgsAndCtx(idlIx, [...args]);
       const tx = new Transaction();
-      if (ctx.instructions !== undefined) {
-        tx.add(...ctx.instructions);
-      }
+      ctx.instructions?.forEach((ix) => tx.add(ix));
       tx.add(ixFn(...args));
       return tx;
     };


### PR DESCRIPTION
An empty instructions array will throw in web3.js add

I feel this check is pointless
https://github.com/solana-labs/solana/blob/49d3d794590303f135561bee68aff8ff77927e70/web3.js/src/transaction.ts#L181-L200 

But at least we remain consistent, we do the same for signers, we support an empty array.