### PR TITLE
spl: add create metadata v3 and set collection size ix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 * client: Add `transaction` functions to RequestBuilder ([#1958](https://github.com/coral-xyz/anchor/pull/1958)).
+* spl: Add `create_metadata_accounts_v3` and `set_collection_size` wrappers ([#2119](https://github.com/coral-xyz/anchor/pull/2119))
 
 ## [0.25.0] - 2022-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b06b6275bd3f6444e22b03de7bdf6145ee6d6fa3e14415ddd317473b9ef807"
+checksum = "029a329d7a89f7a3caf0b91bec307531f4b6c9cca34aa775454845fbbd05ac57"
 dependencies = [
  "arrayref",
  "borsh",
@@ -3117,18 +3117,18 @@ dependencies = [
 
 [[package]]
 name = "shank"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cfd616747d1ce69f15e62ea30589e393115e4b884d7c1cbceb751b8753e95d"
+checksum = "85a6c6cad96abd1fd950d1df186ec02e786566161f03adadbb7cf157ae9a82d8"
 dependencies = [
  "shank_macro",
 ]
 
 [[package]]
 name = "shank_macro"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a27d3b536acc60a3ff359181d3a912d10b91539f85909447ca7d33ea0a91d56"
+checksum = "c0b3bf722b43cea02627c7fd89925f5861f7aa27604c1852720f8eee1a73523d"
 dependencies = [
  "proc-macro2 1.0.40",
  "quote 1.0.15",
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7466a15559fd11aeb5fe12a700923f75bb4eaa7bc90962f2bd822708698ab5d"
+checksum = "90a37f762b0529d64a9e3401ac3829e132f58fa9bc50b1fd6ad7b5a1a414a228"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.40",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 description = "CPI clients for SPL programs"
 
 [features]
-default = ["mint", "token", "associated_token", "metadata"]
+default = ["mint", "token", "associated_token"]
 mint = []
 token = ["spl-token"]
 associated_token = ["spl-associated-token-account"]

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 description = "CPI clients for SPL programs"
 
 [features]
-default = ["mint", "token", "associated_token"]
+default = ["mint", "token", "associated_token", "metadata"]
 mint = []
 token = ["spl-token"]
 associated_token = ["spl-associated-token-account"]
@@ -24,4 +24,4 @@ serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "1be91f2
 solana-program = "~1.10.29"
 spl-token = { version = "~3.3.0", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "~1.0.5", features = ["no-entrypoint"], optional = true }
-mpl-token-metadata = { version = "1.2.7", optional = true, features = ["no-entrypoint"] }
+mpl-token-metadata = { version = "1.3.4", optional = true, features = ["no-entrypoint"] }

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -1,6 +1,6 @@
 use anchor_lang::context::CpiContext;
 use anchor_lang::{Accounts, Result, ToAccountInfos};
-use mpl_token_metadata::state::DataV2;
+use mpl_token_metadata::state::{CollectionDetails, DataV2};
 use mpl_token_metadata::ID;
 use solana_program::account_info::AccountInfo;
 use solana_program::pubkey::Pubkey;
@@ -45,6 +45,48 @@ pub fn create_metadata_accounts_v2<'info>(
         is_mutable,
         collection,
         uses,
+    );
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn create_metadata_accounts_v3<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, CreateMetadataAccountsV3<'info>>,
+    data: DataV2,
+    is_mutable: bool,
+    update_authority_is_signer: bool,
+    details: Option<CollectionDetails>,
+) -> Result<()> {
+    let DataV2 {
+        name,
+        symbol,
+        uri,
+        creators,
+        seller_fee_basis_points,
+        collection,
+        uses,
+    } = data;
+    let ix = mpl_token_metadata::instruction::create_metadata_accounts_v3(
+        ID,
+        *ctx.accounts.metadata.key,
+        *ctx.accounts.mint.key,
+        *ctx.accounts.mint_authority.key,
+        *ctx.accounts.payer.key,
+        *ctx.accounts.update_authority.key,
+        name,
+        symbol,
+        uri,
+        creators,
+        seller_fee_basis_points,
+        update_authority_is_signer,
+        is_mutable,
+        collection,
+        uses,
+        details,
     );
     solana_program::program::invoke_signed(
         &ix,
@@ -128,8 +170,40 @@ pub fn mint_new_edition_from_master_edition_via_token<'info>(
     Ok(())
 }
 
+pub fn set_collection_size<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, SetCollectionSize<'info>>,
+    size: u64,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::set_collection_size(
+        ID,
+        *ctx.accounts.metadata.key,
+        *ctx.accounts.update_authority.key,
+        *ctx.accounts.mint.key,
+        None,
+        size,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
 #[derive(Accounts)]
 pub struct CreateMetadataAccountsV2<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub mint_authority: AccountInfo<'info>,
+    pub payer: AccountInfo<'info>,
+    pub update_authority: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub rent: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CreateMetadataAccountsV3<'info> {
     pub metadata: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
@@ -182,4 +256,12 @@ pub struct MintNewEditionFromMasterEditionViaToken<'info> {
     // helper pass in the `edition_mark_pda` directly.
     //
     pub metadata_mint: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetCollectionSize<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub update_authority: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
 }

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -172,6 +172,7 @@ pub fn mint_new_edition_from_master_edition_via_token<'info>(
 
 pub fn set_collection_size<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, SetCollectionSize<'info>>,
+    collection_authority_record: Option<Pubkey>,
     size: u64,
 ) -> Result<()> {
     let ix = mpl_token_metadata::instruction::set_collection_size(
@@ -179,7 +180,7 @@ pub fn set_collection_size<'info>(
         *ctx.accounts.metadata.key,
         *ctx.accounts.update_authority.key,
         *ctx.accounts.mint.key,
-        None,
+        collection_authority_record,
         size,
     );
 


### PR DESCRIPTION
Adds wrapper for `mpl-token-metadata` instructions and updates to `v1.3.4`:
- `create_metadata_accounts_v3`
- `set_collection_size`