### PR TITLE
avm: Handle empty .version file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avm"
-version = "0.1.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm"
-version = "0.1.0"
+version = "0.20.1"
 edition = "2018"
 
 [[bin]]

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -98,6 +98,11 @@ pub fn install_version(version: &Version) -> Result<()> {
         &AVM_HOME.join("bin").join("anchor"),
         &AVM_HOME.join("bin").join(format!("anchor-{}", version)),
     )?;
+    // If .version file is empty or not parseable, write the newly installed version to it
+    if !current_version().is_ok() {
+        let mut current_version_file = fs::File::create(current_version_file_path().as_path())?;
+        current_version_file.write_all(version.to_string().as_bytes())?;
+    }
     Ok(())
 }
 
@@ -174,7 +179,7 @@ pub fn list_versions() -> Result<()> {
         if installed_versions.contains(v) {
             flags.push("installed");
         }
-        if current_version().unwrap() == v.clone() {
+        if current_version().is_ok() && current_version().unwrap() == v.clone() {
             flags.push("current");
         }
         if flags.is_empty() {

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -99,7 +99,7 @@ pub fn install_version(version: &Version) -> Result<()> {
         &AVM_HOME.join("bin").join(format!("anchor-{}", version)),
     )?;
     // If .version file is empty or not parseable, write the newly installed version to it
-    if !current_version().is_ok() {
+    if current_version().is_err() {
         let mut current_version_file = fs::File::create(current_version_file_path().as_path())?;
         current_version_file.write_all(version.to_string().as_bytes())?;
     }

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -5,7 +5,7 @@ use semver::Version;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
-#[clap(name = "avm", about = "Anchor version manager")]
+#[clap(name = "avm", about = "Anchor version manager", version)]
 pub struct Cli {
     #[clap(subcommand)]
     command: Commands,


### PR DESCRIPTION
- Fix panic for `avm list` on empty `.version` file
- If you run `avm install <list>` and the `.version` file is empty, write the installed version to it

Closes https://github.com/project-serum/anchor/issues/1405