### PR TITLE
new clippy lints for rust 1.63

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -323,7 +323,7 @@ pub struct WorkspaceConfig {
     pub types: String,
 }
 
-#[derive(ArgEnum, Parser, Clone, PartialEq, Debug)]
+#[derive(ArgEnum, Parser, Clone, PartialEq, Eq, Debug)]
 pub enum BootstrapMode {
     None,
     Debian,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1440,7 +1440,7 @@ pub fn verify_bin(program_id: Pubkey, bin_path: &Path, cluster: &str) -> Result<
     Ok(BinVerification { state, is_verified })
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct BinVerification {
     pub state: BinVerificationState,
     pub is_verified: bool,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1353,7 +1353,7 @@ fn cd_member(cfg_override: &ConfigOverride, program_name: &str) -> Result<()> {
             return Ok(());
         }
     }
-    return Err(anyhow!("{} is not part of the workspace", program_name,));
+    Err(anyhow!("{} is not part of the workspace", program_name,))
 }
 
 pub fn verify_bin(program_id: Pubkey, bin_path: &Path, cluster: &str) -> Result<BinVerification> {
@@ -1446,7 +1446,7 @@ pub struct BinVerification {
     pub is_verified: bool,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum BinVerificationState {
     Buffer,
     ProgramData {


### PR DESCRIPTION
Just a couple of `Eq`s and the removal of a `return` required to satisfy `cargo clippy` and make the core tests pass again.