### PR TITLE
cli: add short alias for build and test commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * spl: Add more derived traits to `TokenAccount` to `Mint` ([#1818](https://github.com/project-serum/anchor/pull/1818)).
 * cli: Add compilation optimizations to cli template ([#1807](https://github.com/project-serum/anchor/pull/1807)).
 * lang: Add `PartialEq` and `Eq` for `anchor_lang::Error` ([#1544](https://github.com/project-serum/anchor/pull/1544)).
+* cli: Add `b` and `t` aliases for `build` and `test` respectively ([#1823](https://github.com/project-serum/anchor/pull/1823)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -71,6 +71,7 @@ pub enum Command {
         no_git: bool,
     },
     /// Builds the workspace.
+    #[clap(name = "build", alias = "b")]
     Build {
         /// Output directory for the IDL.
         #[clap(short, long)]
@@ -154,6 +155,7 @@ pub enum Command {
         )]
         cargo_args: Vec<String>,
     },
+    #[clap(name = "test", alias = "t")]
     /// Runs integration tests against a localnetwork.
     Test {
         /// Use this flag if you want to run tests against previously deployed


### PR DESCRIPTION
Following cargo, one can say:
cargo build ... OR cargo b ...
cargo test ... OR cargo t ...

The idea is to be able to mimic this behavior with the anchor
cli