### PR TITLE
Update docs on format of method dispatch identifier

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -178,7 +178,7 @@ pub trait AccountDeserialize: Sized {
 pub trait ZeroCopy: Discriminator + Copy + Clone + Zeroable + Pod {}
 
 /// Calculates the data for an instruction invocation, where the data is
-/// `Sha256(<namespace>::<method_name>)[..8] || BorshSerialize(args)`.
+/// `Sha256(<namespace>:<method_name>)[..8] || BorshSerialize(args)`.
 /// `args` is a borsh serialized struct of named fields for each argument given
 /// to an instruction.
 pub trait InstructionData: AnchorSerialize {

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -124,7 +124,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         /// two pieces can be combined to creater a method identifier,
         /// specifically, Anchor uses
         ///
-        /// Sha256("<namespace>::<rust-identifier>")[..8],
+        /// Sha256("<namespace>:<rust-identifier>")[..8],
         ///
         /// where the namespace can be one of three types. 1) "global" for a
         /// regular instruction, 2) "state" for a state struct instruction


### PR DESCRIPTION
There is some documentation showing how method dispatch identifiers are created that isn't correct. This threw my off for a while, so I updated here. 

The method dispatch identifier is created with `Sha256(<namespace>:<method_name>)` (single colon)