### PR TITLE
Don't use wallet object for account.createInstruction function 2112

### DIFF
--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -346,16 +346,8 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
-    // @ts-expect-error
-    if (this._provider.wallet === undefined) {
-      throw new Error(
-        "This function requires the Provider interface implementor to have a 'wallet' field."
-      );
-    }
-
     return SystemProgram.createAccount({
-      // @ts-expect-error
-      fromPubkey: this._provider.wallet.publicKey,
+      fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,
       lamports:

--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -346,7 +346,15 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
+    // @ts-expect-error
+    if (this._provider.publicKey === undefined) {
+      throw new Error(
+        "This function requires the Provider interface implementor to have a 'publicKey' field."
+      );
+    }
+
     return SystemProgram.createAccount({
+      // @ts-expect-error
       fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,

--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -346,7 +346,6 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
-    // @ts-expect-error
     if (this._provider.publicKey === undefined) {
       throw new Error(
         "This function requires the Provider interface implementor to have a 'publicKey' field."
@@ -354,7 +353,6 @@ export class AccountClient<
     }
 
     return SystemProgram.createAccount({
-      // @ts-expect-error
       fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -294,16 +294,8 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
-    // @ts-expect-error
-    if (this._provider.wallet === undefined) {
-      throw new Error(
-        "This function requires the Provider interface implementor to have a 'wallet' field."
-      );
-    }
-
     return SystemProgram.createAccount({
-      // @ts-expect-error
-      fromPubkey: this._provider.wallet.publicKey,
+      fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,
       lamports:

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -294,7 +294,6 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
-    // @ts-expect-error
     if (this._provider.publicKey === undefined) {
       throw new Error(
         "This function requires the Provider interface implementor to have a 'publicKey' field."
@@ -302,7 +301,6 @@ export class AccountClient<
     }
 
     return SystemProgram.createAccount({
-      // @ts-expect-error
       fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -294,7 +294,15 @@ export class AccountClient<
   ): Promise<TransactionInstruction> {
     const size = this.size;
 
+    // @ts-expect-error
+    if (this._provider.publicKey === undefined) {
+      throw new Error(
+        "This function requires the Provider interface implementor to have a 'publicKey' field."
+      );
+    }
+
     return SystemProgram.createAccount({
+      // @ts-expect-error
       fromPubkey: this._provider.publicKey,
       newAccountPubkey: signer.publicKey,
       space: sizeOverride ?? size,


### PR DESCRIPTION
- Deleted the wallet type check
- Replaced to get publicKey from provider