### PR TITLE
lang: add support for logging expected and actual values and pubkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ incremented for features.
 
 * ts: Mark `transaction`, `instruction`, `simulate` and `rpc` program namespaces as deprecated in favor of `methods` ([#1539](https://github.com/project-serum/anchor/pull/1539)).
 * ts: No longer allow manual setting of globally resolvable program public keys in `methods#accounts()`. ([#1548][https://github.com/project-serum/anchor/pull/1548])
-* lang: Remove space calculation using [`#[derive(Default)]`] (https://github.com/project-serum/anchor/pull/1519).
+* lang: Remove space calculation using `#[derive(Default)]` ([#1519](https://github.com/project-serum/anchor/pull/1519)).
+* lang: add support for logging expected and actual values and pubkeys ([#1572](https://github.com/project-serum/anchor/pull/1572)).
 
 ## [0.22.1] - 2022-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ incremented for features.
 * ts: Mark `transaction`, `instruction`, `simulate` and `rpc` program namespaces as deprecated in favor of `methods` ([#1539](https://github.com/project-serum/anchor/pull/1539)).
 * ts: No longer allow manual setting of globally resolvable program public keys in `methods#accounts()`. ([#1548][https://github.com/project-serum/anchor/pull/1548])
 * lang: Remove space calculation using `#[derive(Default)]` ([#1519](https://github.com/project-serum/anchor/pull/1519)).
-* lang: add support for logging expected and actual values and pubkeys ([#1572](https://github.com/project-serum/anchor/pull/1572)).
+* lang: Add support for logging expected and actual values and pubkeys. Add `require_eq` and `require_keys_eq` macros. Add default error code to `require` macro ([#1572](https://github.com/project-serum/anchor/pull/1572)).
 
 ## [0.22.1] - 2022-02-28
 

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -125,15 +125,12 @@ fn create_error(
     };
 
     let expected_actual = match expected_actual {
-        Some(expected_actual) => {
-            let expected = expected_actual.expected;
-            let actual = expected_actual.actual;
-            if expected_actual.pubkeys {
-                quote! { Some(anchor_lang::error::ExpectedActual::Pubkeys([#expected, #actual])) }
-            } else {
+        Some(ExpectedActualInput::Values(expected, actual)) => {
                 quote! { Some(anchor_lang::error::ExpectedActual::Values([#expected.to_string(), #actual.to_string()])) }
-            }
-        }
+        },
+        Some(ExpectedActualInput::Pubkeys(expected, actual)) => {
+                quote! { Some(anchor_lang::error::ExpectedActual::Pubkeys([#expected, #actual])) }
+        },
         None => quote! { None },
     };
 

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -109,7 +109,7 @@ fn create_error(error_code: Expr, source: bool, account_name: Option<Expr>) -> T
                 error_code_number: #error_code.into(),
                 error_msg: #error_code.to_string(),
                 error_origin: #error_origin,
-                expected_actual: None
+                compared_values: None
             }
         )
     })

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 use anchor_syn::codegen;
-use anchor_syn::parser::error::{self as error_parser, ErrorInput, ErrorWithAccountNameInput};
+use anchor_syn::parser::error::{self as error_parser, ErrorInput};
 use anchor_syn::ErrorArgs;
 use syn::{parse_macro_input, Expr};
 

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -88,12 +88,6 @@ pub fn error(ts: proc_macro::TokenStream) -> TokenStream {
     create_error(error_code, true, None)
 }
 
-#[proc_macro]
-pub fn error_with_account_name(ts: proc_macro::TokenStream) -> TokenStream {
-    let input = parse_macro_input!(ts as ErrorWithAccountNameInput);
-    create_error(input.error_code, false, Some(input.account_name))
-}
-
 fn create_error(error_code: Expr, source: bool, account_name: Option<Expr>) -> TokenStream {
     let source = if source {
         quote! {

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -248,7 +248,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
         }
         if info.owner != &T::owner() {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*info.owner, T::owner()]));
+                .with_pubkeys((*info.owner, T::owner())));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(Account::new(info.clone(), T::try_deserialize(&mut data)?))
@@ -264,7 +264,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
         }
         if info.owner != &T::owner() {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*info.owner, T::owner()]));
+                .with_pubkeys((*info.owner, T::owner())));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(Account::new(

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -263,7 +263,8 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
             return Err(ErrorCode::AccountNotInitialized.into());
         }
         if info.owner != &T::owner() {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*info.owner, T::owner()]));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(Account::new(

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -245,8 +245,9 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
         if info.owner == &system_program::ID && info.lamports() == 0 {
             return Err(ErrorCode::AccountNotInitialized.into());
         }
+        assert_pubkeys_eq!(info.owner, T::owner());
         if info.owner != &T::owner() {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(ErrorCode::AccountOwnedByWrongProgram.into()).with_pubkeys(*info.owner, T::owner());
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(Account::new(info.clone(), T::try_deserialize(&mut data)?))

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -120,7 +120,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
     pub fn try_from(acc_info: &AccountInfo<'info>) -> Result<AccountLoader<'info, T>> {
         if acc_info.owner != &T::owner() {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*acc_info.owner, T::owner()]));
+                .with_pubkeys((*acc_info.owner, T::owner())));
         }
         let data: &[u8] = &acc_info.try_borrow_data()?;
         // Discriminator must match.
@@ -140,7 +140,7 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
     ) -> Result<AccountLoader<'info, T>> {
         if acc_info.owner != &T::owner() {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*acc_info.owner, T::owner()]));
+                .with_pubkeys((*acc_info.owner, T::owner())));
         }
         Ok(AccountLoader::new(acc_info.clone()))
     }

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -1,6 +1,6 @@
 //! Type facilitating on demand zero copy deserialization.
 
-use crate::error::ErrorCode;
+use crate::error::{Error, ErrorCode};
 use crate::{
     Accounts, AccountsClose, AccountsExit, Owner, Result, ToAccountInfo, ToAccountInfos,
     ToAccountMetas, ZeroCopy,
@@ -119,7 +119,8 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
     #[inline(never)]
     pub fn try_from(acc_info: &AccountInfo<'info>) -> Result<AccountLoader<'info, T>> {
         if acc_info.owner != &T::owner() {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*acc_info.owner, T::owner()]));
         }
         let data: &[u8] = &acc_info.try_borrow_data()?;
         // Discriminator must match.
@@ -138,7 +139,8 @@ impl<'info, T: ZeroCopy + Owner> AccountLoader<'info, T> {
         acc_info: &AccountInfo<'info>,
     ) -> Result<AccountLoader<'info, T>> {
         if acc_info.owner != &T::owner() {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*acc_info.owner, T::owner()]));
         }
         Ok(AccountLoader::new(acc_info.clone()))
     }

--- a/lang/src/accounts/loader.rs
+++ b/lang/src/accounts/loader.rs
@@ -59,7 +59,7 @@ impl<'info, T: ZeroCopy> Loader<'info, T> {
     ) -> Result<Loader<'info, T>> {
         if acc_info.owner != program_id {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*acc_info.owner, *program_id]));
+                .with_pubkeys((*acc_info.owner, *program_id)));
         }
         let data: &[u8] = &acc_info.try_borrow_data()?;
         // Discriminator must match.
@@ -80,7 +80,7 @@ impl<'info, T: ZeroCopy> Loader<'info, T> {
     ) -> Result<Loader<'info, T>> {
         if acc_info.owner != program_id {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*acc_info.owner, *program_id]));
+                .with_pubkeys((*acc_info.owner, *program_id)));
         }
         Ok(Loader::new(acc_info.clone()))
     }

--- a/lang/src/accounts/loader.rs
+++ b/lang/src/accounts/loader.rs
@@ -1,4 +1,4 @@
-use crate::error::ErrorCode;
+use crate::error::{Error, ErrorCode};
 use crate::{
     Accounts, AccountsClose, AccountsExit, Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
     ZeroCopy,
@@ -58,7 +58,8 @@ impl<'info, T: ZeroCopy> Loader<'info, T> {
         acc_info: &AccountInfo<'info>,
     ) -> Result<Loader<'info, T>> {
         if acc_info.owner != program_id {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*acc_info.owner, *program_id]));
         }
         let data: &[u8] = &acc_info.try_borrow_data()?;
         // Discriminator must match.
@@ -78,7 +79,8 @@ impl<'info, T: ZeroCopy> Loader<'info, T> {
         acc_info: &AccountInfo<'info>,
     ) -> Result<Loader<'info, T>> {
         if acc_info.owner != program_id {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*acc_info.owner, *program_id]));
         }
         Ok(Loader::new(acc_info.clone()))
     }

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -86,7 +86,7 @@ impl<'a, T: Id + Clone> Program<'a, T> {
     #[inline(never)]
     pub fn try_from(info: &AccountInfo<'a>) -> Result<Program<'a, T>> {
         if info.key != &T::id() {
-            return Err(Error::from(ErrorCode::InvalidProgramId).with_pubkeys([*info.key, T::id()]));
+            return Err(Error::from(ErrorCode::InvalidProgramId).with_pubkeys((*info.key, T::id())));
         }
         if !info.executable {
             return Err(ErrorCode::InvalidProgramExecutable.into());

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -1,6 +1,6 @@
 //! Type validating that the account is the given Program
 
-use crate::error::ErrorCode;
+use crate::error::{Error, ErrorCode};
 use crate::*;
 use solana_program::account_info::AccountInfo;
 use solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
@@ -86,7 +86,7 @@ impl<'a, T: Id + Clone> Program<'a, T> {
     #[inline(never)]
     pub fn try_from(info: &AccountInfo<'a>) -> Result<Program<'a, T>> {
         if info.key != &T::id() {
-            return Err(ErrorCode::InvalidProgramId.into());
+            return Err(Error::from(ErrorCode::InvalidProgramId).with_pubkeys([*info.key, T::id()]));
         }
         if !info.executable {
             return Err(ErrorCode::InvalidProgramExecutable.into());

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -38,7 +38,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T>
     pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramAccount<'a, T>> {
         if info.owner != program_id {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*info.owner, *program_id]));
+                .with_pubkeys((*info.owner, *program_id)));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(ProgramAccount::new(
@@ -57,7 +57,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T>
     ) -> Result<ProgramAccount<'a, T>> {
         if info.owner != program_id {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*info.owner, *program_id]));
+                .with_pubkeys((*info.owner, *program_id)));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(ProgramAccount::new(

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -1,6 +1,6 @@
 #[allow(deprecated)]
 use crate::accounts::cpi_account::CpiAccount;
-use crate::error::ErrorCode;
+use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Result,
     ToAccountInfo, ToAccountInfos, ToAccountMetas,
@@ -37,7 +37,8 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T>
     #[inline(never)]
     pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramAccount<'a, T>> {
         if info.owner != program_id {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*info.owner, *program_id]));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(ProgramAccount::new(
@@ -55,7 +56,8 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T>
         info: &AccountInfo<'a>,
     ) -> Result<ProgramAccount<'a, T>> {
         if info.owner != program_id {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*info.owner, *program_id]));
         }
         let mut data: &[u8] = &info.try_borrow_data()?;
         Ok(ProgramAccount::new(

--- a/lang/src/accounts/state.rs
+++ b/lang/src/accounts/state.rs
@@ -1,6 +1,6 @@
 #[allow(deprecated)]
 use crate::accounts::cpi_account::CpiAccount;
-use crate::error::ErrorCode;
+use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Result, ToAccountInfo,
     ToAccountInfos, ToAccountMetas,
@@ -39,7 +39,8 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramState<'a, T> {
     #[inline(never)]
     pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramState<'a, T>> {
         if info.owner != program_id {
-            return Err(ErrorCode::AccountOwnedByWrongProgram.into());
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys([*info.owner, *program_id]));
         }
         if info.key != &Self::address(program_id) {
             solana_program::msg!("Invalid state address");

--- a/lang/src/accounts/state.rs
+++ b/lang/src/accounts/state.rs
@@ -40,7 +40,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramState<'a, T> {
     pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramState<'a, T>> {
         if info.owner != program_id {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
-                .with_pubkeys([*info.owner, *program_id]));
+                .with_pubkeys((*info.owner, *program_id)));
         }
         if info.key != &Self::address(program_id) {
             solana_program::msg!("Invalid state address");

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -256,10 +256,10 @@ impl Error {
     }
 
     pub fn with_pubkeys(mut self, pubkeys: (Pubkey, Pubkey)) -> Self {
-        let pubkeys = Some(ActualExpected::Pubkeys((pubkeys.0, pubkeys.1)));
+        let pubkeys = Some(ComparedValues::Pubkeys((pubkeys.0, pubkeys.1)));
         match &mut self {
-            Error::AnchorError(ae) => ae.expected_actual = pubkeys,
-            Error::ProgramError(pe) => pe.expected_actual = pubkeys,
+            Error::AnchorError(ae) => ae.compared_values = pubkeys,
+            Error::ProgramError(pe) => pe.compared_values = pubkeys,
         };
         self
     }
@@ -267,13 +267,13 @@ impl Error {
     pub fn with_values(mut self, values: (impl ToString, impl ToString)) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {
-                ae.expected_actual = Some(ActualExpected::Values((
+                ae.compared_values = Some(ComparedValues::Values((
                     values.0.to_string(),
                     values.1.to_string(),
                 )))
             }
             Error::ProgramError(pe) => {
-                pe.expected_actual = Some(ActualExpected::Values((
+                pe.compared_values = Some(ComparedValues::Values((
                     values.0.to_string(),
                     values.1.to_string(),
                 )))
@@ -287,7 +287,7 @@ impl Error {
 pub struct ProgramErrorWithOrigin {
     pub program_error: ProgramError,
     pub error_origin: Option<ErrorOrigin>,
-    pub expected_actual: Option<ActualExpected>,
+    pub compared_values: Option<ComparedValues>,
 }
 
 impl Display for ProgramErrorWithOrigin {
@@ -328,14 +328,14 @@ impl ProgramErrorWithOrigin {
                 ));
             }
         }
-        match &self.expected_actual {
-            Some(ActualExpected::Pubkeys((left, right))) => {
+        match &self.compared_values {
+            Some(ComparedValues::Pubkeys((left, right))) => {
                 anchor_lang::solana_program::msg!("Left:");
                 left.log();
                 anchor_lang::solana_program::msg!("Right:");
                 right.log();
             }
-            Some(ActualExpected::Values((left, right))) => {
+            Some(ComparedValues::Values((left, right))) => {
                 anchor_lang::solana_program::msg!("Left: {}", left);
                 anchor_lang::solana_program::msg!("Right: {}", right);
             }
@@ -359,13 +359,13 @@ impl From<ProgramError> for ProgramErrorWithOrigin {
         Self {
             program_error,
             error_origin: None,
-            expected_actual: None,
+            compared_values: None,
         }
     }
 }
 
 #[derive(Debug)]
-pub enum ActualExpected {
+pub enum ComparedValues {
     Values((String, String)),
     Pubkeys((Pubkey, Pubkey)),
 }
@@ -382,7 +382,7 @@ pub struct AnchorError {
     pub error_code_number: u32,
     pub error_msg: String,
     pub error_origin: Option<ErrorOrigin>,
-    pub expected_actual: Option<ActualExpected>,
+    pub compared_values: Option<ComparedValues>,
 }
 
 impl AnchorError {
@@ -414,14 +414,14 @@ impl AnchorError {
                 ));
             }
         }
-        match &self.expected_actual {
-            Some(ActualExpected::Pubkeys((left, right))) => {
+        match &self.compared_values {
+            Some(ComparedValues::Pubkeys((left, right))) => {
                 anchor_lang::solana_program::msg!("Left:");
                 left.log();
                 anchor_lang::solana_program::msg!("Right:");
                 right.log();
             }
-            Some(ActualExpected::Values((left, right))) => {
+            Some(ComparedValues::Values((left, right))) => {
                 anchor_lang::solana_program::msg!("Left: {}", left);
                 anchor_lang::solana_program::msg!("Right: {}", right);
             }

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -106,6 +106,17 @@ pub enum ErrorCode {
     #[msg("A space constraint was violated")]
     ConstraintSpace,
 
+    // Require
+    /// 2500 - A require expression was violated
+    #[msg("A require expression was violated")]
+    RequireViolated = 2500,
+    /// 2501 - A require_eq expression was violated
+    #[msg("A require_eq expression was violated")]
+    RequireEqViolated,
+    /// 2502 - A require_keys_eq expression was violated
+    #[msg("A require_keys_eq expression was violated")]
+    RequireKeysEqViolated,
+
     // Accounts.
     /// 3000 - The account discriminator was already set on this account
     #[msg("The account discriminator was already set on this account")]

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -256,7 +256,7 @@ impl Error {
     }
 
     /// adds an actual and expected value (in that order) to the error
-    pub fn with_values(mut self, values: [&impl ToString; 2]) -> Self {
+    pub fn with_values(mut self, values: [impl ToString; 2]) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {
                 ae.expected_actual = Some(ActualExpected::Values([
@@ -351,13 +351,13 @@ impl AnchorError {
         if let Some(source) = &self.source {
             if let Some(ActualExpected::Values(values)) = &self.expected_actual {
                 anchor_lang::solana_program::msg!(
-                    "AnchorError thrown in {}:{}. Error Code: {}. Error Number: {}. Error Message: {}. Expected: {}. Actual: {}",
+                    "AnchorError thrown in {}:{}. Error Code: {}. Error Number: {}. Error Message: {}. Expected: {}. Actual: {}.",
                     source.filename,
                     source.line,
                     self.error_name,
                     self.error_code_number,
                     self.error_msg,
-                    values[1],
+                    values[0],
                     values[1]
                 );
             } else {
@@ -373,7 +373,7 @@ impl AnchorError {
         } else if let Some(account_name) = &self.account_name {
             if let Some(ActualExpected::Values(values)) = &self.expected_actual {
                 anchor_lang::solana_program::log::sol_log(&format!(
-                    "AnchorError caused by account: {}. Error Code: {}. Error Number: {}. Error Message: {}. Expected: {}. Actual: {}",
+                    "AnchorError caused by account: {}. Error Code: {}. Error Number: {}. Error Message: {}. Expected: {}. Actual: {}.",
                     account_name,
                     self.error_name,
                     self.error_code_number,

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -248,6 +248,7 @@ pub struct ProgramErrorWithOrigin {
     pub program_error: ProgramError,
     pub source: Option<Source>,
     pub account_name: Option<String>,
+    pub expected_actual: Option<ExpectedActual>
 }
 
 impl Display for ProgramErrorWithOrigin {

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -255,6 +255,7 @@ impl Error {
         self
     }
 
+    /// adds an actual and expected value (in that order) to the error
     pub fn with_values(mut self, values: [&impl ToString; 2]) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -405,13 +405,13 @@ macro_rules! require_keys_eq {
 /// ```
 #[macro_export]
 macro_rules! err {
-    ($error:expr $(,)?) => {
-        Err(anchor_lang::anchor_attribute_error::error!($error))
-    };
     ($error:tt $(,)?) => {
         Err(anchor_lang::anchor_attribute_error::error!(
             crate::ErrorCode::$error
         ))
+    };
+    ($error:expr $(,)?) => {
+        Err(anchor_lang::anchor_attribute_error::error!($error))
     };
 }
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -241,10 +241,11 @@ pub mod prelude {
         accounts::signer::Signer, accounts::system_account::SystemAccount,
         accounts::sysvar::Sysvar, accounts::unchecked_account::UncheckedAccount, constant,
         context::Context, context::CpiContext, declare_id, emit, err, error, event, interface,
-        program, require, solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
-        state, zero_copy, AccountDeserialize, AccountSerialize, Accounts, AccountsExit,
-        AnchorDeserialize, AnchorSerialize, Id, Key, Owner, ProgramData, Result, System,
-        ToAccountInfo, ToAccountInfos, ToAccountMetas,
+        program, require, require_eq,
+        solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source, state, zero_copy,
+        AccountDeserialize, AccountSerialize, Accounts, AccountsExit, AnchorDeserialize,
+        AnchorSerialize, Id, Key, Owner, ProgramData, Result, System, ToAccountInfo,
+        ToAccountInfos, ToAccountMetas,
     };
     pub use anchor_attribute_error::*;
     pub use borsh;
@@ -368,6 +369,15 @@ macro_rules! require {
     };
 }
 
+#[macro_export]
+macro_rules! require_eq {
+    ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
+        if $value1 != $value2 {
+            return Err(error!($error_code).with_values([$value1, $value2]));
+        }
+    };
+}
+
 /// Returns with the given error.
 /// Use this with a custom error type.
 ///
@@ -386,13 +396,13 @@ macro_rules! require {
 /// ```
 #[macro_export]
 macro_rules! err {
+    ($error:expr $(,)?) => {
+        Err(anchor_lang::anchor_attribute_error::error!($error))
+    };
     ($error:tt $(,)?) => {
         Err(anchor_lang::anchor_attribute_error::error!(
             crate::ErrorCode::$error
         ))
-    };
-    ($error:expr $(,)?) => {
-        Err(anchor_lang::anchor_attribute_error::error!($error))
     };
 }
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -386,12 +386,6 @@ macro_rules! require {
 /// ```
 #[macro_export]
 macro_rules! err {
-    ($error:expr, pub $value1:expr, pub $value2: expr) => {
-        Err(anchor_lang::anchor_attribute_error::error!($error, pub $value1, pub $value2))
-    };
-    ($error:expr, $value1:expr, $value2: expr) => {
-        Err(anchor_lang::anchor_attribute_error::error!($error, $value1, $value2))
-    };
     ($error:tt $(,)?) => {
         Err(anchor_lang::anchor_attribute_error::error!(
             crate::ErrorCode::$error

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -321,7 +321,7 @@ pub mod __private {
 }
 
 /// Ensures a condition is true, otherwise returns with the given error.
-/// Use this with a custom error type.
+/// Use this with or without a custom error type.
 ///
 /// # Example
 /// ```ignore
@@ -369,6 +369,22 @@ macro_rules! require {
     };
 }
 
+
+/// Ensures two NON-PUBKEY values are equal.
+/// 
+/// Use [require_keys_eq](crate::prelude::require_keys_eq)
+/// to compare two pubkeys.
+/// 
+/// Can be used with or without a custom error code.
+///
+/// # Example
+/// ```rust,ignore
+/// pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+///     require_eq!(ctx.accounts.data.data, 0);
+///     ctx.accounts.data.data = data;
+///     Ok(())
+/// }
+/// ```
 #[macro_export]
 macro_rules! require_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
@@ -384,6 +400,21 @@ macro_rules! require_eq {
     };
 }
 
+/// Ensures two pubkeys values are equal.
+/// 
+/// Use [require_eq](crate::prelude::require_eq)
+/// to compare two non-pubkey values.
+/// 
+/// Can be used with or without a custom error code.
+///
+/// # Example
+/// ```rust,ignore
+/// pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+///     require_keys_eq!(ctx.accounts.data.authority.key(), ctx.accounts.authority.key());
+///     ctx.accounts.data.data = data;
+///     Ok(())
+/// }
+/// ```
 #[macro_export]
 macro_rules! require_keys_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -386,6 +386,12 @@ macro_rules! require {
 /// ```
 #[macro_export]
 macro_rules! err {
+    ($error:expr, pub $value1:expr, pub $value2: expr) => {
+        Err(anchor_lang::anchor_attribute_error::error!($error, pub $value1, pub $value2))
+    };
+    ($error:expr, $value1:expr, $value2: expr) => {
+        Err(anchor_lang::anchor_attribute_error::error!($error, $value1, $value2))
+    };
     ($error:tt $(,)?) => {
         Err(anchor_lang::anchor_attribute_error::error!(
             crate::ErrorCode::$error

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -369,12 +369,11 @@ macro_rules! require {
     };
 }
 
-
 /// Ensures two NON-PUBKEY values are equal.
-/// 
+///
 /// Use [require_keys_eq](crate::prelude::require_keys_eq)
 /// to compare two pubkeys.
-/// 
+///
 /// Can be used with or without a custom error code.
 ///
 /// # Example
@@ -401,10 +400,10 @@ macro_rules! require_eq {
 }
 
 /// Ensures two pubkeys values are equal.
-/// 
+///
 /// Use [require_eq](crate::prelude::require_eq)
 /// to compare two non-pubkey values.
-/// 
+///
 /// Can be used with or without a custom error code.
 ///
 /// # Example

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -373,7 +373,7 @@ macro_rules! require {
 macro_rules! require_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(error!($error_code).with_values([$value1, $value2]));
+            return Err(error!($error_code).with_values(($value1, $value2)));
         }
     };
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -376,6 +376,12 @@ macro_rules! require_eq {
             return Err(error!($error_code).with_values(($value1, $value2)));
         }
     };
+    ($value1: expr, $value2: expr $(,)?) => {
+        if $value1 != $value2 {
+            return Err(error!(anchor_lang::error::ErrorCode::RequireEqViolated)
+                .with_values(($value1, $value2)));
+        }
+    };
 }
 
 #[macro_export]
@@ -383,6 +389,12 @@ macro_rules! require_keys_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
             return Err(error!($error_code).with_pubkeys(($value1, $value2)));
+        }
+    };
+    ($value1: expr, $value2: expr $(,)?) => {
+        if $value1 != $value2 {
+            return Err(error!(anchor_lang::error::ErrorCode::RequireKeysEqViolated)
+                .with_pubkeys(($value1, $value2)));
         }
     };
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -241,7 +241,7 @@ pub mod prelude {
         accounts::signer::Signer, accounts::system_account::SystemAccount,
         accounts::sysvar::Sysvar, accounts::unchecked_account::UncheckedAccount, constant,
         context::Context, context::CpiContext, declare_id, emit, err, error, event, interface,
-        program, require, require_eq,
+        program, require, require_eq, require_keys_eq,
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source, state, zero_copy,
         AccountDeserialize, AccountSerialize, Accounts, AccountsExit, AnchorDeserialize,
         AnchorSerialize, Id, Key, Owner, ProgramData, Result, System, ToAccountInfo,
@@ -374,6 +374,15 @@ macro_rules! require_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
             return Err(error!($error_code).with_values(($value1, $value2)));
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! require_keys_eq {
+    ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
+        if $value1 != $value2 {
+            return Err(error!($error_code).with_pubkeys(($value1, $value2)));
         }
     };
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -158,7 +158,7 @@ pub fn generate_constraint_zeroed(f: &Field, _c: &ConstraintZeroed) -> proc_macr
             __disc_bytes.copy_from_slice(&__data[..8]);
             let __discriminator = u64::from_le_bytes(__disc_bytes);
             if __discriminator != 0 {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintZero, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintZero).with_account_name(#name_str));
             }
             #from_account_info
         };
@@ -171,7 +171,7 @@ pub fn generate_constraint_close(f: &Field, c: &ConstraintClose) -> proc_macro2:
     let target = &c.sol_dest;
     quote! {
         if #field.key() == #target.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintClose, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintClose).with_account_name(#name_str));
         }
     }
 }
@@ -238,7 +238,7 @@ pub fn generate_constraint_literal(
     };
     quote! {
         if !(#lit) {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::Deprecated, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::Deprecated).with_account_name(#name_str));
         }
     }
 }
@@ -277,7 +277,7 @@ pub fn generate_constraint_rent_exempt(
         ConstraintRentExempt::Skip => quote! {},
         ConstraintRentExempt::Enforce => quote! {
             if !__anchor_rent.is_exempt(#info.lamports(), #info.try_data_len()?) {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintRentExempt).with_account_name(#name_str));
             }
         },
     }
@@ -374,10 +374,10 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint != #mint.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenMint).with_account_name(#name_str));
                         }
                         if pa.owner != #owner.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str));
                         }
                     }
                     pa
@@ -409,14 +409,14 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint != #mint.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenMint).with_account_name(#name_str));
                         }
                         if pa.owner != #owner.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str));
                         }
 
                         if pa.key() != anchor_spl::associated_token::get_associated_token_address(&#owner.key(), &#mint.key()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount).with_account_name(#name_str));
                         }
                     }
                     pa
@@ -462,16 +462,16 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint_authority != anchor_lang::solana_program::program_option::COption::Some(#owner.key()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintMintAuthority, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintMintMintAuthority).with_account_name(#name_str));
                         }
                         if pa.freeze_authority
                             .as_ref()
                             .map(|fa| #freeze_authority.as_ref().map(|expected_fa| fa != *expected_fa).unwrap_or(true))
                             .unwrap_or(#freeze_authority.is_some()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintFreezeAuthority, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintMintFreezeAuthority).with_account_name(#name_str));
                         }
                         if pa.decimals != #decimals {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintDecimals, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintMintDecimals).with_account_name(#name_str));
                         }
                     }
                     pa
@@ -525,17 +525,17 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     // Assert the account was created correctly.
                     if #if_needed {
                         if space != actual_field.data_len() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSpace, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSpace).with_account_name(#name_str));
                         }
 
                         if actual_owner != #owner {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintOwner, #name_str));
+                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintOwner).with_account_name(#name_str));
                         }
 
                         {
                             let required_lamports = __anchor_rent.minimum_balance(space);
                             if pa.to_account_info().lamports() < required_lamports {
-                                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
+                                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintRentExempt).with_account_name(#name_str));
                             }
                         }
                     }
@@ -577,10 +577,10 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
         let b = c.bump.as_ref().unwrap();
         quote! {
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str));
             }
             if __bump != #b {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str));
             }
         }
     }
@@ -592,7 +592,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
     else if c.is_init {
         quote! {
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str));
             }
         }
     }
@@ -616,7 +616,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
                 let __pda_address = Pubkey::create_program_address(
                     &[#maybe_seeds_plus_comma &[#b][..]],
                     &#deriving_program_id,
-                ).map_err(|_| anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str))?;
+                ).map_err(|_| anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str))?;
             },
         };
         quote! {
@@ -625,7 +625,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
 
             // Check it.
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str));
             }
         }
     }
@@ -641,11 +641,11 @@ fn generate_constraint_associated_token(
     let spl_token_mint_address = &c.mint;
     quote! {
         if #name.owner != #wallet_address.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str));
         }
         let __associated_token_address = anchor_spl::associated_token::get_associated_token_address(&#wallet_address.key(), &#spl_token_mint_address.key());
         if #name.key() != __associated_token_address {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintAssociated, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintAssociated).with_account_name(#name_str));
         }
     }
 }
@@ -741,7 +741,7 @@ pub fn generate_constraint_executable(
     let name_str = name.to_string();
     quote! {
         if !#name.to_account_info().executable {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintExecutable, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintExecutable).with_account_name(#name_str));
         }
     }
 }
