### PR TITLE
lang: adjust error code so `#[error_code]` works with just importing `anchor_lang::error_code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ incremented for features.
 * spl: Update `spl/governance` to use new errors ([#1582](https://github.com/project-serum/anchor/pull/1582)).
 * client: Fix `Cluster`'s `FromStr` implementation ([#1362](https://github.com/project-serum/anchor/pull/1362)).
 * lang: implement `Key` for `Pubkey` again, so `associated_token::*` constraints can use pubkey targets again ([#1601](https://github.com/project-serum/anchor/pull/1601)).
+* lang: adjust error code so `#[error_code]` works with just importing `anchor_lang::error_code` ([#1610](https://github.com/project-serum/anchor/pull/1610)).
 
 ### Breaking
 

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -1,4 +1,4 @@
-use anchor_attribute_error::error_code;
+use anchor_lang::error_code;
 use borsh::maybestd::io::Error as BorshIoError;
 use solana_program::program_error::ProgramError;
 use std::fmt::{Debug, Display};

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::bpf_upgradeable_state::*;
 pub use anchor_attribute_access_control::access_control;
 pub use anchor_attribute_account::{account, declare_id, zero_copy};
 pub use anchor_attribute_constant::constant;
-pub use anchor_attribute_error;
+pub use anchor_attribute_error::*;
 pub use anchor_attribute_event::{emit, event};
 pub use anchor_attribute_interface::interface;
 pub use anchor_attribute_program::program;
@@ -354,14 +354,12 @@ pub mod __private {
 macro_rules! require {
     ($invariant:expr, $error:tt $(,)?) => {
         if !($invariant) {
-            return Err(anchor_lang::anchor_attribute_error::error!(
-                crate::ErrorCode::$error
-            ));
+            return Err(anchor_lang::error!(crate::ErrorCode::$error));
         }
     };
     ($invariant:expr, $error:expr $(,)?) => {
         if !($invariant) {
-            return Err(anchor_lang::anchor_attribute_error::error!($error));
+            return Err(anchor_lang::error!($error));
         }
     };
 }
@@ -385,12 +383,10 @@ macro_rules! require {
 #[macro_export]
 macro_rules! err {
     ($error:tt $(,)?) => {
-        Err(anchor_lang::anchor_attribute_error::error!(
-            crate::ErrorCode::$error
-        ))
+        Err(anchor_lang::error!(crate::ErrorCode::$error))
     };
     ($error:expr $(,)?) => {
-        Err(anchor_lang::anchor_attribute_error::error!($error))
+        Err(anchor_lang::error!($error))
     };
 }
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -158,7 +158,7 @@ pub fn generate_constraint_zeroed(f: &Field, _c: &ConstraintZeroed) -> proc_macr
             __disc_bytes.copy_from_slice(&__data[..8]);
             let __discriminator = u64::from_le_bytes(__disc_bytes);
             if __discriminator != 0 {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintZero, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintZero, #name_str));
             }
             #from_account_info
         };
@@ -171,7 +171,7 @@ pub fn generate_constraint_close(f: &Field, c: &ConstraintClose) -> proc_macro2:
     let target = &c.sol_dest;
     quote! {
         if #field.key() == #target.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintClose, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintClose, #name_str));
         }
     }
 }
@@ -238,7 +238,7 @@ pub fn generate_constraint_literal(
     };
     quote! {
         if !(#lit) {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::Deprecated, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::Deprecated, #name_str));
         }
     }
 }
@@ -277,7 +277,7 @@ pub fn generate_constraint_rent_exempt(
         ConstraintRentExempt::Skip => quote! {},
         ConstraintRentExempt::Enforce => quote! {
             if !__anchor_rent.is_exempt(#info.lamports(), #info.try_data_len()?) {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
             }
         },
     }
@@ -374,10 +374,10 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint != #mint.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
                         }
                         if pa.owner != #owner.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
                         }
                     }
                     pa
@@ -409,14 +409,14 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint != #mint.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenMint, #name_str));
                         }
                         if pa.owner != #owner.key() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
                         }
 
                         if pa.key() != anchor_spl::associated_token::get_associated_token_address(&#owner.key(), &#mint.key()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount, #name_str));
                         }
                     }
                     pa
