### PR TITLE
Fix governance try_deserialize_unchecked to not check discriminator

### DIFF
--- a/spl/src/governance.rs
+++ b/spl/src/governance.rs
@@ -25,9 +25,6 @@ macro_rules! vote_weight_record {
                 let vwr: spl_governance::addins::voter_weight::VoterWeightRecord =
                     anchor_lang::AnchorDeserialize::deserialize(&mut data)
                         .map_err(|_| anchor_lang::__private::ErrorCode::AccountDidNotDeserialize)?;
-                if vwr.account_type != spl_governance::addins::voter_weight::VoterWeightAccountType::Uninitialized {
-                    return Err(anchor_lang::__private::ErrorCode::AccountDidNotSerialize.into());
-                }
                 Ok(VoterWeightRecord(vwr))
             }
         }


### PR DESCRIPTION
Otherwise the type will not work with init_if_needed: There
Account::try_from_unchecked is called on the data which may or may not
be freshly initialized and it's expected to pass for accounts with and
without set discriminators.