### PR TITLE
docs: Update links to the repository

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -32,7 +32,7 @@ Anchor version manager is a tool for using multiple versions of the anchor-cli. 
 Install `avm` using Cargo. Note this will replace your `anchor` binary if you had one installed.
 
 ```shell
-cargo install --git https://github.com/project-serum/anchor avm --locked --force
+cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
 ```
 
 On Linux systems you may need to install additional dependencies if cargo install fails. E.g. on Ubuntu:
@@ -63,7 +63,7 @@ Anchor binaries are available via an NPM package [`@project-serum/anchor-cli`](h
 We can also use Cargo to install the CLI directly. Make sure that the `--tag` argument uses the version you want (the version here is just an example).
 
 ```shell
-cargo install --git https://github.com/project-serum/anchor --tag v0.24.1 anchor-cli --locked
+cargo install --git https://github.com/coral-xyz/anchor --tag v0.24.1 anchor-cli --locked
 ```
 
 On Linux systems you may need to install additional dependencies if cargo install fails. On Ubuntu,

--- a/docs/src/pages/docs/tic-tac-toe.md
+++ b/docs/src/pages/docs/tic-tac-toe.md
@@ -455,7 +455,7 @@ it('player one wins', async () => {
 
 and run `anchor test`.
 
-You can finish writing the test by yourself (or check out [the reference implementation](https://github.com/project-serum/anchor-book/tree/master/programs/tic-tac-toe)). Try to simulate a win and a tie!
+You can finish writing the test by yourself (or check out [the reference implementation](https://github.com/coral-xyz/anchor/tree/master/docs/programs/tic-tac-toe)). Try to simulate a win and a tie!
 
 Proper testing also includes tests that try to exploit the contract. You can check whether you've protected yourself properly by calling `play` with unexpected parameters. You can also familiarize yourself with the returned `AnchorErrors` this way. For example:
 
@@ -538,7 +538,7 @@ There is more to deployments than this e.g. understanding how the BPFLoader work
 
 ## Program directory organization
 
-> [Program Code](https://github.com/project-serum/anchor-book/tree/master/programs/tic-tac-toe)
+> [Program Code](https://github.com/coral-xyz/anchor/tree/master/docs/programs/tic-tac-toe)
 
 Eventually, some programs become too big to keep them in a single file and it makes sense to break them up.
 


### PR DESCRIPTION
Some parts of documentation were still referring to project-serum/anchor
or project-serum/anchor-book.