### PR TITLE
Fix: IDL gen byte string lit parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 * spl: Add `create_metadata_accounts_v3` and `set_collection_size` wrappers ([#2119](https://github.com/coral-xyz/anchor/pull/2119))
 * spl: Add `MetadataAccount` account deserialization. ([#2014](https://github.com/coral-xyz/anchor/pull/2014)).
 
+### Fixes
+
+* lang: Fix IDL `seed` generation for byte string literals. ([#2125](https://github.com/coral-xyz/anchor/pull/2125))
+
 ## [0.25.0] - 2022-07-05
 
 ### Features

--- a/lang/syn/src/idl/pda.rs
+++ b/lang/syn/src/idl/pda.rs
@@ -5,7 +5,7 @@ use crate::ConstraintSeedsGroup;
 use crate::{AccountsStruct, Field};
 use std::collections::HashMap;
 use std::str::FromStr;
-use syn::Expr;
+use syn::{Expr, ExprLit, Lit};
 
 // Parses a seeds constraint, extracting the IdlSeed types.
 //
@@ -117,6 +117,13 @@ impl<'a> PdaParser<'a> {
             Expr::Index(_) => {
                 println!("WARNING: auto pda derivation not currently supported for slice literals");
                 None
+            }
+            Expr::Lit(ExprLit {
+                lit: Lit::ByteStr(lit_byte_str),
+                ..
+            }) => {
+                let seed_path: SeedPath = SeedPath(lit_byte_str.token().to_string(), Vec::new());
+                self.parse_str_literal(&seed_path)
             }
             // Unknown type. Please file an issue.
             _ => {


### PR DESCRIPTION
Byte strings were not being parsed properly due to the `match` statement not catching syn `Lit`s. This PR adds a pattern to catch and parse these. 

Current build behavior with `seeds=true`:
```bash
WARNING: unexpected seed: Lit(ExprLit { attrs: [], lit: ByteStr(LitByteStr { token: b"some string" }) })
``` 
This will turn the entire seed into `None` if a seeds group contains a byte string literal. In other words, the entire PDA object will be missing in the IDL.

With the fix, the warning is gone and IDLs are generated as they should be.

