### PR TITLE
Add skip-lint to Anchor.toml

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1122,7 +1122,6 @@ impl AnchorPackage {
 
 crate::home_path!(WalletPath, ".config/solana/id.json");
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1138,7 +1137,7 @@ mod tests {
         let config = Config::from_str(&BASE_CONFIG).unwrap();
         assert_eq!(config.provider.skip_lint, None);
     }
-    
+
     #[test]
     fn parse_skip_lint_true() {
         let string = BASE_CONFIG.to_owned() + "skip-lint = true";

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1134,7 +1134,7 @@ mod tests {
 
     #[test]
     fn parse_skip_lint_none() {
-        let config = Config::from_str(&BASE_CONFIG).unwrap();
+        let config = Config::from_str(BASE_CONFIG).unwrap();
         assert_eq!(config.provider.skip_lint, None);
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1140,14 +1140,14 @@ mod tests {
     }
     
     #[test]
-    fn parse_skip_lint_hyphen_true() {
+    fn parse_skip_lint_true() {
         let string = BASE_CONFIG.to_owned() + "skip-lint = true";
         let config = Config::from_str(&string).unwrap();
         assert_eq!(config.provider.skip_lint, Some(true));
     }
 
     #[test]
-    fn parse_skip_lint_hyphen_false() {
+    fn parse_skip_lint_false() {
         let string = BASE_CONFIG.to_owned() + "skip-lint = false";
         let config = Config::from_str(&string).unwrap();
         assert_eq!(config.provider.skip_lint, Some(false));

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1132,27 +1132,27 @@ mod tests {
     #[test]
     fn parse_skip_lint_no_section() {
         let config = Config::from_str(BASE_CONFIG).unwrap();
-        assert_eq!(config.features.skip_lint, false);
+        assert!(!config.features.skip_lint);
     }
 
     #[test]
     fn parse_skip_lint_no_value() {
         let string = BASE_CONFIG.to_owned() + "[features]";
         let config = Config::from_str(&string).unwrap();
-        assert_eq!(config.features.skip_lint, false);
+        assert!(!config.features.skip_lint);
     }
 
     #[test]
     fn parse_skip_lint_true() {
         let string = BASE_CONFIG.to_owned() + "[features]\nskip-lint = true";
         let config = Config::from_str(&string).unwrap();
-        assert_eq!(config.features.skip_lint, true);
+        assert!(config.features.skip_lint);
     }
 
     #[test]
     fn parse_skip_lint_false() {
         let string = BASE_CONFIG.to_owned() + "[features]\nskip-lint = false";
         let config = Config::from_str(&string).unwrap();
-        assert_eq!(config.features.skip_lint, false);
+        assert!(!config.features.skip_lint);
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1152,18 +1152,4 @@ mod tests {
         let config = Config::from_str(&string).unwrap();
         assert_eq!(config.provider.skip_lint, Some(false));
     }
-    
-    #[test]
-    fn parse_skip_lint_underscore_true() {
-        let string = BASE_CONFIG.to_owned() + "skip_lint = true";
-        let config = Config::from_str(&string).unwrap();
-        assert_eq!(config.provider.skip_lint, Some(true));
-    }
-
-    #[test]
-    fn parse_skip_lint_underscore_false() {
-        let string = BASE_CONFIG.to_owned() + "skip_lint = false";
-        let config = Config::from_str(&string).unwrap();
-        assert_eq!(config.provider.skip_lint, Some(false));
-    }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -421,7 +421,7 @@ struct _Config {
 struct Provider {
     cluster: String,
     wallet: String,
-    #[serde(alias = "skip-lint")]
+    #[serde(rename = "skip-lint")]
     skip_lint: Option<bool>,
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1512,7 +1512,7 @@ fn extract_idl(
         cargo.version(),
         cfg.features.seeds,
         no_docs,
-        !skip_lint,
+        !cfg.provider.skip_lint.unwrap_or(skip_lint),
     )
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1512,7 +1512,7 @@ fn extract_idl(
         cargo.version(),
         cfg.features.seeds,
         no_docs,
-        !cfg.provider.skip_lint.unwrap_or(skip_lint),
+        !(cfg.provider.skip_lint.unwrap_or(false) || skip_lint),
     )
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1512,7 +1512,7 @@ fn extract_idl(
         cargo.version(),
         cfg.features.seeds,
         no_docs,
-        !(cfg.provider.skip_lint.unwrap_or(false) || skip_lint),
+        !(cfg.features.skip_lint || skip_lint),
     )
 }
 


### PR DESCRIPTION
Implements #2021 

I added an optional boolean `skip-lint` ~to the provider section in Anchor.toml. I actually have no idea what "provider" means in this context, but I couldn't think of a better place. I added unit tests to verify that parsing works.~ it went in the features section

The value can be set to true, which has the same effect as including the cli argument. Setting it to false or omitting it results in the same behavior prior to this change. Enabling the flag in the file or the cli will skip linting. I manually tested to verify that linting is:
|  | --skip-lint | no cli flag |
| --- | --- | --- |
| `skip-lint = true` | skipped | skipped  |
| `skip-lint = false` | skipped  | executed |
| omitted from Anchor.toml | skipped  | executed |

Note that this means that explicitly adding `skip-lint = false` to Anchor.toml has no effect, since false is the default, and the cli argument would set it to true. I think this is the most reasonable behavior. CLI arguments typically have precedence over config files. Alternatively, `skip-lint = false` could block the cli argument. The implementation would be just as simple. But that behavior is unusual in my opinion.