### PR TITLE
lang: add `set_inner` function to `Account<'a, T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ incremented for features.
 * lang: Add `programdata_address: Option<Pubkey>` field to `Program` account. Will be populated if account is a program owned by the upgradable bpf loader ([#1125](https://github.com/project-serum/anchor/pull/1125))
 * lang,ts,ci,cli,docs: update solana toolchain to version 1.8.5([#1133](https://github.com/project-serum/anchor/pull/1133))
 * ts: Add optional commitment argument to `fetch` and `fetchMultiple` ([#1171](https://github.com/project-serum/anchor/pull/1171))
+* lang: Add `set_inner` method to `Account<'a, T>` to enable easy updates ([#1177](https://github.com/project-serum/anchor/pull/1177))
 
 ### Breaking
 

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -73,6 +73,10 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
     pub fn into_inner(self) -> T {
         self.account
     }
+
+    pub fn set_inner(&mut self, inner: T) {
+        self.account = inner;
+    }
 }
 
 impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> Accounts<'info>


### PR DESCRIPTION
closes https://github.com/project-serum/anchor/issues/1115

```
pub fn new_user(ctx: Context<CreateUser>, new_user:User) -> ProgramResult {
    ctx.accounts.user_to_create.set_inner(new_user);
}
```

instead of 
```
pub fn new_user(ctx: Context<CreateUser>, new_user:User) -> ProgramResult {
    (*ctx.accounts.user_to_create).name = new_user.name;
    (*ctx.accounts.user_to_create).age = new_user.age;
    (*ctx.accounts.user_to_create).address = new_user.address;
}
```