### PR TITLE
Create a minified browser build compatible with next.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ ts/docs/
 cli/npm-package/anchor
 cli/npm-package/*.tgz
 docker-target
+.rollup.cache/

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,1 +1,0 @@
-.rollup.cache/

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,0 +1,1 @@
+.rollup.cache/

--- a/ts/package.json
+++ b/ts/package.json
@@ -4,6 +4,7 @@
   "description": "Anchor client",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
+  "browser": "./dist/browser/index.js",
   "license": "(MIT OR Apache-2.0)",
   "types": "dist/cjs/index.d.ts",
   "homepage": "https://github.com/project-serum/anchor#readme",
@@ -21,8 +22,9 @@
     "node": ">=11"
   },
   "scripts": {
-    "build": "rm -rf dist/ && yarn build:node",
+    "build": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:node": "tsc && tsc -p tsconfig.cjs.json",
+    "build:browser": "rollup --config",
     "lint:fix": "prettier src/** tests/** -w",
     "lint": "prettier src/** tests/** --check",
     "watch": "tsc -p tsconfig.cjs.json --watch",
@@ -49,6 +51,10 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-replace": "^3.0.0",
+    "@rollup/plugin-typescript": "^8.3.0",
     "@types/bn.js": "^4.11.6",
     "@types/bs58": "^4.0.1",
     "@types/crypto-hash": "^1.1.2",
@@ -63,9 +69,13 @@
     "jest-config": "27.3.1",
     "lint-staged": "^10.5.0",
     "prettier": "^2.1.2",
+    "rimraf": "^3.0.2",
+    "rollup": "^2.60.2",
+    "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.7",
     "ts-jest-resolver": "^2.0.0",
     "ts-node": "^9.0.0",
+    "tslib": "^2.3.1",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.2"
   }

--- a/ts/package.json
+++ b/ts/package.json
@@ -36,7 +36,7 @@
     "base64-js": "^1.5.1",
     "bn.js": "^5.1.2",
     "bs58": "^4.0.1",
-    "buffer-layout": "^1.2.0",
+    "buffer-layout": "^1.2.2",
     "camelcase": "^5.3.1",
     "crypto-hash": "^1.3.0",
     "eventemitter3": "^4.0.7",

--- a/ts/rollup.config.ts
+++ b/ts/rollup.config.ts
@@ -48,7 +48,7 @@ export default {
   ],
   output: {
     file: "dist/browser/index.js",
-    format: "cjs",
+    format: "es",
     sourcemap: true,
   },
 };

--- a/ts/rollup.config.ts
+++ b/ts/rollup.config.ts
@@ -1,0 +1,54 @@
+import nodeResolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import replace from "@rollup/plugin-replace";
+import commonjs from "@rollup/plugin-commonjs";
+import { terser } from "rollup-plugin-terser";
+
+const env = process.env.NODE_ENV;
+
+export default {
+  input: "src/index.ts",
+  plugins: [
+    commonjs(),
+    nodeResolve({
+      browser: true,
+      extensions: [".js", ".ts"],
+      dedupe: ["bn.js", "buffer"],
+      preferBuiltins: false,
+    }),
+    typescript({
+      tsconfig: "./tsconfig.base.json",
+      moduleResolution: "node",
+      outDir: "types",
+      target: "es2019",
+      outputToFilesystem: false,
+    }),
+    replace({
+      preventAssignment: true,
+      values: {
+        "process.env.NODE_ENV": JSON.stringify(env),
+        "process.env.BROWSER": JSON.stringify(true),
+      },
+    }),
+    terser(),
+  ],
+  external: [
+    "@project-serum/borsh",
+    "@solana/web3.js",
+    "assert",
+    "base64-js",
+    "bn.js",
+    "bs58",
+    "buffer",
+    "camelcase",
+    "eventemitter3",
+    "js-sha256",
+    "pako",
+    "toml",
+  ],
+  output: {
+    file: "dist/browser/index.js",
+    format: "cjs",
+    sourcemap: true,
+  },
+};

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -19,6 +19,6 @@ export * as utils from "./utils/index.js";
 export * from "./program/index.js";
 
 if (!isBrowser) {
-  exports.workspace = require("./workspace.js");
-  exports.Wallet = require("./nodewallet.js");
+  exports.workspace = require("./workspace.js").default;
+  exports.Wallet = require("./nodewallet.js").default;
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -19,6 +19,6 @@ export * as utils from "./utils/index.js";
 export * from "./program/index.js";
 
 if (!isBrowser) {
-  exports.workspace = require("./workspace");
-  exports.Wallet = require("./nodewallet");
+  exports.workspace = require("./workspace.js");
+  exports.Wallet = require("./nodewallet.js");
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,11 +1,8 @@
+import { isBrowser } from "./utils/common.js";
+
 export { default as BN } from "bn.js";
 export * as web3 from "@solana/web3.js";
-export {
-  default as Provider,
-  getProvider,
-  setProvider,
-  NodeWallet as Wallet,
-} from "./provider.js";
+export { default as Provider, getProvider, setProvider } from "./provider.js";
 export {
   default as Coder,
   InstructionCoder,
@@ -17,6 +14,11 @@ export {
 export * from "./error.js";
 export { Instruction } from "./coder/instruction.js";
 export { Idl } from "./idl.js";
-export { default as workspace } from "./workspace.js";
+
 export * as utils from "./utils/index.js";
 export * from "./program/index.js";
+
+if (!isBrowser) {
+  exports.workspace = require("./workspace");
+  exports.Wallet = require("./nodewallet");
+}

--- a/ts/src/nodewallet.ts
+++ b/ts/src/nodewallet.ts
@@ -4,7 +4,7 @@ import { Wallet } from "./provider";
 /**
  * Node only wallet.
  */
