### PR TITLE
lang: make generated fn `entry` always public

### DIFF
--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -51,7 +51,6 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         ///
         /// The `entry` function here, defines the standard entry to a Solana
         /// program, where execution begins.
-        #[cfg(not(feature = "no-entrypoint"))]
         pub fn entry(program_id: &Pubkey, accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
             #[cfg(feature = "anchor-debug")]
             {


### PR DESCRIPTION
Remove the compilation flag preventing the `entry` function from being included in a program crate when building with the `no-entrypoint` feature. This makes it easy for consumers (e.g. tests) to invoke the program code without needing execution on a validator.

~Add another feature flag that can be used to include the generated `entry` function in the crate, but without the solana `entrypoint` function. This is primarily useful when writing integration tests which attempt to test the program code directly via invoking `entry` function directly (without a validator/network). Included as a new flag to ensure compatibility between tests and other programs in the workspace which may be using the `cpi` and `no-entrypoint` flags already.~