### PR TITLE
lang, docs: improved constraints reference

### DIFF
--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -52,7 +52,7 @@ use syn::parse_macro_input;
 ///                 <pre><code>
 /// #[account(signer)]
 /// pub authority: AccountInfo<'info>,
-/// #[account(signer @ MyError::PayerSignatureMissing)]
+/// #[account(signer @ MyError::MyErrorCode)]
 /// pub payer: AccountInfo<'info>
 ///                 </code></pre>
 ///             </td>
@@ -69,7 +69,7 @@ use syn::parse_macro_input;
 ///                 <pre><code>
 /// #[account(mut)]
 /// pub data_account: Account<'info, MyData>,
-/// #[account(mut @ MyError::DataAccountTwoNotMutable)]
+/// #[account(mut @ MyError::MyErrorCode)]
 /// pub data_account_two: Account<'info, MyData>
 ///                 </code></pre>
 ///             </td>
@@ -102,7 +102,7 @@ use syn::parse_macro_input;
 ///                 <pre><code>
 /// #[account(address = crate::ID)]
 /// pub data: Account<'info, MyData>,
-/// #[account(address = crate::ID @ MyError::DataTwoInvalidAddress)]
+/// #[account(address = crate::ID @ MyError::MyErrorCode)]
 /// pub data_two: Account<'info, MyData>
 ///                 </code></pre>
 ///             </td>
@@ -116,7 +116,7 @@ use syn::parse_macro_input;
 ///                 Custom errors are supported via <code>@</code>.<br><br>
 ///                 Example:
 ///                 <pre><code>
-/// #[account(owner = Token::ID @ MyError::NotOwnedByTokenProgram)]
+/// #[account(owner = Token::ID @ MyError::MyErrorCode)]
 /// pub data: Account<'info, MyData>,
 /// #[account(owner = token_program.key())]
 /// pub data_two: Account<'info, MyData>,
@@ -168,6 +168,40 @@ use syn::parse_macro_input;
 ///                 <pre><code>
 /// #[account(zero)]
 /// pub my_account: Account<'info, MyData>
+///                 </code></pre>
+///             </td>
+///         </tr>
+///         <tr>
+///             <td>
+///                 <code>#[account(close = &lt;target&gt;)]</code>
+///             </td>
+///             <td>
+///                 Marks the account as closed at the end of the instruction’s execution
+///                 (sets its discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`)
+///                 and sends its lamports to the specified account.<br>
+///                 <br><br>
+///                 Example:
+///                 <pre><code>
+/// #[account(close = receiver)]
+/// pub data_account: Account<'info, MyData>,
+/// #[account(mut)]
+/// pub receiver: SystemAccount<'info>
+///                 </code></pre>
+///             </td>
+///         </tr>
+///         <tr>
+///             <td>
+///                 <code>#[account(constraint = &lt;expr&gt;)]</code><br><br><code>#[account(constraint = &lt;expr&gt; @ &lt;custom_error&gt;)]</code>
+///             </td>
+///             <td>
+///                 Constraint that checks whether the given expression evaluates to true.<br>
+///                 Use this when no other constraint fits your use case.
+///                 <br><br>
+///                 Example:
+///                 <pre><code>
+/// #[account(constraint = data_account.keys[0].age == other_data_account.market.apple.age)]
+/// pub data_account: Account<'info, MyData>,
+/// pub other_data_account: Account<'info, OtherData>
 ///                 </code></pre>
 ///             </td>
 ///         </tr>

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -6,20 +6,20 @@ use syn::parse_macro_input;
 
 /// Implements an [`Accounts`](./trait.Accounts.html) deserializer on the given
 /// struct. Can provide further functionality through the use of attributes.
-/// 
+///
 /// # Table of Contents
 /// - [Instruction Attribute](#instruction-attribute)
 /// - [Constraints](#constraints)
-/// 
+///
 /// # Instruction Attribute
-/// 
+///
 /// You can access the instruction's arguments with the
 /// `#[instruction(..)]` attribute. You have to list them
 /// in the same order as in the instruction but you can
 /// omit all arguments after the last one you need.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```ignore
 /// ...
 /// pub fn initialize(ctx: Context<Create>, bump: u8, authority: Pubkey, data: u64) -> ProgramResult {
@@ -33,11 +33,11 @@ use syn::parse_macro_input;
 ///     ...
 /// }
 /// ```
