### PR TITLE
ts: remove event error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ incremented for features.
 ### Features
 
 * lang: Add `seeds::program` constraint for specifying which program_id to use when deriving PDAs.([#1197](https://github.com/project-serum/anchor/pull/1197))
+* ts: Remove error logging in the event parser when log websocket encounters a program error. ([#1313](https://github.com/project-serum/anchor/pull/1313))
 
 ### Breaking
 

--- a/ts/src/program/event.ts
+++ b/ts/src/program/event.ts
@@ -95,7 +95,6 @@ export class EventManager {
       this._programId,
       (logs, ctx) => {
         if (logs.err) {
-          console.error(logs);
           return;
         }
         this._eventParser.parseLogs(logs.logs, (event) => {


### PR DESCRIPTION
This log doesn't really serve any benefit as it just creates noise.

Any error log from your program will just log and return.
```
{
  signature: '451AeeyezdmobLtwUnLPZguR2qj2FzjfjVWEnbmiodT6yVaHLo3eGtTWAhrnSYDQhH91NFbMMrRRZtxDLZQgSvdq',
  err: { InstructionError: [ 0, [Object] ] },
  logs: [
    'Program BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7invoke [1]',
    'Program log: Cancel order.',
    'Program BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7invoke [2]',
    'Program zDEXqXEG7gAyxb1Kg9mK5fPnUdENCGKzWrM21RMdWRq consumed 2776 of 179069 compute units',
    'Program zDEXqXEG7gAyxb1Kg9mK5fPnUdENCGKzWrM21RMdWRq failed: custom program error: 0x3b',
    'Program BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7consumed 23707 of 200000 compute units',
    'Program BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7failed: custom program error: 0x3b'
  ]
}
```

All clients using some common SDK that listens to events for your program will see this noise and just creates confusion.