### PR TITLE
Add `accounts.is_empty()` check in generated `try_accounts`

### DIFF
--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -35,6 +35,9 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     if is_init(af) || f.constraints.zeroed.is_some() {
                         let name = &f.ident;
                         quote!{
+                            if accounts.is_empty() {
+                                return Err(anchor_lang::error::ErrorCode::AccountNotEnoughKeys.into());
+                            }
                             let #name = &accounts[0];
                             *accounts = &accounts[1..];
                         }


### PR DESCRIPTION
This is another "better to return an error than panic" PR.

I'm not sure that this is the best possible fix, because it creates a `return` with no clear context.

I am open to adjusting (or closing) this PR, as desired.