### PR TITLE
ts: add docs field to IdlAccoutDef and IdlTypeDef types

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -82,11 +82,13 @@ export type IdlField = {
 
 export type IdlTypeDef = {
   name: string;
+  docs?: string[];
   type: IdlTypeDefTy;
 };
 
 export type IdlAccountDef = {
   name: string;
+  docs?: string[];
   type: IdlTypeDefTyStruct;
 };
 


### PR DESCRIPTION
As seen [here](https://github.com/ebrightfield/anchor/blob/45fe6212e46f58998084b4af12044e8e6d786129/lang/syn/src/idl/mod.rs#L153) the accounts and types can also have a doc field in the IDL.