### PR TITLE
ts: add getAccountInfo helper method to account namespace/client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ incremented for features.
 
 * lang: Add `ErrorCode::AccountNotInitialized` error to separate the situation when the account has the wrong owner from when it does not exist (#[1024](https://github.com/project-serum/anchor/pull/1024))
 * lang: Called instructions now log their name by default. This can be turned off with the `no-log-ix-name` flag ([#1057](https://github.com/project-serum/anchor/pull/1057))
+* ts: Add `getAccountInfo` helper method to account namespace/client ([#1084](https://github.com/project-serum/anchor/pull/1084))
 * lang: `ProgramData` and `UpgradableLoaderState` can now be passed into `Account` as generics. see [UpgradeableLoaderState](https://docs.rs/solana-program/latest/solana_program/bpf_loader_upgradeable/enum.UpgradeableLoaderState.html). `UpgradableLoaderState` can also be matched on to get `ProgramData`, but when `ProgramData` is used instead, anchor does the serialization and checking that it is actually program data for you  ([#1095](https://github.com/project-serum/anchor/pull/1095))
 * ts: Add better error msgs in the ts client if something wrong (i.e. not a pubkey or a string) is passed in as an account in an instruction accounts object ([#1098](https://github.com/project-serum/anchor/pull/1098))
+
 
 ## [0.18.2] - 2021-11-14
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -9,6 +9,7 @@ import {
   TransactionInstruction,
   Commitment,
   GetProgramAccountsFilter,
+  AccountInfo,
 } from "@solana/web3.js";
 import Provider from "../../provider.js";
 import { Idl, IdlTypeDef } from "../../idl.js";
@@ -344,7 +345,10 @@ export class AccountClient<
     return await pubkeyUtil.associated(this._programId, ...args);
   }
 
-  async getAccountInfo(address: Address, commitment?: Commitment) {
+  getAccountInfo(
+    address: Address,
+    commitment?: Commitment
+  ): Promise<AccountInfo<Buffer> | null> {
     return this._provider.connection.getAccountInfo(
       translateAddress(address),
       commitment

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -137,9 +137,7 @@ export class AccountClient<
    * @param address The address of the account to fetch.
    */
   async fetchNullable(address: Address): Promise<T | null> {
-    const accountInfo = await this._provider.connection.getAccountInfo(
-      translateAddress(address)
-    );
+    const accountInfo = await this.getAccountInfo(translateAddress(address));
     if (accountInfo === null) {
       return null;
     }
@@ -344,6 +342,13 @@ export class AccountClient<
     ...args: Array<PublicKey | Buffer>
   ): Promise<PublicKey> {
     return await pubkeyUtil.associated(this._programId, ...args);
+  }
+
+  async getAccountInfo(address: Address, commitment?: Commitment) {
+    return this._provider.connection.getAccountInfo(
+      translateAddress(address),
+      commitment
+    );
   }
 }
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -345,11 +345,11 @@ export class AccountClient<
     return await pubkeyUtil.associated(this._programId, ...args);
   }
 
-  getAccountInfo(
+  async getAccountInfo(
     address: Address,
     commitment?: Commitment
   ): Promise<AccountInfo<Buffer> | null> {
-    return this._provider.connection.getAccountInfo(
+    return await this._provider.connection.getAccountInfo(
       translateAddress(address),
       commitment
     );

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -138,7 +138,7 @@ export class AccountClient<
    * @param address The address of the account to fetch.
    */
   async fetchNullable(address: Address): Promise<T | null> {
-    const accountInfo = await this.getAccountInfo(translateAddress(address));
+    const accountInfo = await this.getAccountInfo(address);
     if (accountInfo === null) {
       return null;
     }


### PR DESCRIPTION
Closes #640 

This exposes `connection.getAccountInfo` to the namespace client's public API.

I've written an integration test separately but wasn't sure how to symlink a locally built anchor cli to run the tests. It seems all the integration tests run against the published/installed version of anchor. Should I just do that separately when this change is merged and published?