### PR TITLE
tests: update assertions to use chai and more strict

### DIFF
--- a/tests/bpf-upgradeable-state/tests/bpf-upgradable-state.ts
+++ b/tests/bpf-upgradeable-state/tests/bpf-upgradable-state.ts
@@ -30,7 +30,9 @@ describe("bpf_upgradeable_state", () => {
       signers: [settings],
     });
     assert.strictEqual(
-      (await program.account.settings.fetch(settings.publicKey)).adminData,
+      (
+        await program.account.settings.fetch(settings.publicKey)
+      ).adminData.toNumber(),
       500
     );
   });
@@ -51,7 +53,9 @@ describe("bpf_upgradeable_state", () => {
       }
     );
     assert.strictEqual(
-      (await program.account.settings.fetch(settings.publicKey)).adminData,
+      (
+        await program.account.settings.fetch(settings.publicKey)
+      ).adminData.toNumber(),
       500
     );
   });

--- a/tests/bpf-upgradeable-state/tests/bpf-upgradable-state.ts
+++ b/tests/bpf-upgradeable-state/tests/bpf-upgradable-state.ts
@@ -2,7 +2,7 @@ import * as anchor from "@project-serum/anchor";
 import { AnchorError, Program } from "@project-serum/anchor";
 import { findProgramAddressSync } from "@project-serum/anchor/dist/cjs/utils/pubkey";
 import { PublicKey } from "@solana/web3.js";
-import assert from "assert";
+import { assert } from "chai";
 import { BpfUpgradeableState } from "../target/types/bpf_upgradeable_state";
 
 describe("bpf_upgradeable_state", () => {
@@ -29,7 +29,7 @@ describe("bpf_upgradeable_state", () => {
       },
       signers: [settings],
     });
-    assert.equal(
+    assert.strictEqual(
       (await program.account.settings.fetch(settings.publicKey)).adminData,
       500
     );
@@ -50,7 +50,7 @@ describe("bpf_upgradeable_state", () => {
         signers: [settings],
       }
     );
-    assert.equal(
+    assert.strictEqual(
       (await program.account.settings.fetch(settings.publicKey)).adminData,
       500
     );
@@ -79,10 +79,13 @@ describe("bpf_upgradeable_state", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2003);
-      assert.equal(err.error.errorMessage, "A raw constraint was violated");
+      assert.strictEqual(err.error.errorCode.number, 2003);
+      assert.strictEqual(
+        err.error.errorMessage,
+        "A raw constraint was violated"
+      );
     }
   });
 
@@ -101,10 +104,10 @@ describe("bpf_upgradeable_state", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 3013);
-      assert.equal(
+      assert.strictEqual(err.error.errorCode.number, 3013);
+      assert.strictEqual(
         err.error.errorMessage,
         "The given account is not a program data account"
       );
@@ -126,10 +129,10 @@ describe("bpf_upgradeable_state", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 3007);
-      assert.equal(
+      assert.strictEqual(err.error.errorCode.number, 3007);
+      assert.strictEqual(
         err.error.errorMessage,
         "The given account is owned by a different program than expected"
       );
@@ -159,9 +162,9 @@ describe("bpf_upgradeable_state", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 6000);
+      assert.strictEqual(err.error.errorCode.number, 6000);
     }
   });
 
@@ -188,9 +191,9 @@ describe("bpf_upgradeable_state", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2003);
+      assert.strictEqual(err.error.errorCode.number, 2003);
     }
   });
 });

--- a/tests/cashiers-check/tests/cashiers-check.js
+++ b/tests/cashiers-check/tests/cashiers-check.js
@@ -1,6 +1,6 @@
 const anchor = require("@project-serum/anchor");
 const serumCmn = require("@project-serum/common");
-const {assert} = require("chai");
+const { assert } = require("chai");
 const { TOKEN_PROGRAM_ID } = require("@solana/spl-token");
 
 describe("cashiers-check", () => {

--- a/tests/cashiers-check/tests/cashiers-check.js
+++ b/tests/cashiers-check/tests/cashiers-check.js
@@ -1,6 +1,6 @@
 const anchor = require("@project-serum/anchor");
 const serumCmn = require("@project-serum/common");
-const assert = require("assert");
+const {assert} = require("chai");
 const { TOKEN_PROGRAM_ID } = require("@solana/spl-token");
 
 describe("cashiers-check", () => {
@@ -64,19 +64,19 @@ describe("cashiers-check", () => {
     });
 
     const checkAccount = await program.account.check.fetch(check.publicKey);
-    assert.ok(checkAccount.from.equals(god));
-    assert.ok(checkAccount.to.equals(receiver));
-    assert.ok(checkAccount.amount.eq(new anchor.BN(100)));
-    assert.ok(checkAccount.memo === "Hello world");
-    assert.ok(checkAccount.vault.equals(vault.publicKey));
-    assert.ok(checkAccount.nonce === nonce);
-    assert.ok(checkAccount.burned === false);
+    assert.isTrue(checkAccount.from.equals(god));
+    assert.isTrue(checkAccount.to.equals(receiver));
+    assert.isTrue(checkAccount.amount.eq(new anchor.BN(100)));
+    assert.strictEqual(checkAccount.memo, "Hello world");
+    assert.isTrue(checkAccount.vault.equals(vault.publicKey));
+    assert.strictEqual(checkAccount.nonce, nonce);
+    assert.isFalse(checkAccount.burned);
 
     let vaultAccount = await serumCmn.getTokenAccount(
       program.provider,
       checkAccount.vault
     );
-    assert.ok(vaultAccount.amount.eq(new anchor.BN(100)));
+    assert.isTrue(vaultAccount.amount.eq(new anchor.BN(100)));
   });
 
   it("Cashes a check", async () => {
@@ -92,18 +92,18 @@ describe("cashiers-check", () => {
     });
 
     const checkAccount = await program.account.check.fetch(check.publicKey);
-    assert.ok(checkAccount.burned === true);
+    assert.isTrue(checkAccount.burned);
 
     let vaultAccount = await serumCmn.getTokenAccount(
       program.provider,
       checkAccount.vault
     );
-    assert.ok(vaultAccount.amount.eq(new anchor.BN(0)));
+    assert.isTrue(vaultAccount.amount.eq(new anchor.BN(0)));
 
     let receiverAccount = await serumCmn.getTokenAccount(
       program.provider,
       receiver
     );
-    assert.ok(receiverAccount.amount.eq(new anchor.BN(100)));
+    assert.isTrue(receiverAccount.amount.eq(new anchor.BN(100)));
   });
 });

--- a/tests/cfo/tests/cfo.js
+++ b/tests/cfo/tests/cfo.js
@@ -1,4 +1,4 @@
-const assert = require("assert");
+const { assert } = require("chai");
 const { Token } = require("@solana/spl-token");
 const anchor = require("@project-serum/anchor");
 const serumCmn = require("@project-serum/common");
