### PR TITLE
docs: add theme color to header logo text

### DIFF
--- a/docs/src/components/Logo.jsx
+++ b/docs/src/components/Logo.jsx
@@ -4,7 +4,7 @@ export function Logo() {
   return (
     <div className="hidden min-w-full items-center gap-2 lg:flex">
       <Image src="/logo.png" alt="Logo" width={30} height={30} />
-      <span className="text-xl font-semibold">Anchor</span>
+      <span className="text-xl font-semibold dark:text-white">Anchor</span>
     </div>
   )
 }


### PR DESCRIPTION
The "Anchor" text next to the logo in the top left of the page header did not respect the active theme.

Added `dark:text-white` to the class list for the `span` element.

(new docs look awesome @italoacasas !)