### PR TITLE
cli: change error message on startup_wait

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2017,7 +2017,7 @@ fn start_test_validator(
     }
     if count == ms_wait {
         eprintln!(
-            "Unable to start test validator. Check {} for errors.",
+            "Unable to get recent blockhash. Test validator does not look started. Check {} for errors. Consider increasing [test.startup_wait] in Anchor.toml.",
             test_ledger_log_filename
         );
         validator_handle.kill()?;


### PR DESCRIPTION
Closes #989 
Related with #1299

Not sure that is the best possible error message but I think it's better than before.