### PR TITLE
add wallet publickey to Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 * cli: Move `overflow-checks` into workspace `Cargo.toml` so that it will not be ignored by compiler ([#1806](https://github.com/project-serum/anchor/pull/1806)).
 * lang: Fix missing account name information when deserialization fails when using `init` or `zero` ([#1800](https://github.com/project-serum/anchor/pull/1800)).
+* ts: Expose the wallet's publickey on the Provider ([#1845](https://github.com/project-serum/anchor/pull/1845)).
 
 ## [0.24.2] - 2022-04-13
 

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -20,6 +20,7 @@ import {
 
 export default interface Provider {
   readonly connection: Connection;
+  readonly publicKey: PublicKey;
 
   send?(
     tx: Transaction,
@@ -48,6 +49,8 @@ export default interface Provider {
  * by the provider.
  */
 export class AnchorProvider implements Provider {
+  readonly publicKey: PublicKey;
+  
   /**
    * @param connection The cluster connection where the program is deployed.
    * @param wallet     The wallet used to pay for and sign all transactions.
@@ -57,7 +60,9 @@ export class AnchorProvider implements Provider {
     readonly connection: Connection,
     readonly wallet: Wallet,
     readonly opts: ConfirmOptions
-  ) {}
+  ) {
+    this.publicKey = wallet.publicKey;
+  }
 
   static defaultOptions(): ConfirmOptions {
     return {

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -50,7 +50,7 @@ export default interface Provider {
  */
 export class AnchorProvider implements Provider {
   readonly publicKey: PublicKey;
-  
+
   /**
    * @param connection The cluster connection where the program is deployed.
    * @param wallet     The wallet used to pay for and sign all transactions.


### PR DESCRIPTION
PsyOptions client code uses the encapsulated wallet key from the Provider. This PR updates the interface to expose the wallet's publicKey