### PR TITLE
Fill some gaps in generating types for Typescript from the IDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ incremented for features.
 ### Fixes
 
 * ts: Fix the root type declaration of the `Wallet` / `NodeWallet` class. ([#1363](https://github.com/project-serum/anchor/pull/1363))
+* ts: Improve type mapping of Account fields into Typescript with additional support for `Option<T>` and `Vec<String>` types. ([#1393](https://github.com/project-serum/anchor/pull/1393))
 
 ### Features
 

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -105,6 +105,8 @@ export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
   ? Defined[T["defined"]]
   : T extends { option: { defined: keyof Defined } }
   ? Defined[T["option"]["defined"]] | null
+  : T extends { option: keyof TypeMap }
+  ? TypeMap[T["option"]]
   : T extends { vec: keyof TypeMap }
   ? TypeMap[T["vec"]][]
   : T extends { array: [defined: keyof TypeMap, size: number] }

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -92,6 +92,7 @@ export type MethodsFn<
 type TypeMap = {
   publicKey: PublicKey;
   bool: boolean;
+  string: string;
 } & {
   [K in "u8" | "i8" | "u16" | "i16" | "u32" | "i32"]: number;
 } &


### PR DESCRIPTION
Closes #1392 

We've run up against two small issues when working in Typescript with the types generated for account fields from the IDLs. 

1. `Option<T>` fields map to `unknown` type in Typescript when `T` is one of the standard types defined in `TypeMap`, e.g., 
```
#[account]
pub struct MyAccount {
    pub counter: Option<u16>,
}
```

```
const accountAddress = "...";
const myAccount = await myProgram.account.myAccount.fetch(accountAddress);
const counterPlusOne = myAccount.counter + 1;  // Assuming the counter has been initialised
``` 
Results in `TS2365: Operator '+' cannot be applied to types 'unknown' and '1'.`

Adding in an additional clause to `DecodeType<T extends IdlType, Defined>` allows the types declared in `TypeMap` to be supported as type parameters of `Option<T>`, and for those types to map correctly into Typescript types.

2. `Vec<String>` fields map to `unknown` type in Typescript. Only the types defined in `TypeMap` are considered when determining how to map a `Vec<T>` to some `T'[]`. 

```
#[account]
pub struct MyAccount {
    pub my_strings: Vec<String>,
}
```

```
const accountAddress = "...";
const myAccount = await myProgram.account.myAccount.fetch(accountAddress);
const myStrings = myAccount.myStrings;

for (const myString of myStrings) { ...
```
Results in `TS2488: Type 'unknown' must have a '[Symbol.iterator]()' method that returns an iterator.` Adding in a mapping from `string: string` in `TypeMap` corrects this. 

Keen for input on whether we can get this fixed and if there are any additional changes we should make or code paths we should investigate; Or to understand if there are other changes to type support in Typescript coming that means we should leave this as it is for now. 

Thanks!