### PR TITLE
Fix: new clippy lints

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -408,7 +408,7 @@ pub struct RequestBuilder<'a> {
     namespace: RequestNamespace,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum RequestNamespace {
     Global,
     State {

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -500,7 +500,7 @@ pub struct CompositeField {
 }
 
 // A type of an account field.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Ty {
     AccountInfo,
     UncheckedAccount,
@@ -518,7 +518,7 @@ pub enum Ty {
     ProgramData,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SysvarTy {
     Clock,
     Rent,
@@ -532,41 +532,41 @@ pub enum SysvarTy {
     Rewards,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProgramStateTy {
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CpiStateTy {
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProgramAccountTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CpiAccountTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AccountLoaderTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct LoaderTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AccountTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
@@ -574,7 +574,7 @@ pub struct AccountTy {
     pub boxed: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProgramTy {
     // The struct type of the account.
     pub account_type_path: TypePath,


### PR DESCRIPTION
New rust version adds lints that require deriving Eq for everything that already derives PartialEq. This shouldn't actually impact anything. 