### PR TITLE
Remove (seemingly) dead projects

### DIFF
--- a/docs/src/getting-started/projects.md
+++ b/docs/src/getting-started/projects.md
@@ -14,8 +14,6 @@ Open a pull request to add your project to the [list](https://github.com/project
 * [Cyclos](https://cyclos.io/)
 * [Solend](https://solend.fi)
 * [Drift](https://www.drift.trade/)
-* [SpringBoard](https://springboard.finance/)
-* [Unk](https://unk.finance/)
 * [Fabric](https://stake.fsynth.io/)
 * [Jet Protocol](https://jetprotocol.io/)
 * [Quarry](https://quarry.so/)


### PR DESCRIPTION
Neither of these addresses resolve:

* [SpringBoard](https://springboard.finance/)  - DNS doesn't resolve
* [Unk](https://unk.finance/) - SSL Error, then 404 from Vervel