### PR TITLE
feat: Update seeds inference to allow nested user defined structs as part of the seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Fixes
 
 * lang: Fix IDL `seed` generation for byte string literals. ([#2125](https://github.com/coral-xyz/anchor/pull/2125))
+* ts: Update seeds inference to allow nested user defined structs within the seeds ([#2198](https://github.com/coral-xyz/anchor/pull/2198))
 
 ## [0.25.0] - 2022-07-05
 

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -271,7 +271,7 @@ impl std::str::FromStr for IdlType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdlErrorCode {
     pub code: u32,
     pub name: String,

--- a/lang/syn/src/parser/error.rs
+++ b/lang/syn/src/parser/error.rs
@@ -27,7 +27,7 @@ pub fn parse(error_enum: &mut syn::ItemEnum, args: Option<ErrorArgs>) -> Error {
             last_discriminant = id + 1;
 
             // Remove any non-doc attributes on the error variant.
-            variant.attrs = variant
+            variant
                 .attrs
                 .retain(|attr| attr.path.segments[0].ident == "doc");
 

--- a/lang/syn/src/parser/error.rs
+++ b/lang/syn/src/parser/error.rs
@@ -29,10 +29,7 @@ pub fn parse(error_enum: &mut syn::ItemEnum, args: Option<ErrorArgs>) -> Error {
             // Remove any non-doc attributes on the error variant.
             variant.attrs = variant
                 .attrs
-                .iter()
-                .filter(|attr| attr.path.segments[0].ident == "doc")
-                .cloned()
-                .collect();
+                .retain(|attr| attr.path.segments[0].ident == "doc");
 
             ErrorCode { id, ident, msg }
         })

--- a/ts/packages/anchor/src/index.ts
+++ b/ts/packages/anchor/src/index.ts
@@ -12,6 +12,8 @@ export {
 export * from "./error.js";
 export { Instruction } from "./coder/borsh/instruction.js";
 export { Idl } from "./idl.js";
+export { CustomAccountResolver } from "./program/accounts-resolver.js";
+
 export * from "./coder/index.js";
 export * as utils from "./utils/index.js";
 export * from "./program/index.js";

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -247,7 +247,10 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     }
 
     const programId = await this.parseProgramId(accountDesc);
-    const [pubkey] = await PublicKey.findProgramAddress(seeds as Buffer[], programId);
+    const [pubkey] = await PublicKey.findProgramAddress(
+      seeds as Buffer[],
+      programId
+    );
 
     this.set([...path, camelCase(accountDesc.name)], pubkey);
   }
@@ -290,13 +293,15 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
    */
   private getType(type: IdlType, path: string[] = []): string {
     if (path.length > 0 && (type as any).defined) {
-      const subType = this._idlTypes.find(t => t.name === (type as any).defined);
+      const subType = this._idlTypes.find(
+        (t) => t.name === (type as any).defined
+      );
       if (!subType) {
         throw new Error(`Cannot find type ${(type as any).defined}`);
       }
 
       const structType = subType.type as IdlTypeDefTyStruct; // enum not supported yet
-      const field = structType.fields.find(field => field.name === path[0]);
+      const field = structType.fields.find((field) => field.name === path[0]);
 
       return this.getType(field!.type, path.slice(1));
     }
@@ -305,13 +310,16 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
   }
 
   private toBufferConst(seedDesc: IdlSeed): Buffer {
-    return this.toBufferValue(this.getType(seedDesc.type, (seedDesc.path || "").split(".").slice(1)), seedDesc.value);
+    return this.toBufferValue(
+      this.getType(seedDesc.type, (seedDesc.path || "").split(".").slice(1)),
+      seedDesc.value
+    );
   }
 
   private async toBufferArg(seedDesc: IdlSeed): Promise<Buffer | undefined> {
     const argValue = this.argValue(seedDesc);
     if (!argValue) {
-      return
+      return;
     }
     return this.toBufferValue(
       this.getType(seedDesc.type, (seedDesc.path || "").split(".").slice(1)),
@@ -329,16 +337,18 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     if (idlArgPosition === -1) {
       throw new Error(`Unable to find argument for seed: ${seedArgName}`);
     }
- 
+
     return split
       .slice(1)
       .reduce((curr, path) => (curr || {})[path], this._args[idlArgPosition]);
   }
 
-  private async toBufferAccount(seedDesc: IdlSeed): Promise<Buffer | undefined> {
+  private async toBufferAccount(
+    seedDesc: IdlSeed
+  ): Promise<Buffer | undefined> {
     const accountValue = await this.accountValue(seedDesc);
     if (!accountValue) {
-      return
+      return;
     }
     return this.toBufferValue(seedDesc.type, accountValue);
   }

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -116,7 +116,6 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
   ): Promise<void> {
     for (let k = 0; k < accounts.length; k += 1) {
       const accountDescOrAccounts = accounts[k];
-      console.log(accountDescOrAccounts);
       const subAccounts = (accountDescOrAccounts as IdlAccounts).accounts;
       if (subAccounts) {
         await this.resolveConst(subAccounts, [
@@ -145,7 +144,6 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
         Reflect.has(AccountsResolver.CONST_ACCOUNTS, accountDescName) &&
         !this.get([...path, accountDescName])
       ) {
-        console.log("RESOOOLVE", accountDescName)
         this.set(
           [...path, accountDescName],
           AccountsResolver.CONST_ACCOUNTS[accountDescName]

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -1,5 +1,10 @@
 import camelCase from "camelcase";
-import { PublicKey, SystemProgram, SYSVAR_CLOCK_PUBKEY, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  SYSVAR_CLOCK_PUBKEY,
+  SYSVAR_RENT_PUBKEY,
+} from "@solana/web3.js";
 import {
   Idl,
   IdlSeed,

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -185,8 +185,9 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
         accountDescCasted.pda.seeds.length > 0 &&
         !this.get([...path, accountDescName])
       ) {
-        await this.autoPopulatePda(accountDescCasted, path);
-        found += 1;
+        if (Boolean(await this.autoPopulatePda(accountDescCasted, path))) {
+          found += 1;
+        }
       }
     }
     return found;

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -11,6 +11,10 @@ import {
   IdlAccount,
   IdlAccountItem,
   IdlAccounts,
+  IdlTypeDef,
+  IdlTypeDefStruct,
+  IdlTypeDefTyStruct,
+  IdlType,
 } from "../idl.js";
 import * as utf8 from "../utils/bytes/utf8.js";
 import { TOKEN_PROGRAM_ID, ASSOCIATED_PROGRAM_ID } from "../utils/token.js";
@@ -50,6 +54,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     private _programId: PublicKey,
     private _idlIx: AllInstructions<IDL>,
     _accountNamespace: AccountNamespace<IDL>,
+    private _idlTypes: IdlTypeDef[],
     private _customResolver?: CustomAccountResolver<IDL>
   ) {
     this._args = _args;
@@ -233,12 +238,16 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     if (!accountDesc.pda || !accountDesc.pda.seeds)
       throw new Error("Must have seeds");
 
-    const seeds: Buffer[] = await Promise.all(
+    const seeds: (Buffer | undefined)[] = await Promise.all(
       accountDesc.pda.seeds.map((seedDesc: IdlSeed) => this.toBuffer(seedDesc))
     );
 
+    if (seeds.some((seed) => typeof seed == "undefined")) {
+      return;
+    }
+
     const programId = await this.parseProgramId(accountDesc);
-    const [pubkey] = await PublicKey.findProgramAddress(seeds, programId);
+    const [pubkey] = await PublicKey.findProgramAddress(seeds as Buffer[], programId);
 
     this.set([...path, camelCase(accountDesc.name)], pubkey);
   }
@@ -263,7 +272,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     }
   }
 
-  private async toBuffer(seedDesc: IdlSeed): Promise<Buffer> {
+  private async toBuffer(seedDesc: IdlSeed): Promise<Buffer | undefined> {
     switch (seedDesc.kind) {
       case "const":
         return this.toBufferConst(seedDesc);
@@ -276,17 +285,43 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     }
   }
 
-  private toBufferConst(seedDesc: IdlSeed): Buffer {
-    return this.toBufferValue(seedDesc.type, seedDesc.value);
+  /**
+   * Recursively get the type at some path of either a primitive or a user defined struct.
+   */
+  private getType(type: IdlType, path: string[] = []): string {
+    if (path.length > 0 && (type as any).defined) {
+      const subType = this._idlTypes.find(t => t.name === (type as any).defined);
+      if (!subType) {
+        throw new Error(`Cannot find type ${(type as any).defined}`);
+      }
+
+      const structType = subType.type as IdlTypeDefTyStruct; // enum not supported yet
+      const field = structType.fields.find(field => field.name === path[0]);
+
+      return this.getType(field!.type, path.slice(1));
+    }
+
+    return type as string;
   }
 
-  private async toBufferArg(seedDesc: IdlSeed): Promise<Buffer> {
+  private toBufferConst(seedDesc: IdlSeed): Buffer {
+    return this.toBufferValue(this.getType(seedDesc.type, (seedDesc.path || "").split(".").slice(1)), seedDesc.value);
+  }
+
+  private async toBufferArg(seedDesc: IdlSeed): Promise<Buffer | undefined> {
     const argValue = this.argValue(seedDesc);
-    return this.toBufferValue(seedDesc.type, argValue);
+    if (!argValue) {
+      return
+    }
+    return this.toBufferValue(
+      this.getType(seedDesc.type, (seedDesc.path || "").split(".").slice(1)),
+      argValue
+    );
   }
 
   private argValue(seedDesc: IdlSeed): any {
-    const seedArgName = camelCase(seedDesc.path.split(".")[0]);
+    const split = seedDesc.path.split(".");
+    const seedArgName = camelCase(split[0]);
 
     const idlArgPosition = this._idlIx.args.findIndex(
       (argDesc: any) => argDesc.name === seedArgName
@@ -294,12 +329,17 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     if (idlArgPosition === -1) {
       throw new Error(`Unable to find argument for seed: ${seedArgName}`);
     }
-
-    return this._args[idlArgPosition];
+ 
+    return split
+      .slice(1)
+      .reduce((curr, path) => (curr || {})[path], this._args[idlArgPosition]);
   }
 
-  private async toBufferAccount(seedDesc: IdlSeed): Promise<Buffer> {
+  private async toBufferAccount(seedDesc: IdlSeed): Promise<Buffer | undefined> {
     const accountValue = await this.accountValue(seedDesc);
+    if (!accountValue) {
+      return
+    }
     return this.toBufferValue(seedDesc.type, accountValue);
   }
 

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -1,5 +1,5 @@
 import camelCase from "camelcase";
-import { PublicKey, SystemProgram, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
+import { PublicKey, SystemProgram, SYSVAR_CLOCK_PUBKEY, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
 import {
   Idl,
   IdlSeed,
@@ -33,6 +33,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     rent: SYSVAR_RENT_PUBKEY,
     systemProgram: SystemProgram.programId,
     tokenProgram: TOKEN_PROGRAM_ID,
+    clock: SYSVAR_CLOCK_PUBKEY,
   };
 
   private _accountStore: AccountStore<IDL>;
@@ -64,34 +65,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
   //       dependency graph and resolve automatically.
   //
   public async resolve() {
-    for (let k = 0; k < this._idlIx.accounts.length; k += 1) {
-      // Cast is ok because only a non-nested IdlAccount can have a seeds
-      // cosntraint.
-      const accountDesc = this._idlIx.accounts[k] as IdlAccount;
-      const accountDescName = camelCase(accountDesc.name);
-
-      // Signers default to the provider.
-      if (accountDesc.isSigner && !this._accounts[accountDescName]) {
-        // @ts-expect-error
-        if (this._provider.wallet === undefined) {
-          throw new Error(
-            "This function requires the Provider interface implementor to have a 'wallet' field."
-          );
-        }
-        // @ts-expect-error
-        this._accounts[accountDescName] = this._provider.wallet.publicKey;
-        continue;
-      }
-
-      // Common accounts are auto populated with magic names by convention.
-      if (
-        Reflect.has(AccountsResolver.CONST_ACCOUNTS, accountDescName) &&
-        !this._accounts[accountDescName]
-      ) {
-        this._accounts[accountDescName] =
-          AccountsResolver.CONST_ACCOUNTS[accountDescName];
-      }
-    }
+    await this.resolveConst(this._idlIx.accounts);
 
     // Auto populate pdas and relations until we stop finding new accounts
     while (
@@ -136,6 +110,50 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
     });
   }
 
+  private async resolveConst(
+    accounts: IdlAccountItem[],
+    path: string[] = []
+  ): Promise<void> {
+    for (let k = 0; k < accounts.length; k += 1) {
+      const accountDescOrAccounts = accounts[k];
+      console.log(accountDescOrAccounts);
+      const subAccounts = (accountDescOrAccounts as IdlAccounts).accounts;
+      if (subAccounts) {
+        await this.resolveConst(subAccounts, [
+          ...path,
+          camelCase(accountDescOrAccounts.name),
+        ]);
+      }
+
+      const accountDesc = accountDescOrAccounts as IdlAccount;
+      const accountDescName = camelCase(accountDescOrAccounts.name);
+
+      // Signers default to the provider.
+      if (accountDesc.isSigner && !this.get([...path, accountDescName])) {
+        // @ts-expect-error
+        if (this._provider.wallet === undefined) {
+          throw new Error(
+            "This function requires the Provider interface implementor to have a 'wallet' field."
+          );
+        }
+        // @ts-expect-error
+        this.set([...path, accountDescName], this._provider.wallet.publicKey);
+      }
+
+      // Common accounts are auto populated with magic names by convention.
+      if (
+        Reflect.has(AccountsResolver.CONST_ACCOUNTS, accountDescName) &&
+        !this.get([...path, accountDescName])
+      ) {
+        console.log("RESOOOLVE", accountDescName)
+        this.set(
+          [...path, accountDescName],
+          AccountsResolver.CONST_ACCOUNTS[accountDescName]
+        );
+      }
+    }
+  }
+
   private async resolvePdas(
     accounts: IdlAccountItem[],
     path: string[] = []
@@ -147,7 +165,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
       if (subAccounts) {
         found += await this.resolvePdas(subAccounts, [
           ...path,
-          accountDesc.name,
+          camelCase(accountDesc.name),
         ]);
       }
 
@@ -177,7 +195,7 @@ export class AccountsResolver<IDL extends Idl, I extends AllInstructions<IDL>> {
       if (subAccounts) {
         found += await this.resolveRelations(subAccounts, [
           ...path,
-          accountDesc.name,
+          camelCase(accountDesc.name),
         ]);
       }
       const relations = (accountDesc as IdlAccount).relations || [];

--- a/ts/packages/anchor/src/program/namespace/index.ts
+++ b/ts/packages/anchor/src/program/namespace/index.ts
@@ -90,6 +90,7 @@ export default class NamespaceFactory {
         simulateItem,
         viewItem,
         account,
+        idl.types || [],
         getCustomResolver && getCustomResolver(idlIx)
       );
       const name = camelCase(idlIx.name);

--- a/ts/packages/anchor/src/program/namespace/methods.ts
+++ b/ts/packages/anchor/src/program/namespace/methods.ts
@@ -1,14 +1,17 @@
 import {
-  AccountMeta, ConfirmOptions, PublicKey, Signer,
+  AccountMeta,
+  ConfirmOptions,
+  PublicKey,
+  Signer,
   Transaction,
   TransactionInstruction,
-  TransactionSignature
+  TransactionSignature,
 } from "@solana/web3.js";
 import { Idl, IdlTypeDef } from "../../idl.js";
 import Provider from "../../provider.js";
 import {
   AccountsResolver,
-  CustomAccountResolver
+  CustomAccountResolver,
 } from "../accounts-resolver.js";
 import { Accounts } from "../context.js";
 import { AccountNamespace } from "./account.js";
@@ -17,7 +20,10 @@ import { RpcFn } from "./rpc.js";
 import { SimulateFn, SimulateResponse } from "./simulate.js";
 import { TransactionFn } from "./transaction.js";
 import {
-  AllInstructions, InstructionAccountAddresses, MakeMethodsNamespace, MethodsFn
+  AllInstructions,
+  InstructionAccountAddresses,
+  MakeMethodsNamespace,
+  MethodsFn,
 } from "./types.js";
 import { ViewFn } from "./views.js";
 

--- a/ts/packages/anchor/src/program/namespace/methods.ts
+++ b/ts/packages/anchor/src/program/namespace/methods.ts
@@ -1,32 +1,25 @@
 import {
-  ConfirmOptions,
-  AccountMeta,
-  Signer,
+  AccountMeta, ConfirmOptions, PublicKey, Signer,
   Transaction,
   TransactionInstruction,
-  TransactionSignature,
-  PublicKey,
+  TransactionSignature
 } from "@solana/web3.js";
-import { SimulateResponse } from "./simulate.js";
-import { TransactionFn } from "./transaction.js";
-import { Idl } from "../../idl.js";
-import {
-  AllInstructions,
-  MethodsFn,
-  MakeMethodsNamespace,
-  InstructionAccountAddresses,
-} from "./types.js";
-import { InstructionFn } from "./instruction.js";
-import { RpcFn } from "./rpc.js";
-import { SimulateFn } from "./simulate.js";
-import { ViewFn } from "./views.js";
+import { Idl, IdlTypeDef } from "../../idl.js";
 import Provider from "../../provider.js";
-import { AccountNamespace } from "./account.js";
 import {
   AccountsResolver,
-  CustomAccountResolver,
+  CustomAccountResolver
 } from "../accounts-resolver.js";
 import { Accounts } from "../context.js";
+import { AccountNamespace } from "./account.js";
+import { InstructionFn } from "./instruction.js";
+import { RpcFn } from "./rpc.js";
+import { SimulateFn, SimulateResponse } from "./simulate.js";
+import { TransactionFn } from "./transaction.js";
+import {
+  AllInstructions, InstructionAccountAddresses, MakeMethodsNamespace, MethodsFn
+} from "./types.js";
+import { ViewFn } from "./views.js";
 
 export type MethodsNamespace<
   IDL extends Idl = Idl,
@@ -44,6 +37,7 @@ export class MethodsBuilderFactory {
     simulateFn: SimulateFn<IDL>,
     viewFn: ViewFn<IDL> | undefined,
     accountNamespace: AccountNamespace<IDL>,
+    idlTypes: IdlTypeDef[],
     customResolver?: CustomAccountResolver<IDL>
   ): MethodsFn<IDL, I, MethodsBuilder<IDL, I>> {
     return (...args) =>
@@ -58,6 +52,7 @@ export class MethodsBuilderFactory {
         programId,
         idlIx,
         accountNamespace,
+        idlTypes,
         customResolver
       );
   }
@@ -84,6 +79,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
     _programId: PublicKey,
     _idlIx: AllInstructions<IDL>,
     _accountNamespace: AccountNamespace<IDL>,
+    _idlTypes: IdlTypeDef[],
     _customResolver?: CustomAccountResolver<IDL>
   ) {
     this._args = _args;
@@ -94,6 +90,7 @@ export class MethodsBuilder<IDL extends Idl, I extends AllInstructions<IDL>> {
       _programId,
       _idlIx,
       _accountNamespace,
+      _idlTypes,
       _customResolver
     );
   }


### PR DESCRIPTION
Something like this would cause an error in PDA derivation in typescript:

```

#[derive(Accounts)]
#[instruction(args: Args)
pub struct Something<'info> {
  #[account(
      seeds = [b"hey", args.key.as_ref()],
      bump
   )]
  pub account: AccountInfo<'info>
}
```