### PR TITLE
ts: fix methods builder `.accounts` requiring global programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ incremented for features.
 ### Breaking
 
 * ts: Mark `transaction`, `instruction`, `simulate` and `rpc` program namespaces as deprecated in favor of `methods` ([#1539](https://github.com/project-serum/anchor/pull/1539)).
+* ts: No longer allow manual setting of globally resolvable program public keys in `methods#accounts()`. ([#1548][https://github.com/project-serum/anchor/pull/1548])
 
 ## [0.22.1] - 2022-02-28
 

--- a/ts/src/program/accounts-resolver.ts
+++ b/ts/src/program/accounts-resolver.ts
@@ -10,6 +10,13 @@ import { coder } from "../spl/token";
 
 // Populates a given accounts context with PDAs and common missing accounts.
 export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
+  static readonly CONST_ACCOUNTS = {
+    systemProgram: SystemProgram.programId,
+    tokenProgram: TOKEN_PROGRAM_ID,
+    associatedTokenProgram: ASSOCIATED_PROGRAM_ID,
+    rent: SYSVAR_RENT_PUBKEY,
+  };
+
   private _accountStore: AccountStore<IDL>;
 
   constructor(
@@ -57,23 +64,9 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
       }
 
       // Common accounts are auto populated with magic names by convention.
-      switch (accountDescName) {
-        case "systemProgram":
-          if (this._accounts[accountDescName] === undefined) {
-            this._accounts[accountDescName] = SystemProgram.programId;
-          }
-        case "rent":
-          if (this._accounts[accountDescName] === undefined) {
-            this._accounts[accountDescName] = SYSVAR_RENT_PUBKEY;
-          }
-        case "tokenProgram":
-          if (this._accounts[accountDescName] === undefined) {
-            this._accounts[accountDescName] = TOKEN_PROGRAM_ID;
-          }
-        case "associatedTokenProgram":
-          if (this._accounts[accountDescName] === undefined) {
-            this._accounts[accountDescName] = ASSOCIATED_PROGRAM_ID;
-          }
+      if (Reflect.has(AccountsResolver.CONST_ACCOUNTS, accountDescName)) {
+        this._accounts[accountDescName] =
+          AccountsResolver.CONST_ACCOUNTS[accountDescName];
       }
     }
   }

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -80,7 +80,12 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public accounts(
-    accounts: Accounts<I["accounts"][number]>
+    accounts: Accounts<
+      Exclude<
+        I["accounts"][number],
+        keyof typeof AccountsResolver.CONST_ACCOUNTS
+      >
+    >
   ): MethodsBuilder<IDL, I> {
     Object.assign(this._accounts, accounts);
     return this;

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -80,11 +80,9 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public accounts(
-    accounts: Accounts<
-      Exclude<
-        I["accounts"][number],
-        keyof typeof AccountsResolver.CONST_ACCOUNTS
-      >
+    accounts: Omit<
+      Accounts<I["accounts"][number]>,
+      keyof typeof AccountsResolver.CONST_ACCOUNTS
     >
   ): MethodsBuilder<IDL, I> {
     Object.assign(this._accounts, accounts);

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -80,10 +80,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public accounts(
-    accounts: Omit<
-      Accounts<I["accounts"][number]>,
-      keyof typeof AccountsResolver.CONST_ACCOUNTS
-    >
+    accounts: Partial<Accounts<I["accounts"][number]>>
   ): MethodsBuilder<IDL, I> {
     Object.assign(this._accounts, accounts);
     return this;


### PR DESCRIPTION
After my last PR (#1539), the `.accounts()` function on the methods builder was requiring that global on-chain programs (`systemProgram`, `tokenProgram`, etc) be manually added.

This PR fixes that by having a static mapping in `AccountsResolver` of the resolvable global names and their `PublicKey`s and then excluding those names from the object provided to `.accounts()`.

This has the implication that we no longer allow developers to manually add those program public keys to the `.accounts()` object which would prevent user error with public key inputs.

resolves #1547 