### PR TITLE
client: derive cluster ws url like web3.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ incremented for features.
 
 * ts: Fix the loss of strict typing using the `methods` namespace on builder functions ([#1539](https://github.com/project-serum/anchor/pull/1539)).
 * spl: Update `spl/governance` to use new errors ([#1582](https://github.com/project-serum/anchor/pull/1582)).
+* client: Fix `Cluster`'s `FromStr` implementation ([#1362](https://github.com/project-serum/anchor/pull/1362)).
 
 ### Breaking
 


### PR DESCRIPTION
This fixes two issues with `Cluster`'s `FromStr` implementation, namely:

  * url being lowercased
  * websocket port defaulting to 8900

The implementation has been changed to match that of the official
`web3.js` library.

See https://github.com/solana-labs/solana/blob/aea8f0df1610248d29d8ca3bc0d60e9fabc99e31/web3.js/src/util/url.ts.