### PR TITLE
Allow extraction of instructions from RequestBuilder

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -409,27 +409,25 @@ impl<'a> RequestBuilder<'a> {
 
     pub fn instructions(&self) -> Result<Vec<Instruction>, ClientError> {
         let mut accounts = match self.namespace {
-            RequestNamespace::State { new } => {
-                match new {
-                    false => vec![AccountMeta::new(
+            RequestNamespace::State { new } => match new {
+                false => vec![AccountMeta::new(
+                    anchor_lang::__private::state::address(&self.program_id),
+                    false,
+                )],
+                true => vec![
+                    AccountMeta::new_readonly(self.payer.pubkey(), true),
+                    AccountMeta::new(
                         anchor_lang::__private::state::address(&self.program_id),
                         false,
-                    )],
-                    true => vec![
-                        AccountMeta::new_readonly(self.payer.pubkey(), true),
-                        AccountMeta::new(
-                            anchor_lang::__private::state::address(&self.program_id),
-                            false,
-                        ),
-                        AccountMeta::new_readonly(
-                            Pubkey::find_program_address(&[], &self.program_id).0,
-                            false,
-                        ),
-                        AccountMeta::new_readonly(system_program::ID, false),
-                        AccountMeta::new_readonly(self.program_id, false),
-                    ],
-                }
-            }
+                    ),
+                    AccountMeta::new_readonly(
+                        Pubkey::find_program_address(&[], &self.program_id).0,
+                        false,
+                    ),
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new_readonly(self.program_id, false),
+                ],
+            },
             _ => Vec::new(),
         };
         accounts.extend_from_slice(&self.accounts);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -407,10 +407,10 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    pub fn send(self) -> Result<Signature, ClientError> {
-        let accounts = match self.namespace {
+    pub fn instructions(&self) -> Result<Vec<Instruction>, ClientError> {
+        let mut accounts = match self.namespace {
             RequestNamespace::State { new } => {
-                let mut accounts = match new {
+                match new {
                     false => vec![AccountMeta::new(
                         anchor_lang::__private::state::address(&self.program_id),
                         false,
@@ -428,20 +428,26 @@ impl<'a> RequestBuilder<'a> {
                         AccountMeta::new_readonly(system_program::ID, false),
                         AccountMeta::new_readonly(self.program_id, false),
                     ],
-                };
-                accounts.extend_from_slice(&self.accounts);
-                accounts
+                }
             }
-            _ => self.accounts,
+            _ => Vec::new(),
         };
-        let mut instructions = self.instructions;
-        if let Some(ix_data) = self.instruction_data {
+        accounts.extend_from_slice(&self.accounts);
+
+        let mut instructions = self.instructions.clone();
+        if let Some(ix_data) = &self.instruction_data {
             instructions.push(Instruction {
                 program_id: self.program_id,
-                data: ix_data,
+                data: ix_data.clone(),
                 accounts,
             });
         }
+
+        Ok(instructions)
+    }
+
+    pub fn send(self) -> Result<Signature, ClientError> {
+        let instructions = self.instructions()?;
 
         let mut signers = self.signers;
         signers.push(&self.payer);


### PR DESCRIPTION
Currently, RequestBuilder will only let you send instructions over its internally managed rpc client. This precludes several important use cases, such as:
- Custom rpc client
- Combining multiple anchor instructions into a single transaction
- Sending anchor instructions as data to another program such as multisig

This change lets clients call the new method `RequestBuilder::instructions`, returning `Vec<Instruction>` to use as they please.