### PR TITLE
fix(ts/idl): export all IDL types

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -102,9 +102,9 @@ export type IdlTypeDefTyEnum = {
   variants: IdlEnumVariant[];
 };
 
-type IdlTypeDefTy = IdlTypeDefTyEnum | IdlTypeDefTyStruct;
+export type IdlTypeDefTy = IdlTypeDefTyEnum | IdlTypeDefTyStruct;
 
-type IdlTypeDefStruct = Array<IdlField>;
+export type IdlTypeDefStruct = Array<IdlField>;
 
 export type IdlType =
   | "bool"
@@ -155,11 +155,11 @@ export type IdlEnumVariant = {
   fields?: IdlEnumFields;
 };
 
-type IdlEnumFields = IdlEnumFieldsNamed | IdlEnumFieldsTuple;
+export type IdlEnumFields = IdlEnumFieldsNamed | IdlEnumFieldsTuple;
 
-type IdlEnumFieldsNamed = IdlField[];
+export type IdlEnumFieldsNamed = IdlField[];
 
-type IdlEnumFieldsTuple = IdlType[];
+export type IdlEnumFieldsTuple = IdlType[];
 
 export type IdlErrorCode = {
   code: number;


### PR DESCRIPTION
I have no idea why these are specifically not exported. It is bad practice to use types in the interface but not export them. 

(It also stops me from writing tooling that uses these types, since I cannot access some of them.)