@@ -758,10 +758,10 @@ pub fn generate_constraint_state(f: &Field, c: &ConstraintState) -> proc_macro2:
         // Checks the given state account is the canonical state account for
         // the target program.
         if #ident.key() != anchor_lang::accounts::cpi_state::CpiState::<#account_ty>::address(&#program_target.key()) {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintState).with_account_name(#name_str));
         }
         if #ident.as_ref().owner != &#program_target.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintState).with_account_name(#name_str));
         }
     }
 }
@@ -774,10 +774,10 @@ fn generate_custom_error(
     let account_name = account_name.to_string();
     match custom_error {
         Some(error) => {
-            quote! { Err(anchor_lang::anchor_attribute_error::error_with_account_name!(#error, #account_name)) }
+            quote! { Err(anchor_lang::error::Error::from(#error).with_account_name(#account_name)) }
         }
         None => {
-            quote! { Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::#error, #account_name)) }
+            quote! { Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::#error).with_account_name(#account_name)) }
         }
     }
 }

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -82,8 +82,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
                         error_name: error_code.name(),
                         error_code_number: error_code.into(),
                         error_msg: error_code.to_string(),
-                        source: None,
-                        account_name: None,
+                        error_origin: None,
                         expected_actual: None
                     }
                 )

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -83,7 +83,8 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
                         error_code_number: error_code.into(),
                         error_msg: error_code.to_string(),
                         source: None,
-                        account_name: None
+                        account_name: None,
+                        expected_actual: None
                     }
                 )
             }

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -83,7 +83,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
                         error_code_number: error_code.into(),
                         error_msg: error_code.to_string(),
                         error_origin: None,
-                        expected_actual: None
+                        compared_values: None
                     }
                 )
             }

