### PR TITLE
Adds purpose of seeds = true does in an Anchor.toml file

### DIFF
--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -37,6 +37,19 @@ Example:
 url = "https://anchor.projectserum.com"
 ```
 
+## features
+
+#### seeds
+
+This tells the IDL to include seed generation for PDA Accounts. The default is `false`
+
+Example:
+
+```
+[features]
+seeds = true
+```
+
 ## workspace
 
 #### types


### PR DESCRIPTION
Updates Anchor.toml docs to explain what `seeds = true` signifies in an Anchor.toml file, which is to ensure the IDL can generate PDA seeds.
```
[features]
seeds = true 
```