### PR TITLE
Added alternative to rpc deprecated comments

### DIFF
--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -79,7 +79,7 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    * @deprecated
-   * Use program.methods.<method>(...args) instead of the rpc call
+   * Use program.methods.<method>(...args).rpc() instead
    */
   readonly rpc: RpcNamespace<IDL>;
 

--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -79,6 +79,7 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    * @deprecated
+   * Use program.methods.<method>(...args) instead of the rpc call
    */
   readonly rpc: RpcNamespace<IDL>;
 


### PR DESCRIPTION
Rpc is marked as deprecated but no alternative is mentioned unlike when Instructions were deprecated for preInstructions hence added a line mentioning to use methods.<method> instead of rpc 