### PR TITLE
fix: translateAddress should not rely on PublicKey constructor nam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Fixes
+
+* ts: fix `translateAddress` which currently leads to failing browser code. Now uses `PublicKey` constructor instead of prototype chain constructor name checking which doesn't work in the presence of code minifying/mangling([1138](https://github.com/project-serum/anchor/pull/1138))
+
 ### Features
 
 * lang: Add `programdata_address: Option<Pubkey>` field to `Program` account. Will be populated if account is a program owned by the upgradable bpf loader ([#1125](https://github.com/project-serum/anchor/pull/1125))

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -50,17 +50,17 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/anchor@^0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.18.2.tgz#0f13b5c2046446b7c24cf28763eec90febb28485"
-  integrity sha512-uyjiN/3Ipp+4hrZRm/hG18HzGLZyvP790LXrCsGO3IWxSl28YRhiGEpKnZycfMW94R7nxdUoE3wY67V+ZHSQBQ==
+"@project-serum/anchor@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.19.0.tgz#79f1fbe7c3134860ccbfe458a0e09daf79644885"
+  integrity sha512-cs0LBmJOrL9eJ8MRNqitnzbpCT5QEzVdJmiIjfNV5YaGn1K9vISR7DtISj3Bdl3KBdLqii4CTw1mpHdi8iXUCg==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
     "@solana/web3.js" "^1.17.0"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
-    buffer-layout "^1.2.0"
+    buffer-layout "^1.2.2"
     camelcase "^5.3.1"
     crypto-hash "^1.3.0"
     eventemitter3 "^4.0.7"
@@ -334,7 +334,7 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer-layout@^1.2.0:
+buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/buffer-layout/-/buffer-layout-1.2.2.tgz#b9814e7c7235783085f9ca4966a0cfff112259d5"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==

--- a/ts/src/program/common.ts
+++ b/ts/src/program/common.ts
@@ -55,7 +55,7 @@ export function validateAccounts(
 
 // Translates an address to a Pubkey.
 export function translateAddress(address: Address): PublicKey {
-  return new PublicKey(address);
+  return address instanceof PublicKey ? address : new PublicKey(address);
 }
 
 /**

--- a/ts/src/program/common.ts
+++ b/ts/src/program/common.ts
@@ -55,14 +55,7 @@ export function validateAccounts(
 
 // Translates an address to a Pubkey.
 export function translateAddress(address: Address): PublicKey {
-  if (typeof address === "string") {
-    const pk = new PublicKey(address);
-    return pk;
-  } else if (address.constructor.prototype.constructor.name === "PublicKey") {
-    return address;
-  } else {
-    throw new Error("Given address is not a PublicKey nor a string.");
-  }
+  return new PublicKey(address);
 }
 
 /**

--- a/ts/tests/program-common.spec.ts
+++ b/ts/tests/program-common.spec.ts
@@ -1,0 +1,56 @@
+import BN from "bn.js";
+import bs58 from "bs58";
+import { PublicKey } from "@solana/web3.js";
+
+import { translateAddress } from "../src/program/common";
+
+describe("program/common", () => {
+  describe("translateAddress", () => {
+    it("should accept a valid string address", () => {
+      const address = "11111111111111111111111111111111";
+
+      const func = () => translateAddress(address);
+      expect(func).not.toThrow();
+
+      const output = func();
+      expect(output).toBeInstanceOf(PublicKey);
+      expect(new PublicKey(address).equals(output)).toBeTruthy();
+    });
+
+    it("should accept a PublicKey address", () => {
+      const publicKey = new PublicKey("11111111111111111111111111111111");
+
+      const func = () => translateAddress(publicKey);
+      expect(func).not.toThrow();
+
+      const output = func();
+      expect(output).toBeInstanceOf(PublicKey);
+      expect(new PublicKey(publicKey).equals(output)).toBe(true);
+    });
+
+    it("should accept an object with a PublicKey shape { _bn }", () => {
+      const obj = ({
+        _bn: new BN(bs58.decode("11111111111111111111111111111111")),
+      } as any) as PublicKey;
+      const func = () => translateAddress(obj);
+
+      expect(func).not.toThrow();
+      const output = func();
+
+      expect(output).toBeInstanceOf(PublicKey);
+      expect(new PublicKey(obj).equals(output)).toBe(true);
+    });
+
+    it("should not accept an invalid string address", () => {
+      const invalid = "invalid";
+      const func = () => translateAddress(invalid);
+      expect(func).toThrow();
+    });
+
+    it("should not accept an invalid object", () => {
+      const invalid = {} as PublicKey;
+      const func = () => translateAddress(invalid);
+      expect(func).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Since anchor is used in web projects which will minify/mangle function
names, checking an input object for a custom constructor name is unsafe.

Moreover, checking the type of the input Address is unnecessary since
`PublicKey`'s constructor handles:
- `string`
- `array`
- object with a `{ _bn }` shape (like `PublicKey` itself)

For additional safety, a unit test should be added to prevent `PublicKey`
to stop supporting this unexpectedly.

See [`PublicKey` implementation](https://github.com/solana-labs/solana-web3.js/blob/31c40523f1ee75340157b46e5a735394afa45d3e/src/publickey.ts#L26-L69):

```
/**
 * JSON object representation of PublicKey class
 */
export type PublicKeyData = {
  /** @internal */
  _bn: BN;
};

function isPublicKeyData(value: PublicKeyInitData): value is PublicKeyData {
  return (value as PublicKeyData)._bn !== undefined;
}

export class PublicKey extends Struct {
  /** @internal */
  _bn: BN;

  /**
   * Create a new PublicKey object
   * @param value ed25519 public key as buffer or base-58 encoded string
   */
  constructor(value: PublicKeyInitData) {
    super({});
    if (isPublicKeyData(value)) {
      this._bn = value._bn;
    } else {
      if (typeof value === 'string') {
        // assume base 58 encoding by default
        const decoded = bs58.decode(value);
        if (decoded.length != 32) {
          throw new Error(`Invalid public key input`);
        }
        this._bn = new BN(decoded);
      } else {
        this._bn = new BN(value);
      }

      if (this._bn.byteLength() > 32) {
        throw new Error(`Invalid public key input`);
      }
    }
  }
```