### PR TITLE
client: fill config structs with defaults to avoid compatibility issues

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -164,10 +164,9 @@ impl Program {
             filters: Some([vec![account_type_filter], filters].concat()),
             account_config: RpcAccountInfoConfig {
                 encoding: Some(UiAccountEncoding::Base64),
-                data_slice: None,
-                commitment: None,
+                ..RpcAccountInfoConfig::default()
             },
-            with_context: None,
+            ..RpcProgramAccountsConfig::default()
         };
         Ok(ProgramAccountsIterator {
             inner: self


### PR DESCRIPTION
#### Problem
When new config fields are added upstream, the anchor client breaks if it tries to set all config fields explicitly

#### Changes
- Fill remaining config fields with default values