--- a/lang/syn/src/parser/error.rs
+++ b/lang/syn/src/parser/error.rs
@@ -1,7 +1,6 @@
 use crate::{Error, ErrorArgs, ErrorCode};
-use syn::ext::IdentExt;
-use syn::parse::{Error as ParseError, Parse, Result as ParseResult};
-use syn::{Expr, Ident, Token};
+use syn::parse::{Parse, Result as ParseResult};
+use syn::Expr;
 
 // Removes any internal #[msg] attributes, as they are inert.
 pub fn parse(error_enum: &mut syn::ItemEnum, args: Option<ErrorArgs>) -> Error {
@@ -87,22 +86,5 @@ impl Parse for ErrorInput {
     fn parse(stream: syn::parse::ParseStream) -> ParseResult<Self> {
         let error_code = stream.call(Expr::parse)?;
         Ok(Self { error_code })
-    }
-}
-
-pub struct ErrorWithAccountNameInput {
-    pub error_code: Expr,
-    pub account_name: Expr,
-}
-
-impl Parse for ErrorWithAccountNameInput {
-    fn parse(stream: syn::parse::ParseStream) -> ParseResult<Self> {
-        let error_code = stream.call(Expr::parse)?;
-        let _ = stream.parse::<Token!(,)>();
-        let account_name = stream.call(Expr::parse)?;
-        Ok(Self {
-            error_code,
-            account_name,
-        })
     }
 }

--- a/lang/syn/src/parser/error.rs
+++ b/lang/syn/src/parser/error.rs
@@ -80,18 +80,27 @@ fn parse_error_attribute(variant: &syn::Variant) -> Option<String> {
 
 pub struct ErrorInput {
     pub error_code: Expr,
+    pub expected_actual: Option<ExpectedActualInput>,
 }
 
 impl Parse for ErrorInput {
     fn parse(stream: syn::parse::ParseStream) -> ParseResult<Self> {
         let error_code = stream.call(Expr::parse)?;
-        Ok(Self { error_code })
+        let expected_actual = match stream.parse::<Token!(,)>() {
+            Ok(_) => Some(stream.parse::<ExpectedActualInput>()?),
+            _ => None,
+        };
+        Ok(Self {
+            error_code,
+            expected_actual,
+        })
     }
 }
 
 pub struct ErrorWithAccountNameInput {
     pub error_code: Expr,
     pub account_name: Expr,
+    pub expected_actual: Option<ExpectedActualInput>,
 }
 
 impl Parse for ErrorWithAccountNameInput {
@@ -99,9 +108,33 @@ impl Parse for ErrorWithAccountNameInput {
         let error_code = stream.call(Expr::parse)?;
         let _ = stream.parse::<Token!(,)>();
         let account_name = stream.call(Expr::parse)?;
+        let expected_actual = match stream.parse::<Token!(,)>() {
+            Ok(_) => Some(stream.parse::<ExpectedActualInput>()?),
+            _ => None,
+        };
         Ok(Self {
             error_code,
             account_name,
+            expected_actual,
+        })
+    }
+}
+
+pub struct ExpectedActualInput {
+    pub pubkeys: bool,
+    pub expected: Expr,
+    pub actual: Expr,
+}
+
+impl Parse for ExpectedActualInput {
+    fn parse(stream: syn::parse::ParseStream) -> ParseResult<Self> {
+        let expected = stream.call(Expr::parse)?;
+        let _ = stream.parse::<Token!(,)>();
+        let actual = stream.call(Expr::parse)?;
+        Ok(Self {
+            pubkeys: false,
+            expected,
+            actual,
         })
     }
 }

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -58,7 +58,14 @@ mod errors {
         Ok(())
     }
 
-    pub fn account_owned_by_wrong_program_error(_ctx: Context<AccountOwnedByWrongProgramError>) -> Result<()> {
+    pub fn account_owned_by_wrong_program_error(
+        _ctx: Context<AccountOwnedByWrongProgramError>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn require_eq(_ctx: Context<RequireEq>) -> Result<()> {
+        require_eq!(5241, 124124124, MyError::ValueMismatch);
         Ok(())
     }
 }
@@ -105,8 +112,11 @@ pub struct AccountNotInitializedError<'info> {
 
 #[derive(Accounts)]
 pub struct AccountOwnedByWrongProgramError<'info> {
-    pub wrong_account: Account<'info, AnyAccount>
+    pub wrong_account: Account<'info, AnyAccount>,
 }
+
+#[derive(Accounts)]
+pub struct RequireEq {}
 
 #[error_code]
 pub enum MyError {
@@ -115,4 +125,17 @@ pub enum MyError {
     HelloNoMsg = 123,
     HelloNext,
     HelloCustom,
+    ValueMismatch,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SomeStruct {
+    pub val: u64,
+    pub other_val: String,
+}
+
+impl std::fmt::Display for SomeStruct {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        <Self as std::fmt::Debug>::fmt(self, f)
+    }
 }

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -57,6 +57,10 @@ mod errors {
     pub fn account_not_initialized_error(_ctx: Context<AccountNotInitializedError>) -> Result<()> {
         Ok(())
     }
+
+    pub fn account_owned_by_wrong_program_error(_ctx: Context<AccountOwnedByWrongProgramError>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -97,6 +101,11 @@ pub struct AnyAccount {}
 #[derive(Accounts)]
 pub struct AccountNotInitializedError<'info> {
     not_initialized_account: Account<'info, AnyAccount>,
+}
+
+#[derive(Accounts)]
+pub struct AccountOwnedByWrongProgramError<'info> {
+    pub wrong_account: Account<'info, AnyAccount>
 }
 
 #[error_code]

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -147,9 +147,3 @@ pub enum MyError {
     HelloCustom,
     ValueMismatch,
 }
-
-#[derive(Debug, PartialEq)]
-pub struct SomeStruct {
-    pub val: u64,
-    pub other_val: String,
-}

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -68,6 +68,11 @@ mod errors {
         require_eq!(5241, 124124124, MyError::ValueMismatch);
         Ok(())
     }
+
+    pub fn require_keys_eq(ctx: Context<RequireKeysEq>) -> Result<()> {
+        require_keys_eq!(ctx.accounts.some_account.key(), *ctx.program_id, MyError::ValueMismatch);
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -118,6 +123,11 @@ pub struct AccountOwnedByWrongProgramError<'info> {
 #[derive(Accounts)]
 pub struct RequireEq {}
 
+#[derive(Accounts)]
+pub struct RequireKeysEq<'info> {
+    pub some_account: UncheckedAccount<'info>
+}
+
 #[error_code]
 pub enum MyError {
     #[msg("This is an error message clients will automatically display")]
@@ -132,10 +142,4 @@ pub enum MyError {
 pub struct SomeStruct {
     pub val: u64,
     pub other_val: String,
-}
-
-impl std::fmt::Display for SomeStruct {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        <Self as std::fmt::Debug>::fmt(self, f)
-    }
 }

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -69,8 +69,18 @@ mod errors {
         Ok(())
     }
 
+    pub fn require_eq_default_error(_ctx: Context<RequireEq>) -> Result<()> {
+        require_eq!(5241, 124124124);
+        Ok(())
+    }
+
     pub fn require_keys_eq(ctx: Context<RequireKeysEq>) -> Result<()> {
         require_keys_eq!(ctx.accounts.some_account.key(), *ctx.program_id, MyError::ValueMismatch);
+        Ok(())
+    }
+
+    pub fn require_keys_eq_default_error(ctx: Context<RequireKeysEq>) -> Result<()> {
+        require_keys_eq!(ctx.accounts.some_account.key(), *ctx.program_id);
         Ok(())
     }
 }

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -312,7 +312,7 @@ describe("errors", () => {
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:68. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.",
       "Program log: Left: 5241",
-      "Program log: Right: 124124124"
+      "Program log: Right: 124124124",
     ]);
   });
 
@@ -322,8 +322,8 @@ describe("errors", () => {
       try {
         const tx = await program.rpc.requireKeysEq({
           accounts: {
-            someAccount
-          }
+            someAccount,
+          },
         });
         assert.fail(
           "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
@@ -336,7 +336,7 @@ describe("errors", () => {
       "Program log: Left:",
       `Program log: ${someAccount}`,
       "Program log: Right:",
-      `Program log: ${program.programId}`
+      `Program log: ${program.programId}`,
     ]);
   });
 });

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -316,6 +316,23 @@ describe("errors", () => {
     ]);
   });
 
