### PR TITLE
lang: implement AsRef<T> for Account<'a, T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ incremented for features.
 * lang: Add `programdata_address: Option<Pubkey>` field to `Program` account. Will be populated if account is a program owned by the upgradable bpf loader ([#1125](https://github.com/project-serum/anchor/pull/1125))
 * lang,ts,ci,cli,docs: update solana toolchain to version 1.8.5([#1133](https://github.com/project-serum/anchor/pull/1133))
 * ts: Add optional commitment argument to `fetch` and `fetchMultiple` ([#1171](https://github.com/project-serum/anchor/pull/1171))
+* lang: Implement `AsRef<T>` for `Account<'a, T>`([#1172](https://github.com/project-serum/anchor/pull/1172))
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ incremented for features.
 * lang: Add `programdata_address: Option<Pubkey>` field to `Program` account. Will be populated if account is a program owned by the upgradable bpf loader ([#1125](https://github.com/project-serum/anchor/pull/1125))
 * lang,ts,ci,cli,docs: update solana toolchain to version 1.8.5([#1133](https://github.com/project-serum/anchor/pull/1133))
 * ts: Add optional commitment argument to `fetch` and `fetchMultiple` ([#1171](https://github.com/project-serum/anchor/pull/1171))
-* lang: Implement `AsRef<T>` for `Account<'a, T>`([#1172](https://github.com/project-serum/anchor/pull/1172))
+* lang: Implement `AsRef<T>` for `Account<'a, T>`([#1173](https://github.com/project-serum/anchor/pull/1173))
 
 ### Breaking
 

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -156,6 +156,14 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> AsRef<Acco
     }
 }
 
+impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> AsRef<T>
+    for Account<'info, T>
+{
+    fn as_ref(&self) -> &T {
+        &self.account
+    }
+}
+
 impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Deref for Account<'a, T> {
     type Target = T;
 


### PR DESCRIPTION
Given that `Account<'a, T>` is a simple wrapper type, it makes sense to implement `AsRef<T>` for it