@@ -90,7 +90,7 @@ describe("cfo", () => {
     const tokenAccount = await USDC_TOKEN_CLIENT.getAccountInfo(
       ORDERBOOK_ENV.marketA._decoded.quoteVault
     );
-    assert.ok(tokenAccount.amount.toString() === "10000902263700");
+    assert.strictEqual(tokenAccount.amount.toString(), "10000902263700");
   });
 
   it("BOILERPLATE: Executes trades to generate fees", async () => {
@@ -111,7 +111,10 @@ describe("cfo", () => {
       { commitment: "processed" },
       DEX_PID
     );
-    assert.ok(marketAClient._decoded.quoteFeesAccrued.toString() === FEES);
+    assert.strictEqual(
+      marketAClient._decoded.quoteFeesAccrued.toString(),
+      FEES
+    );
   });
 
   it("BOILERPLATE: Sets up the staking pools", async () => {
@@ -245,12 +248,12 @@ describe("cfo", () => {
       .rpc();
 
     officerAccount = await program.account.officer.fetch(officer);
-    assert.ok(
+    assert.isTrue(
       officerAccount.authority.equals(program.provider.wallet.publicKey)
     );
-    assert.ok(
-      JSON.stringify(officerAccount.distribution) ===
-        JSON.stringify(distribution)
+    assert.strictEqual(
+      JSON.stringify(officerAccount.distribution),
+      JSON.stringify(distribution)
     );
   });
 
@@ -268,8 +271,8 @@ describe("cfo", () => {
       })
       .rpc();
     const tokenAccount = await B_TOKEN_CLIENT.getAccountInfo(bVault);
-    assert.ok(tokenAccount.state === 1);
-    assert.ok(tokenAccount.isInitialized);
+    assert.strictEqual(tokenAccount.state, 1);
+    assert.isTrue(tokenAccount.isInitialized);
   });
 
   it("Creates an open orders account for the officer", async () => {
@@ -327,9 +330,9 @@ describe("cfo", () => {
       program.provider,
       sweepVault
     );
-    assert.ok(
-      afterTokenAccount.amount.sub(beforeTokenAccount.amount).toString() ===
-        FEES
+    assert.strictEqual(
+      afterTokenAccount.amount.sub(beforeTokenAccount.amount).toString(),
+      FEES
     );
   });
 
@@ -409,10 +412,10 @@ describe("cfo", () => {
     const bVaultAfter = await B_TOKEN_CLIENT.getAccountInfo(bVault);
     const usdcVaultAfter = await USDC_TOKEN_CLIENT.getAccountInfo(usdcVault);
 
-    assert.ok(bVaultBefore.amount.toNumber() === 616035558100);
-    assert.ok(usdcVaultBefore.amount.toNumber() === 6160355581);
-    assert.ok(bVaultAfter.amount.toNumber() === 615884458100);
-    assert.ok(usdcVaultAfter.amount.toNumber() === 7060634298);
+    assert.strictEqual(bVaultBefore.amount.toNumber(), 616035558100);
+    assert.strictEqual(usdcVaultBefore.amount.toNumber(), 6160355581);
+    assert.strictEqual(bVaultAfter.amount.toNumber(), 615884458100);
+    assert.strictEqual(usdcVaultAfter.amount.toNumber(), 7060634298);
   });
 
   it("Swaps to SRM", async () => {
@@ -457,10 +460,10 @@ describe("cfo", () => {
     const srmVaultAfter = await SRM_TOKEN_CLIENT.getAccountInfo(srmVault);
     const usdcVaultAfter = await USDC_TOKEN_CLIENT.getAccountInfo(usdcVault);
 
-    assert.ok(srmVaultBefore.amount.toNumber() === 0);
-    assert.ok(srmVaultAfter.amount.toNumber() === 1152000000);
-    assert.ok(usdcVaultBefore.amount.toNumber() === 7060634298);
-    assert.ok(usdcVaultAfter.amount.toNumber() === 530863);
+    assert.strictEqual(srmVaultBefore.amount.toNumber(), 0);
+    assert.strictEqual(srmVaultAfter.amount.toNumber(), 1152000000);
+    assert.strictEqual(usdcVaultBefore.amount.toNumber(), 7060634298);
+    assert.strictEqual(usdcVaultAfter.amount.toNumber(), 530863);
   });
 
   it("Distributes the tokens to categories", async () => {
@@ -488,21 +491,21 @@ describe("cfo", () => {
     const mintInfoAfter = await SRM_TOKEN_CLIENT.getMintInfo();
 
     const beforeAmount = 1152000000;
-    assert.ok(srmVaultBefore.amount.toNumber() === beforeAmount);
-    assert.ok(srmVaultAfter.amount.toNumber() === 0); // Fully distributed.
-    assert.ok(
-      stakeAfter.amount.toNumber() ===
-        beforeAmount * (distribution.stake / 100.0)
+    assert.strictEqual(srmVaultBefore.amount.toNumber(), beforeAmount);
+    assert.strictEqual(srmVaultAfter.amount.toNumber(), 0); // Fully distributed.
+    assert.strictEqual(
+      stakeAfter.amount.toNumber(),
+      beforeAmount * (distribution.stake / 100.0)
     );
-    assert.ok(
-      treasuryAfter.amount.toNumber() ===
-        beforeAmount * (distribution.treasury / 100.0)
+    assert.strictEqual(
+      treasuryAfter.amount.toNumber(),
+      beforeAmount * (distribution.treasury / 100.0)
     );
     // Check burn amount.
-    assert.ok(mintInfoBefore.supply.toString() === "1000000000000000000");
-    assert.ok(
-      mintInfoBefore.supply.sub(mintInfoAfter.supply).toNumber() ===
-        beforeAmount * (distribution.burn / 100.0)
+    assert.strictEqual(mintInfoBefore.supply.toString(), "1000000000000000000");
+    assert.strictEqual(
+      mintInfoBefore.supply.sub(mintInfoAfter.supply).toNumber(),
+      beforeAmount * (distribution.burn / 100.0)
     );
   });
 });

--- a/tests/chat/tests/chat.js
+++ b/tests/chat/tests/chat.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 const { PublicKey } = anchor.web3;
 
 describe("chat", () => {
@@ -26,10 +26,10 @@ describe("chat", () => {
 
     const chat = await program.account.chatRoom.fetch(chatRoom.publicKey);
     const name = new TextDecoder("utf-8").decode(new Uint8Array(chat.name));
-    assert.ok(name.startsWith("Test Chat")); // [u8; 280] => trailing zeros.
-    assert.ok(chat.messages.length === 33607);
-    assert.ok(chat.head.toNumber() === 0);
-    assert.ok(chat.tail.toNumber() === 0);
+    assert.isTrue(name.startsWith("Test Chat")); // [u8; 280] => trailing zeros.
+    assert.lengthOf(chat.messages, 33607);
+    assert.strictEqual(chat.head.toNumber(), 0);
+    assert.strictEqual(chat.tail.toNumber(), 0);
   });
 
   it("Creates a user", async () => {
@@ -46,8 +46,8 @@ describe("chat", () => {
       },
     });
     const account = await program.account.user.fetch(user);
-    assert.ok(account.name === "My User");
-    assert.ok(account.authority.equals(authority));
+    assert.strictEqual(account.name, "My User");
+    assert.isTrue(account.authority.equals(authority));
   });
 
   it("Sends messages", async () => {
@@ -85,19 +85,20 @@ describe("chat", () => {
     // Check the chat room state is as expected.
     const chat = await program.account.chatRoom.fetch(chatRoom.publicKey);
     const name = new TextDecoder("utf-8").decode(new Uint8Array(chat.name));
-    assert.ok(name.startsWith("Test Chat")); // [u8; 280] => trailing zeros.
-    assert.ok(chat.messages.length === 33607);
-    assert.ok(chat.head.toNumber() === numMessages);
-    assert.ok(chat.tail.toNumber() === 0);
+    assert.isTrue(name.startsWith("Test Chat")); // [u8; 280] => trailing zeros.
+    assert.lengthOf(chat.messages, 33607);
+    assert.strictEqual(chat.head.toNumber(), numMessages);
+    assert.strictEqual(chat.tail.toNumber(), 0);
     chat.messages.forEach((msg, idx) => {
       if (idx < 10) {
         const data = new TextDecoder("utf-8").decode(new Uint8Array(msg.data));
         console.log("Message", data);
-        assert.ok(msg.from.equals(user));
-        assert.ok(data.startsWith(messages[idx]));
+        assert.isTrue(msg.from.equals(user));
+        assert.isTrue(data.startsWith(messages[idx]));
       } else {
-        assert.ok(
-          JSON.stringify(msg.data) === JSON.stringify(new Array(280).fill(0))
+        assert.strictEqual(
+          JSON.stringify(msg.data),
+          JSON.stringify(new Array(280).fill(0))
         );
       }
     });

--- a/tests/composite/tests/composite.js
+++ b/tests/composite/tests/composite.js
@@ -1,4 +1,4 @@
-const assert = require("assert");
+const { assert } = require("chai");
 const anchor = require("@project-serum/anchor");
 
 describe("composite", () => {
@@ -44,7 +44,7 @@ describe("composite", () => {
     const dummyAAccount = await program.account.dummyA.fetch(dummyA.publicKey);
     const dummyBAccount = await program.account.dummyB.fetch(dummyB.publicKey);
 
-    assert.ok(dummyAAccount.data.eq(new anchor.BN(1234)));
-    assert.ok(dummyBAccount.data.eq(new anchor.BN(4321)));
+    assert.isTrue(dummyAAccount.data.eq(new anchor.BN(1234)));
+    assert.isTrue(dummyBAccount.data.eq(new anchor.BN(4321)));
   });
 });

--- a/tests/custom-coder/tests/custom-coder.ts
+++ b/tests/custom-coder/tests/custom-coder.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@project-serum/anchor";
 import { Spl } from "@project-serum/anchor";
-import * as assert from "assert";
+import { assert } from "chai";
 import BN from "bn.js";
 import { Keypair, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
 
@@ -34,13 +34,13 @@ describe("custom-coder", () => {
       }
     );
     const mintAccount = await program.account.mint.fetch(mintKeypair.publicKey);
-    assert.ok(
+    assert.isTrue(
       mintAccount.mintAuthority.equals(program.provider.wallet.publicKey)
     );
-    assert.ok(mintAccount.freezeAuthority === null);
-    assert.ok(mintAccount.decimals === 6);
-    assert.ok(mintAccount.isInitialized);
-    assert.ok(mintAccount.supply.toNumber() === 0);
+    assert.isNull(mintAccount.freezeAuthority);
+    assert.strictEqual(mintAccount.decimals, 6);
+    assert.isTrue(mintAccount.isInitialized);
+    assert.strictEqual(mintAccount.supply.toNumber(), 0);
   });
 
   it("Creates a token account for alice", async () => {
@@ -59,14 +59,14 @@ describe("custom-coder", () => {
     const token = await program.account.token.fetch(
       aliceTokenKeypair.publicKey
     );
-    assert.ok(token.authority.equals(program.provider.wallet.publicKey));
-    assert.ok(token.mint.equals(mintKeypair.publicKey));
-    assert.ok(token.amount.toNumber() === 0);
-    assert.ok(token.delegate === null);
-    assert.ok(token.state === 1);
-    assert.ok(token.isNative === null);
-    assert.ok(token.delegatedAmount.toNumber() === 0);
-    assert.ok(token.closeAuthority === null);
+    assert.isTrue(token.authority.equals(program.provider.wallet.publicKey));
+    assert.isTrue(token.mint.equals(mintKeypair.publicKey));
+    assert.strictEqual(token.amount.toNumber(), 0);
+    assert.isNull(token.delegate);
+    assert.strictEqual(token.state, 1);
+    assert.isNull(token.isNative);
+    assert.strictEqual(token.delegatedAmount.toNumber(), 0);
+    assert.isNull(token.closeAuthority);
   });
 
   it("Mints a token to alice", async () => {
@@ -82,8 +82,8 @@ describe("custom-coder", () => {
       aliceTokenKeypair.publicKey
     );
     const mint = await program.account.mint.fetch(mintKeypair.publicKey);
-    assert.ok(token.amount.toNumber() === 2);
-    assert.ok(mint.supply.toNumber() === 2);
+    assert.strictEqual(token.amount.toNumber(), 2);
+    assert.strictEqual(mint.supply.toNumber(), 2);
   });
 
   it("Creates a token for bob", async () => {
@@ -115,8 +115,8 @@ describe("custom-coder", () => {
     const bobToken = await program.account.token.fetch(
       bobTokenKeypair.publicKey
     );
-    assert.ok(aliceToken.amount.toNumber() === 1);
-    assert.ok(bobToken.amount.toNumber() === 1);
+    assert.strictEqual(aliceToken.amount.toNumber(), 1);
+    assert.strictEqual(bobToken.amount.toNumber(), 1);
   });
 
   it("Alice burns a token", async () => {
@@ -131,7 +131,7 @@ describe("custom-coder", () => {
       aliceTokenKeypair.publicKey
     );
     const mint = await program.account.mint.fetch(mintKeypair.publicKey);
-    assert.ok(aliceToken.amount.toNumber() === 0);
-    assert.ok(mint.supply.toNumber() === 1);
+    assert.strictEqual(aliceToken.amount.toNumber(), 0);
+    assert.strictEqual(mint.supply.toNumber(), 1);
   });
 });

--- a/tests/declare-id/tests/declare-id.ts
+++ b/tests/declare-id/tests/declare-id.ts
@@ -2,7 +2,6 @@ import * as anchor from "@project-serum/anchor";
 import { AnchorError, Program } from "@project-serum/anchor";
 import splToken from "@solana/spl-token";
 import { DeclareId } from "../target/types/declare_id";
-
 import { assert } from "chai";
 
 describe("declare_id", () => {
@@ -14,9 +13,9 @@ describe("declare_id", () => {
       await program.rpc.initialize();
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 4100);
+      assert.strictEqual(err.error.errorCode.number, 4100);
     }
   });
 });

--- a/tests/errors/tests/errors.ts
+++ b/tests/errors/tests/errors.ts
@@ -59,7 +59,7 @@ const withLogTest = async (callback, expectedLogs) => {
     throw err;
   }
   anchor.getProvider().connection.removeOnLogsListener(listener);
-  assert.ok(logTestOk);
+  assert.isTrue(logTestOk);
 };
 
 describe("errors", () => {
@@ -79,16 +79,19 @@ describe("errors", () => {
         const tx = await program.rpc.hello();
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
         const errMsg =
           "This is an error message clients will automatically display";
         const fullErrMsg =
           "AnchorError thrown in programs/errors/src/lib.rs:13. Error Code: Hello. Error Number: 6000. Error Message: This is an error message clients will automatically display.";
-        assert.equal(err.toString(), fullErrMsg);
-        assert.equal(err.error.errorMessage, errMsg);
-        assert.equal(err.error.errorCode.number, 6000);
-        assert.equal(err.program.toString(), program.programId.toString());
+        assert.strictEqual(err.toString(), fullErrMsg);
+        assert.strictEqual(err.error.errorMessage, errMsg);
+        assert.strictEqual(err.error.errorCode.number, 6000);
+        assert.strictEqual(
+          err.program.toString(),
+          program.programId.toString()
+        );
         expect(err.error.origin).to.deep.equal({
           file: "programs/errors/src/lib.rs",
           line: 13,
@@ -104,13 +107,13 @@ describe("errors", () => {
       const tx = await program.rpc.testRequire();
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
       const errMsg =
         "This is an error message clients will automatically display";
-      assert.equal(err.error.errorMessage, errMsg);
-      assert.equal(err.error.errorCode.number, 6000);
-      assert.equal(err.error.errorCode.code, "Hello");
+      assert.strictEqual(err.error.errorMessage, errMsg);
+      assert.strictEqual(err.error.errorCode.number, 6000);
+      assert.strictEqual(err.error.errorCode.code, "Hello");
     }
   });
 
@@ -119,12 +122,12 @@ describe("errors", () => {
       const tx = await program.rpc.testErr();
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
       const errMsg =
         "This is an error message clients will automatically display";
-      assert.equal(err.error.errorMessage, errMsg);
-      assert.equal(err.error.errorCode.number, 6000);
+      assert.strictEqual(err.error.errorMessage, errMsg);
+      assert.strictEqual(err.error.errorCode.number, 6000);
     }
   });
 
@@ -164,10 +167,10 @@ describe("errors", () => {
       const tx = await program.rpc.helloNoMsg();
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorMessage, "HelloNoMsg");
-      assert.equal(err.error.errorCode.number, 6123);
+      assert.strictEqual(err.error.errorMessage, "HelloNoMsg");
+      assert.strictEqual(err.error.errorCode.number, 6123);
     }
   });
 
@@ -176,10 +179,10 @@ describe("errors", () => {
       const tx = await program.rpc.helloNext();
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorMessage, "HelloNext");
-      assert.equal(err.error.errorCode.number, 6124);
+      assert.strictEqual(err.error.errorMessage, "HelloNext");
+      assert.strictEqual(err.error.errorCode.number, 6124);
     }
   });
 
@@ -193,11 +196,14 @@ describe("errors", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorMessage, "A mut constraint was violated");
-        assert.equal(err.error.errorCode.number, 2000);
-        assert.equal(err.error.origin, "my_account");
+        assert.strictEqual(
+          err.error.errorMessage,
+          "A mut constraint was violated"
+        );
+        assert.strictEqual(err.error.errorCode.number, 2000);
+        assert.strictEqual(err.error.origin, "my_account");
       }
     }, [
       "Program log: AnchorError caused by account: my_account. Error Code: ConstraintMut. Error Number: 2000. Error Message: A mut constraint was violated.",
@@ -221,16 +227,19 @@ describe("errors", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(
+        assert.strictEqual(
           err.error.errorMessage,
           "A has one constraint was violated"
         );
-        assert.equal(err.error.errorCode.number, 2001);
-        assert.equal(err.error.errorCode.code, "ConstraintHasOne");
-        assert.equal(err.error.origin, "my_account");
-        assert.equal(err.program.toString(), program.programId.toString());
+        assert.strictEqual(err.error.errorCode.number, 2001);
+        assert.strictEqual(err.error.errorCode.code, "ConstraintHasOne");
+        assert.strictEqual(err.error.origin, "my_account");
+        assert.strictEqual(
+          err.program.toString(),
+          program.programId.toString()
+        );
         expect(
           err.error.comparedValues.map((pk) => pk.toString())
         ).to.deep.equal([
@@ -275,7 +284,7 @@ describe("errors", () => {
     } catch (err) {
       anchor.getProvider().connection.removeOnLogsListener(listener);
       const errMsg = `Error: Raw transaction ${signature} failed ({"err":{"InstructionError":[0,{"Custom":3010}]}})`;
-      assert.equal(err.toString(), errMsg);
+      assert.strictEqual(err.toString(), errMsg);
     } finally {
       anchor.getProvider().connection.removeOnLogsListener(listener);
     }
@@ -290,11 +299,11 @@ describe("errors", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
       const errMsg = "HelloCustom";
-      assert.equal(err.error.errorMessage, errMsg);
-      assert.equal(err.error.errorCode.number, 6125);
+      assert.strictEqual(err.error.errorMessage, errMsg);
+      assert.strictEqual(err.error.errorCode.number, 6125);
     }
   });
 
@@ -310,11 +319,11 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have fail with `AccountNotInitialized` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
         const errMsg =
           "The program expected this account to be already initialized";
-        assert.equal(err.error.errorMessage, errMsg);
+        assert.strictEqual(err.error.errorMessage, errMsg);
       }
     }, [
       "Program log: AnchorError caused by account: not_initialized_account. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.",
@@ -342,11 +351,11 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `AccountOwnedByWrongProgram` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
         const errMsg =
           "The given account is owned by a different program than expected";
-        assert.equal(err.error.errorMessage, errMsg);
+        assert.strictEqual(err.error.errorMessage, errMsg);
       }
     }, [
       "Program log: AnchorError caused by account: wrong_account. Error Code: AccountOwnedByWrongProgram. Error Number: 3007. Error Message: The given account is owned by a different program than expected.",
@@ -365,9 +374,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6126);
+        assert.strictEqual(err.error.errorCode.number, 6126);
         expect(err.error.comparedValues).to.deep.equal(["5241", "124124124"]);
       }
     }, [
@@ -385,9 +394,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2501);
+        assert.strictEqual(err.error.errorCode.number, 2501);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:73. Error Code: RequireEqViolated. Error Number: 2501. Error Message: A require_eq expression was violated.",
@@ -404,9 +413,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6127);
+        assert.strictEqual(err.error.errorCode.number, 6127);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:78. Error Code: ValueMatch. Error Number: 6127. Error Message: ValueMatch.",
@@ -423,9 +432,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `RequireNeqViolated` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2503);
+        assert.strictEqual(err.error.errorCode.number, 2503);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:83. Error Code: RequireNeqViolated. Error Number: 2503. Error Message: A require_neq expression was violated.",
@@ -447,9 +456,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6126);
+        assert.strictEqual(err.error.errorCode.number, 6126);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:88. Error Code: ValueMismatch. Error Number: 6126. Error Message: ValueMismatch.",
@@ -473,9 +482,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMismatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2502);
+        assert.strictEqual(err.error.errorCode.number, 2502);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:97. Error Code: RequireKeysEqViolated. Error Number: 2502. Error Message: A require_keys_eq expression was violated.",
@@ -499,9 +508,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueMatch` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6127);
+        assert.strictEqual(err.error.errorCode.number, 6127);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:102. Error Code: ValueMatch. Error Number: 6127. Error Message: ValueMatch.",
@@ -525,9 +534,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `RequireKeysNeqViolated` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2504);
+        assert.strictEqual(err.error.errorCode.number, 2504);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:111. Error Code: RequireKeysNeqViolated. Error Number: 2504. Error Message: A require_keys_neq expression was violated.",
@@ -546,9 +555,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueLessOrEqual` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6129);
+        assert.strictEqual(err.error.errorCode.number, 6129);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:116. Error Code: ValueLessOrEqual. Error Number: 6129. Error Message: ValueLessOrEqual.",
@@ -565,9 +574,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `RequireGtViolated` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2505);
+        assert.strictEqual(err.error.errorCode.number, 2505);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:121. Error Code: RequireGtViolated. Error Number: 2505. Error Message: A require_gt expression was violated.",
@@ -584,9 +593,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `ValueLess` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 6128);
+        assert.strictEqual(err.error.errorCode.number, 6128);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:126. Error Code: ValueLess. Error Number: 6128. Error Message: ValueLess.",
@@ -603,9 +612,9 @@ describe("errors", () => {
           "Unexpected success in creating a transaction that should have failed with `RequireGteViolated` error"
         );
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2506);
+        assert.strictEqual(err.error.errorCode.number, 2506);
       }
     }, [
       "Program log: AnchorError thrown in programs/errors/src/lib.rs:131. Error Code: RequireGteViolated. Error Number: 2506. Error Message: A require_gte expression was violated.",

--- a/tests/escrow/tests/escrow.ts
+++ b/tests/escrow/tests/escrow.ts
@@ -82,8 +82,11 @@ describe("escrow", () => {
     );
     let _takerTokenAccountB = await mintB.getAccountInfo(takerTokenAccountB);
 
-    assert.ok(_initializerTokenAccountA.amount.toNumber() == initializerAmount);
-    assert.ok(_takerTokenAccountB.amount.toNumber() == takerAmount);
+    assert.strictEqual(
+      _initializerTokenAccountA.amount.toNumber(),
+      initializerAmount
+    );
+    assert.strictEqual(_takerTokenAccountB.amount.toNumber(), takerAmount);
   });
 
   it("Initialize escrow", async () => {
@@ -119,18 +122,23 @@ describe("escrow", () => {
       await program.account.escrowAccount.fetch(escrowAccount.publicKey);
 
     // Check that the new owner is the PDA.
-    assert.ok(_initializerTokenAccountA.owner.equals(pda));
+    assert.isTrue(_initializerTokenAccountA.owner.equals(pda));
 
     // Check that the values in the escrow account match what we expect.
-    assert.ok(_escrowAccount.initializerKey.equals(provider.wallet.publicKey));
-    assert.ok(_escrowAccount.initializerAmount.toNumber() == initializerAmount);
-    assert.ok(_escrowAccount.takerAmount.toNumber() == takerAmount);
-    assert.ok(
+    assert.isTrue(
+      _escrowAccount.initializerKey.equals(provider.wallet.publicKey)
+    );
+    assert.strictEqual(
+      _escrowAccount.initializerAmount.toNumber(),
+      initializerAmount
+    );
+    assert.strictEqual(_escrowAccount.takerAmount.toNumber(), takerAmount);
+    assert.isTrue(
       _escrowAccount.initializerDepositTokenAccount.equals(
         initializerTokenAccountA
       )
     );
-    assert.ok(
+    assert.isTrue(
       _escrowAccount.initializerReceiveTokenAccount.equals(
         initializerTokenAccountB
       )
@@ -162,12 +170,18 @@ describe("escrow", () => {
     );
 
     // Check that the initializer gets back ownership of their token account.
-    assert.ok(_takerTokenAccountA.owner.equals(provider.wallet.publicKey));
+    assert.isTrue(_takerTokenAccountA.owner.equals(provider.wallet.publicKey));
 
-    assert.ok(_takerTokenAccountA.amount.toNumber() == initializerAmount);
-    assert.ok(_initializerTokenAccountA.amount.toNumber() == 0);
-    assert.ok(_initializerTokenAccountB.amount.toNumber() == takerAmount);
-    assert.ok(_takerTokenAccountB.amount.toNumber() == 0);
+    assert.strictEqual(
+      _takerTokenAccountA.amount.toNumber(),
+      initializerAmount
+    );
+    assert.strictEqual(_initializerTokenAccountA.amount.toNumber(), 0);
+    assert.strictEqual(
+      _initializerTokenAccountB.amount.toNumber(),
+      takerAmount
+    );
+    assert.strictEqual(_takerTokenAccountB.amount.toNumber(), 0);
   });
 
   let newEscrow = Keypair.generate();
@@ -202,7 +216,7 @@ describe("escrow", () => {
     );
 
     // Check that the new owner is the PDA.
-    assert.ok(_initializerTokenAccountA.owner.equals(pda));
+    assert.isTrue(_initializerTokenAccountA.owner.equals(pda));
 
     // Cancel the escrow.
     await program.rpc.cancelEscrow({
@@ -219,11 +233,14 @@ describe("escrow", () => {
     _initializerTokenAccountA = await mintA.getAccountInfo(
       initializerTokenAccountA
     );
-    assert.ok(
+    assert.isTrue(
       _initializerTokenAccountA.owner.equals(provider.wallet.publicKey)
     );
 
     // Check all the funds are still there.
-    assert.ok(_initializerTokenAccountA.amount.toNumber() == initializerAmount);
+    assert.strictEqual(
+      _initializerTokenAccountA.amount.toNumber(),
+      initializerAmount
+    );
   });
 });

--- a/tests/events/tests/events.js
+++ b/tests/events/tests/events.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("events", () => {
   // Configure the client to use the local cluster.
@@ -17,9 +17,9 @@ describe("events", () => {
     });
     await program.removeEventListener(listener);
 
-    assert.ok(slot > 0);
-    assert.ok(event.data.toNumber() === 5);
-    assert.ok(event.label === "hello");
+    assert.isAbove(slot, 0);
+    assert.strictEqual(event.data.toNumber(), 5);
+    assert.strictEqual(event.label, "hello");
   });
 
   it("Multiple events", async () => {
@@ -46,13 +46,13 @@ describe("events", () => {
     await program.removeEventListener(listenerOne);
     await program.removeEventListener(listenerTwo);
 
-    assert.ok(slotOne > 0);
-    assert.ok(eventOne.data.toNumber() === 5);
-    assert.ok(eventOne.label === "hello");
+    assert.isAbove(slotOne, 0);
+    assert.strictEqual(eventOne.data.toNumber(), 5);
+    assert.strictEqual(eventOne.label, "hello");
 
-    assert.ok(slotTwo > 0);
-    assert.ok(eventTwo.data.toNumber() === 6);
-    assert.ok(eventTwo.label === "bye");
+    assert.isAbove(slotTwo, 0);
+    assert.strictEqual(eventTwo.data.toNumber(), 6);
+    assert.strictEqual(eventTwo.label, "bye");
   });
 });
 

--- a/tests/floats/tests/floats.ts
+++ b/tests/floats/tests/floats.ts
@@ -2,7 +2,7 @@ import * as anchor from "@project-serum/anchor";
 import { Program, getProvider } from "@project-serum/anchor";
 import { Keypair, SystemProgram } from "@solana/web3.js";
 import { Floats } from "../target/types/floats";
-import assert from "assert";
+import { assert } from "chai";
 
 describe("floats", () => {
   // Configure the client to use the local cluster.

--- a/tests/ido-pool/tests/ido-pool.js
+++ b/tests/ido-pool/tests/ido-pool.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 const {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
@@ -59,7 +59,9 @@ describe("ido-pool", () => {
       provider,
       idoAuthorityWatermelon
     );
-    assert.ok(idoAuthority_watermelon_account.amount.eq(watermelonIdoAmount));
+    assert.isTrue(
+      idoAuthority_watermelon_account.amount.eq(watermelonIdoAmount)
+    );
   });
 
   // These are all variables the client will need to create in order to
@@ -131,7 +133,7 @@ describe("ido-pool", () => {
       provider,
       idoAuthorityWatermelon
     );
-    assert.ok(idoAuthorityWatermelonAccount.amount.eq(new anchor.BN(0)));
+    assert.isTrue(idoAuthorityWatermelonAccount.amount.eq(new anchor.BN(0)));
   });
 
   // We're going to need to start using the associated program account for creating token accounts
@@ -190,7 +192,7 @@ describe("ido-pool", () => {
 
     // Check if we inited correctly
     userUsdcAccount = await getTokenAccount(provider, userUsdc);
-    assert.ok(userUsdcAccount.amount.eq(firstDeposit));
+    assert.isTrue(userUsdcAccount.amount.eq(firstDeposit));
 
     const [userRedeemable] = await anchor.web3.PublicKey.findProgramAddress(
       [
@@ -232,9 +234,9 @@ describe("ido-pool", () => {
       console.log("This is the error message", err.toString());
     }
     poolUsdcAccount = await getTokenAccount(provider, poolUsdc);
-    assert.ok(poolUsdcAccount.amount.eq(firstDeposit));
+    assert.isTrue(poolUsdcAccount.amount.eq(firstDeposit));
     userRedeemableAccount = await getTokenAccount(provider, userRedeemable);
-    assert.ok(userRedeemableAccount.amount.eq(firstDeposit));
+    assert.isTrue(userRedeemableAccount.amount.eq(firstDeposit));
   });
 
   // 23 usdc
@@ -291,7 +293,7 @@ describe("ido-pool", () => {
 
     // Checking the transfer went through
     secondUserUsdcAccount = await getTokenAccount(provider, secondUserUsdc);
-    assert.ok(secondUserUsdcAccount.amount.eq(secondDeposit));
+    assert.isTrue(secondUserUsdcAccount.amount.eq(secondDeposit));
 
     const [secondUserRedeemable] =
       await anchor.web3.PublicKey.findProgramAddress(
@@ -335,11 +337,11 @@ describe("ido-pool", () => {
       provider,
       secondUserRedeemable
     );
-    assert.ok(secondUserRedeemableAccount.amount.eq(secondDeposit));
+    assert.isTrue(secondUserRedeemableAccount.amount.eq(secondDeposit));
 
     totalPoolUsdc = firstDeposit.add(secondDeposit);
     poolUsdcAccount = await getTokenAccount(provider, poolUsdc);
-    assert.ok(poolUsdcAccount.amount.eq(totalPoolUsdc));
+    assert.isTrue(poolUsdcAccount.amount.eq(totalPoolUsdc));
   });
 
   const firstWithdrawal = new anchor.BN(2_000_000);
@@ -407,9 +409,9 @@ describe("ido-pool", () => {
 
     totalPoolUsdc = totalPoolUsdc.sub(firstWithdrawal);
     poolUsdcAccount = await getTokenAccount(provider, poolUsdc);
-    assert.ok(poolUsdcAccount.amount.eq(totalPoolUsdc));
+    assert.isTrue(poolUsdcAccount.amount.eq(totalPoolUsdc));
     escrowUsdcAccount = await getTokenAccount(provider, escrowUsdc);
-    assert.ok(escrowUsdcAccount.amount.eq(firstWithdrawal));
+    assert.isTrue(escrowUsdcAccount.amount.eq(firstWithdrawal));
   });
 
   it("Exchanges user Redeemable tokens for watermelon", async () => {
@@ -469,9 +471,9 @@ describe("ido-pool", () => {
       .mul(watermelonIdoAmount)
       .div(totalPoolUsdc);
     let remainingWatermelon = watermelonIdoAmount.sub(redeemedWatermelon);
-    assert.ok(poolWatermelonAccount.amount.eq(remainingWatermelon));
+    assert.isTrue(poolWatermelonAccount.amount.eq(remainingWatermelon));
     userWatermelonAccount = await getTokenAccount(provider, userWatermelon);
-    assert.ok(userWatermelonAccount.amount.eq(redeemedWatermelon));
+    assert.isTrue(userWatermelonAccount.amount.eq(redeemedWatermelon));
   });
 
   it("Exchanges second user's Redeemable tokens for watermelon", async () => {
@@ -521,7 +523,7 @@ describe("ido-pool", () => {
     });
 
     poolWatermelonAccount = await getTokenAccount(provider, poolWatermelon);
-    assert.ok(poolWatermelonAccount.amount.eq(new anchor.BN(0)));
+    assert.isTrue(poolWatermelonAccount.amount.eq(new anchor.BN(0)));
   });
 
   it("Withdraws total USDC from pool account", async () => {
@@ -548,9 +550,9 @@ describe("ido-pool", () => {
     });
 
     poolUsdcAccount = await getTokenAccount(provider, poolUsdc);
-    assert.ok(poolUsdcAccount.amount.eq(new anchor.BN(0)));
+    assert.isTrue(poolUsdcAccount.amount.eq(new anchor.BN(0)));
     idoAuthorityUsdcAccount = await getTokenAccount(provider, idoAuthorityUsdc);
-    assert.ok(idoAuthorityUsdcAccount.amount.eq(totalPoolUsdc));
+    assert.isTrue(idoAuthorityUsdcAccount.amount.eq(totalPoolUsdc));
   });
 
   it("Withdraws USDC from the escrow account after waiting period is over", async () => {
@@ -586,7 +588,7 @@ describe("ido-pool", () => {
     });
 
     userUsdcAccount = await getTokenAccount(provider, userUsdc);
-    assert.ok(userUsdcAccount.amount.eq(firstWithdrawal));
+    assert.isTrue(userUsdcAccount.amount.eq(firstWithdrawal));
   });
 
   function PoolBumps() {

--- a/tests/interface/tests/interface.js
+++ b/tests/interface/tests/interface.js
@@ -1,5 +1,6 @@
 const anchor = require("@project-serum/anchor");
 const { assert } = require("chai");
+const nativeAssert = require("assert");
 
 describe("interface", () => {
   // Configure the client to use the local cluster.
@@ -16,7 +17,7 @@ describe("interface", () => {
   });
 
   it("Should fail to go from even to even", async () => {
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await counter.state.rpc.setCount(new anchor.BN(4), {
           accounts: {

--- a/tests/interface/tests/interface.js
+++ b/tests/interface/tests/interface.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("interface", () => {
   // Configure the client to use the local cluster.
@@ -11,8 +11,8 @@ describe("interface", () => {
     await counter.state.rpc.new(counterAuth.programId);
 
     const stateAccount = await counter.state.fetch();
-    assert.ok(stateAccount.count.eq(new anchor.BN(0)));
-    assert.ok(stateAccount.authProgram.equals(counterAuth.programId));
+    assert.isTrue(stateAccount.count.eq(new anchor.BN(0)));
+    assert.isTrue(stateAccount.authProgram.equals(counterAuth.programId));
   });
 
   it("Should fail to go from even to even", async () => {
@@ -40,6 +40,6 @@ describe("interface", () => {
       },
     });
     const stateAccount = await counter.state.fetch();
-    assert.ok(stateAccount.count.eq(new anchor.BN(3)));
+    assert.isTrue(stateAccount.count.eq(new anchor.BN(3)));
   });
 });

--- a/tests/lockup/tests/lockup.js
+++ b/tests/lockup/tests/lockup.js
@@ -1,10 +1,8 @@
-const assert = require("assert");
 const anchor = require("@project-serum/anchor");
 const serumCmn = require("@project-serum/common");
 const { TOKEN_PROGRAM_ID } = require("@solana/spl-token");
 const utils = require("./utils");
-const chai = require("chai");
-const expect = chai.expect;
+const { assert, expect } = require("chai");
 
 anchor.utils.features.set("anchor-deprecated-state");
 
@@ -43,10 +41,10 @@ describe("Lockup and Registry", () => {
     lockupAddress = await lockup.state.address();
     const lockupAccount = await lockup.state.fetch();
 
-    assert.ok(lockupAccount.authority.equals(provider.wallet.publicKey));
-    assert.ok(lockupAccount.whitelist.length === WHITELIST_SIZE);
+    assert.isTrue(lockupAccount.authority.equals(provider.wallet.publicKey));
+    assert.strictEqual(lockupAccount.whitelist.length, WHITELIST_SIZE);
     lockupAccount.whitelist.forEach((e) => {
-      assert.ok(e.programId.equals(anchor.web3.PublicKey.default));
+      assert.isTrue(e.programId.equals(anchor.web3.PublicKey.default));
     });
   });
 
@@ -68,7 +66,7 @@ describe("Lockup and Registry", () => {
     });
 
     let lockupAccount = await lockup.state.fetch();
-    assert.ok(lockupAccount.authority.equals(newAuthority.publicKey));
+    assert.isTrue(lockupAccount.authority.equals(newAuthority.publicKey));
 
     await lockup.state.rpc.setAuthority(provider.wallet.publicKey, {
       accounts: {
@@ -78,7 +76,7 @@ describe("Lockup and Registry", () => {
     });
 
     lockupAccount = await lockup.state.fetch();
-    assert.ok(lockupAccount.authority.equals(provider.wallet.publicKey));
+    assert.isTrue(lockupAccount.authority.equals(provider.wallet.publicKey));
   });
 
   const entries = [];
@@ -103,7 +101,7 @@ describe("Lockup and Registry", () => {
 
     let lockupAccount = await lockup.state.fetch();
 
-    assert.ok(lockupAccount.whitelist.length === 1);
+    assert.lengthOf(lockupAccount.whitelist, 1);
     assert.deepEqual(lockupAccount.whitelist, [entries[0]]);
 
     for (let k = 1; k < WHITELIST_SIZE; k += 1) {
@@ -120,8 +118,8 @@ describe("Lockup and Registry", () => {
         await lockup.state.rpc.whitelistAdd(e, { accounts });
       },
       (err) => {
-        assert.equal(err.error.errorCode.number, 6008);
-        assert.equal(err.error.errorMessage, "Whitelist is full");
+        assert.strictEqual(err.error.errorCode.number, 6008);
+        assert.strictEqual(err.error.errorMessage, "Whitelist is full");
         return true;
       }
     );
@@ -189,17 +187,17 @@ describe("Lockup and Registry", () => {
 
     vestingAccount = await lockup.account.vesting.fetch(vesting.publicKey);
 
-    assert.ok(vestingAccount.beneficiary.equals(provider.wallet.publicKey));
-    assert.ok(vestingAccount.mint.equals(mint));
-    assert.ok(vestingAccount.grantor.equals(provider.wallet.publicKey));
-    assert.ok(vestingAccount.outstanding.eq(depositAmount));
-    assert.ok(vestingAccount.startBalance.eq(depositAmount));
-    assert.ok(vestingAccount.whitelistOwned.eq(new anchor.BN(0)));
-    assert.equal(vestingAccount.nonce, nonce);
-    assert.ok(vestingAccount.createdTs.gt(new anchor.BN(0)));
-    assert.ok(vestingAccount.startTs.eq(startTs));
-    assert.ok(vestingAccount.endTs.eq(endTs));
-    assert.ok(vestingAccount.realizor === null);
+    assert.isTrue(vestingAccount.beneficiary.equals(provider.wallet.publicKey));
+    assert.isTrue(vestingAccount.mint.equals(mint));
+    assert.isTrue(vestingAccount.grantor.equals(provider.wallet.publicKey));
+    assert.isTrue(vestingAccount.outstanding.eq(depositAmount));
+    assert.isTrue(vestingAccount.startBalance.eq(depositAmount));
+    assert.isTrue(vestingAccount.whitelistOwned.eq(new anchor.BN(0)));
+    assert.strictEqual(vestingAccount.nonce, nonce);
+    assert.isTrue(vestingAccount.createdTs.gt(new anchor.BN(0)));
+    assert.isTrue(vestingAccount.startTs.eq(startTs));
+    assert.isTrue(vestingAccount.endTs.eq(endTs));
+    assert.isNull(vestingAccount.realizor);
   });
 
   it("Fails to withdraw from a vesting account before vesting", async () => {
@@ -218,8 +216,8 @@ describe("Lockup and Registry", () => {
         });
       },
       (err) => {
-        assert.equal(err.error.errorCode.number, 6007);
-        assert.equal(
+        assert.strictEqual(err.error.errorCode.number, 6007);
+        assert.strictEqual(
           err.error.errorMessage,
           "Insufficient withdrawal balance."
         );
@@ -252,16 +250,16 @@ describe("Lockup and Registry", () => {
     });
 
     vestingAccount = await lockup.account.vesting.fetch(vesting.publicKey);
-    assert.ok(vestingAccount.outstanding.eq(new anchor.BN(0)));
+    assert.isTrue(vestingAccount.outstanding.eq(new anchor.BN(0)));
 
     const vaultAccount = await serumCmn.getTokenAccount(
       provider,
       vestingAccount.vault
     );
-    assert.ok(vaultAccount.amount.eq(new anchor.BN(0)));
+    assert.isTrue(vaultAccount.amount.eq(new anchor.BN(0)));
 
     const tokenAccount = await serumCmn.getTokenAccount(provider, token);
-    assert.ok(tokenAccount.amount.eq(new anchor.BN(100)));
+    assert.isTrue(tokenAccount.amount.eq(new anchor.BN(100)));
   });
 
   const registrar = anchor.web3.Keypair.generate();
@@ -291,7 +289,7 @@ describe("Lockup and Registry", () => {
     });
 
     const state = await registry.state.fetch();
-    assert.ok(state.lockupProgram.equals(lockup.programId));
+    assert.isTrue(state.lockupProgram.equals(lockup.programId));
 
     // Should not allow a second initializatoin.
     await assert.rejects(
@@ -331,13 +329,13 @@ describe("Lockup and Registry", () => {
       registrar.publicKey
     );
 
-    assert.ok(registrarAccount.authority.equals(provider.wallet.publicKey));
-    assert.equal(registrarAccount.nonce, nonce);
-    assert.ok(registrarAccount.mint.equals(mint));
-    assert.ok(registrarAccount.poolMint.equals(poolMint));
-    assert.ok(registrarAccount.stakeRate.eq(stakeRate));
-    assert.ok(registrarAccount.rewardEventQ.equals(rewardQ.publicKey));
-    assert.ok(registrarAccount.withdrawalTimelock.eq(withdrawalTimelock));
+    assert.isTrue(registrarAccount.authority.equals(provider.wallet.publicKey));
+    assert.strictEqual(registrarAccount.nonce, nonce);
+    assert.isTrue(registrarAccount.mint.equals(mint));
+    assert.isTrue(registrarAccount.poolMint.equals(poolMint));
+    assert.isTrue(registrarAccount.stakeRate.eq(stakeRate));
+    assert.isTrue(registrarAccount.rewardEventQ.equals(rewardQ.publicKey));
+    assert.isTrue(registrarAccount.withdrawalTimelock.eq(withdrawalTimelock));
   });
 
   const member = anchor.web3.Keypair.generate();
@@ -390,19 +388,19 @@ describe("Lockup and Registry", () => {
 
     memberAccount = await registry.account.member.fetch(member.publicKey);
 
-    assert.ok(memberAccount.registrar.equals(registrar.publicKey));
-    assert.ok(memberAccount.beneficiary.equals(provider.wallet.publicKey));
-    assert.ok(memberAccount.metadata.equals(anchor.web3.PublicKey.default));
-    assert.equal(
+    assert.isTrue(memberAccount.registrar.equals(registrar.publicKey));
+    assert.isTrue(memberAccount.beneficiary.equals(provider.wallet.publicKey));
+    assert.isTrue(memberAccount.metadata.equals(anchor.web3.PublicKey.default));
+    assert.strictEqual(
       JSON.stringify(memberAccount.balances),
       JSON.stringify(balances)
     );
-    assert.equal(
+    assert.strictEqual(
       JSON.stringify(memberAccount.balancesLocked),
       JSON.stringify(balancesLocked)
     );
-    assert.ok(memberAccount.rewardsCursor === 0);
-    assert.ok(memberAccount.lastStakeTs.eq(new anchor.BN(0)));
+    assert.strictEqual(memberAccount.rewardsCursor, 0);
+    assert.isTrue(memberAccount.lastStakeTs.eq(new anchor.BN(0)));
   });
 
   it("Deposits (unlocked) to a member", async () => {
@@ -422,7 +420,7 @@ describe("Lockup and Registry", () => {
       provider,
       memberAccount.balances.vault
     );
-    assert.ok(memberVault.amount.eq(depositAmount));
+    assert.isTrue(memberVault.amount.eq(depositAmount));
   });
 
   it("Stakes to a member (unlocked)", async () => {
@@ -460,9 +458,9 @@ describe("Lockup and Registry", () => {
       memberAccount.balances.spt
     );
 
-    assert.ok(vault.amount.eq(new anchor.BN(100)));
-    assert.ok(vaultStake.amount.eq(new anchor.BN(20)));
-    assert.ok(spt.amount.eq(new anchor.BN(10)));
+    assert.isTrue(vault.amount.eq(new anchor.BN(100)));
+    assert.isTrue(vaultStake.amount.eq(new anchor.BN(20)));
+    assert.isTrue(spt.amount.eq(new anchor.BN(10)));
   });
 
   const unlockedVendor = anchor.web3.Keypair.generate();
@@ -521,25 +519,27 @@ describe("Lockup and Registry", () => {
       unlockedVendor.publicKey
     );
 
-    assert.ok(vendorAccount.registrar.equals(registrar.publicKey));
-    assert.ok(vendorAccount.vault.equals(unlockedVendorVault.publicKey));
-    assert.ok(vendorAccount.nonce === nonce);
-    assert.ok(vendorAccount.poolTokenSupply.eq(new anchor.BN(10)));
-    assert.ok(vendorAccount.expiryTs.eq(expiry));
-    assert.ok(vendorAccount.expiryReceiver.equals(provider.wallet.publicKey));
-    assert.ok(vendorAccount.total.eq(rewardAmount));
-    assert.ok(vendorAccount.expired === false);
-    assert.ok(vendorAccount.rewardEventQCursor === 0);
+    assert.isTrue(vendorAccount.registrar.equals(registrar.publicKey));
+    assert.isTrue(vendorAccount.vault.equals(unlockedVendorVault.publicKey));
+    assert.strictEqual(vendorAccount.nonce, nonce);
+    assert.isTrue(vendorAccount.poolTokenSupply.eq(new anchor.BN(10)));
+    assert.isTrue(vendorAccount.expiryTs.eq(expiry));
+    assert.isTrue(
+      vendorAccount.expiryReceiver.equals(provider.wallet.publicKey)
+    );
+    assert.isTrue(vendorAccount.total.eq(rewardAmount));
+    assert.isFalse(vendorAccount.expired);
+    assert.strictEqual(vendorAccount.rewardEventQCursor, 0);
     assert.deepEqual(vendorAccount.kind, rewardKind);
 
     const rewardQAccount = await registry.account.rewardQueue.fetch(
       rewardQ.publicKey
     );
-    assert.ok(rewardQAccount.head === 1);
-    assert.ok(rewardQAccount.tail === 0);
+    assert.strictEqual(rewardQAccount.head, 1);
+    assert.strictEqual(rewardQAccount.tail, 0);
     const e = rewardQAccount.events[0];
-    assert.ok(e.vendor.equals(unlockedVendor.publicKey));
-    assert.equal(e.locked, false);
+    assert.isTrue(e.vendor.equals(unlockedVendor.publicKey));
+    assert.strictEqual(e.locked, false);
   });
 
   it("Collects an unlocked reward", async () => {
@@ -570,10 +570,10 @@ describe("Lockup and Registry", () => {
     });
 
     let tokenAccount = await serumCmn.getTokenAccount(provider, token);
-    assert.ok(tokenAccount.amount.eq(new anchor.BN(200)));
+    assert.isTrue(tokenAccount.amount.eq(new anchor.BN(200)));
 
     const memberAccount = await registry.account.member.fetch(member.publicKey);
-    assert.ok(memberAccount.rewardsCursor == 1);
+    assert.strictEqual(memberAccount.rewardsCursor, 1);
   });
 
   const lockedVendor = anchor.web3.Keypair.generate();
@@ -638,16 +638,18 @@ describe("Lockup and Registry", () => {
       lockedVendor.publicKey
     );
 
-    assert.ok(vendorAccount.registrar.equals(registrar.publicKey));
-    assert.ok(vendorAccount.vault.equals(lockedVendorVault.publicKey));
-    assert.ok(vendorAccount.nonce === nonce);
-    assert.ok(vendorAccount.poolTokenSupply.eq(new anchor.BN(10)));
-    assert.ok(vendorAccount.expiryTs.eq(expiry));
-    assert.ok(vendorAccount.expiryReceiver.equals(provider.wallet.publicKey));
-    assert.ok(vendorAccount.total.eq(lockedRewardAmount));
-    assert.ok(vendorAccount.expired === false);
-    assert.ok(vendorAccount.rewardEventQCursor === 1);
-    assert.equal(
+    assert.isTrue(vendorAccount.registrar.equals(registrar.publicKey));
+    assert.isTrue(vendorAccount.vault.equals(lockedVendorVault.publicKey));
+    assert.strictEqual(vendorAccount.nonce, nonce);
+    assert.isTrue(vendorAccount.poolTokenSupply.eq(new anchor.BN(10)));
+    assert.isTrue(vendorAccount.expiryTs.eq(expiry));
+    assert.isTrue(
+      vendorAccount.expiryReceiver.equals(provider.wallet.publicKey)
+    );
+    assert.isTrue(vendorAccount.total.eq(lockedRewardAmount));
+    assert.isFalse(vendorAccount.expired);
+    assert.strictEqual(vendorAccount.rewardEventQCursor, 1);
+    assert.strictEqual(
       JSON.stringify(vendorAccount.kind),
       JSON.stringify(lockedRewardKind)
     );
@@ -655,11 +657,11 @@ describe("Lockup and Registry", () => {
     const rewardQAccount = await registry.account.rewardQueue.fetch(
       rewardQ.publicKey
     );
-    assert.ok(rewardQAccount.head === 2);
-    assert.ok(rewardQAccount.tail === 0);
+    assert.strictEqual(rewardQAccount.head, 2);
+    assert.strictEqual(rewardQAccount.tail, 0);
     const e = rewardQAccount.events[1];
-    assert.ok(e.vendor.equals(lockedVendor.publicKey));
-    assert.ok(e.locked === true);
+    assert.isTrue(e.vendor.equals(lockedVendor.publicKey));
+    assert.isTrue(e.locked);
   });
 
   let vendoredVesting = null;
@@ -728,18 +730,18 @@ describe("Lockup and Registry", () => {
       vendoredVesting.publicKey
     );
 
-    assert.ok(lockupAccount.beneficiary.equals(provider.wallet.publicKey));
-    assert.ok(lockupAccount.mint.equals(mint));
-    assert.ok(lockupAccount.vault.equals(vendoredVestingVault.publicKey));
-    assert.ok(lockupAccount.outstanding.eq(lockedRewardAmount));
-    assert.ok(lockupAccount.startBalance.eq(lockedRewardAmount));
-    assert.ok(lockupAccount.endTs.eq(lockedRewardKind.locked.endTs));
-    assert.ok(
+    assert.isTrue(lockupAccount.beneficiary.equals(provider.wallet.publicKey));
+    assert.isTrue(lockupAccount.mint.equals(mint));
+    assert.isTrue(lockupAccount.vault.equals(vendoredVestingVault.publicKey));
+    assert.isTrue(lockupAccount.outstanding.eq(lockedRewardAmount));
+    assert.isTrue(lockupAccount.startBalance.eq(lockedRewardAmount));
+    assert.isTrue(lockupAccount.endTs.eq(lockedRewardKind.locked.endTs));
+    assert.isTrue(
       lockupAccount.periodCount.eq(lockedRewardKind.locked.periodCount)
     );
-    assert.ok(lockupAccount.whitelistOwned.eq(new anchor.BN(0)));
-    assert.ok(lockupAccount.realizor.program.equals(registry.programId));
-    assert.ok(lockupAccount.realizor.metadata.equals(member.publicKey));
+    assert.isTrue(lockupAccount.whitelistOwned.eq(new anchor.BN(0)));
+    assert.isTrue(lockupAccount.realizor.program.equals(registry.programId));
+    assert.isTrue(lockupAccount.realizor.metadata.equals(member.publicKey));
   });
 
   it("Waits for the lockup period to pass", async () => {
@@ -778,9 +780,9 @@ describe("Lockup and Registry", () => {
       (err) => {
         // Solana doesn't propagate errors across CPI. So we receive the registry's error code,
         // not the lockup's.
-        assert.equal(err.error.errorCode.number, 6020);
-        assert.equal(err.error.errorCode.code, "UnrealizedReward");
-        assert.equal(
+        assert.strictEqual(err.error.errorCode.number, 6020);
+        assert.strictEqual(err.error.errorCode.code, "UnrealizedReward");
+        assert.strictEqual(
           err.error.errorMessage,
           "Locked rewards cannot be realized until one unstaked all tokens."
         );
@@ -788,7 +790,7 @@ describe("Lockup and Registry", () => {
           file: "programs/registry/src/lib.rs",
           line: 63,
         });
-        assert.equal(
+        assert.strictEqual(
           err.program.toString(),
           "HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L"
         );
@@ -845,9 +847,9 @@ describe("Lockup and Registry", () => {
       memberAccount.balances.spt
     );
 
-    assert.ok(vaultPw.amount.eq(new anchor.BN(20)));
-    assert.ok(vaultStake.amount.eq(new anchor.BN(0)));
-    assert.ok(spt.amount.eq(new anchor.BN(0)));
+    assert.isTrue(vaultPw.amount.eq(new anchor.BN(20)));
+    assert.isTrue(vaultStake.amount.eq(new anchor.BN(0)));
+    assert.isTrue(spt.amount.eq(new anchor.BN(0)));
   });
 
   const tryEndUnstake = async () => {
@@ -876,8 +878,8 @@ describe("Lockup and Registry", () => {
         await tryEndUnstake();
       },
       (err) => {
-        assert.equal(err.error.errorCode.number, 6009);
-        assert.equal(
+        assert.strictEqual(err.error.errorCode.number, 6009);
+        assert.strictEqual(
           err.error.errorMessage,
           "The unstake timelock has not yet expired."
         );
@@ -902,8 +904,8 @@ describe("Lockup and Registry", () => {
       memberAccount.balances.vaultPw
     );
 
-    assert.ok(vault.amount.eq(new anchor.BN(120)));
-    assert.ok(vaultPw.amount.eq(new anchor.BN(0)));
+    assert.isTrue(vault.amount.eq(new anchor.BN(120)));
+    assert.isTrue(vaultPw.amount.eq(new anchor.BN(0)));
   });
 
   it("Withdraws deposits (unlocked)", async () => {
@@ -926,7 +928,7 @@ describe("Lockup and Registry", () => {
     });
 
     const tokenAccount = await serumCmn.getTokenAccount(provider, token);
-    assert.ok(tokenAccount.amount.eq(withdrawAmount));
+    assert.isTrue(tokenAccount.amount.eq(withdrawAmount));
   });
 
   it("Should succesfully unlock a locked reward after unstaking", async () => {
@@ -957,6 +959,6 @@ describe("Lockup and Registry", () => {
       ],
     });
     const tokenAccount = await serumCmn.getTokenAccount(provider, token);
-    assert.ok(tokenAccount.amount.eq(withdrawAmount));
+    assert.isTrue(tokenAccount.amount.eq(withdrawAmount));
   });
 });

--- a/tests/lockup/tests/lockup.js
+++ b/tests/lockup/tests/lockup.js
@@ -3,6 +3,7 @@ const serumCmn = require("@project-serum/common");
 const { TOKEN_PROGRAM_ID } = require("@solana/spl-token");
 const utils = require("./utils");
 const { assert, expect } = require("chai");
+const nativeAssert = require("assert");
 
 anchor.utils.features.set("anchor-deprecated-state");
 
@@ -112,7 +113,7 @@ describe("Lockup and Registry", () => {
 
     assert.deepEqual(lockupAccount.whitelist, entries);
 
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         const e = await generateEntry();
         await lockup.state.rpc.whitelistAdd(e, { accounts });
@@ -201,7 +202,7 @@ describe("Lockup and Registry", () => {
   });
 
   it("Fails to withdraw from a vesting account before vesting", async () => {
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await lockup.rpc.withdraw(new anchor.BN(100), {
           accounts: {
@@ -292,7 +293,7 @@ describe("Lockup and Registry", () => {
     assert.isTrue(state.lockupProgram.equals(lockup.programId));
 
     // Should not allow a second initializatoin.
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await registry.state.rpc.new(lockup.programId);
       },
@@ -754,7 +755,7 @@ describe("Lockup and Registry", () => {
       mint,
       provider.wallet.publicKey
     );
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         const withdrawAmount = new anchor.BN(10);
         await lockup.rpc.withdraw(withdrawAmount, {
@@ -873,7 +874,7 @@ describe("Lockup and Registry", () => {
   };
 
   it("Fails to end unstaking before timelock", async () => {
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await tryEndUnstake();
       },

--- a/tests/misc/tests/misc.ts
+++ b/tests/misc/tests/misc.ts
@@ -13,7 +13,7 @@ import {
 } from "@solana/spl-token";
 import { Misc } from "../target/types/misc";
 const utf8 = anchor.utils.bytes.utf8;
-const assert = require("assert");
+const { assert } = require("chai");
 const miscIdl = require("../target/idl/misc.json");
 
 describe("misc", () => {
@@ -27,8 +27,8 @@ describe("misc", () => {
     const addr = await program.state.address();
     const state = await program.state.fetch();
     const accountInfo = await program.provider.connection.getAccountInfo(addr);
-    assert.ok(state.v.equals(Buffer.from([])));
-    assert.ok(accountInfo.data.length === 99);
+    assert.isTrue(state.v.equals(Buffer.from([])));
+    assert.lengthOf(accountInfo.data, 99);
   });
 
   it("Can use remaining accounts for a state instruction", async () => {
@@ -55,8 +55,8 @@ describe("misc", () => {
       }
     );
     const dataAccount = await program.account.data.fetch(data.publicKey);
-    assert.ok(dataAccount.udata.eq(new anchor.BN(1234)));
-    assert.ok(dataAccount.idata.eq(new anchor.BN(22)));
+    assert.isTrue(dataAccount.udata.eq(new anchor.BN(1234)));
+    assert.isTrue(dataAccount.idata.eq(new anchor.BN(22)));
   });
 
   it("Can use u16", async () => {
@@ -70,7 +70,7 @@ describe("misc", () => {
       instructions: [await program.account.dataU16.createInstruction(data)],
     });
     const dataAccount = await program.account.dataU16.fetch(data.publicKey);
-    assert.ok(dataAccount.data === 99);
+    assert.strictEqual(dataAccount.data, 99);
   });
 
   it("Can embed programs into genesis from the Anchor.toml", async () => {
@@ -78,7 +78,7 @@ describe("misc", () => {
       "FtMNMKp9DZHKWUyVAsj3Q5QV8ow4P3fUPP7ZrWEQJzKr"
     );
     let accInfo = await anchor.getProvider().connection.getAccountInfo(pid);
-    assert.ok(accInfo.executable);
+    assert.isTrue(accInfo.executable);
   });
 
   it("Can use the owner constraint", async () => {
@@ -133,8 +133,8 @@ describe("misc", () => {
       },
     });
     let stateAccount = await misc2Program.state.fetch();
-    assert.ok(stateAccount.data.eq(oldData));
-    assert.ok(stateAccount.auth.equals(program.provider.wallet.publicKey));
+    assert.isTrue(stateAccount.data.eq(oldData));
+    assert.isTrue(stateAccount.auth.equals(program.provider.wallet.publicKey));
     const newData = new anchor.BN(2134);
     await program.rpc.testStateCpi(newData, {
       accounts: {
@@ -144,8 +144,8 @@ describe("misc", () => {
       },
     });
     stateAccount = await misc2Program.state.fetch();
-    assert.ok(stateAccount.data.eq(newData));
-    assert.ok(stateAccount.auth.equals(program.provider.wallet.publicKey));
+    assert.isTrue(stateAccount.data.eq(newData));
+    assert.isTrue(stateAccount.auth.equals(program.provider.wallet.publicKey));
   });
 
   it("Can retrieve events when simulating a transaction", async () => {
@@ -163,18 +163,18 @@ describe("misc", () => {
     ];
 
     assert.deepStrictEqual(expectedRaw, resp.raw);
-    assert.ok(resp.events[0].name === "E1");
-    assert.ok(resp.events[0].data.data === 44);
-    assert.ok(resp.events[1].name === "E2");
-    assert.ok(resp.events[1].data.data === 1234);
-    assert.ok(resp.events[2].name === "E3");
-    assert.ok(resp.events[2].data.data === 9);
-    assert.ok(resp.events[3].name === "E5");
+    assert.strictEqual(resp.events[0].name, "E1");
+    assert.strictEqual(resp.events[0].data.data, 44);
+    assert.strictEqual(resp.events[1].name, "E2");
+    assert.strictEqual(resp.events[1].data.data, 1234);
+    assert.strictEqual(resp.events[2].name, "E3");
+    assert.strictEqual(resp.events[2].data.data, 9);
+    assert.strictEqual(resp.events[3].name, "E5");
     assert.deepStrictEqual(
       resp.events[3].data.data,
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     );
-    assert.ok(resp.events[4].name === "E6");
+    assert.strictEqual(resp.events[4].name, "E6");
     assert.deepStrictEqual(
       resp.events[4].data.data,
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -194,7 +194,7 @@ describe("misc", () => {
       signers: [dataI8],
     });
     const dataAccount = await program.account.dataI8.fetch(dataI8.publicKey);
-    assert.ok(dataAccount.data === -3);
+    assert.strictEqual(dataAccount.data, -3);
   });
 
   let dataPubkey;
@@ -210,7 +210,7 @@ describe("misc", () => {
       signers: [data],
     });
     const dataAccount = await program.account.dataI16.fetch(data.publicKey);
-    assert.ok(dataAccount.data === -2048);
+    assert.strictEqual(dataAccount.data, -2048);
 
     dataPubkey = data.publicKey;
   });
@@ -219,7 +219,7 @@ describe("misc", () => {
     const dataAccount = await program.account.dataI16.fetch(
       dataPubkey.toString()
     );
-    assert.ok(dataAccount.data === -2048);
+    assert.strictEqual(dataAccount.data, -2048);
   });
 
   it("Should fail to close an account when sending lamports to itself", async () => {
@@ -233,8 +233,8 @@ describe("misc", () => {
       assert.ok(false);
     } catch (err) {
       const errMsg = "A close constraint was violated";
-      assert.equal(err.error.errorMessage, errMsg);
-      assert.equal(err.error.errorCode.number, 2011);
+      assert.strictEqual(err.error.errorMessage, errMsg);
+      assert.strictEqual(err.error.errorCode.number, 2011);
     }
   });
 
@@ -242,7 +242,7 @@ describe("misc", () => {
     const openAccount = await program.provider.connection.getAccountInfo(
       data.publicKey
     );
-    assert.ok(openAccount !== null);
+    assert.isNotNull(openAccount);
 
     let beforeBalance = (
       await program.provider.connection.getAccountInfo(
@@ -269,7 +269,7 @@ describe("misc", () => {
     const closedAccount = await program.provider.connection.getAccountInfo(
       data.publicKey
     );
-    assert.ok(closedAccount === null);
+    assert.isNull(closedAccount);
   });
 
   it("Can use instruction data in accounts constraints", async () => {
@@ -313,7 +313,7 @@ describe("misc", () => {
     });
 
     const myPdaAccount = await program.account.dataU16.fetch(myPda);
-    assert.ok(myPdaAccount.data === 6);
+    assert.strictEqual(myPdaAccount.data, 6);
   });
 
   it("Can create a zero copy PDA account", async () => {
@@ -331,8 +331,8 @@ describe("misc", () => {
     });
 
     const myPdaAccount = await program.account.dataZeroCopy.fetch(myPda);
-    assert.ok(myPdaAccount.data === 9);
-    assert.ok(myPdaAccount.bump === nonce);
+    assert.strictEqual(myPdaAccount.data, 9);
+    assert.strictEqual(myPdaAccount.bump, nonce);
   });
 
   it("Can write to a zero copy PDA account", async () => {
@@ -348,8 +348,8 @@ describe("misc", () => {
     });
 
     const myPdaAccount = await program.account.dataZeroCopy.fetch(myPda);
-    assert.ok(myPdaAccount.data === 1234);
-    assert.ok(myPdaAccount.bump === bump);
+    assert.strictEqual(myPdaAccount.data, 1234);
+    assert.strictEqual(myPdaAccount.bump, bump);
   });
 
   it("Can create a token account from seeds pda", async () => {
@@ -379,11 +379,11 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const account = await mintAccount.getAccountInfo(myPda);
-    assert.ok(account.state === 1);
-    assert.ok(account.amount.toNumber() === 0);
-    assert.ok(account.isInitialized);
-    assert.ok(account.owner.equals(program.provider.wallet.publicKey));
-    assert.ok(account.mint.equals(mint));
+    assert.strictEqual(account.state, 1);
+    assert.strictEqual(account.amount.toNumber(), 0);
+    assert.isTrue(account.isInitialized);
+    assert.isTrue(account.owner.equals(program.provider.wallet.publicKey));
+    assert.isTrue(account.mint.equals(mint));
   });
 
   it("Can execute a fallback function", async () => {
@@ -392,7 +392,7 @@ describe("misc", () => {
         await anchor.utils.rpc.invoke(program.programId);
       },
       (err) => {
-        assert.ok(err.toString().includes("custom program error: 0x4d2"));
+        assert.isTrue(err.toString().includes("custom program error: 0x4d2"));
         return true;
       }
     );
@@ -410,7 +410,7 @@ describe("misc", () => {
     });
 
     const account = await program.account.dataI8.fetch(data.publicKey);
-    assert.ok(account.data === 3);
+    assert.strictEqual(account.data, 3);
   });
 
   it("Can init a random account prefunded", async () => {
@@ -432,7 +432,7 @@ describe("misc", () => {
     });
 
     const account = await program.account.dataI8.fetch(data.publicKey);
-    assert.ok(account.data === 3);
+    assert.strictEqual(account.data, 3);
   });
 
   it("Can init a random zero copy account", async () => {
@@ -446,8 +446,8 @@ describe("misc", () => {
       signers: [data],
     });
     const account = await program.account.dataZeroCopy.fetch(data.publicKey);
-    assert.ok(account.data === 10);
-    assert.ok(account.bump === 2);
+    assert.strictEqual(account.data, 10);
+    assert.strictEqual(account.bump, 2);
   });
 
   let mint = undefined;
@@ -471,11 +471,11 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const mintAccount = await client.getMintInfo();
-    assert.ok(mintAccount.decimals === 6);
-    assert.ok(
+    assert.strictEqual(mintAccount.decimals, 6);
+    assert.isTrue(
       mintAccount.mintAuthority.equals(program.provider.wallet.publicKey)
     );
-    assert.ok(
+    assert.isTrue(
       mintAccount.freezeAuthority.equals(program.provider.wallet.publicKey)
     );
   });
@@ -506,8 +506,8 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const mintAccount = await client.getMintInfo();
-    assert.ok(mintAccount.decimals === 6);
-    assert.ok(
+    assert.strictEqual(mintAccount.decimals, 6);
+    assert.isTrue(
       mintAccount.mintAuthority.equals(program.provider.wallet.publicKey)
     );
   });
@@ -532,11 +532,11 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const account = await client.getAccountInfo(token.publicKey);
-    assert.ok(account.state === 1);
-    assert.ok(account.amount.toNumber() === 0);
-    assert.ok(account.isInitialized);
-    assert.ok(account.owner.equals(program.provider.wallet.publicKey));
-    assert.ok(account.mint.equals(mint.publicKey));
+    assert.strictEqual(account.state, 1);
+    assert.strictEqual(account.amount.toNumber(), 0);
+    assert.isTrue(account.isInitialized);
+    assert.isTrue(account.owner.equals(program.provider.wallet.publicKey));
+    assert.isTrue(account.mint.equals(mint.publicKey));
   });
 
   it("Can create a random token with prefunding", async () => {
@@ -566,11 +566,11 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const account = await client.getAccountInfo(token.publicKey);
-    assert.ok(account.state === 1);
-    assert.ok(account.amount.toNumber() === 0);
-    assert.ok(account.isInitialized);
-    assert.ok(account.owner.equals(program.provider.wallet.publicKey));
-    assert.ok(account.mint.equals(mint.publicKey));
+    assert.strictEqual(account.state, 1);
+    assert.strictEqual(account.amount.toNumber(), 0);
+    assert.isTrue(account.isInitialized);
+    assert.isTrue(account.owner.equals(program.provider.wallet.publicKey));
+    assert.isTrue(account.mint.equals(mint.publicKey));
   });
 
   it("Can create a random token with prefunding under the rent exemption", async () => {
@@ -600,11 +600,11 @@ describe("misc", () => {
       program.provider.wallet.payer
     );
     const account = await client.getAccountInfo(token.publicKey);
-    assert.ok(account.state === 1);
-    assert.ok(account.amount.toNumber() === 0);
-    assert.ok(account.isInitialized);
-    assert.ok(account.owner.equals(program.provider.wallet.publicKey));
-    assert.ok(account.mint.equals(mint.publicKey));
+    assert.strictEqual(account.state, 1);
+    assert.strictEqual(account.amount.toNumber(), 0);
+    assert.isTrue(account.isInitialized);
+    assert.isTrue(account.owner.equals(program.provider.wallet.publicKey));
+    assert.isTrue(account.mint.equals(mint.publicKey));
   });
 
   it("Can initialize multiple accounts via a composite payer", async () => {
@@ -625,11 +625,11 @@ describe("misc", () => {
     });
 
     const account1 = await program.account.dataI8.fetch(data1.publicKey);
-    assert.equal(account1.data, 1);
+    assert.strictEqual(account1.data, 1);
 
     const account2 = await program.account.data.fetch(data2.publicKey);
-    assert.equal(account2.udata, 2);
-    assert.equal(account2.idata, 3);
+    assert.strictEqual(account2.udata, 2);
+    assert.strictEqual(account2.idata, 3);
   });
 
   describe("associated_token constraints", () => {
@@ -666,11 +666,11 @@ describe("misc", () => {
       });
 
       const account = await localClient.getAccountInfo(associatedToken);
-      assert.ok(account.state === 1);
-      assert.ok(account.amount.toNumber() === 0);
-      assert.ok(account.isInitialized);
-      assert.ok(account.owner.equals(program.provider.wallet.publicKey));
-      assert.ok(account.mint.equals(localClient.publicKey));
+      assert.strictEqual(account.state, 1);
+      assert.strictEqual(account.amount.toNumber(), 0);
+      assert.isTrue(account.isInitialized);
+      assert.isTrue(account.owner.equals(program.provider.wallet.publicKey));
+      assert.isTrue(account.mint.equals(localClient.publicKey));
     });
 
     it("Can validate associated_token constraints", async () => {
@@ -703,7 +703,7 @@ describe("misc", () => {
           });
         },
         (err) => {
-          assert.equal(err.error.errorCode.number, 2009);
+          assert.strictEqual(err.error.errorCode.number, 2009);
           return true;
         }
       );
@@ -738,7 +738,7 @@ describe("misc", () => {
           });
         },
         (err) => {
-          assert.equal(err.error.errorCode.number, 2015);
+          assert.strictEqual(err.error.errorCode.number, 2015);
           return true;
         }
       );
@@ -832,15 +832,15 @@ describe("misc", () => {
         { memcmp: { offset: 40, bytes: filterable2.toBase58() } },
       ]);
     // Without filters there should be 4 accounts.
-    assert.equal(allAccounts.length, 4);
+    assert.lengthOf(allAccounts, 4);
     // Filtering by main wallet there should be 3 accounts.
-    assert.equal(allAccountsFilteredByBuffer.length, 3);
+    assert.lengthOf(allAccountsFilteredByBuffer, 3);
     // Filtering all the main wallet accounts and matching the filterable1 value
     // results in a 2 accounts.
-    assert.equal(allAccountsFilteredByProgramFilters1.length, 2);
+    assert.lengthOf(allAccountsFilteredByProgramFilters1, 2);
     // Filtering all the main wallet accounts and matching the filterable2 value
     // results in 1 account.
-    assert.equal(allAccountsFilteredByProgramFilters2.length, 1);
+    assert.lengthOf(allAccountsFilteredByProgramFilters2, 1);
   });
 
   it("Can use pdas with empty seeds", async () => {
@@ -891,7 +891,7 @@ describe("misc", () => {
       signers: [ifNeededAcc],
     });
     const account = await program.account.dataU16.fetch(ifNeededAcc.publicKey);
-    assert.equal(account.data, 1);
+    assert.strictEqual(account.data, 1);
   });
 
   it("Can init if needed a previously created account", async () => {
@@ -904,7 +904,7 @@ describe("misc", () => {
       signers: [ifNeededAcc],
     });
     const account = await program.account.dataU16.fetch(ifNeededAcc.publicKey);
-    assert.equal(account.data, 3);
+    assert.strictEqual(account.data, 3);
   });
 
   it("Can use const for array size", async () => {
@@ -945,26 +945,23 @@ describe("misc", () => {
   });
 
   it("Should include BASE const in IDL", async () => {
-    assert(
+    assert.isDefined(
       miscIdl.constants.find(
         (c) => c.name === "BASE" && c.type === "u128" && c.value === "1_000_000"
-      ) !== undefined
+      )
     );
   });
 
   it("Should include DECIMALS const in IDL", async () => {
-    assert(
+    assert.isDefined(
       miscIdl.constants.find(
         (c) => c.name === "DECIMALS" && c.type === "u8" && c.value === "6"
-      ) !== undefined
+      )
     );
   });
 
   it("Should not include NO_IDL const in IDL", async () => {
-    assert.equal(
-      miscIdl.constants.find((c) => c.name === "NO_IDL"),
-      undefined
-    );
+    assert.isUndefined(miscIdl.constants.find((c) => c.name === "NO_IDL"));
   });
 
   it("init_if_needed throws if account exists but is not owned by the expected program", async () => {
@@ -992,9 +989,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2004);
+      assert.strictEqual(err.error.errorCode.number, 2004);
     }
   });
 
@@ -1031,9 +1028,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2006);
+      assert.strictEqual(err.error.errorCode.number, 2006);
     }
   });
 
@@ -1060,9 +1057,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2019);
+      assert.strictEqual(err.error.errorCode.number, 2019);
     }
   });
 
@@ -1094,9 +1091,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2016);
+      assert.strictEqual(err.error.errorCode.number, 2016);
     }
   });
 
@@ -1128,9 +1125,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2017);
+      assert.strictEqual(err.error.errorCode.number, 2017);
     }
   });
 
@@ -1162,9 +1159,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2018);
+      assert.strictEqual(err.error.errorCode.number, 2018);
     }
   });
 
@@ -1209,9 +1206,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2015);
+      assert.strictEqual(err.error.errorCode.number, 2015);
     }
   });
 
@@ -1268,9 +1265,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2014);
+      assert.strictEqual(err.error.errorCode.number, 2014);
     }
   });
 
@@ -1321,9 +1318,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2015);
+      assert.strictEqual(err.error.errorCode.number, 2015);
     }
   });
 
@@ -1386,9 +1383,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2014);
+      assert.strictEqual(err.error.errorCode.number, 2014);
     }
   });
 
@@ -1452,9 +1449,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 3014);
+      assert.strictEqual(err.error.errorCode.number, 3014);
     }
   });
 
@@ -1480,9 +1477,9 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2005);
+      assert.strictEqual(err.error.errorCode.number, 2005);
     }
   });
 
@@ -1608,10 +1605,10 @@ describe("misc", () => {
       });
       assert.ok(false);
     } catch (_err) {
-      assert.ok(_err instanceof AnchorError);
+      assert.isTrue(_err instanceof AnchorError);
       const err: AnchorError = _err;
-      assert.equal(err.error.errorCode.number, 2005);
-      assert.equal(
+      assert.strictEqual(err.error.errorCode.number, 2005);
+      assert.strictEqual(
         "A rent exemption constraint was violated",
         err.error.errorMessage
       );
@@ -1642,9 +1639,9 @@ describe("misc", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2006);
+        assert.strictEqual(err.error.errorCode.number, 2006);
       }
 
       // matching bump seed for wrong address but derived from wrong program
@@ -1657,9 +1654,9 @@ describe("misc", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2006);
+        assert.strictEqual(err.error.errorCode.number, 2006);
       }
 
       // correct inputs should lead to successful tx
@@ -1696,9 +1693,9 @@ describe("misc", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2006);
+        assert.strictEqual(err.error.errorCode.number, 2006);
       }
 
       // same seeds but derived from wrong program
@@ -1711,9 +1708,9 @@ describe("misc", () => {
         });
         assert.ok(false);
       } catch (_err) {
-        assert.ok(_err instanceof AnchorError);
+        assert.isTrue(_err instanceof AnchorError);
         const err: AnchorError = _err;
-        assert.equal(err.error.errorCode.number, 2006);
+        assert.strictEqual(err.error.errorCode.number, 2006);
       }
 
       // correct inputs should lead to successful tx

--- a/tests/misc/tests/misc.ts
+++ b/tests/misc/tests/misc.ts
@@ -14,6 +14,7 @@ import {
 import { Misc } from "../target/types/misc";
 const utf8 = anchor.utils.bytes.utf8;
 const { assert } = require("chai");
+const nativeAssert = require("assert");
 const miscIdl = require("../target/idl/misc.json");
 
 describe("misc", () => {
@@ -89,7 +90,7 @@ describe("misc", () => {
       },
     });
 
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await program.rpc.testOwner({
           accounts: {
@@ -111,7 +112,7 @@ describe("misc", () => {
       },
     });
 
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await program.rpc.testExecutable({
           accounts: {
@@ -387,7 +388,7 @@ describe("misc", () => {
   });
 
   it("Can execute a fallback function", async () => {
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await anchor.utils.rpc.invoke(program.programId);
       },
@@ -628,8 +629,8 @@ describe("misc", () => {
     assert.strictEqual(account1.data, 1);
 
     const account2 = await program.account.data.fetch(data2.publicKey);
-    assert.strictEqual(account2.udata, 2);
-    assert.strictEqual(account2.idata, 3);
+    assert.strictEqual(account2.udata.toNumber(), 2);
+    assert.strictEqual(account2.idata.toNumber(), 3);
   });
 
   describe("associated_token constraints", () => {
@@ -692,7 +693,7 @@ describe("misc", () => {
         TOKEN_PROGRAM_ID
       );
 
-      await assert.rejects(
+      await nativeAssert.rejects(
         async () => {
           await program.rpc.testValidateAssociatedToken({
             accounts: {
@@ -727,7 +728,7 @@ describe("misc", () => {
         []
       );
 
-      await assert.rejects(
+      await nativeAssert.rejects(
         async () => {
           await program.rpc.testValidateAssociatedToken({
             accounts: {
@@ -866,7 +867,7 @@ describe("misc", () => {
       ["non-empty"],
       program.programId
     );
-    await assert.rejects(
+    await nativeAssert.rejects(
       program.rpc.testEmptySeedsConstraint({
         accounts: {
           pda: pda2,

--- a/tests/multisig/tests/multisig.js
+++ b/tests/multisig/tests/multisig.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("multisig", () => {
   // Configure the client to use the local cluster.
@@ -41,8 +41,8 @@ describe("multisig", () => {
       multisig.publicKey
     );
 
-    assert.equal(multisigAccount.nonce, nonce);
-    assert.ok(multisigAccount.threshold.eq(new anchor.BN(2)));
+    assert.strictEqual(multisigAccount.nonce, nonce);
+    assert.isTrue(multisigAccount.threshold.eq(new anchor.BN(2)));
     assert.deepEqual(multisigAccount.owners, owners);
 
     const pid = program.programId;
@@ -85,11 +85,11 @@ describe("multisig", () => {
       transaction.publicKey
     );
 
-    assert.ok(txAccount.programId.equals(pid));
+    assert.isTrue(txAccount.programId.equals(pid));
     assert.deepEqual(txAccount.accounts, accounts);
     assert.deepEqual(txAccount.data, data);
-    assert.ok(txAccount.multisig.equals(multisig.publicKey));
-    assert.equal(txAccount.didExecute, false);
+    assert.isTrue(txAccount.multisig.equals(multisig.publicKey));
+    assert.strictEqual(txAccount.didExecute, false);
 
     // Other owner approves transaction.
     await program.rpc.approve({
@@ -128,8 +128,8 @@ describe("multisig", () => {
 
     multisigAccount = await program.account.multisig.fetch(multisig.publicKey);
 
-    assert.equal(multisigAccount.nonce, nonce);
-    assert.ok(multisigAccount.threshold.eq(new anchor.BN(2)));
+    assert.strictEqual(multisigAccount.nonce, nonce);
+    assert.isTrue(multisigAccount.threshold.eq(new anchor.BN(2)));
     assert.deepEqual(multisigAccount.owners, newOwners);
   });
 });

--- a/tests/pyth/tests/pyth.spec.ts
+++ b/tests/pyth/tests/pyth.spec.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@project-serum/anchor";
 import { BN, Program, web3 } from "@project-serum/anchor";
-import assert from "assert";
+import { assert } from "chai";
 import { createPriceFeed, setFeedPrice, getFeedData } from "./oracleUtils";
 
 describe("pyth-oracle", () => {
@@ -15,7 +15,7 @@ describe("pyth-oracle", () => {
       expo: -6,
     });
     const feedData = await getFeedData(program, priceFeedAddress);
-    assert.ok(feedData.price === price);
+    assert.strictEqual(feedData.price, price);
   });
 
   it("change feed price", async () => {
@@ -27,13 +27,13 @@ describe("pyth-oracle", () => {
       expo: expo,
     });
     const feedDataBefore = await getFeedData(program, priceFeedAddress);
-    assert.ok(feedDataBefore.price === price);
-    assert.ok(feedDataBefore.exponent === expo);
+    assert.strictEqual(feedDataBefore.price, price);
+    assert.strictEqual(feedDataBefore.exponent, expo);
 
     const newPrice = 55000;
     await setFeedPrice(program, newPrice, priceFeedAddress);
     const feedDataAfter = await getFeedData(program, priceFeedAddress);
-    assert.ok(feedDataAfter.price === newPrice);
-    assert.ok(feedDataAfter.exponent === expo);
+    assert.strictEqual(feedDataAfter.price, newPrice);
+    assert.strictEqual(feedDataAfter.exponent, expo);
   });
 });

--- a/tests/spl/token-proxy/tests/token-proxy.js
+++ b/tests/spl/token-proxy/tests/token-proxy.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("token", () => {
   const provider = anchor.Provider.local();
@@ -31,7 +31,7 @@ describe("token", () => {
 
     const fromAccount = await getTokenAccount(provider, from);
 
-    assert.ok(fromAccount.amount.eq(new anchor.BN(1000)));
+    assert.isTrue(fromAccount.amount.eq(new anchor.BN(1000)));
   });
 
   it("Transfers a token", async () => {
@@ -47,8 +47,8 @@ describe("token", () => {
     const fromAccount = await getTokenAccount(provider, from);
     const toAccount = await getTokenAccount(provider, to);
 
-    assert.ok(fromAccount.amount.eq(new anchor.BN(600)));
-    assert.ok(toAccount.amount.eq(new anchor.BN(400)));
+    assert.isTrue(fromAccount.amount.eq(new anchor.BN(600)));
+    assert.isTrue(toAccount.amount.eq(new anchor.BN(400)));
   });
 
   it("Burns a token", async () => {
@@ -62,7 +62,7 @@ describe("token", () => {
     });
 
     const toAccount = await getTokenAccount(provider, to);
-    assert.ok(toAccount.amount.eq(new anchor.BN(1)));
+    assert.isTrue(toAccount.amount.eq(new anchor.BN(1)));
   });
 
   it("Set new mint authority", async () => {
@@ -80,7 +80,7 @@ describe("token", () => {
     );
 
     const mintInfo = await getMintInfo(provider, mint);
-    assert.ok(mintInfo.mintAuthority.equals(newMintAuthority.publicKey));
+    assert.isTrue(mintInfo.mintAuthority.equals(newMintAuthority.publicKey));
   });
 });
 

--- a/tests/swap/tests/swap.js
+++ b/tests/swap/tests/swap.js
@@ -1,4 +1,4 @@
-const assert = require("assert");
+const { assert } = require("chai");
 const anchor = require("@project-serum/anchor");
 const BN = anchor.BN;
 const OpenOrders = require("@project-serum/serum").OpenOrders;
@@ -120,8 +120,8 @@ describe("swap", () => {
       }
     );
 
-    assert.ok(tokenAChange === expectedResultantAmount);
-    assert.ok(usdcChange === -swapAmount.toNumber() / 10 ** 6);
+    assert.strictEqual(tokenAChange, expectedResultantAmount);
+    assert.strictEqual(usdcChange, -swapAmount.toNumber() / 10 ** 6);
   });
 
   it("Swaps from Token A to USDC", async () => {
@@ -149,8 +149,8 @@ describe("swap", () => {
       }
     );
 
-    assert.ok(tokenAChange === -swapAmount);
-    assert.ok(usdcChange === resultantAmount.toNumber() / 10 ** 6);
+    assert.strictEqual(tokenAChange, -swapAmount);
+    assert.strictEqual(usdcChange, resultantAmount.toNumber() / 10 ** 6);
   });
 
   it("Swaps from Token A to Token B", async () => {
@@ -208,10 +208,10 @@ describe("swap", () => {
       }
     );
 
-    assert.ok(tokenAChange === -swapAmount);
+    assert.strictEqual(tokenAChange, -swapAmount);
     // TODO: calculate this dynamically from the swap amount.
-    assert.ok(tokenBChange === 9.8);
-    assert.ok(usdcChange === 0);
+    assert.strictEqual(tokenBChange, 9.8);
+    assert.strictEqual(usdcChange, 0);
   });
 
   it("Swaps from Token B to Token A", async () => {
@@ -270,9 +270,9 @@ describe("swap", () => {
     );
 
     // TODO: calculate this dynamically from the swap amount.
-    assert.ok(tokenAChange === 22.6);
-    assert.ok(tokenBChange === -swapAmount);
-    assert.ok(usdcChange === 0);
+    assert.strictEqual(tokenAChange, 22.6);
+    assert.strictEqual(tokenBChange, -swapAmount);
+    assert.strictEqual(usdcChange, 0);
   });
 });
 

--- a/tests/system-accounts/tests/system-accounts.js
+++ b/tests/system-accounts/tests/system-accounts.js
@@ -1,6 +1,6 @@
 const anchor = require("@project-serum/anchor");
 const splToken = require("@solana/spl-token");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("system_accounts", () => {
   anchor.setProvider(anchor.Provider.local());
@@ -52,8 +52,8 @@ describe("system_accounts", () => {
       assert.ok(false);
     } catch (err) {
       const errMsg = "The given account is not owned by the system program";
-      assert.equal(err.error.errorMessage, errMsg);
-      assert.equal(err.error.errorCode.number, 3011);
+      assert.strictEqual(err.error.errorMessage, errMsg);
+      assert.strictEqual(err.error.errorCode.number, 3011);
     }
   });
 });

--- a/tests/sysvars/tests/sysvars.js
+++ b/tests/sysvars/tests/sysvars.js
@@ -1,5 +1,5 @@
 const anchor = require("@project-serum/anchor");
-const assert = require("assert");
+const { assert } = require("chai");
 
 describe("sysvars", () => {
   // Configure the client to use the local cluster.

--- a/tests/validator-clone/tests/validator-clone.ts
+++ b/tests/validator-clone/tests/validator-clone.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
-import assert from "assert";
+import { assert } from "chai";
 import { ValidatorClone } from "../target/types/validator_clone";
 
 describe("validator-clone", () => {
@@ -17,7 +17,7 @@ describe("validator-clone", () => {
       connection,
       [new anchor.web3.PublicKey(account)]
     );
-    assert.ok(accountInfo !== null, "Account " + account + " not found");
+    assert.isNotNull(accountInfo, "Account " + account + " not found");
   });
 
   it("Cloned bpf2-program account", async () => {
@@ -27,7 +27,7 @@ describe("validator-clone", () => {
       connection,
       [new anchor.web3.PublicKey(account)]
     );
-    assert.ok(accountInfo !== null, "Account " + account + " not found");
+    assert.isNotNull(accountInfo, "Account " + account + " not found");
   });
 
   it("Cloned bpf3-program accounts and their program data", async () => {
@@ -47,7 +47,7 @@ describe("validator-clone", () => {
     );
 
     accountInfos.forEach((acc, i) => {
-      assert.ok(acc !== null, "Account " + accounts[i] + " not found");
+      assert.isNotNull(acc, "Account " + accounts[i] + " not found");
     });
   });
 
@@ -64,7 +64,7 @@ describe("validator-clone", () => {
     );
 
     accountInfos.forEach((acc, i) => {
-      assert.ok(acc !== null, "Account " + accounts[i] + " not found");
+      assert.isNotNull(acc, "Account " + accounts[i] + " not found");
     });
   });
 });

--- a/tests/zero-copy/tests/zero-copy.js
+++ b/tests/zero-copy/tests/zero-copy.js
@@ -1,7 +1,7 @@
 const anchor = require("@project-serum/anchor");
+const { assert } = require("chai");
 const PublicKey = anchor.web3.PublicKey;
 const BN = anchor.BN;
-const assert = require("assert");
 
 describe("zero-copy", () => {
   // Configure the client to use the local cluster.
@@ -22,15 +22,15 @@ describe("zero-copy", () => {
       signers: [foo],
     });
     const account = await program.account.foo.fetch(foo.publicKey);
-    assert.ok(
-      JSON.stringify(account.authority.toBuffer()) ===
-        JSON.stringify(program.provider.wallet.publicKey.toBuffer())
+    assert.strictEqual(
+      JSON.stringify(account.authority.toBuffer()),
+      JSON.stringify(program.provider.wallet.publicKey.toBuffer())
     );
-    assert.ok(account.data.toNumber() === 0);
-    assert.ok(account.secondData.toNumber() === 0);
-    assert.ok(
-      JSON.stringify(account.secondAuthority) ===
-        JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
+    assert.strictEqual(account.data.toNumber(), 0);
+    assert.strictEqual(account.secondData.toNumber(), 0);
+    assert.strictEqual(
+      JSON.stringify(account.secondAuthority),
+      JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
     );
   });
 
@@ -44,15 +44,15 @@ describe("zero-copy", () => {
 
     const account = await program.account.foo.fetch(foo.publicKey);
 
-    assert.ok(
-      JSON.stringify(account.authority.toBuffer()) ===
-        JSON.stringify(program.provider.wallet.publicKey.toBuffer())
+    assert.strictEqual(
+      JSON.stringify(account.authority.toBuffer()),
+      JSON.stringify(program.provider.wallet.publicKey.toBuffer())
     );
-    assert.ok(account.data.toNumber() === 1234);
-    assert.ok(account.secondData.toNumber() === 0);
-    assert.ok(
-      JSON.stringify(account.secondAuthority) ===
-        JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
+    assert.strictEqual(account.data.toNumber(), 1234);
+    assert.strictEqual(account.secondData.toNumber(), 0);
+    assert.strictEqual(
+      JSON.stringify(account.secondAuthority),
+      JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
     );
   });
 
@@ -66,15 +66,15 @@ describe("zero-copy", () => {
 
     const account = await program.account.foo.fetch(foo.publicKey);
 
-    assert.ok(
-      JSON.stringify(account.authority.toBuffer()) ===
-        JSON.stringify(program.provider.wallet.publicKey.toBuffer())
+    assert.strictEqual(
+      JSON.stringify(account.authority.toBuffer()),
+      JSON.stringify(program.provider.wallet.publicKey.toBuffer())
     );
-    assert.ok(account.data.toNumber() === 1234);
-    assert.ok(account.secondData.toNumber() === 55);
-    assert.ok(
-      JSON.stringify(account.secondAuthority) ===
-        JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
+    assert.strictEqual(account.data.toNumber(), 1234);
+    assert.strictEqual(account.secondData.toNumber(), 55);
+    assert.strictEqual(
+      JSON.stringify(account.secondAuthority),
+      JSON.stringify([...program.provider.wallet.publicKey.toBuffer()])
     );
   });
 
@@ -106,8 +106,10 @@ describe("zero-copy", () => {
       )
     )[0];
     const barAccount = await program.account.bar.fetch(bar);
-    assert.ok(barAccount.authority.equals(program.provider.wallet.publicKey));
-    assert.ok(barAccount.data.toNumber() === 0);
+    assert.isTrue(
+      barAccount.authority.equals(program.provider.wallet.publicKey)
+    );
+    assert.strictEqual(barAccount.data.toNumber(), 0);
   });
 
   it("Updates an associated zero copy account", async () => {
@@ -128,8 +130,10 @@ describe("zero-copy", () => {
       },
     });
     const barAccount = await program.account.bar.fetch(bar);
-    assert.ok(barAccount.authority.equals(program.provider.wallet.publicKey));
-    assert.ok(barAccount.data.toNumber() === 99);
+    assert.isTrue(
+      barAccount.authority.equals(program.provider.wallet.publicKey)
+    );
+    assert.strictEqual(barAccount.data.toNumber(), 99);
     // Check zero_copy CPI
     await programCpi.rpc.checkCpi(new BN(1337), {
       accounts: {
@@ -140,10 +144,10 @@ describe("zero-copy", () => {
       },
     });
     const barAccountAfterCpi = await program.account.bar.fetch(bar);
-    assert.ok(
+    assert.isTrue(
       barAccountAfterCpi.authority.equals(program.provider.wallet.publicKey)
     );
-    assert.ok(barAccountAfterCpi.data.toNumber() === 1337);
+    assert.strictEqual(barAccountAfterCpi.data.toNumber(), 1337);
   });
 
   const eventQ = anchor.web3.Keypair.generate();
@@ -161,10 +165,10 @@ describe("zero-copy", () => {
       signers: [eventQ],
     });
     const account = await program.account.eventQ.fetch(eventQ.publicKey);
-    assert.ok(account.events.length === 25000);
+    assert.strictEqual(account.events.length, 25000);
     account.events.forEach((event) => {
-      assert.ok(event.from.equals(PublicKey.default));
-      assert.ok(event.data.toNumber() === 0);
+      assert.isTrue(event.from.equals(PublicKey.default));
+      assert.strictEqual(event.data.toNumber(), 0);
     });
   });
 
@@ -178,14 +182,14 @@ describe("zero-copy", () => {
     });
     // Verify update.
     let account = await program.account.eventQ.fetch(eventQ.publicKey);
-    assert.ok(account.events.length === 25000);
+    assert.strictEqual(account.events.length, 25000);
     account.events.forEach((event, idx) => {
       if (idx === 0) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 48);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 48);
       } else {
-        assert.ok(event.from.equals(PublicKey.default));
-        assert.ok(event.data.toNumber() === 0);
+        assert.isTrue(event.from.equals(PublicKey.default));
+        assert.strictEqual(event.data.toNumber(), 0);
       }
     });
 
@@ -198,17 +202,17 @@ describe("zero-copy", () => {
     });
     // Verify update.
     account = await program.account.eventQ.fetch(eventQ.publicKey);
-    assert.ok(account.events.length === 25000);
+    assert.strictEqual(account.events.length, 25000);
     account.events.forEach((event, idx) => {
       if (idx === 0) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 48);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 48);
       } else if (idx === 11111) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 1234);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 1234);
       } else {
-        assert.ok(event.from.equals(PublicKey.default));
-        assert.ok(event.data.toNumber() === 0);
+        assert.isTrue(event.from.equals(PublicKey.default));
+        assert.strictEqual(event.data.toNumber(), 0);
       }
     });
 
@@ -221,20 +225,20 @@ describe("zero-copy", () => {
     });
     // Verify update.
     account = await program.account.eventQ.fetch(eventQ.publicKey);
-    assert.ok(account.events.length === 25000);
+    assert.strictEqual(account.events.length, 25000);
     account.events.forEach((event, idx) => {
       if (idx === 0) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 48);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 48);
       } else if (idx === 11111) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 1234);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 1234);
       } else if (idx === 24999) {
-        assert.ok(event.from.equals(program.provider.wallet.publicKey));
-        assert.ok(event.data.toNumber() === 99);
+        assert.isTrue(event.from.equals(program.provider.wallet.publicKey));
+        assert.strictEqual(event.data.toNumber(), 99);
       } else {
-        assert.ok(event.from.equals(PublicKey.default));
-        assert.ok(event.data.toNumber() === 0);
+        assert.isTrue(event.from.equals(PublicKey.default));
+        assert.strictEqual(event.data.toNumber(), 0);
       }
     });
   });

--- a/tests/zero-copy/tests/zero-copy.js
+++ b/tests/zero-copy/tests/zero-copy.js
@@ -1,5 +1,6 @@
 const anchor = require("@project-serum/anchor");
 const { assert } = require("chai");
+const nativeAssert = require("assert");
 const PublicKey = anchor.web3.PublicKey;
 const BN = anchor.BN;
 
@@ -245,7 +246,7 @@ describe("zero-copy", () => {
 
   it("Errors when setting an out of bounds index", async () => {
     // Fail to set non existing index.
-    await assert.rejects(
+    await nativeAssert.rejects(
       async () => {
         await program.rpc.updateLargeAccount(25000, new BN(1), {
           accounts: {


### PR DESCRIPTION
Replace `assert.ok` using the native `assert` module with `chai.assert` and use more strict assertion functions than `assert.ok`.

resolves #1657 