### PR TITLE
DOCS: Add libssl-dev to additional deps

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -38,7 +38,7 @@ cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
 On Linux systems you may need to install additional dependencies if cargo install fails. E.g. on Ubuntu:
 
 ```shell
-sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev
+sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 ```
 
 Install the latest version of the CLI using `avm`, and then set it to be the version to use.


### PR DESCRIPTION
libssl-dev is required on a clean Ubuntu install