### PR TITLE
ci: Remove nightly clippy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,6 @@ jobs:
       - run: cargo build
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
-      - run: rustup toolchain install nightly --profile minimal --component clippy
-      - run: cargo +nightly clippy --all-targets -- -D warnings
       - run: cargo test
       - run: cd ts && yarn
       - run: cd ts && yarn test


### PR DESCRIPTION
This seems to be [broken](https://github.com/briansmith/ring/issues/1469), it was added in response to this [issue ](https://github.com/project-serum/anchor/issues/1148) but it probably needs to be removed if it is going to occasionally [break CI](https://github.com/project-serum/anchor/runs/5670417034?check_suite_focus=true). 