### PR TITLE
lang: forbid pubkey mint on token init

### DIFF
--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -121,6 +121,10 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 }
             }
             match kind {
+                // this doesn't catch cases like
+                // account.key() or account.key but
+                // my guess is that doesn't happen often and we
+                // can revisit this if I'm wrong
                 InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. } => {
                     if !fields.iter().any(|f| {
                         f.ident()

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -120,6 +120,18 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     ));
                 }
             }
+            match kind {
+                InitKind::Token { mint, .. } |
+                InitKind::AssociatedToken { mint, .. } => {
+                    if !fields.iter().any(|f| f.ident().to_string().starts_with(&mint.to_token_stream().to_string())) {
+                        return Err(ParseError::new(
+                            field.ident.span(),
+                            "the mint constraint has to be an account field for token initializations (not a public key)",
+                        ));
+                    } 
+                },
+                _ => ()
+            }
         }
     }
     Ok(())

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -121,10 +121,9 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 }
             }
             match kind {
-                // this doesn't catch cases like
-                // account.key() or account.key but
-                // my guess is that doesn't happen often and we
-                // can revisit this if I'm wrong
+                // This doesn't catch cases like account.key() or account.key.
+                // My guess is that doesn't happen often and we can revisit
+                // this if I'm wrong.
                 InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. } => {
                     if !fields.iter().any(|f| {
                         f.ident()

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -121,16 +121,19 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 }
             }
             match kind {
-                InitKind::Token { mint, .. } |
-                InitKind::AssociatedToken { mint, .. } => {
-                    if !fields.iter().any(|f| f.ident().to_string().starts_with(&mint.to_token_stream().to_string())) {
+                InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. } => {
+                    if !fields.iter().any(|f| {
+                        f.ident()
+                            .to_string()
+                            .starts_with(&mint.to_token_stream().to_string())
+                    }) {
                         return Err(ParseError::new(
                             field.ident.span(),
                             "the mint constraint has to be an account field for token initializations (not a public key)",
                         ));
-                    } 
-                },
-                _ => ()
+                    }
+                }
+                _ => (),
             }
         }
     }


### PR DESCRIPTION
This PR makes the parser fail if `init` is used with `token` or `associated_token` and the `mint = ` constraint is used with a pubkey instead of an account