### PR TITLE
fix: check if name in keyword

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -392,6 +392,27 @@ fn init(cfg_override: &ConfigOverride, name: String, javascript: bool) -> Result
         return Err(anyhow!("Workspace already initialized"));
     }
 
+    // The list is taken from https://doc.rust-lang.org/reference/keywords.html
+    let key_words = [
+        "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
+        "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",
+        "return", "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
+        "use", "where", "while", "async", "await", "dyn", "abstract", "become", "box", "do",
+        "final", "macro", "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
+        "unique",
+    ];
+
+    if key_words.contains(&name[..].into()) {
+        return Err(anyhow!(
+            "{} is a reserved word in rust, name your project something else!",
+            name
+        ));
+    } else if name.chars().next().unwrap().is_numeric() {
+        return Err(anyhow!(
+            "Cannot start project name with numbers, name your project something else!"
+        ));
+    }
+
     fs::create_dir(name.clone())?;
     std::env::set_current_dir(&name)?;
     fs::create_dir("app")?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -392,7 +392,7 @@ fn init(cfg_override: &ConfigOverride, name: String, javascript: bool) -> Result
         return Err(anyhow!("Workspace already initialized"));
     }
 
-    // The list is taken from https://doc.rust-lang.org/reference/keywords.html
+    // The list is taken from https://doc.rust-lang.org/reference/keywords.html.
     let key_words = [
         "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
         "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",


### PR DESCRIPTION
Fixes #1018 

The list is taken from https://doc.rust-lang.org/reference/keywords.html

Have included all three types - strict, reserved, weak

@fanatid looks good?