### PR TITLE
cli: Add version name from programs Cargo.toml to IDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ incremented for features.
 ### Fixes
 
 * lang: Add `deprecated` attribute to `ProgramAccount` ([#1014](https://github.com/project-serum/anchor/pull/1014)).
+* cli: Add version number from programs `Cargo.toml` into extracted IDL
 
 ### Features
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -145,8 +145,13 @@ impl WithPath<Config> {
     pub fn read_all_programs(&self) -> Result<Vec<Program>> {
         let mut r = vec![];
         for path in self.get_program_list()? {
-            let idl = anchor_syn::idl::file::parse(path.join("src/lib.rs"))?;
-            let lib_name = Manifest::from_path(&path.join("Cargo.toml"))?.lib_name()?;
+            let cargo = Manifest::from_path(&path.join("Cargo.toml"))?;
+            let lib_name = cargo.lib_name()?;
+            let version = match &cargo.package {
+                Some(package) => &package.version,
+                None => "0.0.0",
+            };
+            let idl = anchor_syn::idl::file::parse(path.join("src/lib.rs"), version.to_string())?;
             r.push(Program {
                 lib_name,
                 path,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1125,7 +1125,12 @@ fn fetch_idl(cfg_override: &ConfigOverride, idl_addr: Pubkey) -> Result<Idl> {
 
 fn extract_idl(file: &str) -> Result<Option<Idl>> {
     let file = shellexpand::tilde(file);
-    anchor_syn::idl::file::parse(&*file)
+    let cargo = Manifest::discover()?.ok_or_else(|| anyhow!("Cargo.toml not found"))?;
+    let version = match &cargo.package {
+        Some(package) => &package.version,
+        None => "0.0.0",
+    };
+    anchor_syn::idl::file::parse(&*file, version.to_string())
 }
 
 fn idl(cfg_override: &ConfigOverride, subcmd: IdlCommand) -> Result<()> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1125,12 +1125,11 @@ fn fetch_idl(cfg_override: &ConfigOverride, idl_addr: Pubkey) -> Result<Idl> {
 
 fn extract_idl(file: &str) -> Result<Option<Idl>> {
     let file = shellexpand::tilde(file);
-    let cargo = Manifest::discover()?.ok_or_else(|| anyhow!("Cargo.toml not found"))?;
-    let version = match &cargo.package {
-        Some(package) => &package.version,
-        None => "0.0.0",
-    };
-    anchor_syn::idl::file::parse(&*file, version.to_string())
+    let manifest_from_path =
+        std::env::current_dir()?.join(PathBuf::from(&*file).parent().unwrap().to_path_buf());
+    let cargo = Manifest::discover_from_path(manifest_from_path)?
+        .ok_or_else(|| anyhow!("Cargo.toml not found"))?;
+    anchor_syn::idl::file::parse(&*file, cargo.version())
 }
 
 fn idl(cfg_override: &ConfigOverride, subcmd: IdlCommand) -> Result<()> {

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -14,7 +14,7 @@ const DERIVE_NAME: &str = "Accounts";
 const ERROR_CODE_OFFSET: u32 = 300;
 
 // Parse an entire interface file.
-pub fn parse(filename: impl AsRef<Path>) -> Result<Option<Idl>> {
+pub fn parse(filename: impl AsRef<Path>, version: String) -> Result<Option<Idl>> {
     let ctx = CrateContext::parse(filename)?;
 
     let program_mod = match parse_program_mod(&ctx) {
@@ -224,7 +224,7 @@ pub fn parse(filename: impl AsRef<Path>) -> Result<Option<Idl>> {
     }
 
     Ok(Some(Idl {
-        version: "0.0.0".to_string(),
+        version,
         name: p.name.to_string(),
         state,
         instructions,


### PR DESCRIPTION
This required some changes to the manifest discovery code because `anchor idl parse` doesn't necessarily execute from within the program directory like the `anchor build` does.

It might be cleaner to do this all in `lang/syn/src/idl/file.rs` but it probably requires duplicating that manifest discovery code rather than just passing the version as an arg.

Closes #349 

Example:

```
anchor idl parse --file programs/basic-0/src/lib.rs
{
  "version": "0.1.0",
  "name": "basic_0",
  "instructions": [
    {
      "name": "initialize",
      "accounts": [],
      "args": []
    }
  ]
}
```