### PR TITLE
lang: add fmt::Debug to structs

### DIFF
--- a/lang/src/account.rs
+++ b/lang/src/account.rs
@@ -5,6 +5,7 @@ use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 /// Account container that checks ownership on deserialization.
@@ -12,6 +13,17 @@ use std::ops::{Deref, DerefMut};
 pub struct Account<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> {
     account: T,
     info: AccountInfo<'info>,
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone + fmt::Debug> fmt::Debug
+    for Account<'info, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Account")
+            .field("account", &self.account)
+            .field("info", &self.info)
+            .finish()
+    }
 }
 
 impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T> {

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -2,6 +2,7 @@ use crate::{Accounts, ToAccountInfos, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
+use std::fmt;
 
 /// Provides non-argument inputs to the program.
 pub struct Context<'a, 'b, 'c, 'info, T> {
@@ -12,6 +13,16 @@ pub struct Context<'a, 'b, 'c, 'info, T> {
     /// Remaining accounts given but not deserialized or validated.
     /// Be very careful when using this directly.
     pub remaining_accounts: &'c [AccountInfo<'info>],
+}
+
+impl<'a, 'b, 'c, 'info, T: fmt::Debug> fmt::Debug for Context<'a, 'b, 'c, 'info, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("program_id", &self.program_id)
+            .field("accounts", &self.accounts)
+            .field("remaining_accounts", &self.remaining_accounts)
+            .finish()
+    }
 }
 
 impl<'a, 'b, 'c, 'info, T: Accounts<'info>> Context<'a, 'b, 'c, 'info, T> {

--- a/lang/src/loader.rs
+++ b/lang/src/loader.rs
@@ -9,6 +9,7 @@ use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
+use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::ops::DerefMut;
@@ -27,6 +28,15 @@ use std::ops::DerefMut;
 pub struct Loader<'info, T: ZeroCopy> {
     acc_info: AccountInfo<'info>,
     phantom: PhantomData<&'info T>,
+}
+
+impl<'info, T: ZeroCopy + fmt::Debug> fmt::Debug for Loader<'info, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Loader")
+            .field("acc_info", &self.acc_info)
+            .field("phantom", &self.phantom)
+            .finish()
+    }
 }
 
 impl<'info, T: ZeroCopy> Loader<'info, T> {

--- a/lang/src/loader_account.rs
+++ b/lang/src/loader_account.rs
@@ -9,6 +9,7 @@ use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
+use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::ops::DerefMut;
@@ -28,6 +29,15 @@ use std::ops::DerefMut;
 pub struct AccountLoader<'info, T: ZeroCopy + Owner> {
     acc_info: AccountInfo<'info>,
     phantom: PhantomData<&'info T>,
+}
+
+impl<'info, T: ZeroCopy + Owner + fmt::Debug> fmt::Debug for AccountLoader<'info, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AccountLoader")
+            .field("acc_info", &self.acc_info)
+            .field("phantom", &self.phantom)
+            .finish()
+    }
 }
 
 impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {

--- a/lang/src/program.rs
+++ b/lang/src/program.rs
@@ -4,6 +4,7 @@ use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+use std::fmt;
 use std::ops::Deref;
 
 /// Account container that checks ownership on deserialization.
@@ -11,6 +12,15 @@ use std::ops::Deref;
 pub struct Program<'info, T: Id + AccountDeserialize + Clone> {
     _account: T,
     info: AccountInfo<'info>,
+}
+
+impl<'info, T: Id + AccountDeserialize + Clone + fmt::Debug> fmt::Debug for Program<'info, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Program")
+            .field("account", &self._account)
+            .field("info", &self.info)
+            .finish()
+    }
 }
 
 impl<'a, T: Id + AccountDeserialize + Clone> Program<'a, T> {

--- a/lang/src/signer.rs
+++ b/lang/src/signer.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 /// Type validating that the account signed the transaction. No other ownership
 /// or type checks are done. If this is used, one should not try to access the
 /// underlying account data.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Signer<'info> {
     info: AccountInfo<'info>,
 }

--- a/lang/src/system_account.rs
+++ b/lang/src/system_account.rs
@@ -8,7 +8,7 @@ use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
 use std::ops::Deref;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SystemAccount<'info> {
     info: AccountInfo<'info>,
 }

--- a/lang/src/system_program.rs
+++ b/lang/src/system_program.rs
@@ -4,7 +4,7 @@ use solana_program::pubkey::Pubkey;
 
 pub use solana_program::system_program::ID;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct System;
 
 impl anchor_lang::AccountDeserialize for System {

--- a/lang/src/sysvar.rs
+++ b/lang/src/sysvar.rs
@@ -5,12 +5,22 @@ use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 /// Container for sysvars.
 pub struct Sysvar<'info, T: solana_program::sysvar::Sysvar> {
     info: AccountInfo<'info>,
     account: T,
+}
+
+impl<'info, T: solana_program::sysvar::Sysvar + fmt::Debug> fmt::Debug for Sysvar<'info, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sysvar")
+            .field("info", &self.info)
+            .field("account", &self.account)
+            .finish()
+    }
 }
 
 impl<'info, T: solana_program::sysvar::Sysvar> Sysvar<'info, T> {

--- a/lang/src/unchecked_account.rs
+++ b/lang/src/unchecked_account.rs
@@ -8,7 +8,7 @@ use solana_program::pubkey::Pubkey;
 use std::ops::Deref;
 
 /// Explicit wrapper for AccountInfo types.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UncheckedAccount<'info>(AccountInfo<'info>);
 
 impl<'info> UncheckedAccount<'info> {


### PR DESCRIPTION
Today I found that I can not log `Account` because `Debug` is not implemented :(

~To where except `Account` do I need to add `Debug`?~