### PR TITLE
Add typed getProgramAccounts support to rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "anyhow",
  "regex",
  "serde",
+ "solana-account-decoder",
  "solana-client",
  "solana-sdk",
  "thiserror",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,5 +16,6 @@ regex = "1.4.5"
 serde = { version = "1.0.122", features = ["derive"] }
 solana-client = "1.7.2"
 solana-sdk = "1.7.2"
+solana-account-decoder = "1.7.2"
 thiserror = "1.0.20"
 url = "2.2.2"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -257,11 +257,14 @@ impl Program {
     }
 }
 
-// Hides the inner type from usages so the implementation can be changed
+/// Iterator with items of type (Pubkey, T). Used to lazily deserialize account structs.
+/// Wrapper type hides the inner type from usages so the implementation can be changed.
 pub struct ProgramAccountsIterator<T> {
-    inner:
-        Map<IntoIter<(Pubkey, Account)>, fn((Pubkey, Account)) -> Result<(Pubkey, T), ClientError>>,
+    inner: Map<IntoIter<(Pubkey, Account)>, AccountConverterFunction<T>>,
 }
+
+/// Function type that accepts solana accounts and returns deserialized anchor accounts
+type AccountConverterFunction<T> = fn((Pubkey, Account)) -> Result<(Pubkey, T), ClientError>;
 
 impl<T> Iterator for ProgramAccountsIterator<T> {
     type Item = Result<(Pubkey, T), ClientError>;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,8 +11,11 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_client::client_error::ClientError as SolanaClientError;
 use solana_client::pubsub_client::{PubsubClient, PubsubClientError, PubsubClientSubscription};
 use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter, RpcProgramAccountsConfig, RpcAccountInfoConfig};
-use solana_client::rpc_filter::{RpcFilterType, MemcmpEncodedBytes, Memcmp};
+use solana_client::rpc_config::{
+    RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcTransactionLogsConfig,
+    RpcTransactionLogsFilter,
+};
+use solana_client::rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType};
 use solana_client::rpc_response::{Response as RpcResponse, RpcLogsResponse};
 use solana_sdk::bs58;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -139,9 +142,7 @@ impl Program {
     ) -> Result<Vec<(Pubkey, T)>, ClientError> {
         let account_type_filter = RpcFilterType::Memcmp(Memcmp {
             offset: 0,
-            bytes: MemcmpEncodedBytes::Base58(
-                bs58::encode(T::discriminator()).into_string()
-            ),
+            bytes: MemcmpEncodedBytes::Base58(bs58::encode(T::discriminator()).into_string()),
             encoding: None,
         });
         let config = RpcProgramAccountsConfig {
@@ -156,8 +157,7 @@ impl Program {
         self.rpc()
             .get_program_accounts_with_config(&self.id(), config)?
             .into_iter()
-            .map(|(key, account)|
-                Ok((key, T::try_deserialize(&mut (&account.data as &[u8]))?)))
+            .map(|(key, account)| Ok((key, T::try_deserialize(&mut (&account.data as &[u8]))?)))
             .collect()
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -32,8 +32,6 @@ mod cluster;
 /// EventHandle unsubscribes from a program event stream on drop.
 pub type EventHandle = PubsubClientSubscription<RpcResponse<RpcLogsResponse>>;
 
-const ANCHOR_HDR_LEN: usize = 8;
-
 /// Client defines the base configuration for building RPC clients to
 /// communitcate with Anchor programs running on a Solana cluster. It's
 /// primary use is to build a `Program` client via the `program` method.


### PR DESCRIPTION
Currently, the rust client can retrieve a program owned account when the pubkey is known, but unlike the javascript client, the rust client does not support the RPC call `getProgramAccounts` to retrieve all program owned accounts that match some optional filters.

The existing method is called `account`. When provided an account type T and a Pubkey, it returns a single account struct matching that pubkey.

This change implements the method `accounts`. When provided an anchor account type T and optionally some additional filters, `accounts` returns all program owned accounts of the type T which match the optional filters. It is implemented using `RpcClient::get_program_accounts` with a `MemCmp` filter using the account discriminator. The return type is `Result<Vec<(Pubkey, T)>, ClientError>`, which is analogous to the return type of `get_program_accounts` -> `Result<Vec<(Pubkey, Account)>, ClientError>`.

Additionally, this change implements a method called `accounts_lazy`. This is similar to `accounts` except it returns `Iterator<Item = Result<(Pubkey, T), ClientError>>`. Account deserialization will be executed lazily, enabling some performance optimizations. For example, there may be a million accounts returned, but the client is only interested in processing the first 100 accounts, so there is no point in deserializing every single account.