-/// 
+///
 /// # Constraints
-/// 
+///
 /// There are different types of constraints that can be applied with the `#[account(..)]` attribute.
-/// 
+///
 /// - [Normal Constraints](#normal-constraints)
 /// - [SPL Constraints](#spl-constraints)
 /// # Normal Constraints
@@ -365,7 +365,7 @@ use syn::parse_macro_input;
 ///         </tr>
 ///     </tbody>
 /// </table>
-/// 
+///
 /// # SPL Constraints
 ///
 /// The full list of available attributes is as follows.

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -37,7 +37,7 @@ use syn::parse_macro_input;
 /// # Constraints
 ///
 /// There are different types of constraints that can be applied with the `#[account(..)]` attribute.
-/// 
+///
 /// Attributes may reference other data structures. When `<expr>` is used in the tables below, an arbitrary expression
 /// may be passed in as long as it evaluates to a value of the expected type, e.g. `owner = token_program.key()`. If `target_account`
 /// used, the `target_account` must exist in the struct and the `.key()` is implicit, e.g. `payer = authority`.
@@ -168,7 +168,7 @@ use syn::parse_macro_input;
 /// #[instruction(bump: u8)]
 /// pub struct Initialize<'info> {
 /// &nbsp;&nbsp;&nbsp;&nbsp;#[account(
-/// &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;init, payer = payer, 
+/// &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;init, payer = payer,
 /// &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;seeds = [b"example_seed".as_ref()], bump = bump
 /// &nbsp;&nbsp;&nbsp;&nbsp;)]
 /// &nbsp;&nbsp;&nbsp;&nbsp;pub pda_data_account: Account<'info, MyData>,
@@ -388,7 +388,7 @@ use syn::parse_macro_input;
 /// </table>
 ///
 /// # SPL Constraints
-/// 
+///
 /// Anchor provides constraints that make verifying SPL accounts easier.
 ///
 /// <table>

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -7,31 +7,10 @@ use syn::parse_macro_input;
 /// Implements an [`Accounts`](./trait.Accounts.html) deserializer on the given
 /// struct, applying any constraints specified via inert `#[account(..)]`
 /// attributes upon deserialization.
-///
-/// # Example
-///
-/// ```ignore
-/// #[derive(Accounts)]
-/// pub struct Auth<'info> {
-///     #[account(mut, has_one = authority)]
-///     pub data: Account<'info, MyData>,
-///     pub authority: Signer<'info>,
-/// }
-///
-/// #[account]
-/// pub struct MyData {
-///   authority: Pubkey,
-///   protected_data: u64,
-/// }
-/// ```
-///
-/// Here, any instance of the `Auth` struct created via
-/// [`try_accounts`](trait.Accounts.html#tymethod.try_accounts) is guaranteed
-/// to have been both
-///
-/// * Signed by `authority`.
-/// * Checked that `&data.authority == authority.key`.
-///
+/// 
+/// - [Normal Constraints](#normal-constraints)
+/// - [SPL Constraints](#spl-constraints)
+/// # Normal Constraints
 /// <table>
 ///     <thead>
 ///         <tr>
@@ -177,8 +156,8 @@ use syn::parse_macro_input;
 ///             </td>
 ///             <td>
 ///                 Marks the account as closed at the end of the instruction’s execution
-///                 (sets its discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`)
-///                 and sends its lamports to the specified account.<br>
+///                 (sets its discriminator to the <code>CLOSED_ACCOUNT_DISCRIMINATOR</code>)
+///                 and sends its lamports to the specified account.
 ///                 <br><br>
 ///                 Example:
 ///                 <pre><code>
@@ -207,6 +186,8 @@ use syn::parse_macro_input;
 ///         </tr>
 ///     </tbody>
 /// </table>
+/// 
+/// # SPL Constraints
 ///
 /// The full list of available attributes is as follows.
 ///


### PR DESCRIPTION
This PR adds detailed descriptions and examples for all constraints.

- adds instruction attribute reference
- adds constraints reference
- adds SPL constraints reference
- removes `Location` column in tables (tentatively). It was mostly wrong/outdated and I dont see much use it in as it's quite obvious (at least to me) which account can go where. (e.g. you cant put `has_one` on an AccountInfo because AccountInfo does not deserialize)