### PR TITLE
book: add reference links section

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,3 +19,7 @@
   - [CLI](./chapter_4/cli.md)
   - [IDL]()
 - [Anchor BTS]()
+
+---
+
+- [Reference Links](./reference_links.md)

--- a/book/src/reference_links.md
+++ b/book/src/reference_links.md
@@ -1,0 +1,5 @@
+# Reference Links
+
+- [Accounts Reference](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/index.html)
+- [Constraints Reference](https://docs.rs/anchor-lang/latest/anchor_lang/derive.Accounts.html)
+- [Error Codes](https://docs.rs/anchor-lang/latest/anchor_lang/__private/enum.ErrorCode.html)


### PR DESCRIPTION
this pr adds a section to the book with links to common reference pages.

This is especially useful for docs that are difficult to find e.g. the docs for constraints which can only be found by searching for `Accounts` because theyre in the docs for the `Accounts` derive macro