### PR TITLE
fixup! avm: force file sync (#1457)

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -281,6 +281,9 @@ mod tests {
         let mut current_version_file =
             fs::File::create(current_version_file_path().as_path()).unwrap();
         current_version_file.write_all("0.18.2".as_bytes()).unwrap();
+        // Sync the file to disk before the read in current_version() to
+        // mitigate the read not seeing the written version bytes.
+        current_version_file.sync_all().unwrap();
         // Create a fake binary for anchor-0.18.2 in the bin directory
         fs::File::create(version_binary_path(&version)).unwrap();
         uninstall_version(&version).unwrap();


### PR DESCRIPTION
Sorry for second PR; didn't browse deep enough to see this one could be problematic as well. Don't see any other instances of `write_all()` in this file's tests.

```
     Running unittests (target/debug/deps/avm-57a23adf9ea2b364)
 
running 7 tests
test tests::test_version_binary_path ... ok
test tests::test_current_version_file_path ... ok
test tests::test_uninstall_non_installed_version - should panic ... ok
test tests::test_ensure_paths ... ok
test tests::test_read_installed_versions ... ok
test tests::test_uninstalled_in_use_version - should panic ... FAILED
test tests::test_current_version ... ok
 
failures:
 
---- tests::test_uninstalled_in_use_version stdout ----
thread 'tests::test_uninstalled_in_use_version' panicked at 'called `Result::unwrap()` on an `Err` value: Could not parse version file: unexpected end of input while parsing major version number', avm/src/lib.rs:121:38
note: panic did not contain expected string
      panic message: `"called `Result::unwrap()` on an `Err` value: Could not parse version file: unexpected end of input while parsing major version number"`,
 expected substring: `"anchor-cli 0.18.2 is currently in use"`
 
failures:
    tests::test_uninstalled_in_use_version
```    