### PR TITLE
Add send w/ spinner and options to rust client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ com/project-serum/anchor/pull/1841)).
 * cli: Add `b` and `t` aliases for `build` and `test` respectively ([#1823](https://github.com/project-serum/anchor/pull/1823)).
 * spl: Add `sync_native` token program CPI wrapper function ([#1833](https://github.com/project-serum/anchor/pull/1833)).
 * ts: Implement a coder for system program ([#1920](https://github.com/project-serum/anchor/pull/1920)).
+* client: Add send_with_spinner_and_config function to RequestBuilder ([#1926](https://github.com/project-serum/anchor/pull/1926))
 
 ### Fixes
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,7 +11,10 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_client::client_error::ClientError as SolanaClientError;
 use solana_client::pubsub_client::{PubsubClient, PubsubClientError, PubsubClientSubscription};
 use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig, RpcTransactionLogsConfig, RpcTransactionLogsFilter};
+use solana_client::rpc_config::{
+    RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig,
+    RpcTransactionLogsConfig, RpcTransactionLogsFilter,
+};
 use solana_client::rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType};
 use solana_client::rpc_response::{Response as RpcResponse, RpcLogsResponse};
 use solana_sdk::account::Account;
@@ -554,7 +557,10 @@ impl<'a> RequestBuilder<'a> {
             .map_err(Into::into)
     }
 
-    pub fn send_with_spinner_and_config(self, config: RpcSendTransactionConfig) -> Result<Signature, ClientError> {
+    pub fn send_with_spinner_and_config(
+        self,
+        config: RpcSendTransactionConfig,
+    ) -> Result<Signature, ClientError> {
         let instructions = self.instructions()?;
 
         let mut signers = self.signers;
@@ -573,7 +579,11 @@ impl<'a> RequestBuilder<'a> {
         };
 
         rpc_client
-            .send_and_confirm_transaction_with_spinner_and_config(&tx, rpc_client.commitment(), config)
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &tx,
+                rpc_client.commitment(),
+                config,
+            )
             .map_err(Into::into)
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,10 +11,7 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_client::client_error::ClientError as SolanaClientError;
 use solana_client::pubsub_client::{PubsubClient, PubsubClientError, PubsubClientSubscription};
 use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_config::{
-    RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcTransactionLogsConfig,
-    RpcTransactionLogsFilter,
-};
+use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig, RpcTransactionLogsConfig, RpcTransactionLogsFilter};
 use solana_client::rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType};
 use solana_client::rpc_response::{Response as RpcResponse, RpcLogsResponse};
 use solana_sdk::account::Account;
@@ -554,6 +551,29 @@ impl<'a> RequestBuilder<'a> {
 
         rpc_client
             .send_and_confirm_transaction(&tx)
+            .map_err(Into::into)
+    }
+
+    pub fn send_with_spinner_and_config(self, config: RpcSendTransactionConfig) -> Result<Signature, ClientError> {
+        let instructions = self.instructions()?;
+
+        let mut signers = self.signers;
+        signers.push(&*self.payer);
+
+        let rpc_client = RpcClient::new_with_commitment(self.cluster, self.options);
+
+        let tx = {
+            let latest_hash = rpc_client.get_latest_blockhash()?;
+            Transaction::new_signed_with_payer(
+                &instructions,
+                Some(&self.payer.pubkey()),
+                &signers,
+                latest_hash,
+            )
+        };
+
+        rpc_client
+            .send_and_confirm_transaction_with_spinner_and_config(&tx, rpc_client.commitment(), config)
             .map_err(Into::into)
     }
 }


### PR DESCRIPTION
Currently, it is very clunky to take a builder and convert that to a send w/ options. Sending with options is useful in order to be able to customize the transaction config in order to turn off preflight checks (which make it easier to debug errors). 

This change adds a single function to the RequestBuilder struct, send_with_spinner_and_config (name is placeholder at the moment. Feel free to change it if its too long). Tests passing and tested it locally and everything still works. 