### PR TITLE
ts: add metadata field to Idl type

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -15,7 +15,7 @@ export type Idl = {
   metadata?: IdlMetadata;
 };
 
-export type IdlMetadata = any
+export type IdlMetadata = any;
 
 export type IdlConstant = {
   name: string;

--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -12,7 +12,10 @@ export type Idl = {
   events?: IdlEvent[];
   errors?: IdlErrorCode[];
   constants?: IdlConstant[];
+  metadata?: IdlMetadata;
 };
+
+export type IdlMetadata = any
 
 export type IdlConstant = {
   name: string;


### PR DESCRIPTION
The new(-ish?) version of anchor generates the metadata field in the IDL which includes the program address, but this field is missing from the Idl type in ts so I've added it.