### PR TITLE
ts: add optional commitment arg to 'fetch' and 'fetchMultiple', adjust getMultipleAccountsCore so it mirrors solana/web3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ incremented for features.
 
 * lang: Add `programdata_address: Option<Pubkey>` field to `Program` account. Will be populated if account is a program owned by the upgradable bpf loader ([#1125](https://github.com/project-serum/anchor/pull/1125))
 * lang,ts,ci,cli,docs: update solana toolchain to version 1.8.5([#1133](https://github.com/project-serum/anchor/pull/1133))
+* ts: Add optional commitment argument to `fetch` and `fetchMultiple` ([#1171](https://github.com/project-serum/anchor/pull/1171))
 
 ### Breaking
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -136,8 +136,11 @@ export class AccountClient<
    *
    * @param address The address of the account to fetch.
    */
-  async fetchNullable(address: Address): Promise<T | null> {
-    const accountInfo = await this.getAccountInfo(address);
+  async fetchNullable(
+    address: Address,
+    commitment?: Commitment
+  ): Promise<T | null> {
+    const accountInfo = await this.getAccountInfo(address, commitment);
     if (accountInfo === null) {
       return null;
     }
@@ -161,8 +164,8 @@ export class AccountClient<
    *
    * @param address The address of the account to fetch.
    */
-  async fetch(address: Address): Promise<T> {
-    const data = await this.fetchNullable(address);
+  async fetch(address: Address, commitment?: Commitment): Promise<T> {
+    const data = await this.fetchNullable(address, commitment);
     if (data === null) {
       throw new Error(`Account does not exist ${address.toString()}`);
     }
@@ -175,10 +178,14 @@ export class AccountClient<
    *
    * @param addresses The addresses of the accounts to fetch.
    */
-  async fetchMultiple(addresses: Address[]): Promise<(Object | null)[]> {
+  async fetchMultiple(
+    addresses: Address[],
+    commitment?: Commitment
+  ): Promise<(Object | null)[]> {
     const accounts = await rpcUtil.getMultipleAccounts(
       this._provider.connection,
-      addresses.map((address) => translateAddress(address))
+      addresses.map((address) => translateAddress(address)),
+      commitment
     );
 
     const discriminator = AccountsCoder.accountDiscriminator(

--- a/ts/src/utils/rpc.ts
+++ b/ts/src/utils/rpc.ts
@@ -8,6 +8,7 @@ import {
   TransactionSignature,
   Transaction,
   TransactionInstruction,
+  Commitment,
 } from "@solana/web3.js";
 import { chunks } from "../utils/common.js";
 import { Address, translateAddress } from "../program/common.js";
@@ -44,29 +45,44 @@ const GET_MULTIPLE_ACCOUNTS_LIMIT: number = 99;
 
 export async function getMultipleAccounts(
   connection: Connection,
-  publicKeys: PublicKey[]
+  publicKeys: PublicKey[],
+  commitment?: Commitment
 ): Promise<
   Array<null | { publicKey: PublicKey; account: AccountInfo<Buffer> }>
 > {
   if (publicKeys.length <= GET_MULTIPLE_ACCOUNTS_LIMIT) {
-    return await getMultipleAccountsCore(connection, publicKeys);
+    return await getMultipleAccountsCore(connection, publicKeys, commitment);
   } else {
     const batches = chunks(publicKeys, GET_MULTIPLE_ACCOUNTS_LIMIT);
     const results = await Promise.all<
       Array<null | { publicKey: PublicKey; account: AccountInfo<Buffer> }>
-    >(batches.map((batch) => getMultipleAccountsCore(connection, batch)));
+    >(
+      batches.map((batch) =>
+        getMultipleAccountsCore(connection, batch, commitment)
+      )
+    );
     return results.flat();
   }
 }
 
 async function getMultipleAccountsCore(
   connection: Connection,
-  publicKeys: PublicKey[]
+  publicKeys: PublicKey[],
+  commitmentOverride?: Commitment
 ): Promise<
   Array<null | { publicKey: PublicKey; account: AccountInfo<Buffer> }>
 > {
-  const args = [publicKeys.map((k) => k.toBase58()), { commitment: "recent" }];
-  // @ts-ignore
+  const commitment = commitmentOverride ?? connection.commitment;
+  const args: (
+    | string[]
+    | {
+        commitment: Commitment;
+      }
+  )[] = [publicKeys.map((k) => k.toBase58())];
+  if (commitment) {
+    args.push({ commitment });
+  }
+  // @ts-expect-error
   const res = await connection._rpcRequest("getMultipleAccounts", args);
   if (res.error) {
     throw new Error(


### PR DESCRIPTION
changes: 
- add optional `commitment` arg to `fetch` and `fetchMultiple`
- adjust `getMultipleAccountsCore` so its commitment handling matches that of `@solana/web3.js`

closes #353