### PR TITLE
cli: Improve npm-cli error if global anchor not found

### DIFF
--- a/cli/npm-package/anchor.js
+++ b/cli/npm-package/anchor.js
@@ -72,6 +72,11 @@ function trySystemAnchor() {
       return true;
     });
 
+  if (!absolutePath) {
+    console.error(`Could not find globally installed anchor, install with cargo.`);
+    process.exit();
+  }
+
   const absoluteBinaryPath = `${absolutePath}/anchor`;
 
   const [error, binaryVersion] = getBinaryVersion(absoluteBinaryPath);


### PR DESCRIPTION
Seen a few of these errors in Discord/issues:

```
$ npx anchor --version
Package binary version is not correct. Expected "anchor-cli 0.18.1", found "anchor-cli 0.18.0".
Trying globally installed anchor.
Failed to get version of global binary: Error: spawnSync undefined/anchor ENOENT
```

This just cleans that error up a bit and provides some guidance.