### PR TITLE
cli: Add ability to verify non-upgradeable programs

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1147,7 +1147,7 @@ pub fn verify_bin(program_id: Pubkey, bin_path: &Path, cluster: &str) -> Result<
         if account.owner == bpf_loader::id() || account.owner == bpf_loader_deprecated::id() {
             let bin = account.data.to_vec();
             let state = BinVerificationState::ProgramData {
-                slot: 0, // need to look through the transaction history
+                slot: 0, // Need to look through the transaction history.
                 upgrade_authority_address: None,
             };
             (bin, state)


### PR DESCRIPTION
#### Problem

Some programs don't use the upgradeable loader, but it would be neat to verify them too!  The main case for this is the SPL token program.

#### Solution

When fetching the account binary data, just return the data if it's owned by the bpf loader or deprecated bpf loader.

This adds a check to make sure that the upgradeable program is owned by the upgradeable loader, which may be overkill.  Happy to change it back!