### PR TITLE
ts: better public key error msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ incremented for features.
 
 * lang: Add `ErrorCode::AccountNotInitialized` error to separate the situation when the account has the wrong owner from when it does not exist (#[1024](https://github.com/project-serum/anchor/pull/1024))
 * lang: Called instructions now log their name by default. This can be turned off with the `no-log-ix-name` flag ([#1057](https://github.com/project-serum/anchor/pull/1057))
+* ts: Add better error msgs in the ts client if something wrong (i.e. not a pubkey or a string) is passed in as an account in an instruction accounts object ([#1098](https://github.com/project-serum/anchor/pull/1098))
 
 ## [0.18.2] - 2021-11-14
 

--- a/ts/src/program/common.ts
+++ b/ts/src/program/common.ts
@@ -1,6 +1,5 @@
 import EventEmitter from "eventemitter3";
 import { PublicKey } from "@solana/web3.js";
-import { web3 } from "../index";
 import { Idl, IdlInstruction, IdlAccountItem, IdlStateMethod } from "../idl.js";
 import { Accounts } from "./context.js";
 

--- a/ts/src/program/common.ts
+++ b/ts/src/program/common.ts
@@ -55,12 +55,8 @@ export function validateAccounts(
 
 // Translates an address to a Pubkey.
 export function translateAddress(address: Address): PublicKey {
-  if (typeof address === "string") {
-    const pk = new PublicKey(address);
-    return pk;
-  } else {
-    return address;
-  }
+  // this will error if address is not a string or public key
+  return new PublicKey(address.toString());
 }
 
 /**

--- a/ts/src/program/common.ts
+++ b/ts/src/program/common.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "eventemitter3";
 import { PublicKey } from "@solana/web3.js";
+import { web3 } from "../index";
 import { Idl, IdlInstruction, IdlAccountItem, IdlStateMethod } from "../idl.js";
 import { Accounts } from "./context.js";
 
@@ -55,8 +56,14 @@ export function validateAccounts(
 
 // Translates an address to a Pubkey.
 export function translateAddress(address: Address): PublicKey {
-  // this will error if address is not a string or public key
-  return new PublicKey(address.toString());
+  if (typeof address === "string") {
+    const pk = new PublicKey(address);
+    return pk;
+  } else if (address.constructor.prototype.constructor.name === "PublicKey") {
+    return address;
+  } else {
+    throw new Error("Given address is not a PublicKey nor a string.");
+  }
 }
 
 /**

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -116,7 +116,11 @@ export class StateClient<IDL extends Idl> {
           ixItem["accounts"] = (accounts) => {
             const keys = stateInstructionKeys(programId, provider, m, accounts);
             return keys.concat(
-              InstructionNamespaceFactory.accountsArray(accounts, m.accounts)
+              InstructionNamespaceFactory.accountsArray(
+                accounts,
+                m.accounts,
+                m.name
+              )
             );
           };
           // Build transaction method.


### PR DESCRIPTION
when you add a non publickey/string to the accounts object for an instruction you currently get this error.
```
Error: Non-base58 character
```

This PR changes the code so you get a more helpful error
```
Error: Wrong input type for account "authority" in the instruction accounts object for instruction "initialize". Expected PublicKey or string.
```