+  it("Emits a RequireEqViolated error via require_eq", async () => {
+    await withLogTest(async () => {
+      try {
+        const tx = await program.rpc.requireEqDefaultError();
+        assert.fail(
+          "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
+        );
+      } catch (err) {
+        assert.equal(err.code, 2501);
+      }
+    }, [
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:73. Error Code: RequireEqViolated. Error Number: 2501. Error Message: A require_eq expression was violated.",
+      "Program log: Left: 5241",
+      "Program log: Right: 124124124",
+    ]);
+  });
+
   it("Emits a ValueMismatch error via require_keys_eq", async () => {
     const someAccount = anchor.web3.Keypair.generate().publicKey;
     await withLogTest(async () => {
@@ -332,7 +349,31 @@ describe("errors", () => {
         assert.equal(err.code, 6126);
       }
     }, [
-      "Program log: AnchorError thrown in programs/errors/src/lib.rs:73. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.",
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:78. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.",
+      "Program log: Left:",
+      `Program log: ${someAccount}`,
+      "Program log: Right:",
+      `Program log: ${program.programId}`,
+    ]);
+  });
+
+  it("Emits a RequireKeysEqViolated error via require_keys_eq", async () => {
+    const someAccount = anchor.web3.Keypair.generate().publicKey;
+    await withLogTest(async () => {
+      try {
+        const tx = await program.rpc.requireKeysEqDefaultError({
+          accounts: {
+            someAccount,
+          },
+        });
+        assert.fail(
+          "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
+        );
+      } catch (err) {
+        assert.equal(err.code, 2502);
+      }
+    }, [
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:83. Error Code: RequireKeysEqViolated. Error Number: 2502. Error Message: A require_keys_eq expression was violated.",
       "Program log: Left:",
       `Program log: ${someAccount}`,
       "Program log: Right:",

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -304,7 +304,7 @@ describe("errors", () => {
         assert.equal(err.code, 6126);
       }
     }, [
-      "Program log: AnchorError thrown in programs/errors/src/lib.rs:66. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241.",
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:68. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241.",
     ]);
   });
 });

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -286,10 +286,10 @@ describe("errors", () => {
       }
     }, [
       "Program log: AnchorError caused by account: wrong_account. Error Code: AccountOwnedByWrongProgram. Error Number: 3007. Error Message: The given account is owned by a different program than expected.",
-      "Program log: Expected:",
-      "Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-      "Program log: Actual:",
+      "Program log: Left:",
       "Program log: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      "Program log: Right:",
+      "Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
     ]);
   });
 
