### PR TITLE
tests: add tests for rent_exempt constraint

### DIFF
--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -278,7 +278,7 @@ pub struct TestInitIfNeededChecksOwner<'info> {
     pub data: UncheckedAccount<'info>,
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,
-    pub owner: AccountInfo<'info>
+    pub owner: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -302,7 +302,7 @@ pub struct TestInitMintIfNeeded<'info> {
     pub system_program: AccountInfo<'info>,
     pub token_program: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
-    pub freeze_authority: AccountInfo<'info>, 
+    pub freeze_authority: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -333,7 +333,7 @@ pub struct TestInitAssociatedTokenIfNeeded<'info> {
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
     pub associated_token_program: Program<'info, AssociatedToken>,
-    pub authority: AccountInfo<'info>
+    pub authority: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -350,17 +350,11 @@ pub struct TestConstArraySize<'info> {
 
 #[derive(Accounts)]
 pub struct NoRentExempt<'info> {
-    pub data: AccountInfo<'info>
+    pub data: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
 pub struct EnforceRentExempt<'info> {
     #[account(rent_exempt = enforce)]
-    pub data: AccountInfo<'info>
-}
-
-#[derive(Accounts)]
-pub struct SkipRentExempt<'info> {
-    #[account(rent_exempt = skip)]
-    pub data: AccountInfo<'info>
+    pub data: AccountInfo<'info>,
 }

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -124,6 +124,17 @@ pub struct Initialize<'info> {
 }
 
 #[derive(Accounts)]