@@ -462,16 +462,16 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     let pa: #ty_decl = #from_account_info;
                     if #if_needed {
                         if pa.mint_authority != anchor_lang::solana_program::program_option::COption::Some(#owner.key()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintMintAuthority, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintMintAuthority, #name_str));
                         }
                         if pa.freeze_authority
                             .as_ref()
                             .map(|fa| #freeze_authority.as_ref().map(|expected_fa| fa != *expected_fa).unwrap_or(true))
                             .unwrap_or(#freeze_authority.is_some()) {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintFreezeAuthority, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintFreezeAuthority, #name_str));
                         }
                         if pa.decimals != #decimals {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintDecimals, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintMintDecimals, #name_str));
                         }
                     }
                     pa
@@ -525,17 +525,17 @@ fn generate_constraint_init_group(f: &Field, c: &ConstraintInitGroup) -> proc_ma
                     // Assert the account was created correctly.
                     if #if_needed {
                         if space != actual_field.data_len() {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSpace, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSpace, #name_str));
                         }
 
                         if actual_owner != #owner {
-                            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintOwner, #name_str));
+                            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintOwner, #name_str));
                         }
 
                         {
                             let required_lamports = __anchor_rent.minimum_balance(space);
                             if pa.to_account_info().lamports() < required_lamports {
-                                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
+                                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintRentExempt, #name_str));
                             }
                         }
                     }
@@ -577,10 +577,10 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
         let b = c.bump.as_ref().unwrap();
         quote! {
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
             }
             if __bump != #b {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
             }
         }
     }
@@ -592,7 +592,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
     else if c.is_init {
         quote! {
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
             }
         }
     }
@@ -616,7 +616,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
                 let __pda_address = Pubkey::create_program_address(
                     &[#maybe_seeds_plus_comma &[#b][..]],
                     &#deriving_program_id,
-                ).map_err(|_| anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str))?;
+                ).map_err(|_| anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str))?;
             },
         };
         quote! {
@@ -625,7 +625,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
 
             // Check it.
             if #name.key() != __pda_address {
-                return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
+                return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintSeeds, #name_str));
             }
         }
     }
@@ -641,11 +641,11 @@ fn generate_constraint_associated_token(
     let spl_token_mint_address = &c.mint;
     quote! {
         if #name.owner != #wallet_address.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintTokenOwner, #name_str));
         }
         let __associated_token_address = anchor_spl::associated_token::get_associated_token_address(&#wallet_address.key(), &#spl_token_mint_address.key());
         if #name.key() != __associated_token_address {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintAssociated, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintAssociated, #name_str));
         }
     }
 }
@@ -741,7 +741,7 @@ pub fn generate_constraint_executable(
     let name_str = name.to_string();
     quote! {
         if !#name.to_account_info().executable {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintExecutable, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintExecutable, #name_str));
         }
     }
 }
@@ -758,10 +758,10 @@ pub fn generate_constraint_state(f: &Field, c: &ConstraintState) -> proc_macro2:
         // Checks the given state account is the canonical state account for
         // the target program.
         if #ident.key() != anchor_lang::accounts::cpi_state::CpiState::<#account_ty>::address(&#program_target.key()) {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
         }
         if #ident.as_ref().owner != &#program_target.key() {
-            return Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
+            return Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::ConstraintState, #name_str));
         }
     }
 }
@@ -774,10 +774,10 @@ fn generate_custom_error(
     let account_name = account_name.to_string();
     match custom_error {
         Some(error) => {
-            quote! { Err(anchor_lang::anchor_attribute_error::error_with_account_name!(#error, #account_name)) }
+            quote! { Err(anchor_lang::error_with_account_name!(#error, #account_name)) }
         }
         None => {
-            quote! { Err(anchor_lang::anchor_attribute_error::error_with_account_name!(anchor_lang::error::ErrorCode::#error, #account_name)) }
+            quote! { Err(anchor_lang::error_with_account_name!(anchor_lang::error::ErrorCode::#error, #account_name)) }
         }
     }
 }

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -76,7 +76,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
         }
 
         impl From<#enum_name> for anchor_lang::error::Error {
-            fn from(error_code: #enum_name) -> Error {
+            fn from(error_code: #enum_name) -> anchor_lang::error::Error {
                 anchor_lang::error::Error::from(
                     anchor_lang::error::AnchorError {
                         error_name: error_code.name(),


### PR DESCRIPTION
you currently have to import `anchor_lang::prelude::*` / more imports than just `anchor_lang::error_code` so it compiles