### PR TITLE
ts: add provider parameter to spl token client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incremented for features.
 
 * lang: Add new `AccountSysvarMismatch` error code and test cases for sysvars ([#1535](https://github.com/project-serum/anchor/pull/1535)).
 * spl: Add support for revoke instruction ([#1493](https://github.com/project-serum/anchor/pull/1493)).
+* ts: Add provider parameter to `Spl.token` factory method ([#1597](https://github.com/project-serum/anchor/pull/1597)).
 
 ### Fixes
 

--- a/ts/src/spl/index.ts
+++ b/ts/src/spl/index.ts
@@ -1,10 +1,10 @@
-import { Program } from "../index.js";
+import { Program, Provider } from "../index.js";
 import { program as tokenProgram, SplToken } from "./token.js";
 
 export { SplToken } from "./token.js";
 
 export class Spl {
-  public static token(): Program<SplToken> {
-    return tokenProgram();
+  public static token(provider?: Provider): Program<SplToken> {
+    return tokenProgram(provider);
   }
 }


### PR DESCRIPTION
Currently the only way to use this is via `Provider.local` or by using `anchor.setProvider`.