### PR TITLE
Make sure program_paths only includes directories.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -124,6 +124,7 @@ impl WithPath<Config> {
             if members.is_empty() {
                 let path = self.path().parent().unwrap().join("programs");
                 fs::read_dir(path)?
+                    .filter(|entry| entry.as_ref().map(|e| e.path().is_dir()).unwrap_or(false))
                     .map(|dir| dir.map(|d| d.path().canonicalize().unwrap()))
                     .collect::<Vec<Result<PathBuf, std::io::Error>>>()
                     .into_iter()


### PR DESCRIPTION
This fixes the issue some mac people run into where having `.DS_Store`s in their programs/ directory will crash anchor build/test. (You can reproduce the issue on a non-mac by just doing something like `touch programs/hmm`.)