### PR TITLE
ts: fix `Wallet` class declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+### Fixes
+
+* ts: Fix the root type declaration of the `Wallet` / `NodeWallet` class. ([#1363](https://github.com/project-serum/anchor/pull/1363))
+
 ### Features
 
 * lang: Add `seeds::program` constraint for specifying which program_id to use when deriving PDAs.([#1197](https://github.com/project-serum/anchor/pull/1197))

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,5 +1,3 @@
-import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
-import type { Wallet as ProviderWallet } from "./provider";
 import NodeWallet from "./nodewallet";
 import { isBrowser } from "./utils/common.js";
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,3 +1,6 @@
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import type { Wallet as ProviderWallet } from "./provider";
+import NodeWallet from "./nodewallet";
 import { isBrowser } from "./utils/common.js";
 
 export { default as BN } from "bn.js";
@@ -12,7 +15,7 @@ export * from "./program/index.js";
 export * from "./spl/index.js";
 
 export declare const workspace: any;
-export declare const Wallet: import("./nodewallet").default;
+export declare class Wallet extends NodeWallet {}
 
 if (!isBrowser) {
   exports.workspace = require("./workspace.js").default;


### PR DESCRIPTION
Previously, the `Wallet` type declaration at the package root was declared as a `const` of type `NodeWallet`. This doesn't work and causes typing issues since now `Wallet` is a variable and not an instantiable class.

I changed the declaration so that `Wallet` is now a "new class" that extends the functionality of `NodeWallet` allowing it to maintain its class identify and instantiability.