### PR TITLE
Remove os/cpu for anchor-cli npm-package

### DIFF
--- a/cli/npm-package/package.json
+++ b/cli/npm-package/package.json
@@ -17,12 +17,6 @@
   "scripts": {
     "prepack": "[ \"$(uname -op)\" != \"x86_64 GNU/Linux\" ] && (echo Can be packed only on x86_64 GNU/Linux && exit 1) || ([ \"$(./anchor --version)\" != \"anchor-cli $(jq -r .version package.json)\" ] && (echo Check anchor binary version && exit 2) || exit 0)"
   },
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
We have `trySystemAnchor` as a fallback for globally installed anchor cli but the package still can not be installed on other platforms because `os`/`cpu` fields block the process.
https://github.com/project-serum/anchor/blob/4c7cf72dd99d3cc4a43b14b0726b8d977d41c106/cli/npm-package/anchor.js#L61