### PR TITLE
Add coption to DecodeType

### DIFF
--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -112,6 +112,10 @@ export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
   ? Defined[T["option"]["defined"]] | null
   : T extends { option: keyof TypeMap }
   ? TypeMap[T["option"]] | null
+  : T extends { coption: { defined: keyof Defined } }
+  ? Defined[T["coption"]["defined"]] | null
+  : T extends { coption: keyof TypeMap }
+  ? TypeMap[T["coption"]] | null
   : T extends { vec: keyof TypeMap }
   ? TypeMap[T["vec"]][]
   : T extends { array: [defined: keyof TypeMap, size: number] }


### PR DESCRIPTION
`COption` is not totally supported but this would allow the spl token coder types to show properly, as `T | null` rather than unknown.
