### PR TITLE
lang: add `realloc` constraint group

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -360,6 +360,8 @@ jobs:
             path: tests/escrow
           - cmd: cd tests/pyth && anchor test --skip-lint && npx tsc --noEmit
             path: tests/pyth
+          - cmd: cd tests/realloc && anchor test --skip-lint && npx tsc --noEmit
+            path: tests/realloc
           - cmd: cd tests/system-accounts && anchor test --skip-lint
             path: tests/system-accounts
           - cmd: cd tests/misc && anchor test --skip-lint && npx tsc --noEmit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+* lang: Add `realloc` and `allocator` as a new constraint group for program accounts ([#1943](https://github.com/project-serum/anchor/pull/1943)).
 * lang: Add `PartialEq` and `Eq` for `anchor_lang::Error` ([#1544](https://github.com/project-serum/anchor/pull/1544)).
 * cli: Add `--skip-build` to `anchor publish` ([#1786](https://github.
 com/project-serum/anchor/pull/1841)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-* lang: Add `realloc` and `allocator` as a new constraint group for program accounts ([#1943](https://github.com/project-serum/anchor/pull/1943)).
+* lang: Add `realloc`, `realloc::payer`, and `realloc::zero` as a new constraint group for program accounts ([#1943](https://github.com/project-serum/anchor/pull/1943)).
 * lang: Add `PartialEq` and `Eq` for `anchor_lang::Error` ([#1544](https://github.com/project-serum/anchor/pull/1544)).
 * cli: Add `--skip-build` to `anchor publish` ([#1786](https://github.
 com/project-serum/anchor/pull/1841)).

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -44,6 +44,7 @@ use syn::parse_macro_input;
 ///
 /// - [Normal Constraints](#normal-constraints)
 /// - [SPL Constraints](#spl-constraints)
+///
 /// # Normal Constraints
 /// <table>
 ///     <thead>
@@ -416,6 +417,44 @@ use syn::parse_macro_input;
 /// pub one: Account<'info, MyData>,
 /// pub two: Account<'info, OtherData>
 ///                 </code></pre>
+///             </td>
+///         </tr>
+///         <tr>
+///             <td>
+///                 <code>#[account(realloc = &lt;space&gt;, realloc::payer = &lt;target&gt;, realloc::zero = &lt;bool&gt;)]</code>
+///             </td>
+///             <td>
+///                 Used to <a href="https://docs.rs/solana-program/latest/solana_program/account_info/struct.AccountInfo.html#method.realloc" target = "_blank" rel = "noopener noreferrer">realloc</a>
+///                 program account space at the beginning of an instruction.
+///                 <br><br>
+///                 The account must be marked as <code>mut</code> and applied to either <code>Account</code> or <code>AccountLoader</code> types.
+///                 <br><br>
+///                 If the change in account data length is additive, lamports will be transferred from the <code>realloc::payer</code> into the
+///                 program account in order to maintain rent exemption. Likewise, if the change is subtractive, lamports will be transferred from
+///                 the program account back into the <code>realloc::payer</code>.
+///                 <br><br>
+///                 The <code>realloc::zero</code> constraint is required in order to determine whether the new memory should be zero initialized after
+///                 reallocation. Please read the documentation on the <code>AccountInfo::realloc</code> function linked above to understand the
+///                 caveats regarding compute units when providing <code>true</code or <code>false</code> to this flag.
+///                 <br><br>
+///                 Example:
+///                 <pre>
+/// #[derive(Accounts)]
+/// pub struct Example {
+///     #[account(mut)]
+///     pub payer: Signer<'info>,
+///     #[account(
+///         mut,
+///         seeds = [b"example"],
+///         bump,
+///         realloc = 8 + std::mem::size_of::<MyType>() + 100,
+///         realloc::payer = payer,
+///         realloc::zero = false,
+///     )]
+///     pub acc: Account<'info, MyType>,
+///     pub system_program: Program<'info, System>,
+/// }
+///                 </pre>
 ///             </td>
 ///         </tr>
 ///     </tbody>

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -338,25 +338,27 @@ fn generate_constraint_realloc(f: &Field, c: &ConstraintReallocGroup) -> proc_ma
             None => (#field.to_account_info().data_len().checked_sub(#new_space).unwrap(), false),
         };
 
-        let __lamport_amt = __anchor_rent.minimum_balance(__delta_space);
+        if __delta_space > 0 {
+            let __lamport_amt = __anchor_rent.minimum_balance(__delta_space);
 
-        if __additive {
-            anchor_lang::system_program::transfer(
-                anchor_lang::context::CpiContext::new(
-                    system_program.to_account_info(),
-                    anchor_lang::system_program::Transfer {
-                        from: #allocator.to_account_info(),
-                        to: #field.to_account_info(),
-                    },
-                ),
-                __lamport_amt,
-            )?;
-        } else {
-            **#allocator.to_account_info().lamports.borrow_mut() = #allocator.to_account_info().lamports().checked_add(__lamport_amt).unwrap();
-            **#field.to_account_info().lamports.borrow_mut() = #field.to_account_info().lamports().checked_sub(__lamport_amt).unwrap();
-        };
+            if __additive {
+                anchor_lang::system_program::transfer(
+                    anchor_lang::context::CpiContext::new(
+                        system_program.to_account_info(),
+                        anchor_lang::system_program::Transfer {
+                            from: #allocator.to_account_info(),
+                            to: #field.to_account_info(),
+                        },
+                    ),
+                    __lamport_amt,
+                )?;
+            } else {
+                **#allocator.to_account_info().lamports.borrow_mut() = #allocator.to_account_info().lamports().checked_add(__lamport_amt).unwrap();
+                **#field.to_account_info().lamports.borrow_mut() = #field.to_account_info().lamports().checked_sub(__lamport_amt).unwrap();
+            };
 
-        #field.to_account_info().realloc(#new_space, false)?;
+            #field.to_account_info().realloc(#new_space, false)?;
+        }
     }
 }
 

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -637,6 +637,7 @@ pub struct ConstraintGroup {
     associated_token: Option<ConstraintAssociatedToken>,
     token_account: Option<ConstraintTokenAccountGroup>,
     mint: Option<ConstraintTokenMintGroup>,
+    realloc: Option<ConstraintReallocGroup>,
 }
 
 impl ConstraintGroup {
@@ -680,6 +681,7 @@ pub enum Constraint {
     Address(ConstraintAddress),
     TokenAccount(ConstraintTokenAccountGroup),
     Mint(ConstraintTokenMintGroup),
+    Realloc(ConstraintReallocGroup),
 }
 
 // Constraint token is a single keyword in a `#[account(<TOKEN>)]` attribute.
@@ -711,6 +713,8 @@ pub enum ConstraintToken {
     MintDecimals(Context<ConstraintMintDecimals>),
     Bump(Context<ConstraintTokenBump>),
     ProgramSeed(Context<ConstraintProgramSeed>),
+    Realloc(Context<ConstraintRealloc>),
+    Allocator(Context<ConstraintAllocator>),
 }
 
 impl Parse for ConstraintToken {
@@ -733,6 +737,22 @@ pub struct ConstraintZeroed {}
 #[derive(Debug, Clone)]
 pub struct ConstraintMut {
     pub error: Option<Expr>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintReallocGroup {
+    pub allocator: Expr,
+    pub space: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintRealloc {
+    pub space: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintAllocator {
+    pub target: Expr,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -714,7 +714,8 @@ pub enum ConstraintToken {
     Bump(Context<ConstraintTokenBump>),
     ProgramSeed(Context<ConstraintProgramSeed>),
     Realloc(Context<ConstraintRealloc>),
-    Allocator(Context<ConstraintAllocator>),
+    ReallocPayer(Context<ConstraintReallocPayer>),
+    ReallocZero(Context<ConstraintReallocZero>),
 }
 
 impl Parse for ConstraintToken {
@@ -741,8 +742,9 @@ pub struct ConstraintMut {
 
 #[derive(Debug, Clone)]
 pub struct ConstraintReallocGroup {
-    pub allocator: Expr,
+    pub payer: Expr,
     pub space: Expr,
+    pub zero: Expr,
 }
 
 #[derive(Debug, Clone)]
@@ -751,8 +753,13 @@ pub struct ConstraintRealloc {
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstraintAllocator {
+pub struct ConstraintReallocPayer {
     pub target: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintReallocZero {
+    pub zero: Expr,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -256,7 +256,7 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                             zero: stream.parse()?,
                         },
                     )),
-                    _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
+                    _ => return Err(ParseError::new(ident.span(), "Invalid attribute. realloc::payer and realloc::zero are the only valid attributes")),
                 }
             }
         }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -480,13 +480,6 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
 
         // Realloc.
         if let Some(r) = &self.realloc {
-            if self.init.is_some() {
-                return Err(ParseError::new(
-                    r.span(),
-                    "init cannot be provided with realloc",
-                ));
-            }
-
             if self.allocator.is_none() {
                 return Err(ParseError::new(
                     r.span(),
@@ -829,7 +822,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         {
             return Err(ParseError::new(
                 c.span(),
-                "close must be on an Account, ProgramAccount, or Loader",
+                "realloc must be on an Account, ProgramAccount, or Loader",
             ));
         }
         if self.mutable.is_none() {

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -152,6 +152,17 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         .collect();
 
     if !realloc_fields.is_empty() {
+        // realloc needs system program.
+        if fields.iter().all(|f| f.ident() != "system_program") {
+            return Err(ParseError::new(
+                realloc_fields[0].ident.span(),
+                "the realloc constraint requires \
+                the system_program field to exist in the account \
+                validation struct. Use the program type to add \
+                the system_program field to your validation struct.",
+            ));
+        }
+
         for field in realloc_fields {
             // Get allocator for realloc-ed account
             let associated_allocator_name =

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -158,7 +158,7 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 realloc_fields[0].ident.span(),
                 "the realloc constraint requires \
                 the system_program field to exist in the account \
-                validation struct. Use the program type to add \
+                validation struct. Use the Program type to add \
                 the system_program field to your validation struct.",
             ));
         }

--- a/tests/package.json
+++ b/tests/package.json
@@ -24,6 +24,7 @@
     "permissioned-markets",
     "pda-derivation",
     "pyth",
+    "realloc",
     "spl/token-proxy",
     "swap",
     "system-accounts",

--- a/tests/realloc/Anchor.toml
+++ b/tests/realloc/Anchor.toml
@@ -1,0 +1,15 @@
+[features]
+seeds = false
+
+[programs.localnet]
+realloc = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[registry]
+url = "https://anchor.projectserum.com"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/realloc/Cargo.toml
+++ b/tests/realloc/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "programs/*"
+]

--- a/tests/realloc/package.json
+++ b/tests/realloc/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "realloc",
+    "version": "0.24.2",
+    "license": "(MIT OR Apache-2.0)",
+    "homepage": "https://github.com/project-serum/anchor#readme",
+    "bugs": {
+      "url": "https://github.com/project-serum/anchor/issues"
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/project-serum/anchor.git"
+    },
+    "engines": {
+      "node": ">=11"
+    },
+    "scripts": {
+      "test": "anchor test"
+    }
+  }
+  

--- a/tests/realloc/programs/realloc/Cargo.toml
+++ b/tests/realloc/programs/realloc/Cargo.toml
@@ -19,4 +19,4 @@ default = []
 overflow-checks = true
 
 [dependencies]
-anchor-lang = { path = "/users/matt/workspace/callensm/anchor/lang" }
+anchor-lang = { path = "../../../../lang" }

--- a/tests/realloc/programs/realloc/Cargo.toml
+++ b/tests/realloc/programs/realloc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "realloc"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "realloc"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[profile.release]
+overflow-checks = true
+
+[dependencies]
+anchor-lang = { path = "/users/matt/workspace/callensm/anchor/lang" }

--- a/tests/realloc/programs/realloc/Xargo.toml
+++ b/tests/realloc/programs/realloc/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/realloc/programs/realloc/src/lib.rs
+++ b/tests/realloc/programs/realloc/src/lib.rs
@@ -49,7 +49,8 @@ pub struct Realloc<'info> {
         seeds = [b"sample"],
         bump = sample.bump,
         realloc = Sample::space(len as usize),
-        allocator = authority,
+        realloc::payer = authority,
+        realloc::zero = false,
     )]
     pub sample: Account<'info, Sample>,
 

--- a/tests/realloc/programs/realloc/src/lib.rs
+++ b/tests/realloc/programs/realloc/src/lib.rs
@@ -1,0 +1,69 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod realloc {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        ctx.accounts.sample.data = vec![0];
+        ctx.accounts.sample.bump = *ctx.bumps.get("sample").unwrap();
+        Ok(())
+    }
+
+    pub fn realloc(ctx: Context<Realloc>, len: u8) -> Result<()> {
+        ctx.accounts
+            .sample
+            .data
+            .resize_with(len as usize, Default::default);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        init,
+        payer = authority,
+        seeds = [b"sample"],
+        bump,
+        space = Sample::space(1),
+    )]
+    pub sample: Account<'info, Sample>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(len: u8)]
+pub struct Realloc<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"sample"],
+        bump = sample.bump,
+        realloc = Sample::space(len as usize),
+        allocator = authority,
+    )]
+    pub sample: Account<'info, Sample>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct Sample {
+    pub data: Vec<u8>,
+    pub bump: u8,
+}
+
+impl Sample {
+    pub fn space(len: usize) -> usize {
+        8 + (4 + len) + 1
+    }
+}

--- a/tests/realloc/tests/realloc.ts
+++ b/tests/realloc/tests/realloc.ts
@@ -1,0 +1,65 @@
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { assert } from "chai";
+import { Realloc } from "../target/types/realloc";
+
+describe("realloc", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.Realloc as Program<Realloc>;
+  const authority = (program.provider as any).wallet
+    .payer as anchor.web3.Keypair;
+
+  const [sample] = anchor.web3.PublicKey.findProgramAddressSync(
+    [Buffer.from("sample")],
+    program.programId
+  );
+
+  let postAllocBalance: number;
+
+  it("Is initialized!", async () => {
+    const b = await program.provider.connection.getBalance(authority.publicKey);
+    console.log(b);
+
+    await program.methods
+      .initialize()
+      .accounts({ authority: authority.publicKey, sample })
+      .rpc();
+
+    const s = await program.account.sample.fetch(sample);
+    assert.lengthOf(s.data, 1);
+
+    postAllocBalance = await program.provider.connection.getBalance(
+      authority.publicKey
+    );
+    console.log(postAllocBalance);
+  });
+
+  it("realloc additive", async () => {
+    await program.methods
+      .realloc(5)
+      .accounts({ authority: authority.publicKey, sample })
+      .rpc();
+
+    const s = await program.account.sample.fetch(sample);
+    assert.lengthOf(s.data, 5);
+
+    const b = await program.provider.connection.getBalance(authority.publicKey);
+    console.log(b);
+  });
+
+  it("realloc substractive", async () => {
+    await program.methods
+      .realloc(1)
+      .accounts({ authority: authority.publicKey, sample })
+      .rpc();
+
+    const s = await program.account.sample.fetch(sample);
+    assert.lengthOf(s.data, 1);
+
+    const b = await program.provider.connection.getBalance(authority.publicKey);
+    console.log(b);
+    assert.strictEqual(b, postAllocBalance);
+  });
+});

--- a/tests/realloc/tests/realloc.ts
+++ b/tests/realloc/tests/realloc.ts
@@ -11,12 +11,15 @@ describe("realloc", () => {
   const authority = (program.provider as any).wallet
     .payer as anchor.web3.Keypair;
 
-  const [sample] = anchor.web3.PublicKey.findProgramAddressSync(
-    [Buffer.from("sample")],
-    program.programId
-  );
-
+  let sample: anchor.web3.PublicKey;
   let postAllocBalance: number;
+
+  before(async () => {
+    [sample] = await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from("sample")],
+      program.programId
+    );
+  });
 
   it("Is initialized!", async () => {
     const b = await program.provider.connection.getBalance(authority.publicKey);

--- a/tests/realloc/tests/realloc.ts
+++ b/tests/realloc/tests/realloc.ts
@@ -12,7 +12,6 @@ describe("realloc", () => {
     .payer as anchor.web3.Keypair;
 
   let sample: anchor.web3.PublicKey;
-  let postAllocBalance: number;
 
   before(async () => {
     [sample] = await anchor.web3.PublicKey.findProgramAddress(
@@ -22,9 +21,6 @@ describe("realloc", () => {
   });
 
   it("Is initialized!", async () => {
-    const b = await program.provider.connection.getBalance(authority.publicKey);
-    console.log(b);
-
     await program.methods
       .initialize()
       .accounts({ authority: authority.publicKey, sample })
@@ -32,11 +28,6 @@ describe("realloc", () => {
 
     const s = await program.account.sample.fetch(sample);
     assert.lengthOf(s.data, 1);
-
-    postAllocBalance = await program.provider.connection.getBalance(
-      authority.publicKey
-    );
-    console.log(postAllocBalance);
   });
 
   it("realloc additive", async () => {
@@ -47,9 +38,6 @@ describe("realloc", () => {
 
     const s = await program.account.sample.fetch(sample);
     assert.lengthOf(s.data, 5);
-
-    const b = await program.provider.connection.getBalance(authority.publicKey);
-    console.log(b);
   });
 
   it("realloc substractive", async () => {
@@ -60,9 +48,5 @@ describe("realloc", () => {
 
     const s = await program.account.sample.fetch(sample);
     assert.lengthOf(s.data, 1);
-
-    const b = await program.provider.connection.getBalance(authority.publicKey);
-    console.log(b);
-    assert.strictEqual(b, postAllocBalance);
   });
 });

--- a/tests/realloc/tsconfig.json
+++ b/tests/realloc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Creates a new constraint group to include the usage of `realloc = <new_space>`, `realloc::payer = <account>`, and `realloc::zero = <bool>` constraints.

Handles the transfer of lamports between the reallocated and allocator accounts based on the delta-bytes (additive vs subtractive reallocation).

closes #1917 