### PR TITLE
add freeze and thaw delegated account instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * spl: Add `MetadataAccount` account deserialization. ([#2014](https://github.com/coral-xyz/anchor/pull/2014)).
 * lang: Add parsing for consts from impl blocks for IDL PDA seeds generation ([#2128](https://github.com/coral-xyz/anchor/pull/2014))
 * ts: Add coders for SPL programs ([#2143](https://github.com/coral-xyz/anchor/pull/2143)).
+* spl: Add `freeze_delegated_account` and `thaw_delegated_account` wrappers ([#2164](https://github.com/coral-xyz/anchor/pull/2164))
 
 ### Fixes
 

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -193,6 +193,46 @@ pub fn set_collection_size<'info>(
     Ok(())
 }
 
+pub fn freeze_delegated_account<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, FreezeDelegatedAccount<'info>>,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::freeze_delegated_account(
+        ID,
+        *ctx.accounts.delegate.key,
+        *ctx.accounts.token_account.key,
+        *ctx.accounts.edition.key,
+        *ctx.accounts.mint.key,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+
+    Ok(())
+}
+
+pub fn thaw_delegated_account<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, ThawDelegatedAccount<'info>>,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::thaw_delegated_account(
+        ID,
+        *ctx.accounts.delegate.key,
+        *ctx.accounts.token_account.key,
+        *ctx.accounts.edition.key,
+        *ctx.accounts.mint.key,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+
+    Ok(())
+}
+
 #[derive(Accounts)]
 pub struct CreateMetadataAccountsV2<'info> {
     pub metadata: AccountInfo<'info>,
@@ -266,6 +306,26 @@ pub struct SetCollectionSize<'info> {
     pub mint: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
     pub system_program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct FreezeDelegatedAccount<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub delegate: AccountInfo<'info>,
+    pub token_account: AccountInfo<'info>,
+    pub edition: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ThawDelegatedAccount<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub delegate: AccountInfo<'info>,
+    pub token_account: AccountInfo<'info>,
+    pub edition: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
PR to add the following instructions:

1. `freeze_delegated_account`
2. `thaw_delegated_account`

Reference:
https://docs.rs/mpl_token_metadata_extended_uri/0.1.7/src/mpl_token_metadata_extended_uri/instruction.rs.html#1213

These instructions coupled with `Approve` and `Revoke` allow for the freeze and thaw of Metaplex NFTs in the holders wallet.

