### PR TITLE
lang: Fix detection of Accounts derive 

### DIFF
--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -353,9 +353,7 @@ fn parse_account_derives(ctx: &CrateContext) -> HashMap<String, AccountsStruct> 
     ctx.structs()
         .filter_map(|i_strct| {
             for attr in &i_strct.attrs {
-                if attr.path.is_ident("derive")
-                    && attr.tokens.to_string() == format!("({})", DERIVE_NAME)
-                {
+                if attr.path.is_ident("derive") && attr.tokens.to_string().contains(DERIVE_NAME) {
                     let strct = accounts::parse(i_strct).expect("Code not parseable");
                     return Some((strct.ident.to_string(), strct));
                 }

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -353,7 +353,9 @@ fn parse_account_derives(ctx: &CrateContext) -> HashMap<String, AccountsStruct> 
     ctx.structs()
         .filter_map(|i_strct| {
             for attr in &i_strct.attrs {
-                if attr.tokens.to_string().contains(DERIVE_NAME) {
+                if attr.path.is_ident("derive")
+                    && attr.tokens.to_string() == format!("({})", DERIVE_NAME)
+                {
                     let strct = accounts::parse(i_strct).expect("Code not parseable");
                     return Some((strct.ident.to_string(), strct));
                 }


### PR DESCRIPTION
The following snippet breaks the IDL parser due to the presence of `Accounts` in the outer doc comment which leads the IDL parser to think it is an Accounts derive.

```
/// Accounts in context of initialize_vault instruction
#[account]
#[derive(Default)]
pub struct VaultInfo {
    pub token_a: Pubkey,
    pub token_b: Pubkey,
    pub vault_name: [u8; 20],
}
```