### PR TITLE
integer arithmetic safe by default w/o checked

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -65,6 +65,9 @@ no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
 
+[profile.release]
+overflow-checks = true
+
 [dependencies]
 anchor-lang = "{2}"
 "#,


### PR DESCRIPTION
Can/should we add

```
[profile.release]
overflow-checks = true
```

to the `template::cargo_toml` so that all integer arithmetic is safe by default and remove the need for unsightly `checked_xxx(...).unwrap()` operations?