### PR TITLE
implemented more token_metadata wrappers

### DIFF
--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -204,6 +204,29 @@ pub fn verify_collection<'info>(
     .map_err(Into::into)
 }
 
+pub fn set_and_verify_collection<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, SetAndVerifyCollection<'info>>,
+    collection_authority_record: Option<Pubkey>,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::set_and_verify_collection(
+        ID,
+        *ctx.accounts.metadata.key,
+        *ctx.accounts.collection_authority.key,
+        *ctx.accounts.payer.key,
+        *ctx.accounts.update_authority.key,
+        *ctx.accounts.collection_mint.key,
+        *ctx.accounts.collection_metadata.key,
+        *ctx.accounts.collection_master_edition.key,
+        collection_authority_record,
+    );
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
 pub fn freeze_delegated_account<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, FreezeDelegatedAccount<'info>>,
 ) -> Result<()> {
@@ -370,6 +393,17 @@ pub struct VerifyCollection<'info> {
     pub payer: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub collection_authority: AccountInfo<'info>,
+    pub collection_mint: AccountInfo<'info>,
+    pub collection_metadata: AccountInfo<'info>,
+    pub collection_master_edition: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetAndVerifyCollection<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub collection_authority: AccountInfo<'info>,
+    pub payer: AccountInfo<'info>,
+    pub update_authority: AccountInfo<'info>,
     pub collection_mint: AccountInfo<'info>,
     pub collection_metadata: AccountInfo<'info>,
     pub collection_master_edition: AccountInfo<'info>,

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -249,6 +249,29 @@ pub fn set_and_verify_collection<'info>(
     .map_err(Into::into)
 }
 
+pub fn set_and_verify_sized_collection_item<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, SetAndVerifySizedCollectionItem<'info>>,
+    collection_authority_record: Option<Pubkey>,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::set_and_verify_sized_collection_item(
+        ID,
+        *ctx.accounts.metadata.key,
+        *ctx.accounts.collection_authority.key,
+        *ctx.accounts.payer.key,
+        *ctx.accounts.update_authority.key,
+        *ctx.accounts.collection_mint.key,
+        *ctx.accounts.collection_metadata.key,
+        *ctx.accounts.collection_master_edition.key,
+        collection_authority_record,
+    );
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
 pub fn freeze_delegated_account<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, FreezeDelegatedAccount<'info>>,
 ) -> Result<()> {
@@ -432,6 +455,17 @@ pub struct VerifySizedCollectionItem<'info> {
 
 #[derive(Accounts)]
 pub struct SetAndVerifyCollection<'info> {
+    pub metadata: AccountInfo<'info>,
+    pub collection_authority: AccountInfo<'info>,
+    pub payer: AccountInfo<'info>,
+    pub update_authority: AccountInfo<'info>,
+    pub collection_mint: AccountInfo<'info>,
+    pub collection_metadata: AccountInfo<'info>,
+    pub collection_master_edition: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetAndVerifySizedCollectionItem<'info> {
     pub metadata: AccountInfo<'info>,
     pub collection_authority: AccountInfo<'info>,
     pub payer: AccountInfo<'info>,

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -204,6 +204,28 @@ pub fn verify_collection<'info>(
     .map_err(Into::into)
 }
 
+pub fn verify_sized_collection_item<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, VerifySizedCollectionItem<'info>>,
+    collection_authority_record: Option<Pubkey>,
+) -> Result<()> {
+    let ix = mpl_token_metadata::instruction::verify_sized_collection_item(
+        ID,
+        *ctx.accounts.metadata.key,
+        *ctx.accounts.collection_authority.key,
+        *ctx.accounts.payer.key,
+        *ctx.accounts.collection_mint.key,
+        *ctx.accounts.collection_metadata.key,
+        *ctx.accounts.collection_master_edition.key,
+        collection_authority_record,
+    );
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
 pub fn set_and_verify_collection<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, SetAndVerifyCollection<'info>>,
     collection_authority_record: Option<Pubkey>,
@@ -390,6 +412,16 @@ pub struct SetCollectionSize<'info> {
 
 #[derive(Accounts)]
 pub struct VerifyCollection<'info> {
+    pub payer: AccountInfo<'info>,
+    pub metadata: AccountInfo<'info>,
+    pub collection_authority: AccountInfo<'info>,
+    pub collection_mint: AccountInfo<'info>,
+    pub collection_metadata: AccountInfo<'info>,
+    pub collection_master_edition: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct VerifySizedCollectionItem<'info> {
     pub payer: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub collection_authority: AccountInfo<'info>,


### PR DESCRIPTION
- [X] `set_and_verify_collection`

This instruction updates the Collection field of a Metadata account for sized collections using the provided Collection Mint account as long as its Collection Authority signs the transaction and the parent NFT has the collection details field populated (sized)

- [X] `verify_sized_collection_item`

This instruction verifies the collection of a Metadata account, by setting the Verified boolean to True on the Collection field, and increments the size field of the parent NFT.

- [x] `set_and_verify_sized_collection_item`

This instruction updates the Collection field of a Metadata account for sized collections using the provided Collection Mint account as long as its Collection Authority signs the transaction and the parent NFT has the collection details field populated (sized).

#2178 