### PR TITLE
lang, ts: account header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ incremented for features.
 
 * lang: rename `loader_account` module to `account_loader` module ([#1279](https://github.com/project-serum/anchor/pull/1279))
 * ts: `Coder` is now an interface and the existing class has been renamed to `BorshCoder`. This change allows the generation of Anchor clients for non anchor programs  ([#1259](https://github.com/project-serum/anchor/pull/1259/files)).
+* ts: `BorshAccountsCoder.accountDiscriminator` method has been replaced with `BorshAccountHeader.discriminator` ([#]()).
+* lang, ts: 8 byte account discriminator has been replaced with a versioned account header ([#]()).
 
 ## [0.20.1] - 2022-01-09
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -291,12 +291,22 @@ fn handle_program_log<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
         };
 
         let mut slice: &[u8] = &borsh_bytes[..];
+
+        #[cfg(feature = "deprecated-layout")]
         let disc: [u8; 8] = {
             let mut disc = [0; 8];
             disc.copy_from_slice(&borsh_bytes[..8]);
             slice = &slice[8..];
             disc
         };
+        #[cfg(not(feature = "deprecated-layout"))]
+        let disc: [u8; 4] = {
+            let mut disc = [0; 4];
+            disc.copy_from_slice(&borsh_bytes[2..6]);
+            slice = &slice[8..];
+            disc
+        };
+
         let mut event = None;
         if disc == T::discriminator() {
             let e: T = anchor_lang::AnchorDeserialize::deserialize(&mut slice)

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -211,7 +211,6 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::AccountSerialize for #account_name #type_gen #where_clause {
                     fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), ProgramError> {
-                        writer.write_all(&#discriminator).map_err(|_| anchor_lang::__private::ErrorCode::AccountDidNotSerialize)?;
                         AnchorSerialize::serialize(
                             self,
                             writer

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -88,24 +88,6 @@ pub fn account(
     let account_name = &account_strct.ident;
     let (impl_gen, type_gen, where_clause) = account_strct.generics.split_for_impl();
 
-    let discriminator: proc_macro2::TokenStream = {
-        // Namespace the discriminator to prevent collisions.
-        let discriminator_preimage = {
-            // For now, zero copy accounts can't be namespaced.
-            if namespace.is_empty() {
-                format!("account:{}", account_name)
-            } else {
-                format!("{}:{}", namespace, account_name)
-            }
-        };
-
-        let mut discriminator = [0u8; 8];
-        discriminator.copy_from_slice(
-            &anchor_syn::hash::hash(discriminator_preimage.as_bytes()).to_bytes()[..8],
-        );
-        format!("{:?}", discriminator).parse().unwrap()
-    };
-
     let owner_impl = {
         if namespace.is_empty() {
             quote! {
@@ -118,6 +100,60 @@ pub fn account(
             }
         } else {
             quote! {}
+        }
+    };
+
+    let discriminator: proc_macro2::TokenStream = {
+        // Namespace the discriminator to prevent collisions.
+        let discriminator_preimage = {
+            // For now, zero copy accounts can't be namespaced.
+            if namespace.is_empty() {
+                format!("account:{}", account_name)
+            } else {
+                format!("{}:{}", namespace, account_name)
+            }
+        };
+
+        if cfg!(feature = "deprecated-layout") {
+            let mut discriminator = [0u8; 8];
+            discriminator.copy_from_slice(
+                &anchor_syn::hash::hash(discriminator_preimage.as_bytes()).to_bytes()[..8],
+            );
+            format!("{:?}", discriminator).parse().unwrap()
+        } else {
+            let mut discriminator = [0u8; 4];
+            discriminator.copy_from_slice(
+                &anchor_syn::hash::hash(discriminator_preimage.as_bytes()).to_bytes()[..4],
+            );
+            format!("{:?}", discriminator).parse().unwrap()
+        }
+    };
+
+    let disc_bytes = {
+        if cfg!(feature = "deprecated-layout") {
+            quote! {
+                let given_disc = &buf[..8];
+            }
+        } else {
+            quote! {
+                let given_disc = &buf[2..6];
+            }
+        }
+    };
+
+    let disc_fn = {
+        if cfg!(feature = "deprecated-layout") {
+            quote! {
+                fn discriminator() -> [u8; 8] {
+                    #discriminator
+                }
+            }
+        } else {
+            quote! {
+                fn discriminator() -> [u8; 4] {
+                    #discriminator
+                }
+            }
         }
     };
 
@@ -137,9 +173,7 @@ pub fn account(
 
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
-                    fn discriminator() -> [u8; 8] {
-                        #discriminator
-                    }
+                    #disc_fn
                 }
 
                 // This trait is useful for clients deserializing accounts.
@@ -147,10 +181,11 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::AccountDeserialize for #account_name #type_gen #where_clause {
                     fn try_deserialize(buf: &mut &[u8]) -> std::result::Result<Self, ProgramError> {
-                        if buf.len() < #discriminator.len() {
+                        // Header is always 8 bytes.
+                        if buf.len() < 8 {
                             return Err(anchor_lang::__private::ErrorCode::AccountDiscriminatorNotFound.into());
                         }
-                        let given_disc = &buf[..8];
+                        #disc_bytes
                         if &#discriminator != given_disc {
                             return Err(anchor_lang::__private::ErrorCode::AccountDiscriminatorMismatch.into());
                         }
@@ -192,7 +227,7 @@ pub fn account(
                         if buf.len() < #discriminator.len() {
                             return Err(anchor_lang::__private::ErrorCode::AccountDiscriminatorNotFound.into());
                         }
-                        let given_disc = &buf[..8];
+                        #disc_bytes
                         if &#discriminator != given_disc {
                             return Err(anchor_lang::__private::ErrorCode::AccountDiscriminatorMismatch.into());
                         }
@@ -208,9 +243,7 @@ pub fn account(
 
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
-                    fn discriminator() -> [u8; 8] {
-                        #discriminator
-                    }
+                    #disc_fn
                 }
 
                 #owner_impl

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -332,7 +332,10 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> AccountsEx
         if &T::owner() == program_id {
             let info = self.to_account_info();
             let mut data = info.try_borrow_mut_data()?;
-            let dst: &mut [u8] = &mut data;
+
+            // Chop off the header.
+            let dst: &mut [u8] = &mut data[8..];
+
             let mut cursor = std::io::Cursor::new(dst);
             self.account.try_serialize(&mut cursor)?;
         }

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -406,3 +406,10 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> DerefMut for 
         &mut self.account
     }
 }
+
+#[cfg(not(feature = "deprecated-layout"))]
+impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Bump for Account<'a, T> {
+    fn seed(&self) -> u8 {
+        self.info.data.borrow()[1]
+    }
+}

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -1,10 +1,7 @@
 //! Type facilitating on demand zero copy deserialization.
 
 use crate::error::ErrorCode;
-use crate::{
-    Accounts, AccountsClose, AccountsExit, Bump, Owner, ToAccountInfo, ToAccountInfos,
-    ToAccountMetas, ZeroCopy,
-};
+use crate::*;
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -245,11 +242,8 @@ impl<'info, T: ZeroCopy + Owner> ToAccountInfos<'info> for AccountLoader<'info, 
 }
 
 #[cfg(not(feature = "deprecated-layout"))]
-impl<'info, T> Bump for T
-where
-    T: AsRef<AccountInfo<'info>>,
-{
+impl<'a, T: ZeroCopy + Owner> Bump for AccountLoader<'a, T> {
     fn seed(&self) -> u8 {
-        self.as_ref().data.borrow()[1]
+        self.acc_info.data.borrow()[1]
     }
 }

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -113,7 +113,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
         }
     }
 
-    /// Constructs a new `Loader` from a previously initialized account.
+    /// Constructs a new `AccountLoader` from a previously initialized account.
     #[inline(never)]
     pub fn try_from(
         acc_info: &AccountInfo<'info>,
@@ -135,7 +135,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
         Ok(AccountLoader::new(acc_info.clone()))
     }
 
-    /// Constructs a new `Loader` from an uninitialized account.
+    /// Constructs a new `AccountLoader` from an uninitialized account.
     #[inline(never)]
     pub fn try_from_unchecked(
         _program_id: &Pubkey,

--- a/lang/src/accounts/loader.rs
+++ b/lang/src/accounts/loader.rs
@@ -68,8 +68,6 @@ impl<'info, T: ZeroCopy> Loader<'info, T> {
         let disc_bytes = array_ref![data, 2, 4];
 
         if disc_bytes != &T::discriminator() {
-            crate::solana_program::msg!("DISC BYTES: {:?}", disc_bytes);
-            crate::solana_program::msg!("DISC BYTES 2: {:?}", data);
             return Err(ErrorCode::AccountDiscriminatorMismatch.into());
         }
 

--- a/lang/src/accounts/loader.rs
+++ b/lang/src/accounts/loader.rs
@@ -1,7 +1,5 @@
 use crate::error::ErrorCode;
-use crate::{
-    Accounts, AccountsClose, AccountsExit, ToAccountInfo, ToAccountInfos, ToAccountMetas, ZeroCopy,
-};
+use crate::*;
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
@@ -187,5 +185,12 @@ impl<'info, T: ZeroCopy> AsRef<AccountInfo<'info>> for Loader<'info, T> {
 impl<'info, T: ZeroCopy> ToAccountInfos<'info> for Loader<'info, T> {
     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
         vec![self.acc_info.clone()]
+    }
+}
+
+#[cfg(not(feature = "deprecated-layout"))]
+impl<'a, T: ZeroCopy> Bump for Loader<'a, T> {
+    fn seed(&self) -> u8 {
+        self.acc_info.data.borrow()[1]
     }
 }

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -100,7 +100,10 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info
     fn exit(&self, _program_id: &Pubkey) -> ProgramResult {
         let info = self.to_account_info();
         let mut data = info.try_borrow_mut_data()?;
-        let dst: &mut [u8] = &mut data;
+
+        // Chop off the header.
+        let dst: &mut [u8] = &mut data[8..];
+
         let mut cursor = std::io::Cursor::new(dst);
         self.inner.account.try_serialize(&mut cursor)?;
         Ok(())

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -1,10 +1,7 @@
 #[allow(deprecated)]
 use crate::accounts::cpi_account::CpiAccount;
 use crate::error::ErrorCode;
-use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, ToAccountInfo,
-    ToAccountInfos, ToAccountMetas,
-};
+use crate::*;
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::AccountMeta;
@@ -180,5 +177,12 @@ where
 {
     fn from(a: CpiAccount<'info, T>) -> Self {
         Self::new(a.to_account_info(), Deref::deref(&a).clone())
+    }
+}
+
+#[cfg(not(feature = "deprecated-layout"))]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Bump for ProgramAccount<'a, T> {
+    fn seed(&self) -> u8 {
+        self.inner.info.data.borrow()[1]
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -198,7 +198,10 @@ pub trait EventData: AnchorSerialize + Discriminator {
 
 /// 8 byte unique identifier for a type.
 pub trait Discriminator {
+    #[cfg(feature = "deprecated-layout")]
     fn discriminator() -> [u8; 8];
+    #[cfg(not(feature = "deprecated-layout"))]
+    fn discriminator() -> [u8; 4];
 }
 
 /// Bump seed for program derived addresses.

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -644,7 +644,10 @@ pub fn generate_init(
 
             let header_write = {
                 match &f.ty {
-                    Ty::Account(_) | Ty::ProgramAccount(_) => {
+                    Ty::Account(_)
+                    | Ty::ProgramAccount(_)
+                    | Ty::Loader(_)
+                    | Ty::AccountLoader(_) => {
                         let account_ty = f.account_ty();
                         if cfg!(feature = "deprecated-layout") {
                             quote! {

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -238,6 +238,7 @@ pub fn parse(
         .collect::<Vec<IdlConst>>();
 
     Ok(Some(Idl {
+        layout_version: "0.1.0".to_string(),
         version,
         name: p.name.to_string(),
         state,

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -6,6 +6,9 @@ pub mod pda;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Idl {
+    // Version of the idl protocol.
+    pub layout_version: String,
+    // Version of the program.
     pub version: String,
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -5,6 +5,7 @@ pub mod file;
 pub mod pda;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Idl {
     // Version of the idl protocol.
     pub layout_version: String,

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -280,7 +280,7 @@ impl Field {
 
     // TODO: remove the option once `CpiAccount` is completely removed (not
     //       just deprecated).
-    pub fn from_account_info_unchecked(&self, kind: Option<&InitKind>) -> proc_macro2::TokenStream {
+    pub fn from_account_info(&self, kind: Option<&InitKind>) -> proc_macro2::TokenStream {
         let field = &self.ident;
         let container_ty = self.container_ty();
         match &self.ty {
@@ -291,13 +291,13 @@ impl Field {
             Ty::Account(AccountTy { boxed, .. }) => {
                 if *boxed {
                     quote! {
-                        Box::new(#container_ty::try_from_unchecked(
+                        Box::new(#container_ty::try_from(
                             &#field,
                         )?)
                     }
                 } else {
                     quote! {
-                        #container_ty::try_from_unchecked(
+                        #container_ty::try_from(
                             &#field,
                         )?
                     }
@@ -305,7 +305,7 @@ impl Field {
             }
             Ty::CpiAccount(_) => {
                 quote! {
-                    #container_ty::try_from_unchecked(
+                    #container_ty::try_from(
                         &#field,
                     )?
                 }
@@ -321,7 +321,7 @@ impl Field {
                     },
                 };
                 quote! {
-                    #container_ty::try_from_unchecked(
+                    #container_ty::try_from(
                         #owner_addr,
                         &#field,
                     )?

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -310,6 +310,13 @@ impl Field {
                     )?
                 }
             }
+            Ty::AccountLoader(_) => {
+                quote! {
+                    #container_ty::try_from(
+                        &#field,
+                    )?
+                }
+            }
             _ => {
                 let owner_addr = match &kind {
                     None => quote! { program_id },

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -26,6 +26,13 @@ pub(crate) mod hash;
 pub mod idl;
 pub mod parser;
 
+// Layout indices.
+pub const LAYOUT_VERSION: u8 = 0;
+pub const LAYOUT_VERSION_INDEX: u8 = 0;
+pub const LAYOUT_BUMP_INDEX: u8 = 1;
+pub const LAYOUT_DISCRIMINATOR_INDEX: u8 = 2;
+pub const LAYOUT_UNUSED_INDEX: u8 = 6;
+
 #[derive(Debug)]
 pub struct Program {
     pub state: Option<State>,

--- a/tests/chat/programs/chat/src/lib.rs
+++ b/tests/chat/programs/chat/src/lib.rs
@@ -1,7 +1,7 @@
 //! A simple chat program using a ring buffer to store messages.
 
-use anchor_lang::prelude::*;
 use anchor_lang::accounts::loader::Loader;
+use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
@@ -19,7 +19,7 @@ pub mod chat {
         let given_name = name.as_bytes();
         let mut name = [0u8; 280];
         name[..given_name.len()].copy_from_slice(given_name);
-        let mut chat = ctx.accounts.chat_room.load_init()?;
+        let mut chat = ctx.accounts.chat_room.load_mut()?;
         chat.name = name;
         Ok(())
     }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -122,7 +122,7 @@ pub mod misc {
     }
 
     pub fn test_pda_init_zero_copy(ctx: Context<TestPdaInitZeroCopy>, bump: u8) -> ProgramResult {
-        let mut acc = ctx.accounts.my_pda.load_init()?;
+        let mut acc = ctx.accounts.my_pda.load_mut()?;
         acc.data = 9;
         acc.bump = bump;
         Ok(())
@@ -156,7 +156,7 @@ pub mod misc {
     }
 
     pub fn test_init_zero_copy(ctx: Context<TestInitZeroCopy>) -> ProgramResult {
-        let mut data = ctx.accounts.data.load_init()?;
+        let mut data = ctx.accounts.data.load_mut()?;
         data.data = 10;
         data.bump = 2;
         Ok(())
@@ -264,15 +264,17 @@ pub mod misc {
         **ctx.accounts.user.try_borrow_mut_lamports()? += 1;
         Ok(())
     }
-    
-    pub fn init_if_needed_checks_rent_exemption(_ctx: Context<InitIfNeededChecksRentExemption>) -> ProgramResult {
+
+    pub fn init_if_needed_checks_rent_exemption(
+        _ctx: Context<InitIfNeededChecksRentExemption>,
+    ) -> ProgramResult {
         Ok(())
     }
-        
+
     pub fn test_program_id_constraint(
         _ctx: Context<TestProgramIdConstraint>,
         _bump: u8,
-        _second_bump: u8
+        _second_bump: u8,
     ) -> ProgramResult {
         Ok(())
     }

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -1,5 +1,4 @@
-//const anchor = require("@project-serum/anchor");
-const anchor = require("../../../ts");
+const anchor = require("@project-serum/anchor");
 const assert = require("assert");
 const {
   ASSOCIATED_TOKEN_PROGRAM_ID,

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -1,4 +1,5 @@
-const anchor = require("@project-serum/anchor");
+//const anchor = require("@project-serum/anchor");
+const anchor = require("../../../ts");
 const assert = require("assert");
 const {
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -156,7 +157,6 @@ describe("misc", () => {
       "Program Z2Ddx1Lcd8CHTV9tkWtNnFQrSz6kxz2H38wrr18zZRZ consumed 4819 of 200000 compute units",
       "Program Z2Ddx1Lcd8CHTV9tkWtNnFQrSz6kxz2H38wrr18zZRZ success",
     ];
-
     assert.ok(JSON.stringify(expectedRaw), resp.raw);
     assert.ok(resp.events[0].name === "E1");
     assert.ok(resp.events[0].data.data === 44);

--- a/tests/zero-copy/programs/zero-copy/src/lib.rs
+++ b/tests/zero-copy/programs/zero-copy/src/lib.rs
@@ -14,7 +14,7 @@ pub mod zero_copy {
     use super::*;
 
     pub fn create_foo(ctx: Context<CreateFoo>) -> ProgramResult {
-        let foo = &mut ctx.accounts.foo.load_init()?;
+        let foo = &mut ctx.accounts.foo.load_mut()?;
         foo.authority = *ctx.accounts.authority.key;
         foo.set_second_authority(ctx.accounts.authority.key);
         Ok(())
@@ -33,7 +33,7 @@ pub mod zero_copy {
     }
 
     pub fn create_bar(ctx: Context<CreateBar>) -> ProgramResult {
-        let bar = &mut ctx.accounts.bar.load_init()?;
+        let bar = &mut ctx.accounts.bar.load_mut()?;
         bar.authority = *ctx.accounts.authority.key;
         Ok(())
     }

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -21,8 +21,11 @@ async fn update_foo() {
     let authority = Keypair::new();
     let foo_pubkey = Pubkey::new_unique();
     let foo_account = {
-        let mut foo_data = Vec::new();
+        // Write header.
+        let mut foo_data = vec![0, 0];
         foo_data.extend_from_slice(&zero_copy::Foo::discriminator());
+        foo_data.extend_from_slice(&[0, 0]);
+        // Write data.
         foo_data.extend_from_slice(bytemuck::bytes_of(&zero_copy::Foo {
             authority: authority.pubkey(),
             ..zero_copy::Foo::default()

--- a/ts/src/coder/borsh/accounts.ts
+++ b/ts/src/coder/borsh/accounts.ts
@@ -62,7 +62,7 @@ export class BorshAccountsCoder<A extends string = string>
 
   public decode<T = any>(accountName: A, data: Buffer): T {
     const expectedDiscriminator = BorshAccountHeader.discriminator(accountName);
-		const givenDisc = BorshAccountHeader.parseDiscriminator(data);
+    const givenDisc = BorshAccountHeader.parseDiscriminator(data);
     if (expectedDiscriminator.compare(givenDisc)) {
       throw new Error("Invalid account discriminator");
     }
@@ -70,7 +70,7 @@ export class BorshAccountsCoder<A extends string = string>
   }
 
   public decodeUnchecked<T = any>(accountName: A, ix: Buffer): T {
-    const data = ix.slice(BorshAccountHeader.size());   // Chop off the header.
+    const data = ix.slice(BorshAccountHeader.size()); // Chop off the header.
     const layout = this.accountLayouts.get(accountName);
     if (!layout) {
       throw new Error(`Unknown account: ${accountName}`);
@@ -89,28 +89,26 @@ export class BorshAccountsCoder<A extends string = string>
   }
 
   public size(idlAccount: IdlTypeDef): number {
-    return (
-      BorshAccountHeader.size() + (accountSize(this.idl, idlAccount) ?? 0)
-    );
+    return BorshAccountHeader.size() + (accountSize(this.idl, idlAccount) ?? 0);
   }
 }
 
 export class BorshAccountHeader {
-	/**
-	 * Returns the default account header for an account with the given name.
-	 */
-	public static encode(accountName: string): Buffer {
-		if (features.isSet('deprecated-layout')) {
-			return BorshAccountHeader.discriminator(accountName);
-		} else {
-			return Buffer.concat([
-				Buffer.from([0]), // Version.
-				Buffer.from([0]), // Bump.
-				BorshAccountHeader.discriminator(accountName), // Disc.
-				Buffer.from([0, 0]), // Unused.
-			]);
-		}
-	}
+  /**
+   * Returns the default account header for an account with the given name.
+   */
+  public static encode(accountName: string): Buffer {
+    if (features.isSet("deprecated-layout")) {
+      return BorshAccountHeader.discriminator(accountName);
+    } else {
+      return Buffer.concat([
+        Buffer.from([0]), // Version.
+        Buffer.from([0]), // Bump.
+        BorshAccountHeader.discriminator(accountName), // Disc.
+        Buffer.from([0, 0]), // Unused.
+      ]);
+    }
+  }
 
   /**
    * Calculates and returns a unique 8 byte discriminator prepended to all anchor accounts.
@@ -118,43 +116,43 @@ export class BorshAccountHeader {
    * @param name The name of the account to calculate the discriminator.
    */
   public static discriminator(name: string): Buffer {
-		let size: number;
-		if (features.isSet("deprecated-layout")) {
-			size = DEPRECATED_ACCOUNT_DISCRIMINATOR_SIZE;
-		} else {
-			size = ACCOUNT_DISCRIMINATOR_SIZE;
-		}
+    let size: number;
+    if (features.isSet("deprecated-layout")) {
+      size = DEPRECATED_ACCOUNT_DISCRIMINATOR_SIZE;
+    } else {
+      size = ACCOUNT_DISCRIMINATOR_SIZE;
+    }
     return Buffer.from(
       sha256.digest(`account:${camelcase(name, { pascalCase: true })}`)
     ).slice(0, size);
   }
 
-	/**
-	 * Returns the account data index at which the discriminator starts.
-	 */
-	public static discriminatorOffset(): number {
-		if (features.isSet("deprecated-layout")) {
-			return 0;
-		} else {
-			return 2;
-		}
-	}
+  /**
+   * Returns the account data index at which the discriminator starts.
+   */
+  public static discriminatorOffset(): number {
+    if (features.isSet("deprecated-layout")) {
+      return 0;
+    } else {
+      return 2;
+    }
+  }
 
-	/**
-	 * Returns the byte size of the account header.
-	 */
-	public static size(): number {
-		return ACCOUNT_HEADER_SIZE;
-	}
+  /**
+   * Returns the byte size of the account header.
+   */
+  public static size(): number {
+    return ACCOUNT_HEADER_SIZE;
+  }
 
-	/**
-	 * Returns the discriminator from the given account data.
-	 */
-	public static parseDiscriminator(data: Buffer): Buffer {
-		if (features.isSet("deprecated-layout")) {
-			return data.slice(0, 8);
-		} else {
-			return data.slice(2, 6);
-		}
-	}
+  /**
+   * Returns the discriminator from the given account data.
+   */
+  public static parseDiscriminator(data: Buffer): Buffer {
+    if (features.isSet("deprecated-layout")) {
+      return data.slice(0, 8);
+    } else {
+      return data.slice(2, 6);
+    }
+  }
 }

--- a/ts/src/coder/borsh/accounts.ts
+++ b/ts/src/coder/borsh/accounts.ts
@@ -97,9 +97,9 @@ export class BorshAccountHeader {
   /**
    * Returns the default account header for an account with the given name.
    */
-  public static encode(accountName: string): Buffer {
+  public static encode(accountName: string, nameSpace?: string): Buffer {
     if (features.isSet("deprecated-layout")) {
-      return BorshAccountHeader.discriminator(accountName);
+      return BorshAccountHeader.discriminator(accountName, nameSpace);
     } else {
       return Buffer.concat([
         Buffer.from([0]), // Version.
@@ -115,17 +115,17 @@ export class BorshAccountHeader {
    *
    * @param name The name of the account to calculate the discriminator.
    */
-  public static discriminator(name: string): Buffer {
-    let size: number;
-    if (features.isSet("deprecated-layout")) {
-      size = DEPRECATED_ACCOUNT_DISCRIMINATOR_SIZE;
-    } else {
-      size = ACCOUNT_DISCRIMINATOR_SIZE;
-    }
+  public static discriminator(name: string, nameSpace?: string): Buffer {
     return Buffer.from(
-      sha256.digest(`account:${camelcase(name, { pascalCase: true })}`)
-    ).slice(0, size);
+      sha256.digest(`${nameSpace ?? "account"}:${camelcase(name, { pascalCase: true })}`)
+    ).slice(0, BorshAccountHeader.discriminatorSize());
   }
+
+	public static discriminatorSize(): number {
+		return features.isSet("deprecated-layout")
+			? DEPRECATED_ACCOUNT_DISCRIMINATOR_SIZE
+			: ACCOUNT_DISCRIMINATOR_SIZE;
+	}
 
   /**
    * Returns the account data index at which the discriminator starts.

--- a/ts/src/coder/borsh/event.ts
+++ b/ts/src/coder/borsh/event.ts
@@ -42,7 +42,7 @@ export class BorshEventCoder implements EventCoder {
       idl.events === undefined
         ? []
         : idl.events.map((e) => [
-          base64.fromByteArray(EventHeader.discriminator(e.name)),
+            base64.fromByteArray(EventHeader.discriminator(e.name)),
             e.name,
           ])
     );
@@ -79,31 +79,31 @@ export class BorshEventCoder implements EventCoder {
 }
 
 export function eventDiscriminator(name: string): Buffer {
-	return EventHeader.discriminator(name);
+  return EventHeader.discriminator(name);
 }
 
 class EventHeader {
-	public static parseDiscriminator(data: Buffer): Buffer {
-		if (features.isSet("deprecated-layout")) {
-			return data.slice(0, 8);
-		} else {
-			return data.slice(0, 4);
-		}
-	}
+  public static parseDiscriminator(data: Buffer): Buffer {
+    if (features.isSet("deprecated-layout")) {
+      return data.slice(0, 8);
+    } else {
+      return data.slice(0, 4);
+    }
+  }
 
-	public static size(): number {
-		if (features.isSet("deprecated-layout")) {
-			return 8;
-		} else {
-			return 4;
-		}
-	}
+  public static size(): number {
+    if (features.isSet("deprecated-layout")) {
+      return 8;
+    } else {
+      return 4;
+    }
+  }
 
-	public static discriminator(name: string): Buffer {
-		if (features.isSet("deprecated-layout")) {
-		  return Buffer.from(sha256.digest(`event:${name}`)).slice(0, 8);
-		} else {
-			return Buffer.from(sha256.digest(`event:${name}`)).slice(0, 4);
-		}
-	}
+  public static discriminator(name: string): Buffer {
+    if (features.isSet("deprecated-layout")) {
+      return Buffer.from(sha256.digest(`event:${name}`)).slice(0, 8);
+    } else {
+      return Buffer.from(sha256.digest(`event:${name}`)).slice(0, 4);
+    }
+  }
 }

--- a/ts/src/coder/borsh/index.ts
+++ b/ts/src/coder/borsh/index.ts
@@ -6,7 +6,7 @@ import { BorshStateCoder } from "./state.js";
 import { Coder } from "../index.js";
 
 export { BorshInstructionCoder } from "./instruction.js";
-export { BorshAccountsCoder, ACCOUNT_DISCRIMINATOR_SIZE } from "./accounts.js";
+export { BorshAccountsCoder, BorshAccountHeader } from "./accounts.js";
 export { BorshEventCoder, eventDiscriminator } from "./event.js";
 export { BorshStateCoder, stateDiscriminator } from "./state.js";
 

--- a/ts/src/coder/borsh/state.ts
+++ b/ts/src/coder/borsh/state.ts
@@ -20,7 +20,7 @@ export class BorshStateCoder {
     const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const len = this.layout.encode(account, buffer);
 
-		let ns = features.isSet("anchor-deprecated-state") ? "account" : "state";
+    let ns = features.isSet("anchor-deprecated-state") ? "account" : "state";
     const header = BorshAccountHeader.encode(name, ns);
     const accData = buffer.slice(0, len);
 
@@ -37,5 +37,8 @@ export class BorshStateCoder {
 // Calculates unique 8 byte discriminator prepended to all anchor state accounts.
 export async function stateDiscriminator(name: string): Promise<Buffer> {
   let ns = features.isSet("anchor-deprecated-state") ? "account" : "state";
-  return Buffer.from(sha256.digest(`${ns}:${name}`)).slice(0, BorshAccountHeader.discriminatorSize());
+  return Buffer.from(sha256.digest(`${ns}:${name}`)).slice(
+    0,
+    BorshAccountHeader.discriminatorSize()
+  );
 }

--- a/ts/src/coder/borsh/state.ts
+++ b/ts/src/coder/borsh/state.ts
@@ -4,6 +4,7 @@ import { sha256 } from "js-sha256";
 import { Idl } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import * as features from "../../utils/features.js";
+import { BorshAccountHeader } from "./accounts";
 
 export class BorshStateCoder {
   private layout: Layout;
@@ -19,15 +20,16 @@ export class BorshStateCoder {
     const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const len = this.layout.encode(account, buffer);
 
-    const disc = await stateDiscriminator(name);
+		let ns = features.isSet("anchor-deprecated-state") ? "account" : "state";
+    const header = BorshAccountHeader.encode(name, ns);
     const accData = buffer.slice(0, len);
 
-    return Buffer.concat([disc, accData]);
+    return Buffer.concat([header, accData]);
   }
 
-  public decode<T = any>(ix: Buffer): T {
-    // Chop off discriminator.
-    const data = ix.slice(8);
+  public decode<T = any>(data: Buffer): T {
+    // Chop off header.
+    data = data.slice(BorshAccountHeader.size());
     return this.layout.decode(data);
   }
 }
@@ -35,5 +37,5 @@ export class BorshStateCoder {
 // Calculates unique 8 byte discriminator prepended to all anchor state accounts.
 export async function stateDiscriminator(name: string): Promise<Buffer> {
   let ns = features.isSet("anchor-deprecated-state") ? "account" : "state";
-  return Buffer.from(sha256.digest(`${ns}:${name}`)).slice(0, 8);
+  return Buffer.from(sha256.digest(`${ns}:${name}`)).slice(0, BorshAccountHeader.discriminatorSize());
 }

--- a/ts/src/coder/index.ts
+++ b/ts/src/coder/index.ts
@@ -1,3 +1,4 @@
+import { GetProgramAccountsFilter } from "@solana/web3.js";
 import { IdlEvent, IdlTypeDef } from "../idl.js";
 import { Event } from "../program/event.js";
 
@@ -38,7 +39,8 @@ export interface AccountsCoder<A extends string = string> {
   encode<T = any>(accountName: A, account: T): Promise<Buffer>;
   decode<T = any>(accountName: A, ix: Buffer): T;
   decodeUnchecked<T = any>(accountName: A, ix: Buffer): T;
-  memcmp(accountName: A, appendData?: Buffer): any;
+  memcmp(accountName: A): GetProgramAccountsFilter;
+  memcmpDataOffset(): number;
   size(idlAccount: IdlTypeDef): number;
 }
 

--- a/ts/src/coder/spl-token/accounts.ts
+++ b/ts/src/coder/spl-token/accounts.ts
@@ -1,3 +1,4 @@
+import { GetProgramAccountsFilter } from "@solana/web3.js";
 import * as BufferLayout from "buffer-layout";
 import { publicKey, uint64, coption, bool } from "./buffer-layout.js";
 import { AccountsCoder } from "../index.js";
@@ -44,8 +45,7 @@ export class SplTokenAccountsCoder<A extends string = string>
     }
   }
 
-  // TODO: this won't use the appendData.
-  public memcmp(accountName: A, _appendData?: Buffer): any {
+  public memcmp(accountName: A): GetProgramAccountsFilter {
     switch (accountName) {
       case "Token": {
         return {
@@ -61,6 +61,10 @@ export class SplTokenAccountsCoder<A extends string = string>
         throw new Error(`Invalid account name: ${accountName}`);
       }
     }
+  }
+
+  public memcmpDataOffset(): number {
+    return 0;
   }
 
   public size(idlAccount: IdlTypeDef): number {

--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import * as borsh from "@project-serum/borsh";
 
 export type Idl = {
-	layoutVersion: string;
+  layoutVersion: string;
   version: string;
   name: string;
   instructions: IdlInstruction[];

--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -3,6 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import * as borsh from "@project-serum/borsh";
 
 export type Idl = {
+	layoutVersion: string;
   version: string;
   name: string;
   instructions: IdlInstruction[];

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -24,6 +24,7 @@ import InstructionNamespaceFactory from "./instruction.js";
 import RpcNamespaceFactory from "./rpc.js";
 import TransactionNamespaceFactory from "./transaction.js";
 import { IdlTypes, TypeDef } from "./types.js";
+import * as features from "../../utils/features.js";
 
 export default class StateFactory {
   public static build<IDL extends Idl>(
@@ -172,10 +173,19 @@ export class StateClient<IDL extends Idl> {
     if (!state) {
       throw new Error("State is not specified in IDL.");
     }
+
     const expectedDiscriminator = await stateDiscriminator(state.struct.name);
-    if (expectedDiscriminator.compare(accountInfo.data.slice(0, 8))) {
-      throw new Error("Invalid account discriminator");
-    }
+
+		if (features.isSet('deprecated-layout')) {
+			if (expectedDiscriminator.compare(accountInfo.data.slice(0, 8))) {
+				throw new Error("Invalid state discriminator");
+			}
+		} else {
+			if (expectedDiscriminator.compare(accountInfo.data.slice(2, 6))) {
+				throw new Error("Invalid state discriminator");
+			}
+		}
+
     return this.coder.state.decode(accountInfo.data);
   }
 

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -176,15 +176,15 @@ export class StateClient<IDL extends Idl> {
 
     const expectedDiscriminator = await stateDiscriminator(state.struct.name);
 
-		if (features.isSet('deprecated-layout')) {
-			if (expectedDiscriminator.compare(accountInfo.data.slice(0, 8))) {
-				throw new Error("Invalid state discriminator");
-			}
-		} else {
-			if (expectedDiscriminator.compare(accountInfo.data.slice(2, 6))) {
-				throw new Error("Invalid state discriminator");
-			}
-		}
+    if (features.isSet("deprecated-layout")) {
+      if (expectedDiscriminator.compare(accountInfo.data.slice(0, 8))) {
+        throw new Error("Invalid state discriminator");
+      }
+    } else {
+      if (expectedDiscriminator.compare(accountInfo.data.slice(2, 6))) {
+        throw new Error("Invalid state discriminator");
+      }
+    }
 
     return this.coder.state.decode(accountInfo.data);
   }

--- a/ts/src/spl/token.ts
+++ b/ts/src/spl/token.ts
@@ -19,7 +19,7 @@ export function coder(): SplTokenCoder {
  * SplToken IDL.
  */
 export type SplToken = {
-	layoutVersion: "custom",
+  layoutVersion: "custom";
   version: "0.1.0";
   name: "spl_token";
   instructions: [
@@ -625,7 +625,7 @@ export type SplToken = {
 };
 
 export const IDL: SplToken = {
-	layoutVersion: "custom",
+  layoutVersion: "custom",
   version: "0.1.0",
   name: "spl_token",
   instructions: [

--- a/ts/src/spl/token.ts
+++ b/ts/src/spl/token.ts
@@ -19,6 +19,7 @@ export function coder(): SplTokenCoder {
  * SplToken IDL.
  */
 export type SplToken = {
+	layoutVersion: "custom",
   version: "0.1.0";
   name: "spl_token";
   instructions: [
@@ -624,6 +625,7 @@ export type SplToken = {
 };
 
 export const IDL: SplToken = {
+	layoutVersion: "custom",
   version: "0.1.0",
   name: "spl_token",
   instructions: [

--- a/ts/src/utils/features.ts
+++ b/ts/src/utils/features.ts
@@ -1,4 +1,7 @@
-const _AVAILABLE_FEATURES = new Set(["anchor-deprecated-state"]);
+const _AVAILABLE_FEATURES = new Set([
+	"anchor-deprecated-state",
+	"deprecated-layout",
+]);
 
 const _FEATURES = new Map();
 

--- a/ts/src/utils/features.ts
+++ b/ts/src/utils/features.ts
@@ -1,6 +1,6 @@
 const _AVAILABLE_FEATURES = new Set([
-	"anchor-deprecated-state",
-	"deprecated-layout",
+  "anchor-deprecated-state",
+  "deprecated-layout",
 ]);
 
 const _FEATURES = new Map();

--- a/ts/tests/events.spec.ts
+++ b/ts/tests/events.spec.ts
@@ -12,6 +12,7 @@ describe("Events", () => {
       "Program J2XMGdW2qQLx7rAdwWtSZpTXDgAQ988BLP9QTgUZvm54 success",
     ];
     const idl = {
+      layoutVersion: "0.1.0",
       version: "0.0.0",
       name: "basic_0",
       instructions: [

--- a/ts/tests/transaction.spec.ts
+++ b/ts/tests/transaction.spec.ts
@@ -15,6 +15,7 @@ describe("Transaction", () => {
     data: Buffer.from("post"),
   });
   const idl = {
+		layoutVersion: '0.1.0',
     version: "0.0.0",
     name: "basic_0",
     instructions: [

--- a/ts/tests/transaction.spec.ts
+++ b/ts/tests/transaction.spec.ts
@@ -15,7 +15,7 @@ describe("Transaction", () => {
     data: Buffer.from("post"),
   });
   const idl = {
-		layoutVersion: '0.1.0',
+    layoutVersion: "0.1.0",
     version: "0.0.0",
     name: "basic_0",
     instructions: [


### PR DESCRIPTION
Adds a new account header `<1-byte-layout-version> || <1-byte-bump> || <4-byte-discriminator> || <2-byte unused>`

And a new feature flag to enable the old layout, so as not to break existing clients.