### PR TITLE
ts: remove .rollup.cache when publishing npm package

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -79,5 +79,9 @@
     "tslib": "^2.3.1",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.2"
-  }
+  },
+  "files": [
+    "dist",
+    "types"
+  ]
 }


### PR DESCRIPTION
Closes #1713 