### PR TITLE
docs: clarify on program id

### DIFF
--- a/docs/src/tutorials/tutorial-0.md
+++ b/docs/src/tutorials/tutorial-0.md
@@ -123,7 +123,9 @@ Once built, we can deploy the program by running
 anchor deploy
 ```
 
-Take note of the program's deployed address. We'll use it next.
+Take note of the program's deployed address. The address is the actual address of your program as opposed to the sample "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS" address that we have used above.
+
+You can also obtain the program address by running `anchor keys list`.
 
 ## Generating a Client
 

--- a/docs/src/tutorials/tutorial-0.md
+++ b/docs/src/tutorials/tutorial-0.md
@@ -115,6 +115,9 @@ file in your program's crate.
 If you've developed on Ethereum, the IDL is analogous to the `abi.json`.
 :::
 
+The `build` command also generates a random new keypair in the `target/` directory (if there's not one already) whose public key will be the address of your program once deployed. You can obtain the address by running `anchor keys list`.
+Make sure that the public key inside your `lib.rs` (the argument to `declare_id!`) file and your `Anchor.toml` matches the one returned by `anchor keys list`. Then run `build` again to include the `lib.rs` changes in the build.
+
 ## Deploying
 
 Once built, we can deploy the program by running
@@ -122,10 +125,6 @@ Once built, we can deploy the program by running
 ```bash
 anchor deploy
 ```
-
-Take note of the program's deployed address. The address is the actual address of your program as opposed to the sample "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS" address that we have used above.
-
-You can also obtain the program address by running `anchor keys list`.
 
 ## Generating a Client
 


### PR DESCRIPTION
I recently found Anchor and was following through the steps at https://project-serum.github.io/anchor/tutorials/tutorial-0.html#defining-a-program

However I ran into an error as described in #1791 

This PR aims to improve the doc to prevent others from running into the same speedbump. It does so by reminding the reader that the program id in the example will not be the same one that they need to use.