@@ -304,7 +304,9 @@ describe("errors", () => {
         assert.equal(err.code, 6126);
       }
     }, [
-      "Program log: AnchorError thrown in programs/errors/src/lib.rs:68. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241.",
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:68. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.",
+      "Program log: Left: 5241",
+      "Program log: Right: 124124124"
     ]);
   });
 });

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -12,15 +12,23 @@ const sleep = (ms) =>
     setTimeout(() => resolve(), ms);
   });
 
-const withLogTest = async (callback, expectedLog) => {
+const withLogTest = async (callback, expectedLogs) => {
   let logTestOk = false;
   const listener = anchor.getProvider().connection.onLogs(
     "all",
     (logs) => {
-      if (logs.logs.some((logLine) => logLine === expectedLog)) {
-        logTestOk = true;
-      } else {
+      const index = logs.logs.findIndex((logLine) => logLine === expectedLogs[0]);
+      if (index === - 1) {
         console.log(logs);
+      } else {
+        const actualLogs = logs.logs.slice(index, index + expectedLogs.length);
+        for (let i = 0; i < expectedLogs.length; i++) {
+          if (actualLogs[i] !== expectedLogs[i]) {
+            console.log(logs);
+            return logs;
+          }
+        }
+        logTestOk = true;
       }
     },
     "recent"
@@ -56,7 +64,7 @@ describe("errors", () => {
         assert.equal(err.msg, errMsg);
         assert.equal(err.code, 6000);
       }
-    }, "Program log: AnchorError thrown in programs/errors/src/lib.rs:13. Error Code: Hello. Error Number: 6000. Error Message: This is an error message clients will automatically display.");
+    }, ["Program log: AnchorError thrown in programs/errors/src/lib.rs:13. Error Code: Hello. Error Number: 6000. Error Message: This is an error message clients will automatically display."]);
   });
 
   it("Emits a Hello error via require!", async () => {
@@ -93,7 +101,7 @@ describe("errors", () => {
       } catch (err) {
         // No-op (withLogTest expects the callback to catch the initial tx error)
       }
-    }, "Program log: ProgramError occurred. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid.");
+    }, ["Program log: ProgramError occurred. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid."]);
   });
 
   it("Logs a ProgramError with source", async () => {
@@ -104,7 +112,7 @@ describe("errors", () => {
       } catch (err) {
         // No-op (withLogTest expects the callback to catch the initial tx error)
       }
-    }, "Program log: ProgramError thrown in programs/errors/src/lib.rs:38. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid.");
+    }, ["Program log: ProgramError thrown in programs/errors/src/lib.rs:38. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid."]);
   });
 
   it("Emits a HelloNoMsg error", async () => {
@@ -146,7 +154,7 @@ describe("errors", () => {
         assert.equal(err.msg, errMsg);
         assert.equal(err.code, 2000);
       }
-    }, "Program log: AnchorError caused by account: my_account. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated.");
+    }, ["Program log: AnchorError caused by account: my_account. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated."]);
   });
 
   it("Emits a has one error", async () => {
@@ -239,7 +247,7 @@ describe("errors", () => {
           "The program expected this account to be already initialized";
         assert.equal(err.toString(), errMsg);
       }
-    }, "Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.");
+    }, ["Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized."]);
   });
   
   it("Emits an AccountOwnedByWrongProgram error", async () => {
@@ -264,9 +272,15 @@ describe("errors", () => {
         );
       } catch (err) {
         const errMsg =
-          "The program expected this account to be already initialized";
+          "The given account is owned by a different program than expected";
         assert.equal(err.toString(), errMsg);
       }
-    }, "Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized."); 
+    }, [
+      "Program log: AnchorError caused by account: wrong_account. Error Code: AccountOwnedByWrongProgram. Error Number: 3007. Error Message: The given account is owned by a different program than expected.",
+      "Program log: Expected:",
+      "Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+      "Program log: Actual:",
+      "Program log: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    ]); 
   })
 });

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -1,10 +1,7 @@
 const assert = require("assert");
 const anchor = require("@project-serum/anchor");
 const { Account, Transaction, TransactionInstruction } = anchor.web3;
