### PR TITLE
lang: Add `Owner` & `Discriminator` implementation for ix structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: SPL coders have been removed from the main Anchor package. ([#2155](https://github.com/coral-xyz/anchor/pull/2155))
 - lang: Remove `rent` from constraints ([#2265](https://github.com/coral-xyz/anchor/pull/2265)).
 - spl: Remove `rent` from `associated_token::Create` ([#2265](https://github.com/coral-xyz/anchor/pull/2265)).
+- lang: Add `Discriminator` and `Owner` trait implementation for structures representing instructions ([#1997](https://github.com/coral-xyz/anchor/pull/1997))
 
 ## [0.25.0] - 2022-07-05
 

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -139,9 +139,7 @@ pub fn account(
 
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
-                    fn discriminator() -> [u8; 8] {
-                        #discriminator
-                    }
+                    const DISCRIMINATOR: [u8; 8] = #discriminator;
                 }
 
                 // This trait is useful for clients deserializing accounts.
@@ -211,9 +209,7 @@ pub fn account(
 
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
-                    fn discriminator() -> [u8; 8] {
-                        #discriminator
-                    }
+                    const DISCRIMINATOR: [u8; 8] = #discriminator;
                 }
 
                 #owner_impl

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -40,9 +40,7 @@ pub fn event(
         }
 
         impl anchor_lang::Discriminator for #event_name {
-            fn discriminator() -> [u8; 8] {
-                #discriminator
-            }
+            const DISCRIMINATOR: [u8; 8] = #discriminator;
         }
     })
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -182,8 +182,12 @@ pub trait ZeroCopy: Discriminator + Copy + Clone + Zeroable + Pod {}
 /// `Sha256(<namespace>:<method_name>)[..8] || BorshSerialize(args)`.
 /// `args` is a borsh serialized struct of named fields for each argument given
 /// to an instruction.
-pub trait InstructionData: AnchorSerialize {
-    fn data(&self) -> Vec<u8>;
+pub trait InstructionData: Discriminator + AnchorSerialize {
+    fn data(&self) -> Vec<u8> {
+        let mut d = Self::discriminator().to_vec();
+        d.append(&mut self.try_to_vec().expect("Should always serialize"));
+        d
+    }
 }
 
 /// An event that can be emitted via a Solana log. See [`emit!`](crate::prelude::emit) for an example.
@@ -201,7 +205,10 @@ pub trait EventData: AnchorSerialize + Discriminator {
 
 /// 8 byte unique identifier for a type.
 pub trait Discriminator {
-    fn discriminator() -> [u8; 8];
+    const DISCRIMINATOR: [u8; 8];
+    fn discriminator() -> [u8; 8] {
+        Self::DISCRIMINATOR
+    }
 }
 
 /// Bump seed for program derived addresses.

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -39,11 +39,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 /// constructor.
                 #strct
 
-                impl anchor_lang::InstructionData for New {
-                    fn data(&self) -> Vec<u8> {
-                        let mut d = #sighash_tts.to_vec();
-                        d.append(&mut self.try_to_vec().expect("Should always serialize"));
-                        d
+                impl anchor_lang::Discriminator for New {
+                    const DISCRIMINATOR: [u8; 8] = #sighash_tts;
+                }
+                impl anchor_lang::InstructionData for New {}
+                impl anchor_lang::Owner for New {
+                    fn owner() -> Pubkey {
+                        ID
                     }
                 }
             }
@@ -82,11 +84,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             let sighash_tts: proc_macro2::TokenStream =
                                 format!("{:?}", sighash_arr).parse().unwrap();
                             quote! {
-                                impl anchor_lang::InstructionData for #ix_name_camel {
-                                    fn data(&self) -> Vec<u8> {
-                                        let mut d = #sighash_tts.to_vec();
-                                        d.append(&mut self.try_to_vec().expect("Should always serialize"));
-                                        d
+                                impl anchor_lang::Discriminator for #ix_name_camel {
+                                    const DISCRIMINATOR: [u8; 8] = #sighash_tts;
+                                }
+                                impl anchor_lang::InstructionData for #ix_name_camel {}
+                                impl anchor_lang::Owner for #ix_name_camel {
+                                    fn owner() -> Pubkey {
+                                        ID
                                     }
                                 }
                             }
@@ -138,11 +142,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 let sighash_tts: proc_macro2::TokenStream =
                     format!("{:?}", sighash_arr).parse().unwrap();
                 quote! {
-                    impl anchor_lang::InstructionData for #ix_name_camel {
-                        fn data(&self) -> Vec<u8> {
-                            let mut d = #sighash_tts.to_vec();
-                            d.append(&mut self.try_to_vec().expect("Should always serialize"));
-                            d
+                    impl anchor_lang::Discriminator for #ix_name_camel {
+                        const DISCRIMINATOR: [u8; 8] = #sighash_tts;
+                    }
+                    impl anchor_lang::InstructionData for #ix_name_camel {}
+                    impl anchor_lang::Owner for #ix_name_camel {
+                        fn owner() -> Pubkey {
+                            ID
                         }
                     }
                 }


### PR DESCRIPTION
lang: Add into `Discriminator` trait constant `DISCRIMINATOR`
So that during match instructions or other entities there is no explicit instruction call of `discriminator()`
lang: Add `Owner` impl to instructions

Close #1994