### PR TITLE
lang: Make Anchor use fallback function instead of panicking if ix data.len() is < `8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The minor version will be incremented upon a breaking change and the patch versi
 * lang: Add support for multiple test suites with separate local validators ([#1681](https://github.com/project-serum/anchor/pull/1681)).
 * lang: Add return values to CPI client. ([#1598](https://github.com/project-serum/anchor/pull/1598)).
 * avm: New `avm update` command to update the Anchor CLI to the latest version ([#1670](https://github.com/project-serum/anchor/pull/1670)).
-* lang: Use fallback function if ix data length smaller than `8` ([#1721](https://github.com/project-serum/anchor/pull/1721)).
 
 ### Fixes
 
@@ -28,6 +27,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * avm: `amv install` switches to the newly installed version after installation finishes ([#1670](https://github.com/project-serum/anchor/pull/1670)).
 * spl: Re-export the `spl_token` crate ([#1665](https://github.com/project-serum/anchor/pull/1665)).
 * lang, cli, spl: Update solana toolchain to v1.9.13 ([#1653](https://github.com/project-serum/anchor/pull/1653)).
+* lang: Use fallback function if ix data length smaller than `8` instead of panicking ([#1721](https://github.com/project-serum/anchor/pull/1721)).
 
 ## [0.23.0] - 2022-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * lang: Add support for multiple test suites with separate local validators ([#1681](https://github.com/project-serum/anchor/pull/1681)).
 * lang: Add return values to CPI client. ([#1598](https://github.com/project-serum/anchor/pull/1598)).
 * avm: New `avm update` command to update the Anchor CLI to the latest version ([#1670](https://github.com/project-serum/anchor/pull/1670)).
+* lang: Use fallback function if ix data length smaller than `8` ([#1721](https://github.com/project-serum/anchor/pull/1721)).
 
 ### Fixes
 

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -143,33 +143,43 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             // Split the instruction data into the first 8 byte method
             // identifier (sighash) and the serialized instruction data.
             let mut ix_data: &[u8] = data;
-            let sighash: [u8; 8] = {
+            let sighash: Option<[u8; 8]> = {
                 let mut sighash: [u8; 8] = [0; 8];
-                sighash.copy_from_slice(&ix_data[..8]);
-                ix_data = &ix_data[8..];
-                sighash
+                if ix_data.len() < 8 {
+                    None
+                } else {
+                    sighash.copy_from_slice(&ix_data[..8]);
+                    ix_data = &ix_data[8..];
+                    Some(sighash)
+                }
             };
 
             // If the method identifier is the IDL tag, then execute an IDL
             // instruction, injected into all Anchor programs.
             if cfg!(not(feature = "no-idl")) {
-                if sighash == anchor_lang::idl::IDL_IX_TAG.to_le_bytes() {
-                    return __private::__idl::__idl_dispatch(
-                        program_id,
-                        accounts,
-                        &ix_data,
-                    );
+                if let Some(sighash) = sighash {
+                    if sighash == anchor_lang::idl::IDL_IX_TAG.to_le_bytes() {
+                        return __private::__idl::__idl_dispatch(
+                            program_id,
+                            accounts,
+                            &ix_data,
+                        );
+                    }
                 }
             }
-
             match sighash {
-                #ctor_state_dispatch_arm
-                #(#state_dispatch_arms)*
-                #(#trait_dispatch_arms)*
-                #(#global_dispatch_arms)*
-                _ => {
-                    #fallback_fn
+                Some(sighash) => {
+                    match sighash {
+                        #ctor_state_dispatch_arm
+                        #(#state_dispatch_arms)*
+                        #(#trait_dispatch_arms)*
+                        #(#global_dispatch_arms)*
+                        _ => {
+                            #fallback_fn
+                        }
+                    }
                 }
+                None => #fallback_fn
             }
         }
     }

--- a/tests/misc/tests/misc.ts
+++ b/tests/misc/tests/misc.ts
@@ -160,7 +160,7 @@ describe("misc", () => {
       "Program data: jvbowsvlmkcJAAAA",
       "Program data: zxM5neEnS1kBAgMEBQYHCAkK",
       "Program data: g06Ei2GL1gIBAgMEBQYHCAkKCw==",
-      "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh consumed 5395 of 1400000 compute units",
+      "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh consumed 5418 of 1400000 compute units",
       "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh success",
     ];
 

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -38,7 +38,7 @@ async fn update_foo() {
 
     let mut pt = ProgramTest::new("zero_copy", zero_copy::id(), None);
     pt.add_account(foo_pubkey, foo_account);
-    pt.set_compute_max_units(3157);
+    pt.set_compute_max_units(3174);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let client = Client::new_with_options(


### PR DESCRIPTION
this is done so fallback fns can be executed more efficiently by using less than 8 bytes of ix data