### PR TITLE
syn: remove unused instruction_constraints field from Field

### DIFF
--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -214,7 +214,6 @@ impl AccountField {
 pub struct Field {
     pub ident: Ident,
     pub constraints: ConstraintGroup,
-    pub instruction_constraints: ConstraintGroup,
     pub ty: Ty,
     /// IDL Doc comment
     pub docs: Option<Vec<String>>,
@@ -494,7 +493,6 @@ impl Field {
 pub struct CompositeField {
     pub ident: Ident,
     pub constraints: ConstraintGroup,
-    pub instruction_constraints: ConstraintGroup,
     pub symbol: String,
     pub raw_field: syn::Field,
     /// IDL Doc comment

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -6,10 +6,7 @@ use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{bracketed, Expr, Ident, LitStr, Token};
 
-pub fn parse(
-    f: &syn::Field,
-    f_ty: Option<&Ty>,
-) -> ParseResult<ConstraintGroup> {
+pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);
     for attr in f.attrs.iter().filter(is_account) {
         for c in attr.parse_args_with(Punctuated::<ConstraintToken, Comma>::parse_terminated)? {

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -9,8 +9,7 @@ use syn::{bracketed, Expr, Ident, LitStr, Token};
 pub fn parse(
     f: &syn::Field,
     f_ty: Option<&Ty>,
-    has_instruction_api: bool,
-) -> ParseResult<(ConstraintGroup, ConstraintGroup)> {
+) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);
     for attr in f.attrs.iter().filter(is_account) {
         for c in attr.parse_args_with(Punctuated::<ConstraintToken, Comma>::parse_terminated)? {
@@ -18,33 +17,14 @@ pub fn parse(
         }
     }
     let account_constraints = constraints.build()?;
-    let mut constraints = ConstraintGroupBuilder::new(f_ty);
-    for attr in f.attrs.iter().filter(is_instruction) {
-        if !has_instruction_api {
-            return Err(ParseError::new(
-                attr.span(),
-                "an instruction api must be declared",
-            ));
-        }
-        for c in attr.parse_args_with(Punctuated::<ConstraintToken, Comma>::parse_terminated)? {
-            constraints.add(c)?;
-        }
-    }
-    let instruction_constraints = constraints.build()?;
 
-    Ok((account_constraints, instruction_constraints))
+    Ok(account_constraints)
 }
 
 pub fn is_account(attr: &&syn::Attribute) -> bool {
     attr.path
         .get_ident()
         .map_or(false, |ident| ident == "account")
-}
-
-pub fn is_instruction(attr: &&syn::Attribute) -> bool {
-    attr.path
-        .get_ident()
-        .map_or(false, |ident| ident == "instruction")
 }
 
 // Parses a single constraint from a parse stream for `#[account(<STREAM>)]`.

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -150,8 +150,7 @@ pub fn parse_account_field(f: &syn::Field) -> ParseResult<AccountField> {
     let account_field = match is_field_primitive(f)? {
         true => {
             let ty = parse_ty(f)?;
-            let account_constraints =
-                constraints::parse(f, Some(&ty))?;
+            let account_constraints = constraints::parse(f, Some(&ty))?;
             AccountField::Field(Field {
                 ident,
                 ty,
@@ -160,8 +159,7 @@ pub fn parse_account_field(f: &syn::Field) -> ParseResult<AccountField> {
             })
         }
         false => {
-            let account_constraints =
-                constraints::parse(f, None)?;
+            let account_constraints = constraints::parse(f, None)?;
             AccountField::CompositeField(CompositeField {
                 ident,
                 constraints: account_constraints,

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -23,7 +23,7 @@ pub fn parse(strct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {
         syn::Fields::Named(fields) => fields
             .named
             .iter()
-            .map(|f| parse_account_field(f))
+            .map(parse_account_field)
             .collect::<ParseResult<Vec<AccountField>>>()?,
         _ => {
             return Err(ParseError::new_spanned(

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -23,7 +23,7 @@ pub fn parse(strct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {
         syn::Fields::Named(fields) => fields
             .named
             .iter()
-            .map(|f| parse_account_field(f, instruction_api.is_some()))
+            .map(|f| parse_account_field(f))
             .collect::<ParseResult<Vec<AccountField>>>()?,
         _ => {
             return Err(ParseError::new_spanned(
@@ -144,29 +144,27 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
     Ok(())
 }
 
-pub fn parse_account_field(f: &syn::Field, has_instruction_api: bool) -> ParseResult<AccountField> {
+pub fn parse_account_field(f: &syn::Field) -> ParseResult<AccountField> {
     let ident = f.ident.clone().unwrap();
     let docs = docs::parse(&f.attrs);
     let account_field = match is_field_primitive(f)? {
         true => {
             let ty = parse_ty(f)?;
-            let (account_constraints, instruction_constraints) =
-                constraints::parse(f, Some(&ty), has_instruction_api)?;
+            let account_constraints =
+                constraints::parse(f, Some(&ty))?;
             AccountField::Field(Field {
                 ident,
                 ty,
                 constraints: account_constraints,
-                instruction_constraints,
                 docs,
             })
         }
         false => {
-            let (account_constraints, instruction_constraints) =
-                constraints::parse(f, None, has_instruction_api)?;
+            let account_constraints =
+                constraints::parse(f, None)?;
             AccountField::CompositeField(CompositeField {
                 ident,
                 constraints: account_constraints,
-                instruction_constraints,
                 symbol: ident_string(f)?,
                 raw_field: f.clone(),
                 docs,


### PR DESCRIPTION
Not sure how it got there but it's unused and confuses when reading the code. Resolves #1925.