### PR TITLE
Add support for 256-bit integers in the IDL

### DIFF
--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -195,6 +195,8 @@ pub enum IdlType {
     F64,
     U128,
     I128,
+    U256,
+    I256,
     Bytes,
     String,
     PublicKey,

--- a/ts/packages/anchor/src/coder/borsh/idl.ts
+++ b/ts/packages/anchor/src/coder/borsh/idl.ts
@@ -51,6 +51,12 @@ export class IdlCoder {
       case "i128": {
         return borsh.i128(fieldName);
       }
+      case "u256": {
+        return borsh.u256(fieldName);
+      }
+      case "i256": {
+        return borsh.i256(fieldName);
+      }
       case "bytes": {
         return borsh.vecU8(fieldName);
       }

--- a/ts/packages/anchor/src/coder/common.ts
+++ b/ts/packages/anchor/src/coder/common.ts
@@ -58,6 +58,10 @@ function typeSize(idl: Idl, ty: IdlType): number {
       return 16;
     case "i128":
       return 16;
+    case "u256":
+      return 32;
+    case "i256":
+      return 32;
     case "bytes":
       return 1;
     case "string":

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -121,6 +121,8 @@ export type IdlType =
   | "f64"
   | "u128"
   | "i128"
+  | "u256"
+  | "i256"
   | "bytes"
   | "string"
   | "publicKey"

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -121,7 +121,7 @@ type TypeMap = {
 } & {
   [K in "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "f32" | "f64"]: number;
 } & {
-  [K in "u64" | "i64" | "u128" | "i128"]: BN;
+  [K in "u64" | "i64" | "u128" | "i128" | "u256" | "i256"]: BN;
 };
 
 export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap

--- a/ts/packages/anchor/tests/coder-types.spec.ts
+++ b/ts/packages/anchor/tests/coder-types.spec.ts
@@ -44,7 +44,7 @@ describe("coder.types", () => {
     assert.deepEqual(coder.types.decode("MintInfo", encoded), mintInfo);
   });
 
-  test('Can encode and decode 256-bit integers', () => {
+  test("Can encode and decode 256-bit integers", () => {
     const idl = {
       version: "0.0.0",
       name: "basic_0",
@@ -82,6 +82,9 @@ describe("coder.types", () => {
 
     const coder = new BorshCoder(idl);
     const encoded = coder.types.encode("IntegerTest", testing);
-    assert.strictEqual(coder.types.decode("IntegerTest", encoded).toString(), testing.toString());
+    assert.strictEqual(
+      coder.types.decode("IntegerTest", encoded).toString(),
+      testing.toString()
+    );
   });
 });

--- a/ts/packages/anchor/tests/coder-types.spec.ts
+++ b/ts/packages/anchor/tests/coder-types.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import { BorshCoder } from "../src";
+import BN from "bn.js";
 
 describe("coder.types", () => {
   test("Can encode and decode user-defined types", () => {
@@ -41,5 +42,46 @@ describe("coder.types", () => {
     const encoded = coder.types.encode("MintInfo", mintInfo);
 
     assert.deepEqual(coder.types.decode("MintInfo", encoded), mintInfo);
+  });
+
+  test('Can encode and decode 256-bit integers', () => {
+    const idl = {
+      version: "0.0.0",
+      name: "basic_0",
+      instructions: [
+        {
+          name: "initialize",
+          accounts: [],
+          args: [],
+        },
+      ],
+      types: [
+        {
+          name: "IntegerTest",
+          type: {
+            kind: "struct" as const,
+            fields: [
+              {
+                name: "unsigned",
+                type: "u256" as const,
+              },
+              {
+                name: "signed",
+                type: "i256" as const,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const testing = {
+      unsigned: new BN(2588012355),
+      signed: new BN(-93842345),
+    };
+
+    const coder = new BorshCoder(idl);
+    const encoded = coder.types.encode("IntegerTest", testing);
+    assert.strictEqual(coder.types.decode("IntegerTest", encoded).toString(), testing.toString());
   });
 });


### PR DESCRIPTION
The Solang Solidity compiler team at Solana Labs is working towards Anchor IDL compatibility for Solidity contracts. The goal is to allow users to interact with their Solidity contracts using Anchor client libraries.

This PR introduces two changes:
1. Support for 256-bit integers on Anchor Typescript library. This item depends upon the approval of a [PR in the project Serum repository](https://github.com/project-serum/serum-ts/pull/248) that implements the Borsh encoding for 256-bit integers. After approval, the dependency must be updated in Anchor Typescript.
2. I have added two items to the `IdlType` enum in `lang/syn/src/idl/mod.rs` because Solang uses the Anchor Rust crate to generate IDL from Solidity contracts.

What this PR does not introduce:
1. There is no standard way to use 256-bit integers on Rust. As it is not possible to go from an Anchor IDL to a Rust contract, the support for them has not been added in Anchor Rust contracts. There is a discussion about a Solana IDL spec undergoing [here](https://github.com/solana-idl-foundation/solana-idl-spec) and a specific issue about 256-bit integers [here](https://github.com/solana-idl-foundation/solana-idl-spec/issues/6) where we should discuss an optimal way to support those in Rust. 