### PR TITLE
ts: fix type for accounts field in Idl

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -7,7 +7,7 @@ export type Idl = {
   name: string;
   instructions: IdlInstruction[];
   state?: IdlState;
-  accounts?: IdlTypeDef[];
+  accounts?: IdlAccountDef[];
   types?: IdlTypeDef[];
   events?: IdlEvent[];
   errors?: IdlErrorCode[];
@@ -77,6 +77,11 @@ export type IdlField = {
 export type IdlTypeDef = {
   name: string;
   type: IdlTypeDefTy;
+};
+
+export type IdlAccountDef = {
+  name: string;
+  type: IdlTypeDefTyStruct;
 };
 
 export type IdlTypeDefTyStruct = {

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -10,7 +10,7 @@ import {
   AccountInfo,
 } from "@solana/web3.js";
 import Provider, { getProvider } from "../../provider.js";
-import { Idl, IdlTypeDef } from "../../idl.js";
+import { Idl, IdlAccountDef } from "../../idl.js";
 import { Coder, BorshCoder } from "../../coder/index.js";
 import { Subscription, Address, translateAddress } from "../common.js";
 import { AllAccountsMap, IdlTypes, TypeDef } from "./types.js";
@@ -42,7 +42,7 @@ export default class AccountFactory {
 }
 
 type NullableIdlAccount<IDL extends Idl> = IDL["accounts"] extends undefined
-  ? IdlTypeDef
+  ? IdlAccountDef
   : NonNullable<IDL["accounts"]>[number];
 
 /**
@@ -72,7 +72,7 @@ export type AccountNamespace<IDL extends Idl = Idl> = {
 export class AccountClient<
   IDL extends Idl = Idl,
   A extends NullableIdlAccount<IDL> = IDL["accounts"] extends undefined
-    ? IdlTypeDef
+    ? IdlAccountDef
     : NonNullable<IDL["accounts"]>[number],
   T = TypeDef<A, IdlTypes<IDL>>
 > {


### PR DESCRIPTION
The `#[account]` macro can only be used on structs (and not enums) while the `accounts` field in the ts Idl type is defined as `IdlTypeDef` which expects both enums and structs.

Changed it so that the accounts field in the Idl type can only expect structs.