### PR TITLE
cli: move overflow-checks into workspace Cargo.toml so that it will not be ignored by compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+### Fixes
+
+* cli: Move `overflow-checks` into workspace `Cargo.toml` so that it will not be ignored by compiler ([]()).
+
 ## [0.24.2] - 2022-04-13
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-* cli: Move `overflow-checks` into workspace `Cargo.toml` so that it will not be ignored by compiler ([]()).
+* cli: Move `overflow-checks` into workspace `Cargo.toml` so that it will not be ignored by compiler ([#1806](https://github.com/project-serum/anchor/pull/1806)).
 
 ## [0.24.2] - 2022-04-13
 

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -16,6 +16,9 @@ pub fn virtual_manifest() -> &'static str {
 members = [
     "programs/*"
 ]
+
+[profile.release]
+overflow-checks = true
 "#
 }
 
@@ -64,9 +67,6 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
-
-[profile.release]
-overflow-checks = true
 
 [dependencies]
 anchor-lang = "{2}"


### PR DESCRIPTION
the compiler ignores `profile` settings that are not in the workspace root `Cargo.toml`