### PR TITLE
Revert "lang: Make Anchor use fallback function instead of panicking if ix data.len() is < `8` (#1721)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ The minor version will be incremented upon a breaking change and the patch versi
 * avm: `avm install` switches to the newly installed version after installation finishes ([#1670](https://github.com/project-serum/anchor/pull/1670)).
 * spl: Re-export the `spl_token` crate ([#1665](https://github.com/project-serum/anchor/pull/1665)).
 * lang, cli, spl: Update solana toolchain to v1.9.13 ([#1653](https://github.com/project-serum/anchor/pull/1653)).
-* lang: Use fallback function if ix data length smaller than `8` instead of panicking ([#1721](https://github.com/project-serum/anchor/pull/1721)).
 
 ## [0.23.0] - 2022-03-20
 

--- a/tests/misc/tests/misc.ts
+++ b/tests/misc/tests/misc.ts
@@ -160,7 +160,7 @@ describe("misc", () => {
       "Program data: jvbowsvlmkcJAAAA",
       "Program data: zxM5neEnS1kBAgMEBQYHCAkK",
       "Program data: g06Ei2GL1gIBAgMEBQYHCAkKCw==",
-      "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh consumed 5418 of 1400000 compute units",
+      "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh consumed 5395 of 1400000 compute units",
       "Program 3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh success",
     ];
 

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -38,7 +38,7 @@ async fn update_foo() {
 
     let mut pt = ProgramTest::new("zero_copy", zero_copy::id(), None);
     pt.add_account(foo_pubkey, foo_account);
-    pt.set_compute_max_units(3174);
+    pt.set_compute_max_units(3157);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let client = Client::new_with_options(


### PR DESCRIPTION
This reverts commit adb90c33d77cf584dbdd630ae753d2b845c20ebe.

Reverting because it turns out that Anchor already supported this (https://github.com/project-serum/anchor/blob/778e3287532bd8dc345889b3101b48827afac534/lang/syn/src/codegen/program/entry.rs#L69)