### PR TITLE
cli: better errors for config.rs file in cli

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -372,7 +372,7 @@ impl Config {
         fs::read_to_string(&p)
             .with_context(|| {
                 format!(
-                    "Something went wrong reading the file with path: {}",
+                    "Error reading the file with path: {}",
                     p.as_ref().display()
                 )
             })?

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -370,12 +370,7 @@ impl Config {
 
     fn from_path(p: impl AsRef<Path>) -> Result<Self> {
         fs::read_to_string(&p)
-            .with_context(|| {
-                format!(
-                    "Error reading the file with path: {}",
-                    p.as_ref().display()
-                )
-            })?
+            .with_context(|| format!("Error reading the file with path: {}", p.as_ref().display()))?
             .parse()
     }
 


### PR DESCRIPTION
`fs` error return only msgs like `No such file found` without printing the path