### PR TITLE
ts: export error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * cli: Update js/ts templates to use new `program.methods` syntax ([#1732](https://github.com/project-serum/anchor/pull/1732)).
 * cli: Workspaces created with `anchor init` now come with the `prettier` formatter and scripts included ([#1741](https://github.com/project-serum/anchor/pull/1741)).
 * ts: Add `pubkeys` function to methods builder to get all instruction account addresses ([#1733](https://github.com/project-serum/anchor/pull/1733)).
+* ts: Export `LangErrorCode` and `LangErrorMessage` from `error.ts` ([#1756](https://github.com/project-serum/anchor/pull/1756)).
 
 ### Fixes
 

--- a/ts/src/error.ts
+++ b/ts/src/error.ts
@@ -305,7 +305,7 @@ export function translateError(err: any, idlErrors: Map<number, string>) {
   return err;
 }
 
-const LangErrorCode = {
+export const LangErrorCode = {
   // Instructions.
   InstructionMissing: 100,
   InstructionFallbackNotFound: 101,
@@ -374,7 +374,7 @@ const LangErrorCode = {
   Deprecated: 5000,
 };
 
-const LangErrorMessage = new Map([
+export const LangErrorMessage = new Map([
   // Instructions.
   [
     LangErrorCode.InstructionMissing,


### PR DESCRIPTION
They can be useful for error code matching. Also need this in anchor-client-gen to generate anchor errors.