-export class NodeWallet implements Wallet {
+export default class NodeWallet implements Wallet {
   constructor(readonly payer: Keypair) {}
 
   static local(): NodeWallet {

--- a/ts/src/nodewallet.ts
+++ b/ts/src/nodewallet.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "buffer";
 import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
 import { Wallet } from "./provider";
+
 /**
  * Node only wallet.
  */

--- a/ts/src/nodewallet.ts
+++ b/ts/src/nodewallet.ts
@@ -1,0 +1,39 @@
+import { Buffer } from "buffer";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { Wallet } from "./provider";
+/**
+ * Node only wallet.
+ */
+export class NodeWallet implements Wallet {
+  constructor(readonly payer: Keypair) {}
+
+  static local(): NodeWallet {
+    const process = require("process");
+    const payer = Keypair.fromSecretKey(
+      Buffer.from(
+        JSON.parse(
+          require("fs").readFileSync(process.env.ANCHOR_WALLET, {
+            encoding: "utf-8",
+          })
+        )
+      )
+    );
+    return new NodeWallet(payer);
+  }
+
+  async signTransaction(tx: Transaction): Promise<Transaction> {
+    tx.partialSign(this.payer);
+    return tx;
+  }
+
+  async signAllTransactions(txs: Transaction[]): Promise<Transaction[]> {
+    return txs.map((t) => {
+      t.partialSign(this.payer);
+      return t;
+    });
+  }
+
+  get publicKey(): PublicKey {
+    return this.payer.publicKey;
+  }
+}

--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -1,6 +1,6 @@
 import { inflate } from "pako";
 import { PublicKey } from "@solana/web3.js";
-import Provider from "../provider.js";
+import Provider, { getProvider } from "../provider.js";
 import { Idl, idlAddress, decodeIdlAccount } from "../idl.js";
 import Coder from "../coder/index.js";
 import NamespaceFactory, {
@@ -11,7 +11,6 @@ import NamespaceFactory, {
   StateClient,
   SimulateNamespace,
 } from "./namespace/index.js";
-import { getProvider } from "../index.js";
 import { utf8 } from "../utils/bytes/index.js";
 import { EventManager } from "./event.js";
 import { Address, translateAddress } from "./common.js";

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -10,7 +10,7 @@ import {
   Commitment,
   GetProgramAccountsFilter,
 } from "@solana/web3.js";
-import Provider from "../../provider.js";
+import Provider, { getProvider } from "../../provider.js";
 import { Idl, IdlTypeDef } from "../../idl.js";
 import Coder, {
   ACCOUNT_DISCRIMINATOR_SIZE,
@@ -18,7 +18,6 @@ import Coder, {
   AccountsCoder,
 } from "../../coder/index.js";
 import { Subscription, Address, translateAddress } from "../common.js";
-import { getProvider } from "../../index.js";
 import { AllAccountsMap, IdlTypes, TypeDef } from "./types.js";
 import * as pubkeyUtil from "../../utils/pubkey.js";
 import * as rpcUtil from "../../utils/rpc.js";

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -6,7 +6,7 @@ import {
   Commitment,
   AccountMeta,
 } from "@solana/web3.js";
-import Provider from "../../provider.js";
+import Provider, { getProvider } from "../../provider.js";
 import { Idl, IdlInstruction, IdlStateMethod, IdlTypeDef } from "../../idl.js";
 import Coder, { stateDiscriminator } from "../../coder/index.js";
 import {
@@ -14,7 +14,6 @@ import {
   InstructionNamespace,
   TransactionNamespace,
 } from "./index.js";
-import { getProvider } from "../../index.js";
 import { Subscription, validateAccounts, parseIdlErrors } from "../common.js";
 import {
   findProgramAddressSync,

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -44,6 +44,9 @@ export default class Provider {
    * (This api is for Node only.)
    */
   static local(url?: string, opts?: ConfirmOptions): Provider {
+    if (isBrowser) {
+      throw new Error(`Provider local is not available on browser.`);
+    }
     opts = opts ?? Provider.defaultOptions();
     const connection = new Connection(
       url ?? "http://localhost:8899",

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -52,7 +52,7 @@ export default class Provider {
       url ?? "http://localhost:8899",
       opts.preflightCommitment
     );
-    const NodeWallet = require("./nodewallet");
+    const NodeWallet = require("./nodewallet.js");
     const wallet = NodeWallet.local();
     return new Provider(connection, wallet, opts);
   }
@@ -75,7 +75,7 @@ export default class Provider {
     }
     const options = Provider.defaultOptions();
     const connection = new Connection(url, options.commitment);
-    const NodeWallet = require("./nodewallet");
+    const NodeWallet = require("./nodewallet.js");
     const wallet = NodeWallet.local();
 
     return new Provider(connection, wallet, options);

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -52,7 +52,7 @@ export default class Provider {
       url ?? "http://localhost:8899",
       opts.preflightCommitment
     );
-    const NodeWallet = require("./nodewallet.js");
+    const NodeWallet = require("./nodewallet.js").default;
     const wallet = NodeWallet.local();
     return new Provider(connection, wallet, opts);
   }
@@ -75,7 +75,7 @@ export default class Provider {
     }
     const options = Provider.defaultOptions();
     const connection = new Connection(url, options.commitment);
-    const NodeWallet = require("./nodewallet.js");
+    const NodeWallet = require("./nodewallet.js").default;
     const wallet = NodeWallet.local();
 
     return new Provider(connection, wallet, options);

--- a/ts/src/utils/bytes/utf8.ts
+++ b/ts/src/utils/bytes/utf8.ts
@@ -1,15 +1,16 @@
+import { isBrowser } from "../common";
+
 export function decode(array: Uint8Array): string {
-  const decoder =
-    typeof TextDecoder === "undefined"
-      ? new (require("util").TextDecoder)("utf-8") // Node.
-      : new TextDecoder("utf-8"); // Browser.
+  const decoder = isBrowser
+    ? new TextDecoder("utf-8") // Browser https://caniuse.com/textencoder
+    : new (require("util").TextDecoder)("utf-8"); // Node.
+
   return decoder.decode(array);
 }
 
 export function encode(input: string): Uint8Array {
-  const encoder =
-    typeof TextEncoder === "undefined"
-      ? new (require("util").TextEncoder)("utf-8") // Node.
-      : new TextEncoder(); // Browser.
+  const encoder = isBrowser
+    ? new TextEncoder() // Browser.
+    : new (require("util").TextEncoder)("utf-8"); // Node.
   return encoder.encode(input);
 }

--- a/ts/src/utils/bytes/utf8.ts
+++ b/ts/src/utils/bytes/utf8.ts
@@ -2,7 +2,7 @@ import { isBrowser } from "../common";
 
 export function decode(array: Uint8Array): string {
   const decoder = isBrowser
-    ? new TextDecoder("utf-8") // Browser https://caniuse.com/textencoder
+    ? new TextDecoder("utf-8") // Browser https://caniuse.com/textencoder.
     : new (require("util").TextDecoder)("utf-8"); // Node.
 
   return decoder.decode(array);

--- a/ts/src/utils/common.ts
+++ b/ts/src/utils/common.ts
@@ -3,7 +3,8 @@
  * false if in a Node process or electron app.
  */
 export const isBrowser =
-  typeof window !== "undefined" && !window.process?.hasOwnProperty("type");
+  process.env.BROWSER ||
+  (typeof window !== "undefined" && !window.process?.hasOwnProperty("type"));
 
 /**
  * Splits an array into chunks

--- a/ts/tsconfig.base.json
+++ b/ts/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "baseUrl": ".",
+    "typeRoots": [
+      "types/",
+      "node_modules/@types"
+    ],
+    "paths": {
+      "@solana/web3.js": [
+        "./node_modules/@solana/web3.js/lib"
+      ]
+    }
+  }
+}

--- a/ts/tsconfig.cjs.json
+++ b/ts/tsconfig.cjs.json
@@ -1,10 +1,8 @@
-
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2019",
-
     "outDir": "dist/cjs/",
     "rootDir": "./src"
   }

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,29 +1,10 @@
 {
-  "include": ["./src/**/*"],
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "es2022",
     "target": "es2019",
-
     "outDir": "dist/esm/",
     "rootDir": "./src",
-
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "noImplicitAny": false,
-    "strictNullChecks": true,
-
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "composite": true,
-    "baseUrl": ".",
-    "typeRoots": ["types/", "node_modules/@types"],
-    "paths": {
-      "@solana/web3.js": ["./node_modules/@solana/web3.js/lib"]
-    }
   }
 }

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -863,6 +863,56 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@rollup/plugin-commonjs@^21.0.1":
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz#1e57c81ae1518e4df0954d681c642e7d94588fee"
+  integrity sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz#29629070bb767567be8157f575cfa8f2b8e9ef77"
+  integrity sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/plugin-replace@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.0.tgz#3a4c9665d4e7a4ce2c360cf021232784892f3fac"
+  integrity sha512-3c7JCbMuYXM4PbPWT4+m/4Y6U60SgsnDT/cCyAyUKwFHg7pTSfsSQzIpETha3a3ig6OdOKzZz87D9ZXIK3qsDg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
+"@rollup/plugin-typescript@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz#bc1077fa5897b980fc27e376c4e377882c63e68b"
+  integrity sha512-I5FpSvLbtAdwJ+naznv+B4sjXZUcIvLLceYpITAn7wAP8W0wqc5noLdGIp9HGVntNhRWXctwPYrSSFQxtl0FPA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz"
@@ -974,6 +1024,16 @@
   dependencies:
     crypto-hash "*"
 
+"@types/estree@*":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/express-serve-static-core@^4.17.9":
   version "4.17.19"
   resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz"
@@ -1071,6 +1131,13 @@
   version "1.2.3"
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -1508,6 +1575,11 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.2.0"
 
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
@@ -1663,7 +1735,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.3:
+commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1672,6 +1744,11 @@ commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -2122,6 +2199,16 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
@@ -2313,7 +2400,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -2405,7 +2492,7 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.2.0:
+glob@^7.1.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2676,6 +2763,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
@@ -2700,6 +2792,13 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -3183,6 +3282,15 @@ jest-watcher@^27.3.1:
     jest-util "^27.3.1"
     string-length "^4.0.1"
 
+jest-worker@^26.2.1:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jest-worker@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.1.tgz#0def7feae5b8042be38479799aeb7b5facac24b2"
@@ -3470,6 +3578,13 @@ lunr@^2.3.9:
   version "2.3.9"
   resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -3836,7 +3951,7 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-picomatch@^2.2.3:
+picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
@@ -3932,6 +4047,13 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
 
 react-is@^17.0.1:
   version "17.0.1"
@@ -4044,7 +4166,7 @@ resolve@^1.10.0, resolve@^1.17.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resolve@^1.20.0:
+resolve@^1.19.0, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -4071,6 +4193,23 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
+rollup@^2.60.2:
+  version "2.60.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.60.2.tgz#3f45ace36a9b10b4297181831ea0719922513463"
+  integrity sha512-1Bgjpq61sPjgoZzuiDSGvbI1tD91giZABgjCQBKM5aYLnzjq52GoDuWVwT/cm/MCxCMPU8gqQvkj8doQ5C8Oqw==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rpc-websockets@^7.4.2:
   version "7.4.11"
@@ -4099,7 +4238,7 @@ rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -4154,6 +4293,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4235,6 +4381,14 @@ source-map-support@^0.5.17, source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
@@ -4245,10 +4399,15 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -4433,6 +4592,15 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
+terser@^5.0.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc"
+  integrity sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.20"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
@@ -4584,6 +4752,11 @@ tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.17.1"

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1488,6 +1488,11 @@ buffer-layout@^1.2.0:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.0.tgz"
   integrity sha512-iiyRoho/ERzBUv6kFvfsrLNgTlVwOkqQcSQN7WrO3Y+c5SeuEhCn6+y1KwhM0V3ndptF5mI/RI44zkw0qcR5Jg==
 
+buffer-layout@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/buffer-layout/-/buffer-layout-1.2.2.tgz#b9814e7c7235783085f9ca4966a0cfff112259d5"
+  integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
+
 buffer@6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz"


### PR DESCRIPTION
## Browser Build
This PR creates a browser-specific build that includes none of the server-specific code. 

It uses Rollup to create a single output that's tree-shakeable and that will not include node-specific APIs like `NodeWallet` and `Provider.local()`. The build is declared on package.json's `browser` field.

The code is split by individually reviewable commits
 * 4e76e89ad3f39792c46cba98b79c1af5d054f5d1 Updates buffer-layout to pick up browser fixes
 * 4b6c59410752e18f31422930c5cb1666f6e2eb83 and e57244b1f0dbaa0a7d86cec2757b47756cb2f9b3 make sure server-only code is not added to the client bundle
 * 0a05cb304ab003e03f73a4455525246f6f55dd79 adds the rollup config per se

In addition a couple of goodies:
 * 09b6df7a00988e4c04cc3f0a25e7848011427465 removes circular dependencies, which can make Typescript slower
 * 101a71714b40b9a8925adfa275c9c27ef24ce2fd refactors typescript configs into a base so the config is easier to use in rollup

## How was this tested

I created a minimal next.js project which complained about `fs` and `path` being undefined on the client. After doing `yarn link '@project-serum/anchor'` and reloading, the project ran.

Fixes https://github.com/project-serum/anchor/issues/244
See also https://github.com/project-serum/anchor/issues/728 and https://github.com/project-serum/anchor/issues/983

Related to https://github.com/project-serum/anchor/pull/1073

Resulting bundle:
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/37972/144803598-21ed72f3-3ca0-46eb-aa38-b3d4bc37cd89.png">