-const {
-  TOKEN_PROGRAM_ID,
-  Token,
-} = require("@solana/spl-token");
+const { TOKEN_PROGRAM_ID, Token } = require("@solana/spl-token");
 
 // sleep to allow logs to come in
 const sleep = (ms) =>
@@ -17,8 +14,10 @@ const withLogTest = async (callback, expectedLogs) => {
   const listener = anchor.getProvider().connection.onLogs(
     "all",
     (logs) => {
-      const index = logs.logs.findIndex((logLine) => logLine === expectedLogs[0]);
-      if (index === - 1) {
+      const index = logs.logs.findIndex(
+        (logLine) => logLine === expectedLogs[0]
+      );
+      if (index === -1) {
         console.log(logs);
       } else {
         const actualLogs = logs.logs.slice(index, index + expectedLogs.length);
@@ -64,7 +63,9 @@ describe("errors", () => {
         assert.equal(err.msg, errMsg);
         assert.equal(err.code, 6000);
       }
-    }, ["Program log: AnchorError thrown in programs/errors/src/lib.rs:13. Error Code: Hello. Error Number: 6000. Error Message: This is an error message clients will automatically display."]);
+    }, [
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:13. Error Code: Hello. Error Number: 6000. Error Message: This is an error message clients will automatically display.",
+    ]);
   });
 
   it("Emits a Hello error via require!", async () => {
@@ -101,7 +102,9 @@ describe("errors", () => {
       } catch (err) {
         // No-op (withLogTest expects the callback to catch the initial tx error)
       }
-    }, ["Program log: ProgramError occurred. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid."]);
+    }, [
+      "Program log: ProgramError occurred. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid.",
+    ]);
   });
 
   it("Logs a ProgramError with source", async () => {
@@ -112,7 +115,9 @@ describe("errors", () => {
       } catch (err) {
         // No-op (withLogTest expects the callback to catch the initial tx error)
       }
-    }, ["Program log: ProgramError thrown in programs/errors/src/lib.rs:38. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid."]);
+    }, [
+      "Program log: ProgramError thrown in programs/errors/src/lib.rs:38. Error Code: InvalidAccountData. Error Number: 17179869184. Error Message: An account's data contents was invalid.",
+    ]);
   });
 
   it("Emits a HelloNoMsg error", async () => {
@@ -154,7 +159,9 @@ describe("errors", () => {
         assert.equal(err.msg, errMsg);
         assert.equal(err.code, 2000);
       }
-    }, ["Program log: AnchorError caused by account: my_account. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated."]);
+    }, [
+      "Program log: AnchorError caused by account: my_account. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated.",
+    ]);
   });
 
   it("Emits a has one error", async () => {
@@ -247,9 +254,11 @@ describe("errors", () => {
           "The program expected this account to be already initialized";
         assert.equal(err.toString(), errMsg);
       }
-    }, ["Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized."]);
+    }, [
+      "Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.",
+    ]);
   });
