### PR TITLE
Allow zero_size accounts to be larger than account schema

### DIFF
--- a/lang/src/accounts/loader_account.rs
+++ b/lang/src/accounts/loader_account.rs
@@ -13,6 +13,7 @@ use std::cell::{Ref, RefMut};
 use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::DerefMut;
 
 /// Account AccountLoader facilitating on demand zero copy deserialization.
@@ -88,7 +89,9 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
             return Err(ErrorCode::AccountDiscriminatorMismatch.into());
         }
 
-        Ok(Ref::map(data, |data| bytemuck::from_bytes(&data[8..])))
+        Ok(Ref::map(data, |data| {
+            bytemuck::from_bytes(&data[8..mem::size_of::<T>() + 8])
+        }))
     }
 
     /// Returns a `RefMut` to the account data structure for reading or writing.
@@ -107,7 +110,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
         }
 
         Ok(RefMut::map(data, |data| {
-            bytemuck::from_bytes_mut(&mut data.deref_mut()[8..])
+            bytemuck::from_bytes_mut(&mut data.deref_mut()[8..mem::size_of::<T>() + 8])
         }))
     }
 
@@ -131,7 +134,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
         }
 
         Ok(RefMut::map(data, |data| {
-            bytemuck::from_bytes_mut(&mut data.deref_mut()[8..])
+            bytemuck::from_bytes_mut(&mut data.deref_mut()[8..mem::size_of::<T>() + 8])
         }))
     }
 }


### PR DESCRIPTION
Fixes #639

Besides the usecase in the linked issue, it's also good practice to slightly over-allocate accounts in case additional fields might be added in the future.