### PR TITLE
avm: dont set current version if install prompt is declined after `avm use`

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -55,11 +55,17 @@ pub fn use_version(version: &Version) -> Result<()> {
                 "anchor-cli {} is not installed, would you like to install it? (y/n)",
                 version
             ))
-            .with_initial_text("y")
             .default("n".into())
             .interact_text()?;
         if matches!(input.as_str(), "y" | "yy" | "Y" | "yes" | "Yes") {
             install_version(version)?;
+        } else {
+            println!(
+                "Version {} is not installed, staying on version {}.",
+                version,
+                current_version()?
+            );
+            return Ok(());
         }
     }
 


### PR DESCRIPTION
This was missing an error if they user doesn't elect to install the missing version. Without it, it proceeds to overwrite the version file. Also removed the initial text on the prompt for UX.

Closes #1413 