### PR TITLE
Update discord link to invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <p>
     <a href="https://github.com/project-serum/anchor/actions"><img alt="Build Status" src="https://github.com/project-serum/anchor/actions/workflows/tests.yaml/badge.svg" /></a>
     <a href="https://project-serum.github.io/anchor/"><img alt="Tutorials" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
-    <a href="https://discord.com/channels/889577356681945098"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
+    <a href="https://discord.gg/PDeRXyVURd"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/github/license/project-serum/anchor?color=blueviolet" /></a>
   </p>
 </div>


### PR DESCRIPTION
Minor issue. If you're not a member of the Serum discord, then clicking the Discord badge takes you to an error page, probably makes more sense to direct users to the invite link. If you're already a member it will just ask to open Discord. The link I used it from on the project Serum discord anchor channel - https://discord.gg/PDeRXyVURd