### PR TITLE
Remove console logs from Node package

### DIFF
--- a/ts/src/program/context.ts
+++ b/ts/src/program/context.ts
@@ -50,13 +50,6 @@ export type Context<A extends Accounts = Accounts> = {
    * Commitment parameters to use for a transaction.
    */
   options?: ConfirmOptions;
-
-  /**
-   * @hidden
-   *
-   * Private namespace for development.
-   */
-  __private?: { logAccounts: boolean };
 };
 
 /**

--- a/ts/src/program/namespace/instruction.ts
+++ b/ts/src/program/namespace/instruction.ts
@@ -49,9 +49,6 @@ export default class InstructionNamespaceFactory {
         keys.push(...ctx.remainingAccounts);
       }
 
-      if (ctx.__private && ctx.__private.logAccounts) {
-        console.log("Outgoing account metas:", keys);
-      }
       return new TransactionInstruction({
         keys,
         programId,

--- a/ts/src/program/namespace/instruction.ts
+++ b/ts/src/program/namespace/instruction.ts
@@ -18,6 +18,7 @@ import {
   Address,
 } from "../common";
 import { Accounts, splitArgsAndCtx } from "../context";
+import * as features from "../../utils/features";
 import {
   AllInstructions,
   AllInstructionsMap,
@@ -47,6 +48,10 @@ export default class InstructionNamespaceFactory {
 
       if (ctx.remainingAccounts !== undefined) {
         keys.push(...ctx.remainingAccounts);
+      }
+
+      if (features.isSet("debug-logs")) {
+        console.log("Outgoing account metas:", keys);
       }
 
       return new TransactionInstruction({

--- a/ts/src/program/namespace/rpc.ts
+++ b/ts/src/program/namespace/rpc.ts
@@ -24,7 +24,6 @@ export default class RpcFactory {
         const txSig = await provider.send(tx, ctx.signers, ctx.options);
         return txSig;
       } catch (err) {
-        console.log("Translating error", err);
         let translatedErr = ProgramError.parse(err, idlErrors);
         if (translatedErr === null) {
           throw err;

--- a/ts/src/program/namespace/rpc.ts
+++ b/ts/src/program/namespace/rpc.ts
@@ -4,6 +4,7 @@ import { Idl } from "../../idl";
 import { splitArgsAndCtx } from "../context";
 import { TransactionFn } from "./transaction";
 import { ProgramError } from "../../error";
+import * as features from "../../utils/features";
 import {
   AllInstructions,
   InstructionContextFn,
@@ -24,6 +25,10 @@ export default class RpcFactory {
         const txSig = await provider.send(tx, ctx.signers, ctx.options);
         return txSig;
       } catch (err) {
+        if (features.isSet("debug-logs")) {
+          console.log("Translating error:", err);
+        }
+
         let translatedErr = ProgramError.parse(err, idlErrors);
         if (translatedErr === null) {
           throw err;

--- a/ts/src/program/namespace/simulate.ts
+++ b/ts/src/program/namespace/simulate.ts
@@ -36,7 +36,6 @@ export default class SimulateFactory {
       try {
         resp = await provider!.simulate(tx, ctx.signers, ctx.options);
       } catch (err) {
-        console.log("Translating error", err);
         let translatedErr = ProgramError.parse(err, idlErrors);
         if (translatedErr === null) {
           throw err;

--- a/ts/src/program/namespace/simulate.ts
+++ b/ts/src/program/namespace/simulate.ts
@@ -10,6 +10,7 @@ import { EventParser, Event } from "../event";
 import Coder from "../../coder";
 import { Idl, IdlEvent } from "../../idl";
 import { ProgramError } from "../../error";
+import * as features from "../../utils/features";
 import {
   AllInstructions,
   IdlTypes,
@@ -36,6 +37,10 @@ export default class SimulateFactory {
       try {
         resp = await provider!.simulate(tx, ctx.signers, ctx.options);
       } catch (err) {
+        if (features.isSet("debug-logs")) {
+          console.log("Translating error:", err);
+        }
+
         let translatedErr = ProgramError.parse(err, idlErrors);
         if (translatedErr === null) {
           throw err;

--- a/ts/src/workspace.ts
+++ b/ts/src/workspace.ts
@@ -17,8 +17,7 @@ let _populatedWorkspace = false;
 const workspace = new Proxy({} as any, {
   get(workspaceCache: { [key: string]: Program }, programName: string) {
     if (isBrowser) {
-      console.log("Workspaces aren't available in the browser");
-      return undefined;
+      throw new Error("Workspaces aren't available in the browser");
     }
 
     const fs = require("fs");


### PR DESCRIPTION
This change fixes #1016 by remove the 4 console log statements from the node package. The only material change here is that workspaces now raise an error (instead of silently failing) if executed in the browser environment, which seems like a saner approach anyway.