-  
+
   it("Emits an AccountOwnedByWrongProgram error", async () => {
     let client = await Token.createMint(
       program.provider.connection,
@@ -264,7 +273,7 @@ describe("errors", () => {
       try {
         const tx = await program.rpc.accountOwnedByWrongProgramError({
           accounts: {
-            wrongAccount: client.publicKey
+            wrongAccount: client.publicKey,
           },
         });
         assert.fail(
@@ -280,9 +289,9 @@ describe("errors", () => {
       "Program log: Expected:",
       "Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
       "Program log: Actual:",
-      "Program log: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-    ]); 
-  })
+      "Program log: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    ]);
+  });
 
   it("Emits a ValueMismatch error", async () => {
     await withLogTest(async () => {
@@ -295,7 +304,7 @@ describe("errors", () => {
         assert.equal(err.code, 6126);
       }
     }, [
-      "Program log: AnchorError thrown in programs/errors/src/lib.rs:66. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241."
-    ]); 
-  })
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:66. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241.",
+    ]);
+  });
 });

--- a/tests/errors/tests/errors.js
+++ b/tests/errors/tests/errors.js
@@ -268,7 +268,7 @@ describe("errors", () => {
           },
         });
         assert.fail(
-          "Unexpected success in creating a transaction that should have fail with `AccountNotInitialized` error"
+          "Unexpected success in creating a transaction that should have failed with `AccountOwnedByWrongProgram` error"
         );
       } catch (err) {
         const errMsg =
@@ -281,6 +281,21 @@ describe("errors", () => {
       "Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
       "Program log: Actual:",
       "Program log: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    ]); 
+  })
+
+  it("Emits a ValueMismatch error", async () => {
+    await withLogTest(async () => {
+      try {
+        const tx = await program.rpc.requireEq();
+        assert.fail(
+          "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
+        );
+      } catch (err) {
+        assert.equal(err.code, 6126);
+      }
+    }, [
+      "Program log: AnchorError thrown in programs/errors/src/lib.rs:66. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch. Expected: 124124124. Actual: 5241."
     ]); 
   })
 });

