### PR TITLE
ts: fix methods namespace typing loss and deprecate non-methods namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ incremented for features.
 
 * lang: Add new `AccountSysvarMismatch` error code and test cases for sysvars ([#1535](https://github.com/project-serum/anchor/pull/1535)).
 
+### Fixes
+
+* ts: Fix the loss of strict typing using the `methods` namespace on builder functions ([#1539](https://github.com/project-serum/anchor/pull/1539)).
+
+### Breaking
+
+* ts: Mark `transaction`, `instruction`, `simulate` and `rpc` program namespaces as deprecated in favor of `methods` ([#1539](https://github.com/project-serum/anchor/pull/1539)).
+
 ## [0.22.1] - 2022-02-28
 
 ### Fixes

--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -77,6 +77,7 @@ export class Program<IDL extends Idl = Idl> {
    *   },
    * });
    * ```
+   * @deprecated
    */
   readonly rpc: RpcNamespace<IDL>;
 
@@ -130,6 +131,7 @@ export class Program<IDL extends Idl = Idl> {
    *   },
    * });
    * ```
+   * @deprecated
    */
   readonly instruction: InstructionNamespace<IDL>;
 
@@ -161,6 +163,7 @@ export class Program<IDL extends Idl = Idl> {
    *   },
    * });
    * ```
+   * @deprecated
    */
   readonly transaction: TransactionNamespace<IDL>;
 
@@ -197,6 +200,7 @@ export class Program<IDL extends Idl = Idl> {
    *   },
    * });
    * ```
+   * @deprecated
    */
   readonly simulate: SimulateNamespace<IDL>;
 

--- a/ts/src/program/namespace/index.ts
+++ b/ts/src/program/namespace/index.ts
@@ -10,7 +10,6 @@ import RpcFactory, { RpcNamespace } from "./rpc.js";
 import AccountFactory, { AccountNamespace } from "./account.js";
 import SimulateFactory, { SimulateNamespace } from "./simulate.js";
 import { parseIdlErrors } from "../common.js";
-import { AllInstructions } from "./types.js";
 import { MethodsBuilderFactory, MethodsNamespace } from "./methods";
 
 // Re-exports.
@@ -55,8 +54,8 @@ export default class NamespaceFactory {
 
     const state = StateFactory.build(idl, coder, programId, provider);
 
-    idl.instructions.forEach(<I extends AllInstructions<IDL>>(idlIx: I) => {
-      const ixItem = InstructionFactory.build<IDL, I>(
+    idl.instructions.forEach((idlIx) => {
+      const ixItem = InstructionFactory.build<IDL, typeof idlIx>(
         idlIx,
         (ixName, ix) => coder.instruction.encode(ixName, ix),
         programId
@@ -72,7 +71,7 @@ export default class NamespaceFactory {
         programId,
         idl
       );
-      const methodItem = MethodsBuilderFactory.build(
+      const methodItem = MethodsBuilderFactory.build<IDL, typeof idlIx>(
         provider,
         programId,
         idlIx,

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -17,6 +17,7 @@ import { SimulateFn } from "./simulate.js";
 import Provider from "../../provider.js";
 import { AccountNamespace } from "./account.js";
 import { AccountsResolver } from "../accounts-resolver.js";
+import { Accounts } from "../context.js";
 
 export type MethodsNamespace<
   IDL extends Idl = Idl,
@@ -33,9 +34,9 @@ export class MethodsBuilderFactory {
     rpcFn: RpcFn<IDL>,
     simulateFn: SimulateFn<IDL>,
     accountNamespace: AccountNamespace<IDL>
-  ): MethodsFn<IDL, I, any> {
-    const request: MethodsFn<IDL, I, any> = (...args) => {
-      return new MethodsBuilder(
+  ): MethodsFn<IDL, I, MethodsBuilder<IDL, I>> {
+    return (...args) =>
+      new MethodsBuilder(
         args,
         ixFn,
         txFn,
@@ -46,13 +47,11 @@ export class MethodsBuilderFactory {
         idlIx,
         accountNamespace
       );
-    };
-    return request;
   }
 }
 
 export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
-  readonly _accounts: { [name: string]: PublicKey } = {};
+  private readonly _accounts: { [name: string]: PublicKey } = {};
   private _remainingAccounts: Array<AccountMeta> = [];
   private _signers: Array<Signer> = [];
   private _preInstructions: Array<TransactionInstruction> = [];
@@ -80,8 +79,9 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
     );
   }
 
-  // TODO: don't use any.
-  public accounts(accounts: any): MethodsBuilder<IDL, I> {
+  public accounts(
+    accounts: Accounts<I["accounts"][number]>
+  ): MethodsBuilder<IDL, I> {
     Object.assign(this._accounts, accounts);
     return this;
   }
@@ -112,7 +112,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
     return this;
   }
 
-  public async rpc(options: ConfirmOptions): Promise<TransactionSignature> {
+  public async rpc(options?: ConfirmOptions): Promise<TransactionSignature> {
     await this._accountsResolver.resolve();
     // @ts-ignore
     return this._rpcFn(...this._args, {
@@ -126,7 +126,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public async simulate(
-    options: ConfirmOptions
+    options?: ConfirmOptions
   ): Promise<SimulateResponse<any, any>> {
     await this._accountsResolver.resolve();
     // @ts-ignore

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -10,6 +10,7 @@ import {
   IdlTypeDefTyStruct,
 } from "../../idl";
 import { Accounts, Context } from "../context";
+import { MethodsBuilder } from "./methods";
 
 /**
  * All instructions for an IDL.
@@ -66,7 +67,11 @@ export type MakeInstructionsNamespace<
 };
 
 export type MakeMethodsNamespace<IDL extends Idl, I extends IdlInstruction> = {
-  [M in keyof InstructionMap<I>]: MethodsFn<IDL, InstructionMap<I>[M], any>;
+  [M in keyof InstructionMap<I>]: MethodsFn<
+    IDL,
+    InstructionMap<I>[M],
+    MethodsBuilder<IDL, InstructionMap<I>[M]>
+  >;
 };
 
 export type InstructionContextFn<


### PR DESCRIPTION
resolves #1434 
resolves #1442 