### PR TITLE
client: allow execution stack to have multiple program ids

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -340,14 +340,12 @@ impl Execution {
         let re = Regex::new(r"^Program (.*) invoke.*$").unwrap();
         let programs: Vec<String> = logs
             .iter()
-            .map(|l| re.captures(l))
-            .flatten()
-            .map(|str| str.get(1))
-            .flatten()
+            .filter_map(|l| re.captures(l))
+            .filter_map(|str| str.get(1))
             .map(|matched_item| matched_item.as_str().to_string())
             .collect();
 
-        if programs.len() < 1 {
+        if programs.is_empty() {
             return Err(ClientError::MissingInvokeLogError());
         }
 


### PR DESCRIPTION
Fixes #1941

Allows Execution stack to have multiple program ids in it's stack so when multiple instruction are executed as part of single transaction event dispatch will not cause any issue.