### PR TITLE
tests: fix #699 ido-pool seeds constraint was violated

### DIFF
--- a/tests/ido-pool/programs/ido-pool/src/lib.rs
+++ b/tests/ido-pool/programs/ido-pool/src/lib.rs
@@ -475,7 +475,7 @@ pub struct ExchangeRedeemableForWatermelon<'info> {
     pub redeemable_mint: Box<Account<'info, Mint>>,
     #[account(mut,
         seeds = [ido_account.ido_name.as_ref().trim_ascii_whitespace(), b"pool_watermelon"],
-        bump = ido_account.bumps.pool_usdc)]
+        bump = ido_account.bumps.pool_watermelon)]
     pub pool_watermelon: Box<Account<'info, TokenAccount>>,
     // Programs and Sysvars
     pub token_program: Program<'info, Token>,


### PR DESCRIPTION
about issue https://github.com/project-serum/anchor/issues/897

after checking and verification, the `478 lines` in the contract

`bump = ido_account.bumps.pool_usdc`
Should be
`bump = ido_account.bumps.pool_watermelon`

Sometimes it can be verified that the bump number is exactly the same