### PR TITLE
Addition: 'types' setting Anchor.toml to specify the output directory…

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -264,6 +264,8 @@ pub struct WorkspaceConfig {
     pub members: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub types: String,
 }
 
 impl Config {

--- a/docs/src/getting-started/publishing.md
+++ b/docs/src/getting-started/publishing.md
@@ -33,6 +33,7 @@ An example `Anchor.toml` config looks as follows,
 anchor_version = "0.18.2"
 
 [workspace]
+types = "react-app/src/idl/"
 members = ["programs/multisig"]
 
 [provider]

--- a/docs/src/getting-started/publishing.md
+++ b/docs/src/getting-started/publishing.md
@@ -33,7 +33,6 @@ An example `Anchor.toml` config looks as follows,
 anchor_version = "0.18.2"
 
 [workspace]
-types = "react-app/src/idl/"
 members = ["programs/multisig"]
 
 [provider]


### PR DESCRIPTION
#855 add `types` setting Anchor.toml to specify the output directory of idl typescript in `target/types/`
