### PR TITLE
ts: convert `EventParser.parseLogs` to a generator function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ com/project-serum/anchor/pull/1841)).
 * ts: Implement a coder for SPL associated token program ([#1939](https://github.com/coral-xyz/anchor/pull/1939)).
 * ts: verbose error for missing `ANCHOR_WALLET` variable when using `NodeWallet.local()` ([#1958](https://github.com/coral-xyz/anchor/pull/1958)).
 * ts: Add `MethodsBuilder#accountsStrict` for strict typing on ix account input ([#2019](https://github.com/coral-xyz/anchor/pull/2019)).
+* ts: Change `EventParser#parseLogs` implementation to be a generator instead of callback function ([#2018](https://github.com/coral-xyz/anchor/pull/2018)).
 
 ### Fixes
 

--- a/ts/src/program/namespace/simulate.ts
+++ b/ts/src/program/namespace/simulate.ts
@@ -53,9 +53,9 @@ export default class SimulateFactory {
       const events: Event<IdlEvent, IdlTypes<IDL>>[] = [];
       if (idl.events) {
         let parser = new EventParser(programId, coder);
-        parser.parseLogs(logs, (event) => {
+        for (const event of parser.parseLogs(logs)) {
           events.push(event);
-        });
+        }
       }
       return { events, raw: logs };
     };

--- a/ts/tests/events.spec.ts
+++ b/ts/tests/events.spec.ts
@@ -26,9 +26,9 @@ describe("Events", () => {
     const programId = PublicKey.default;
     const eventParser = new EventParser(programId, coder);
 
-    eventParser.parseLogs(logs, () => {
+    if (Array.from(eventParser.parseLogs(logs)).length > 0) {
       throw new Error("Should never find logs");
-    });
+    }
   });
   it("Upgrade event check", () => {
     const logs = [
@@ -54,9 +54,9 @@ describe("Events", () => {
     const programId = PublicKey.default;
     const eventParser = new EventParser(programId, coder);
 
-    eventParser.parseLogs(logs, () => {
+    if (Array.from(eventParser.parseLogs(logs)).length > 0) {
       throw new Error("Should never find logs");
-    });
+    }
   });
   it("Find event with different start log.", (done) => {
     const logs = [
@@ -118,10 +118,11 @@ describe("Events", () => {
     );
     const eventParser = new EventParser(programId, coder);
 
-    eventParser.parseLogs(logs, (event) => {
+    const gen = eventParser.parseLogs(logs);
+    for (const event of gen) {
       expect(event.name).toEqual("NftSold");
       done();
-    });
+    }
   });
   it("Find event from logs", (done) => {
     const logs = [
@@ -213,10 +214,11 @@ describe("Events", () => {
     );
     const eventParser = new EventParser(programId, coder);
 
-    eventParser.parseLogs(logs, (event) => {
+    const gen = eventParser.parseLogs(logs);
+    for (const event of gen) {
       expect(event.name).toEqual("ListingClosed");
       done();
-    });
+    }
   });
   it("Listen to different program and send other program logs with same name", () => {
     const logs = [
@@ -271,8 +273,8 @@ describe("Events", () => {
     );
     const eventParser = new EventParser(programId, coder);
 
-    eventParser.parseLogs(logs, () => {
+    if (Array.from(eventParser.parseLogs(logs)).length > 0) {
       throw new Error("Should never find logs");
-    });
+    }
   });
 });


### PR DESCRIPTION
Removes the use of callbacks from the `EventParser.parseLogs` function and converts to a log generator.