### PR TITLE
ts: fix Module needs an import assertion of type json

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -254,7 +254,7 @@ pub fn ts_package_json() -> String {
     "devDependencies": {{
         "chai": "^4.3.4",
         "mocha": "^9.0.3",
-        "ts-mocha": "^8.0.0",
+        "ts-mocha": "^10.0.0",
         "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.0.0",


### PR DESCRIPTION
This fixes the following error when running `anchor test`:

https://stackoverflow.com/questions/71119753/solana-test-program-anchor-test-failing-tsconfig-json-needs-an-import-asserti

TypeError: Module "file:///Users/someuser/project/tsconfig.json" needs an import assertion of type "json"