### PR TITLE
Added better error messaging when workspace.member or workspace.exclude doesn't exist.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -183,14 +183,14 @@ impl WithPath<Config> {
             .members
             .iter()
             .map(|m| {
-                self.path().parent().unwrap().join(m).canonicalize().expect(
-                    format!(
-                        "Error reading workspace.members. \
-                         File {:?} does not exist at path {:?}.",
-                        m, self.path
-                    )
-                    .as_str(),
-                )
+                self.path()
+                    .parent()
+                    .unwrap()
+                    .join(m)
+                    .canonicalize()
+                    .unwrap_or_else(|_| {
+                        panic!("Error reading workspace.members. File {:?} does not exist at path {:?}.", m, self.path)
+                    })
             })
             .collect();
         let exclude = self
@@ -198,14 +198,14 @@ impl WithPath<Config> {
             .exclude
             .iter()
             .map(|m| {
-                self.path().parent().unwrap().join(m).canonicalize().expect(
-                    format!(
-                        "Error reading workspace.exclude. \
-                         File {:?} does not exist at path {:?}.",
-                        m, self.path
-                    )
-                    .as_str(),
-                )
+                self.path()
+                    .parent()
+                    .unwrap()
+                    .join(m)
+                    .canonicalize()
+                    .unwrap_or_else(|_| {
+                        panic!("Error reading workspace.exclude. File {:?} does not exist at path {:?}.", m, self.path)
+                    })
             })
             .collect();
         Ok((members, exclude))

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -189,7 +189,7 @@ impl WithPath<Config> {
                     .join(m)
                     .canonicalize()
                     .unwrap_or_else(|_| {
-                        panic!("Error reading file {:?} at path {:?}.", m, self.path)
+                        panic!("Error reading workspace.members. File {:?} does not exist at path {:?}.", m, self.path)
                     })
             })
             .collect();
@@ -204,7 +204,7 @@ impl WithPath<Config> {
                     .join(m)
                     .canonicalize()
                     .unwrap_or_else(|_| {
-                        panic!("Error reading file {:?} at path {:?}.", m, self.path)
+                        panic!("Error reading workspace.exclude. File {:?} does not exist at path {:?}.", m, self.path)
                     })
             })
             .collect();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -183,18 +183,14 @@ impl WithPath<Config> {
             .members
             .iter()
             .map(|m| {
-                self.path()
-                    .parent()
-                    .unwrap()
-                    .join(m)
-                    .canonicalize()
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "Error reading workspace.members. \
-                                File {:?} does not exist at path {:?}.",
-                            m, self.path
-                        )
-                    })
+                self.path().parent().unwrap().join(m).canonicalize().expect(
+                    format!(
+                        "Error reading workspace.members. \
+                         File {:?} does not exist at path {:?}.",
+                        m, self.path
+                    )
+                    .as_str(),
+                )
             })
             .collect();
         let exclude = self
@@ -202,18 +198,14 @@ impl WithPath<Config> {
             .exclude
             .iter()
             .map(|m| {
-                self.path()
-                    .parent()
-                    .unwrap()
-                    .join(m)
-                    .canonicalize()
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "Error reading workspace.exclude. \
-                                File {:?} does not exist at path {:?}.",
-                            m, self.path
-                        )
-                    })
+                self.path().parent().unwrap().join(m).canonicalize().expect(
+                    format!(
+                        "Error reading workspace.exclude. \
+                         File {:?} does not exist at path {:?}.",
+                        m, self.path
+                    )
+                    .as_str(),
+                )
             })
             .collect();
         Ok((members, exclude))

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -189,7 +189,11 @@ impl WithPath<Config> {
                     .join(m)
                     .canonicalize()
                     .unwrap_or_else(|_| {
-                        panic!("Error reading workspace.members. File {:?} does not exist at path {:?}.", m, self.path)
+                        panic!(
+                            "Error reading workspace.members. \
+                                File {:?} does not exist at path {:?}.",
+                            m, self.path
+                        )
                     })
             })
             .collect();
@@ -204,7 +208,11 @@ impl WithPath<Config> {
                     .join(m)
                     .canonicalize()
                     .unwrap_or_else(|_| {
-                        panic!("Error reading workspace.exclude. File {:?} does not exist at path {:?}.", m, self.path)
+                        panic!(
+                            "Error reading workspace.exclude. \
+                                File {:?} does not exist at path {:?}.",
+                            m, self.path
+                        )
                     })
             })
             .collect();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -188,7 +188,9 @@ impl WithPath<Config> {
                     .unwrap()
                     .join(m)
                     .canonicalize()
-                    .unwrap()
+                    .unwrap_or_else(|_| {
+                        panic!("Error reading file {:?} at path {:?}.", m, self.path)
+                    })
             })
             .collect();
         let exclude = self
@@ -201,7 +203,9 @@ impl WithPath<Config> {
                     .unwrap()
                     .join(m)
                     .canonicalize()
-                    .unwrap()
+                    .unwrap_or_else(|_| {
+                        panic!("Error reading file {:?} at path {:?}.", m, self.path)
+                    })
             })
             .collect();
         Ok((members, exclude))


### PR DESCRIPTION
When workspace.member or workspace.exclude has an invalid path this panics with a meaningful error. 
Replaces unwrap with unwrap_or_else and panics on error.
There is also a possibility to handle the Err case and parse valid paths and logging an error for invalid paths.

Tests pass. 
No new tests are needed snice this does not change the overall functioning.