### PR TITLE
Add "@types/chai" devDependency to package.json

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -237,6 +237,7 @@ pub fn ts_package_json() -> String {
         "chai": "^4.3.4",
         "mocha": "^9.0.3",
         "ts-mocha": "^8.0.0",
+        "@types/chai": "^4.3.0",
         "@types/mocha": "^9.0.0",
         "typescript": "^4.3.5"
     }}


### PR DESCRIPTION
[Chai](https://www.npmjs.com/package/chai) doesn't have types associated with it. This diff just adds a devDependency on [`@types/chai`](https://www.npmjs.com/package/@types/chai)

#1511 