### PR TITLE
ts: verbose error for missing `ANCHOR_WALLET` in `NodeWallet.local()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ com/project-serum/anchor/pull/1841)).
 * ts: Add `program.coder.types` for encoding/decoding user-defined types ([#1931](https://github.com/project-serum/anchor/pull/1931)).
 * client: Add send_with_spinner_and_config function to RequestBuilder ([#1926](https://github.com/project-serum/anchor/pull/1926)).
 * ts: Implement a coder for SPL associated token program ([#1939](https://github.com/project-serum/anchor/pull/1939)).
+* ts: verbose error for missing `ANCHOR_WALLET` variable when using `NodeWallet.local()` ([#1958](https://github.com/project-serum/anchor/pull/1958)).
 
 ### Fixes
 

--- a/ts/src/nodewallet.ts
+++ b/ts/src/nodewallet.ts
@@ -8,8 +8,15 @@ import { Wallet } from "./provider";
 export default class NodeWallet implements Wallet {
   constructor(readonly payer: Keypair) {}
 
-  static local(): NodeWallet {
+  static local(): NodeWallet | never {
     const process = require("process");
+
+    if (!process.env.ANCHOR_WALLET || process.env.ANCHOR_WALLET === "") {
+      throw new Error(
+        "expected environment variable `ANCHOR_WALLET` is not set."
+      );
+    }
+
     const payer = Keypair.fromSecretKey(
       Buffer.from(
         JSON.parse(
@@ -19,6 +26,7 @@ export default class NodeWallet implements Wallet {
         )
       )
     );
+
     return new NodeWallet(payer);
   }
 

--- a/ts/tests/program-common.spec.ts
+++ b/ts/tests/program-common.spec.ts
@@ -2,6 +2,7 @@ import BN from "bn.js";
 import bs58 from "bs58";
 import { PublicKey } from "@solana/web3.js";
 
+import NodeWallet from "../src/nodewallet";
 import { translateAddress } from "../src/program/common";
 
 describe("program/common", () => {
@@ -51,6 +52,19 @@ describe("program/common", () => {
       const invalid = {} as PublicKey;
       const func = () => translateAddress(invalid);
       expect(func).toThrow();
+    });
+  });
+
+  describe("NodeWallet", () => {
+    it("should throw an error when ANCHOR_WALLET is unset", () => {
+      const oldValue = process.env.ANCHOR_WALLET;
+      delete process.env.ANCHOR_WALLET;
+
+      expect(() => NodeWallet.local()).toThrowError(
+        "expected environment variable `ANCHOR_WALLET` is not set."
+      );
+
+      process.env.ANCHOR_WALLET = oldValue;
     });
   });
 });


### PR DESCRIPTION
closes #1957 