--- a/ts/src/error.ts
+++ b/ts/src/error.ts
@@ -95,6 +95,11 @@ const LangErrorCode = {
   ConstraintMintDecimals: 2018,
   ConstraintSpace: 2019,
 
+  // Require.
+  RequireViolated: 2500,
+  RequireEqViolated: 2501,
+  RequireKeysEqViolated: 2502,
+
   // Accounts.
   AccountDiscriminatorAlreadySet: 3000,
   AccountDiscriminatorNotFound: 3001,
@@ -184,6 +189,14 @@ const LangErrorMessage = new Map([
     "A mint decimals constraint was violated",
   ],
   [LangErrorCode.ConstraintSpace, "A space constraint was violated"],
+
+  // Require.
+  [LangErrorCode.RequireViolated, "A require expression was violated"],
+  [LangErrorCode.RequireEqViolated, "A require_eq expression was violated"],
+  [
+    LangErrorCode.RequireKeysEqViolated,
+    "A require_keys_eq expression was violated",
+  ],
 
   // Accounts.
   [


### PR DESCRIPTION
closes #1586

closes #1464

Future PRs should add more `require` statements that abstract away the implementation details

macros added in this PR:
- `require_eq` macro that is meant to be used with non-pubkey values and results in the following output:
```
'Program log: AnchorError thrown in programs/errors/src/lib.rs:68. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.',
'Program log: Left: 5241',
'Program log: Right: 124124124'
```
- `require_keys_eq` macro that is meant to be used with pubkey values and results in the following output:
```
'Program log: AnchorError thrown in programs/errors/src/lib.rs:73. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.',
'Program log: Left:',
'Program log: HCGsxsDZEKWnaS5t7JBct6cyyLS6Jcx7Mmn4KjUQokZY',
'Program log: Right:',
'Program log: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS'
```

These macros can be used like this `require_eq(value1, value2)` in which case they return an error defined by us or with a custom error `require_eq(value1,value2,MyError:SomeError)`. The `require` macro has also been changed to work the same way

Log statement are intentionally `Left` and `Right` and not `Expected` and `Actual` because future `require` macros would not fit those descriptions (e.g. `require_gt`)