### PR TITLE
ts: add `accountsStrict` for non-resolvable accounts input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ com/project-serum/anchor/pull/1841)).
 * client: Add send_with_spinner_and_config function to RequestBuilder ([#1926](https://github.com/coral-xyz/anchor/pull/1926)).
 * ts: Implement a coder for SPL associated token program ([#1939](https://github.com/coral-xyz/anchor/pull/1939)).
 * ts: verbose error for missing `ANCHOR_WALLET` variable when using `NodeWallet.local()` ([#1958](https://github.com/coral-xyz/anchor/pull/1958)).
+* ts: Add `MethodsBuilder#accountsStrict` for strict typing on ix account input ([#2019](https://github.com/coral-xyz/anchor/pull/2019)).
 
 ### Fixes
 

--- a/ts/src/program/accounts-resolver.ts
+++ b/ts/src/program/accounts-resolver.ts
@@ -11,10 +11,10 @@ import { coder } from "../spl/token";
 // Populates a given accounts context with PDAs and common missing accounts.
 export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
   static readonly CONST_ACCOUNTS = {
-    systemProgram: SystemProgram.programId,
-    tokenProgram: TOKEN_PROGRAM_ID,
     associatedTokenProgram: ASSOCIATED_PROGRAM_ID,
     rent: SYSVAR_RENT_PUBKEY,
+    systemProgram: SystemProgram.programId,
+    tokenProgram: TOKEN_PROGRAM_ID,
   };
 
   private _accountStore: AccountStore<IDL>;

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -65,6 +65,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   private _preInstructions: Array<TransactionInstruction> = [];
   private _postInstructions: Array<TransactionInstruction> = [];
   private _accountsResolver: AccountsResolver<IDL, I>;
+  private _autoResolveAccounts: boolean = true;
 
   constructor(
     private _args: Array<any>,
@@ -98,6 +99,15 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   public accounts(
     accounts: Partial<Accounts<I["accounts"][number]>>
   ): MethodsBuilder<IDL, I> {
+    this._autoResolveAccounts = true;
+    Object.assign(this._accounts, accounts);
+    return this;
+  }
+
+  public accountsStrict(
+    accounts: Accounts<I["accounts"][number]>
+  ): MethodsBuilder<IDL, I> {
+    this._autoResolveAccounts = false;
     Object.assign(this._accounts, accounts);
     return this;
   }
@@ -129,7 +139,10 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public async rpc(options?: ConfirmOptions): Promise<TransactionSignature> {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
+
     // @ts-ignore
     return this._rpcFn(...this._args, {
       accounts: this._accounts,
@@ -142,10 +155,14 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public async view(options?: ConfirmOptions): Promise<any> {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
+
     if (!this._viewFn) {
       throw new Error("Method does not support views");
     }
+
     // @ts-ignore
     return this._viewFn(...this._args, {
       accounts: this._accounts,
@@ -160,7 +177,10 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   public async simulate(
     options?: ConfirmOptions
   ): Promise<SimulateResponse<any, any>> {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
+
     // @ts-ignore
     return this._simulateFn(...this._args, {
       accounts: this._accounts,
@@ -173,7 +193,10 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public async instruction(): Promise<TransactionInstruction> {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
+
     // @ts-ignore
     return this._ixFn(...this._args, {
       accounts: this._accounts,
@@ -185,7 +208,10 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   public async transaction(): Promise<Transaction> {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
+
     // @ts-ignore
     return this._txFn(...this._args, {
       accounts: this._accounts,

--- a/ts/src/program/namespace/methods.ts
+++ b/ts/src/program/namespace/methods.ts
@@ -92,7 +92,9 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
   public async pubkeys(): Promise<
     Partial<InstructionAccountAddresses<IDL, I>>
   > {
-    await this._accountsResolver.resolve();
+    if (this._autoResolveAccounts) {
+      await this._accountsResolver.resolve();
+    }
     return this._accounts as Partial<InstructionAccountAddresses<IDL, I>>;
   }
 


### PR DESCRIPTION
Adds a new `MethodsBuilder#accountsStrict` method to be able to input instruction accounts with strict typing.