### PR TITLE
Attempt to reduce test flakiness by forcing file sync

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -261,6 +261,9 @@ mod tests {
         let mut current_version_file =
             fs::File::create(current_version_file_path().as_path()).unwrap();
         current_version_file.write_all("0.18.2".as_bytes()).unwrap();
+        // Sync the file to disk before the read in current_version() to
+        // mitigate the read not seeing the written version bytes.
+        current_version_file.sync_all().unwrap();
         assert!(current_version().unwrap() == Version::parse("0.18.2").unwrap());
     }
 


### PR DESCRIPTION
Some automated testing has shown this test to fail due to being unable
to read the written version bytes from the file. The root cause would
seem to be something at the OS level, so do a sync_all() to hopefully
ensure that the immediate read after write sees the contents of the
write.

We (Solana) build against this repo as part of our CI to ensure we don't break things (at least compilation 😄 ); this test has been failing intermittently for us ([one such instance](https://buildkite.com/solana-labs/solana/builds/65904#60d404fd-ef99-42ec-96cc-049e43b15263)) as follows:
```
    Running unittests (target/debug/deps/avm-c9bbce84b0ec1ce3)

running 7 tests
test tests::test_version_binary_path ... ok
test tests::test_ensure_paths ... ok
test tests::test_current_version_file_path ... ok
test tests::test_uninstall_non_installed_version - should panic ... ok
test tests::test_read_installed_versions ... ok
test tests::test_uninstalled_in_use_version - should panic ... ok
test tests::test_current_version ... FAILED

failures:

---- tests::test_current_version stdout ----
thread 'tests::test_current_version' panicked at 'called `Result::unwrap()` on an `Err` value: Could not parse version file: unexpected end of input while parsing major version number', avm/src/lib.rs:264:35


failures:
tests::test_current_version
```

Hypothetically, I don't think this change should be strictly necessary; however, I have previously observed issues with unit tests that write a file and immediately read it afterwards.