### PR TITLE
ts: remove find^0.3.0 unused dependency

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -43,7 +43,6 @@
     "cross-fetch": "^3.1.5",
     "crypto-hash": "^1.3.0",
     "eventemitter3": "^4.0.7",
-    "find": "^0.3.0",
     "js-sha256": "^0.9.0",
     "pako": "^2.0.3",
     "snake-case": "^3.0.4",


### PR DESCRIPTION
`find` dependency was introduced in 9570830b654a17d68f834c62acbfeba55e0f1b44, but it stopped being used after 619015d2ed8618a90df415c6f310b4735c41695d. However, the `package.json` still included `find` as a dependency.