### PR TITLE
cli: add NODE_OPTIONS env variable with DNS fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 cache: cargo
 env:
   global:
-    - NODE_VERSION="14.7.0"
+    - NODE_VERSION="17.0.1"
     - SOLANA_CLI_VERSION="1.7.11"
 git:
   submodules: true

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1477,6 +1477,16 @@ fn test(
 
         let url = cluster_url(cfg);
 
+        let node_options = format!(
+            "{} --dns-result-order=ipv4first",
+            match std::env::var_os("NODE_OPTIONS") {
+                Some(value) => value
+                    .into_string()
+                    .map_err(std::env::VarError::NotUnicode)?,
+                None => "".to_owned(),
+            }
+        );
+
         // Setup log reader.
         let log_streams = stream_logs(cfg, &url);
 
@@ -1497,6 +1507,7 @@ fn test(
                 .args(args)
                 .env("ANCHOR_PROVIDER_URL", url)
                 .env("ANCHOR_WALLET", cfg.provider.wallet.to_string())
+                .env("NODE_OPTIONS", node_options)
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .output()


### PR DESCRIPTION
From node v17 release log:

Other Notable Changes

    [1b2749ecbe] - (SEMVER-MAJOR) dns: default to verbatim=true in dns.lookup() (treysis) #39987

See details: https://github.com/nodejs/node/pull/39987

Alternative solution: submit PR to solana for binding on ipv6 by default.