### PR TITLE
lang: Add `deprecated` attribute to `ProgramAccount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Fixes
+
+lang: Add `deprecated` attribute to `ProgramAccount` ([#1014](https://github.com/project-serum/anchor/pull/1014)).
+
 ## [0.18.2] - 2021-11-14
 
 * cli: Replace global JavaScript dependency installs with local.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2346,7 +2346,7 @@ fn publish(
                 // Only add the file if it's not empty.
                 let metadata = fs::File::open(&e)?.metadata()?;
                 if metadata.len() > 0 {
-                    println!("PACKING: {}", e.display().to_string());
+                    println!("PACKING: {}", e.display());
                     if e.is_dir() {
                         tar.append_dir_all(&e, &e)?;
                     } else {
@@ -2453,7 +2453,7 @@ fn keys_list(cfg_override: &ConfigOverride) -> Result<()> {
     let cfg = Config::discover(cfg_override)?.expect("Not in workspace.");
     for program in cfg.read_all_programs()? {
         let pubkey = program.pubkey()?;
-        println!("{}: {}", program.lib_name, pubkey.to_string());
+        println!("{}: {}", program.lib_name, pubkey);
     }
     Ok(())
 }

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -340,7 +340,7 @@ anchor.workspace.{} = new anchor.Program({}, new PublicKey("{}"), provider);
 "#,
             program.name.to_camel_case(),
             serde_json::to_string(&program.idl)?,
-            program.program_id.to_string()
+            program.program_id
         ));
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -166,10 +166,7 @@ impl Program {
                                         if self_program_str == execution.program() {
                                             handle_program_log(&self_program_str, l).unwrap_or_else(
                                                 |e| {
-                                                    println!(
-                                                        "Unable to parse log: {}",
-                                                        e.to_string()
-                                                    );
+                                                    println!("Unable to parse log: {}", e);
                                                     std::process::exit(1);
                                                 },
                                             )

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -89,9 +89,9 @@ pub fn account(
         let discriminator_preimage = {
             // For now, zero copy accounts can't be namespaced.
             if namespace.is_empty() {
-                format!("account:{}", account_name.to_string())
+                format!("account:{}", account_name)
             } else {
-                format!("{}:{}", namespace, account_name.to_string())
+                format!("{}:{}", namespace, account_name)
             }
         };
 
@@ -247,9 +247,9 @@ pub fn derive_zero_copy_accessor(item: proc_macro::TokenStream) -> proc_macro::T
                     let field_name = field.ident.as_ref().unwrap();
 
                     let get_field: proc_macro2::TokenStream =
-                        format!("get_{}", field_name.to_string()).parse().unwrap();
+                        format!("get_{}", field_name).parse().unwrap();
                     let set_field: proc_macro2::TokenStream =
-                        format!("set_{}", field_name.to_string()).parse().unwrap();
+                        format!("set_{}", field_name).parse().unwrap();
 
                     quote! {
                         pub fn #get_field(&self) -> #accessor_ty {

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -17,7 +17,7 @@ pub fn event(
     let event_name = &event_strct.ident;
 
     let discriminator: proc_macro2::TokenStream = {
-        let discriminator_preimage = format!("event:{}", event_name.to_string());
+        let discriminator_preimage = format!("event:{}", event_name);
         let mut discriminator = [0u8; 8];
         discriminator.copy_from_slice(
             &anchor_syn::hash::hash(discriminator_preimage.as_bytes()).to_bytes()[..8],

--- a/lang/src/cpi_account.rs
+++ b/lang/src/cpi_account.rs
@@ -9,7 +9,7 @@ use std::ops::{Deref, DerefMut};
 
 /// Container for any account *not* owned by the current program.
 #[derive(Clone)]
-#[deprecated(note = "Please use Account instead")]
+#[deprecated(since = "0.15.0", note = "Please use Account instead")]
 pub struct CpiAccount<'a, T: AccountDeserialize + Clone> {
     info: AccountInfo<'a>,
     account: Box<T>,

--- a/lang/src/idl.rs
+++ b/lang/src/idl.rs
@@ -48,6 +48,7 @@ pub type IdlCreateAccounts<'info> = crate::ctor::Ctor<'info>;
 #[derive(Accounts)]
 pub struct IdlAccounts<'info> {
     #[account(mut, has_one = authority)]
+    #[allow(deprecated)]
     pub idl: ProgramAccount<'info, IdlAccount>,
     #[account(signer, constraint = authority.key != &Pubkey::new_from_array([0u8; 32]))]
     pub authority: AccountInfo<'info>,
@@ -57,6 +58,7 @@ pub struct IdlAccounts<'info> {
 #[derive(Accounts)]
 pub struct IdlCreateBuffer<'info> {
     #[account(zero)]
+    #[allow(deprecated)]
     pub buffer: ProgramAccount<'info, IdlAccount>,
     #[account(signer, constraint = authority.key != &Pubkey::new_from_array([0u8; 32]))]
     pub authority: AccountInfo<'info>,
@@ -67,9 +69,11 @@ pub struct IdlCreateBuffer<'info> {
 pub struct IdlSetBuffer<'info> {
     // The buffer with the new idl data.
     #[account(mut, constraint = buffer.authority == idl.authority)]
+    #[allow(deprecated)]
     pub buffer: ProgramAccount<'info, IdlAccount>,
     // The idl account to be updated with the buffer's data.
     #[account(mut, has_one = authority)]
+    #[allow(deprecated)]
     pub idl: ProgramAccount<'info, IdlAccount>,
     #[account(signer, constraint = authority.key != &Pubkey::new_from_array([0u8; 32]))]
     pub authority: AccountInfo<'info>,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -252,12 +252,12 @@ pub mod prelude {
         access_control, account, declare_id, emit, error, event, interface, program, require,
         state, zero_copy, Account, AccountDeserialize, AccountLoader, AccountSerialize, Accounts,
         AccountsExit, AnchorDeserialize, AnchorSerialize, Context, CpiContext, Id, Key, Loader,
-        Owner, Program, ProgramAccount, Signer, System, SystemAccount, Sysvar, ToAccountInfo,
-        ToAccountInfos, ToAccountMetas, UncheckedAccount,
+        Owner, Program, Signer, System, SystemAccount, Sysvar, ToAccountInfo, ToAccountInfos,
+        ToAccountMetas, UncheckedAccount,
     };
 
     #[allow(deprecated)]
-    pub use super::{CpiAccount, CpiState, CpiStateContext, ProgramState};
+    pub use super::{CpiAccount, CpiState, CpiStateContext, ProgramAccount, ProgramState};
 
     pub use borsh;
     pub use solana_program::account_info::{next_account_info, AccountInfo};

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -15,6 +15,7 @@ use std::ops::{Deref, DerefMut};
 /// Boxed container for a deserialized `account`. Use this to reference any
 /// account owned by the currently executing program.
 #[derive(Clone)]
+#[deprecated(since = "0.15.0", note = "Please use Account instead")]
 pub struct ProgramAccount<'info, T: AccountSerialize + AccountDeserialize + Clone> {
     inner: Box<Inner<'info, T>>,
 }
@@ -25,6 +26,7 @@ struct Inner<'info, T: AccountSerialize + AccountDeserialize + Clone> {
     account: T,
 }
 
+#[allow(deprecated)]
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T> {
     fn new(info: AccountInfo<'a>, account: T) -> ProgramAccount<'a, T> {
         Self {
@@ -71,6 +73,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T>
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T> Accounts<'info> for ProgramAccount<'info, T>
 where
     T: AccountSerialize + AccountDeserialize + Clone,
@@ -90,6 +93,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info>
     for ProgramAccount<'info, T>
 {
@@ -103,6 +107,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsClose<'info>
     for ProgramAccount<'info, T>
 {
@@ -111,6 +116,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsClose<'inf
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMetas
     for ProgramAccount<'info, T>
 {
@@ -124,6 +130,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMetas
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfos<'info>
     for ProgramAccount<'info, T>
 {
@@ -132,6 +139,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfos<'in
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfo<'info>
     for ProgramAccount<'info, T>
 {
@@ -140,6 +148,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfo<'inf
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
     for ProgramAccount<'info, T>
 {
@@ -148,6 +157,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAccount<'a, T> {
     type Target = T;
 
@@ -156,6 +166,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAcco
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for ProgramAccount<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         #[cfg(feature = "anchor-debug")]
@@ -178,6 +189,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for ProgramAccount<'info, T> {
     fn key(&self) -> Pubkey {
         *self.inner.info.key


### PR DESCRIPTION
`ProgramAccount` is deprecated from 0.15.0: https://github.com/project-serum/anchor/blob/master/CHANGELOG.md#0150---2021-09-07

This PR adds `deprecated` attribute to `ProgramAccount`.