+pub struct InitializeSkipRentExempt<'info> {
+    #[account(zero, rent_exempt = skip)]
+    pub data: Account<'info, Data>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeNoRentExempt<'info> {
+    pub data: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
 pub struct TestOwner<'info> {
     #[account(owner = *misc.key)]
     pub data: AccountInfo<'info>,
@@ -335,4 +346,21 @@ pub struct TestMultidimensionalArray<'info> {
 pub struct TestConstArraySize<'info> {
     #[account(zero)]
     pub data: Account<'info, DataConstArraySize>,
+}
+
+#[derive(Accounts)]
+pub struct NoRentExempt<'info> {
+    pub data: AccountInfo<'info>
+}
+
+#[derive(Accounts)]
+pub struct EnforceRentExempt<'info> {
+    #[account(rent_exempt = enforce)]
+    pub data: AccountInfo<'info>
+}
+
+#[derive(Accounts)]
+pub struct SkipRentExempt<'info> {
+    #[account(rent_exempt = skip)]
+    pub data: AccountInfo<'info>
 }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -209,15 +209,23 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_if_needed_checks_owner(ctx: Context<TestInitIfNeededChecksOwner>) -> ProgramResult {
+    pub fn test_init_if_needed_checks_owner(
+        ctx: Context<TestInitIfNeededChecksOwner>,
+    ) -> ProgramResult {
         Ok(())
     }
 
-    pub fn test_init_if_needed_checks_seeds(ctx: Context<TestInitIfNeededChecksSeeds>, seed_data: String) -> ProgramResult {
+    pub fn test_init_if_needed_checks_seeds(
+        ctx: Context<TestInitIfNeededChecksSeeds>,
+        seed_data: String,
+    ) -> ProgramResult {
         Ok(())
     }
 
-    pub fn test_init_mint_if_needed(ctx: Context<TestInitMintIfNeeded>, decimals: u8) -> ProgramResult {
+    pub fn test_init_mint_if_needed(
+        ctx: Context<TestInitMintIfNeeded>,
+        decimals: u8,
+    ) -> ProgramResult {
         Ok(())
     }
 
@@ -225,7 +233,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_associated_token_if_needed(ctx: Context<TestInitAssociatedTokenIfNeeded>) -> ProgramResult {
+    pub fn test_init_associated_token_if_needed(
+        ctx: Context<TestInitAssociatedTokenIfNeeded>,
+    ) -> ProgramResult {
         Ok(())
     }
 

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -48,6 +48,14 @@ pub mod misc {
         Ok(())
     }
 
+    pub fn initialize_no_rent_exempt(ctx: Context<InitializeNoRentExempt>) -> ProgramResult {
+        Ok(())
+    }
+
+    pub fn initialize_skip_rent_exempt(ctx: Context<InitializeSkipRentExempt>) -> ProgramResult {
+        Ok(())
+    }
+
     pub fn test_owner(_ctx: Context<TestOwner>) -> ProgramResult {
         Ok(())
     }
@@ -225,12 +233,19 @@ pub mod misc {
         Ok(())
     }
 
-
     pub fn test_multidimensional_array(
         ctx: Context<TestMultidimensionalArray>,
         data: [[u8; 10]; 10],
     ) -> ProgramResult {
         ctx.accounts.data.data = data;
+        Ok(())
+    }
+
+    pub fn test_no_rent_exempt(ctx: Context<NoRentExempt>) -> ProgramResult {
+        Ok(())
+    }
+
+    pub fn test_enforce_rent_exempt(ctx: Context<EnforceRentExempt>) -> ProgramResult {
         Ok(())
     }
 }

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -7,6 +7,7 @@ const {
   Token,
 } = require("@solana/spl-token");
 const miscIdl = require("../target/idl/misc.json");
+const { SystemProgram } = require("@solana/web3.js");
 const utf8 = anchor.utils.bytes.utf8;
 
 describe("misc", () => {
@@ -1299,4 +1300,83 @@ describe("misc", () => {
     );
     assert.deepStrictEqual(dataAccount.data, array2d);
   });
+
+  it("allows non-rent exempt accounts", async () => {
+    const data = anchor.web3.Keypair.generate();
+    await program.rpc.initializeNoRentExempt(
+      {
+        accounts: {
+          data: data.publicKey,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        },
+        signers: [data],
+        instructions: [SystemProgram.createAccount({
+          programId: program.programId,
+          space: 8 + 16 + 16,
+          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          fromPubkey: anchor.getProvider().wallet.publicKey,
+          newAccountPubkey: data.publicKey,
+        })],
+      }
+    );
+    await program.rpc.testNoRentExempt({
+      accounts: {
+        data: data.publicKey
+      }
+    })
+  })
+
+  it("allows rent exemption to be skipped", async () => {
+    const data = anchor.web3.Keypair.generate();
+    await program.rpc.initializeSkipRentExempt(
+      {
+        accounts: {
+          data: data.publicKey,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        },
+        signers: [data],
+        instructions: [SystemProgram.createAccount({
+          programId: program.programId,
+          space: 8 + 16 + 16,
+          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          fromPubkey: anchor.getProvider().wallet.publicKey,
+          newAccountPubkey: data.publicKey,
+        })],
+      }
+    );
+  })
+
+  it("can use rent_exempt to enforce rent exemption", async () => {
+    const data = anchor.web3.Keypair.generate();
+    await program.rpc.initializeSkipRentExempt(
+      {
+        accounts: {
+          data: data.publicKey,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        },
+        signers: [data],
+        instructions: [SystemProgram.createAccount({
+          programId: program.programId,
+          space: 8 + 16 + 16,
+          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          fromPubkey: anchor.getProvider().wallet.publicKey,
+          newAccountPubkey: data.publicKey,
+        })],
+      }
+    );
+
+    try {
+      await program.rpc.testEnforceRentExempt(
+        {
+          accounts: {
+            data: data.publicKey
+          },
+        }
+      );
+      assert.ok(false);
+    } catch (err) {
+      assert.equal(2005, err.code);
+      assert.equal("A rent exempt constraint was violated", err.msg);
+    }
+  })
 });

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -1303,80 +1303,87 @@ describe("misc", () => {
 
   it("allows non-rent exempt accounts", async () => {
     const data = anchor.web3.Keypair.generate();
-    await program.rpc.initializeNoRentExempt(
-      {
-        accounts: {
-          data: data.publicKey,
-          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        },
-        signers: [data],
-        instructions: [SystemProgram.createAccount({
+    await program.rpc.initializeNoRentExempt({
+      accounts: {
+        data: data.publicKey,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      },
+      signers: [data],
+      instructions: [
+        SystemProgram.createAccount({
           programId: program.programId,
           space: 8 + 16 + 16,
-          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          lamports:
+            await program.provider.connection.getMinimumBalanceForRentExemption(
+              39
+            ),
           fromPubkey: anchor.getProvider().wallet.publicKey,
           newAccountPubkey: data.publicKey,
-        })],
-      }
-    );
+        }),
+      ],
+    });
     await program.rpc.testNoRentExempt({
       accounts: {
-        data: data.publicKey
-      }
-    })
-  })
+        data: data.publicKey,
+      },
+    });
+  });
 
   it("allows rent exemption to be skipped", async () => {
     const data = anchor.web3.Keypair.generate();
-    await program.rpc.initializeSkipRentExempt(
-      {
-        accounts: {
-          data: data.publicKey,
-          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        },
-        signers: [data],
-        instructions: [SystemProgram.createAccount({
+    await program.rpc.initializeSkipRentExempt({
+      accounts: {
+        data: data.publicKey,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      },
+      signers: [data],
+      instructions: [
+        SystemProgram.createAccount({
           programId: program.programId,
           space: 8 + 16 + 16,
-          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          lamports:
+            await program.provider.connection.getMinimumBalanceForRentExemption(
+              39
+            ),
           fromPubkey: anchor.getProvider().wallet.publicKey,
           newAccountPubkey: data.publicKey,
-        })],
-      }
-    );
-  })
+        }),
+      ],
+    });
+  });
 
   it("can use rent_exempt to enforce rent exemption", async () => {
     const data = anchor.web3.Keypair.generate();
-    await program.rpc.initializeSkipRentExempt(
-      {
-        accounts: {
-          data: data.publicKey,
-          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        },
-        signers: [data],
-        instructions: [SystemProgram.createAccount({
+    await program.rpc.initializeSkipRentExempt({
+      accounts: {
+        data: data.publicKey,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      },
+      signers: [data],
+      instructions: [
+        SystemProgram.createAccount({
           programId: program.programId,
           space: 8 + 16 + 16,
-          lamports: await program.provider.connection.getMinimumBalanceForRentExemption(39),
+          lamports:
+            await program.provider.connection.getMinimumBalanceForRentExemption(
+              39
+            ),
           fromPubkey: anchor.getProvider().wallet.publicKey,
           newAccountPubkey: data.publicKey,
-        })],
-      }
-    );
+        }),
+      ],
+    });
 
     try {
-      await program.rpc.testEnforceRentExempt(
-        {
-          accounts: {
-            data: data.publicKey
-          },
-        }
-      );
+      await program.rpc.testEnforceRentExempt({
+        accounts: {
+          data: data.publicKey,
+        },
+      });
       assert.ok(false);
     } catch (err) {
       assert.equal(2005, err.code);
       assert.equal("A rent exempt constraint was violated", err.msg);
     }
-  })
+  });
 });


### PR DESCRIPTION
There were no tests for the `rent_exempt` constraint before this PR