### PR TITLE
Add optional flag to parseLogs to throw an error on decoding failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Updates `AccountsClose` to make it safe to call manually ([#2209](https://github.com/coral-xyz/anchor/pull/2209))
 - lang: Update rust used in the repo version 1.62 ([#2272](https://github.com/coral-xyz/anchor/pull/2272))
 - cli: Allow custom cluster config ([#2271](https://github.com/coral-xyz/anchor/pull/2271)).
+- ts: Add optional flag to parseLogs to throw an error on decoding failure ([#2043](https://github.com/coral-xyz/anchor/pull/2043))
 
 ### Fixes
 


### PR DESCRIPTION
Addressing this issue: https://github.com/coral-xyz/anchor/issues/2040