### PR TITLE
Chore: Speed up tests

### DIFF
--- a/.github/workflows/no-cashing-tests.yaml
+++ b/.github/workflows/no-cashing-tests.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-core:
     name: Core Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
 
   setup-anchor-cli:
     name: Setup Anchor cli
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
   test-examples:
     needs: setup-anchor-cli
     name: Examples Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
   setup-client-example:
     needs: setup-anchor-cli
     name: Setup Client Example Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -108,7 +108,7 @@ jobs:
   test-client-example:
     needs: setup-client-example
     name: Client Example Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -144,7 +144,7 @@ jobs:
   test-bpf-upgradeable-state:
     needs: setup-anchor-cli
     name: Test tests/bpf-upgradeable-state
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -176,7 +176,7 @@ jobs:
   #   # but that's fine since it's just the cli
   #   needs: setup-anchor-cli
   #   name: Test tests/misc/nonRentExempt
-  #   runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-latest
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v2
@@ -207,7 +207,7 @@ jobs:
   test-anchor-init:
     needs: setup-anchor-cli
     name: Test Anchor Init
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -227,7 +227,7 @@ jobs:
   test-programs:
     needs: setup-anchor-cli
     name: Test ${{ matrix.node.path }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -227,7 +227,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/download-artifact@v2
         with:
@@ -324,7 +324,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/download-artifact@v2
         with:
@@ -422,7 +422,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
             ~/.cargo/git/db/
             ./target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo install --path cli anchor-cli --locked --force
+      - run: cargo install --path cli anchor-cli --locked --force --debug
       - run: chmod +x ~/.cargo/bin/anchor
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   test-core:
     name: Core Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
 
   setup-anchor-cli:
     name: Setup Anchor cli
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
   test-examples:
     needs: setup-anchor-cli
     name: Examples Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
   setup-client-example:
     needs: setup-anchor-cli
     name: Setup Client Example Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -163,7 +163,7 @@ jobs:
   test-client-example:
     needs: setup-client-example
     name: Client Example Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
   test-bpf-upgradeable-state:
     needs: setup-anchor-cli
     name: Test tests/bpf-upgradeable-state
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -256,7 +256,7 @@ jobs:
   #   # but that's fine since it's just the cli
   #   needs: setup-anchor-cli
   #   name: Test tests/misc/nonRentExempt
-  #   runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-latest
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v2
@@ -302,7 +302,7 @@ jobs:
   test-anchor-init:
     needs: setup-anchor-cli
     name: Test Anchor Init
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -334,7 +334,7 @@ jobs:
   test-programs:
     needs: setup-anchor-cli
     name: Test ${{ matrix.node.path }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ on:
 env:
   SOLANA_CLI_VERSION: 1.10.29
   NODE_VERSION: 17.0.1
+  CARGO_PROFILE: debug
 
 jobs:
   test-core:
@@ -66,8 +67,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo install --path cli anchor-cli --locked --force --debug
+        if: env.CARGO_PROFILE == 'debug'
+      - run: cargo install --path cli anchor-cli --locked --force
+        if: env.CARGO_PROFILE != 'debug'
       - run: chmod +x ~/.cargo/bin/anchor
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This PR modifies the caching tests to build the anchor cli in debug mode instead of production. The runtime performance loss is negligible, while the compilation time is down to 1 minute from ~8. The cache keys were updated to include the cargo profile. 