### PR TITLE
ts: ts-ignore crusade

### DIFF
--- a/ts/src/coder/event.ts
+++ b/ts/src/coder/event.ts
@@ -22,7 +22,7 @@ export class EventCoder {
       this.layouts = new Map();
       return;
     }
-    const layouts = idl.events.map((event) => {
+    const layouts: [string, Layout<any>][] = idl.events.map((event) => {
       let eventTypeDef: IdlTypeDef = {
         name: event.name,
         type: {
@@ -34,7 +34,6 @@ export class EventCoder {
       };
       return [event.name, IdlCoder.typeDefLayout(eventTypeDef, idl.types)];
     });
-    // @ts-ignore
     this.layouts = new Map(layouts);
 
     this.discriminators = new Map<string, string>(

--- a/ts/src/coder/idl.ts
+++ b/ts/src/coder/idl.ts
@@ -124,12 +124,14 @@ export class IdlCoder {
           return borsh.struct([], name);
         }
         const fieldLayouts = variant.fields.map((f: IdlField | IdlType) => {
-          // @ts-ignore
-          if (f.name === undefined) {
+          if (!f.hasOwnProperty("name")) {
             throw new Error("Tuple enum variants not yet implemented.");
           }
-          // @ts-ignore
-          return IdlCoder.fieldLayout(f, types);
+          // this typescript conversion is ok
+          // because if f were of type IdlType
+          // (that does not have a name property)
+          // the check before would've errored
+          return IdlCoder.fieldLayout(f as IdlField, types);
         });
         return borsh.struct(fieldLayouts, name);
       });

--- a/ts/src/coder/idl.ts
+++ b/ts/src/coder/idl.ts
@@ -60,7 +60,6 @@ export class IdlCoder {
             IdlCoder.fieldLayout(
               {
                 name: undefined,
-                // @ts-ignore
                 type: field.type.vec,
               },
               types
@@ -124,7 +123,6 @@ export class IdlCoder {
         if (variant.fields === undefined) {
           return borsh.struct([], name);
         }
-        // @ts-ignore
         const fieldLayouts = variant.fields.map((f: IdlField | IdlType) => {
           // @ts-ignore
           if (f.name === undefined) {

--- a/ts/src/coder/instruction.ts
+++ b/ts/src/coder/instruction.ts
@@ -12,6 +12,10 @@ import {
   IdlAccount,
   IdlAccountItem,
   IdlTypeDefTyStruct,
+  IdlTypeVec,
+  IdlTypeOption,
+  IdlTypeDefined,
+  IdlAccounts,
 } from "../idl";
 import { IdlCoder } from "./idl.js";
 import { sighash } from "./common.js";
@@ -92,7 +96,7 @@ export class InstructionCoder {
     const stateMethods = idl.state ? idl.state.methods : [];
 
     const ixLayouts = stateMethods
-      .map((m: IdlStateMethod) => {
+      .map((m: IdlStateMethod): [string, Layout<unknown>] => {
         let fieldLayouts = m.args.map((arg: IdlField) => {
           return IdlCoder.fieldLayout(
             arg,
@@ -114,7 +118,6 @@ export class InstructionCoder {
           return [name, borsh.struct(fieldLayouts, name)];
         })
       );
-    // @ts-ignore
     return new Map(ixLayouts);
   }
 
@@ -245,16 +248,13 @@ class InstructionFormatter {
     if (typeof idlField.type === "string") {
       return data.toString();
     }
-    // @ts-ignore
-    if (idlField.type.vec) {
+    if (idlField.type.hasOwnProperty("vec")) {
       return (
         "[" +
-        data
-          // @ts-ignore
+        (<Array<IdlField>>data)
           .map((d: IdlField) =>
             this.formatIdlData(
-              // @ts-ignore
-              { name: "", type: idlField.type.vec },
+              { name: "", type: (<IdlTypeVec>idlField.type).vec },
               d
             )
           )
@@ -262,26 +262,25 @@ class InstructionFormatter {
         "]"
       );
     }
-    // @ts-ignore
-    if (idlField.type.option) {
+    if (idlField.type.hasOwnProperty("option")) {
       return data === null
         ? "null"
         : this.formatIdlData(
-            // @ts-ignore
-            { name: "", type: idlField.type.option },
+            { name: "", type: (<IdlTypeOption>idlField.type).option },
             data
           );
     }
-    // @ts-ignore
-    if (idlField.type.defined) {
+    if (idlField.type.hasOwnProperty("defined")) {
       if (types === undefined) {
         throw new Error("User defined types not provided");
       }
-      // @ts-ignore
-      const filtered = types.filter((t) => t.name === idlField.type.defined);
+      const filtered = types.filter(
+        (t) => t.name === (<IdlTypeDefined>idlField.type).defined
+      );
       if (filtered.length !== 1) {
-        // @ts-ignore
-        throw new Error(`Type not found: ${idlField.type.defined}`);
+        throw new Error(
+          `Type not found: ${(<IdlTypeDefined>idlField.type).defined}`
+        );
       }
       return InstructionFormatter.formatIdlDataDefined(
         filtered[0],
@@ -356,21 +355,18 @@ class InstructionFormatter {
     accounts: IdlAccountItem[],
     prefix?: string
   ): IdlAccount[] {
-    // @ts-ignore
     return accounts
       .map((account) => {
         const accName = sentenceCase(account.name);
-        // @ts-ignore
-        if (account.accounts) {
+        if (account.hasOwnProperty("accounts")) {
           const newPrefix = prefix ? `${prefix} > ${accName}` : accName;
           return InstructionFormatter.flattenIdlAccounts(
-            // @ts-ignore
-            account.accounts,
+            (<IdlAccounts>account).accounts,
             newPrefix
           );
         } else {
           return {
-            ...account,
+            ...(<IdlAccount>account),
             name: prefix ? `${prefix} > ${accName}` : accName,
           };
         }

--- a/ts/src/coder/instruction.ts
+++ b/ts/src/coder/instruction.ts
@@ -247,7 +247,6 @@ class InstructionFormatter {
     }
     // @ts-ignore
     if (idlField.type.vec) {
-      // @ts-ignore
       return (
         "[" +
         data
@@ -265,7 +264,6 @@ class InstructionFormatter {
     }
     // @ts-ignore
     if (idlField.type.option) {
-      // @ts-ignore
       return data === null
         ? "null"
         : this.formatIdlData(
@@ -365,7 +363,6 @@ class InstructionFormatter {
         // @ts-ignore
         if (account.accounts) {
           const newPrefix = prefix ? `${prefix} > ${accName}` : accName;
-          // @ts-ignore
           return InstructionFormatter.flattenIdlAccounts(
             // @ts-ignore
             account.accounts,

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -245,7 +245,6 @@ async function simulateTransaction(
   const config: any = { encoding: "base64", commitment };
   const args = [encodedTransaction, config];
 
-  // @ts-ignore
   const res = await connection._rpcRequest("simulateTransaction", args);
   if (res.error) {
     throw new Error("failed to simulate transaction: " + res.error.message);

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -245,6 +245,7 @@ async function simulateTransaction(
   const config: any = { encoding: "base64", commitment };
   const args = [encodedTransaction, config];
 
+  // @ts-ignore
   const res = await connection._rpcRequest("simulateTransaction", args);
   if (res.error) {
     throw new Error("failed to simulate transaction: " + res.error.message);

--- a/ts/src/utils/pubkey.ts
+++ b/ts/src/utils/pubkey.ts
@@ -81,14 +81,11 @@ const toBuffer = (arr: Buffer | Uint8Array | Array<number>): Buffer => {
 
 export async function associated(
   programId: Address,
-  ...args: Array<PublicKey | Buffer>
+  ...args: Array<Address | Buffer>
 ): Promise<PublicKey> {
   let seeds = [Buffer.from([97, 110, 99, 104, 111, 114])]; // b"anchor".
   args.forEach((arg) => {
-    seeds.push(
-      // @ts-ignore
-      arg.buffer !== undefined ? arg : translateAddress(arg).toBuffer()
-    );
+    seeds.push(arg instanceof Buffer ? arg : translateAddress(arg).toBuffer());
   });
   const [assoc] = await PublicKey.findProgramAddress(
     seeds,

--- a/ts/src/utils/rpc.ts
+++ b/ts/src/utils/rpc.ts
@@ -82,7 +82,7 @@ async function getMultipleAccountsCore(
   if (commitment) {
     args.push({ commitment });
   }
-  // @ts-expect-error
+  // @ts-ignore
   const res = await connection._rpcRequest("getMultipleAccounts", args);
   if (res.error) {
     throw new Error(


### PR DESCRIPTION
will close #374 after the ts-ignores have been crusaded against and all remaining insurgents have been eliminated

The ts-ignores left alive are needed to access solana internal functions that are not declared in type files. Could create types for them but personally I like it this way to convey that these functions are inner functions not normally used