### PR TITLE
fix: return err on test result err

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1975,7 +1975,8 @@ fn run_test_suite(
             }
         }
         Err(err) => {
-            println!("Failed to run test: {:#}", err)
+            println!("Failed to run test: {:#}", err);
+            return Err(err);
         }
     }
 


### PR DESCRIPTION
not sure why `run_test_suite` is allowed to return `Ok(())` when test_result erred.
Seems dangerous.