### PR TITLE
fix anchor keys list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+* cli: Fix `anchor keys list` reading the `target` folder in the wrong path ([#2063](https://github.com/coral-xyz/anchor/pull/2063)).
 * cli: Move `overflow-checks` into workspace `Cargo.toml` so that it will not be ignored by compiler ([#1806](https://github.com/coral-xyz/anchor/pull/1806)).
 * lang: Fix missing account name information when deserialization fails when using `init` or `zero` ([#1800](https://github.com/coral-xyz/anchor/pull/1800)).
 * ts: Expose the wallet's publickey on the Provider ([#1845](https://github.com/coral-xyz/anchor/pull/1845)).

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3047,12 +3047,13 @@ fn keys(cfg_override: &ConfigOverride, cmd: KeysCommand) -> Result<()> {
 }
 
 fn keys_list(cfg_override: &ConfigOverride) -> Result<()> {
-    let cfg = Config::discover(cfg_override)?.expect("Not in workspace.");
-    for program in cfg.read_all_programs()? {
-        let pubkey = program.pubkey()?;
-        println!("{}: {}", program.lib_name, pubkey);
-    }
-    Ok(())
+    with_workspace(cfg_override, |cfg| {
+        for program in cfg.read_all_programs()? {
+            let pubkey = program.pubkey()?;
+            println!("{}: {}", program.lib_name, pubkey);
+        }
+        Ok(())
+    })
 }
 
 fn localnet(


### PR DESCRIPTION
**Problem**
the flag `anchor keys list`is intended to show (or generate if not exists) the current program pubkeys

However, since it's not ensured that the current working directory is always the top level, the behavior is not desired since it will try to create a new `target` folder in the invoking path

**Solution**
move the function to the `with_workspace` closure 