### PR TITLE
Remove terser for react-native support

### DIFF
--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -72,7 +72,6 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.60.2",
-    "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.7",
     "ts-jest-resolver": "^2.0.0",
     "ts-node": "^9.0.0",

--- a/ts/packages/anchor/rollup.config.ts
+++ b/ts/packages/anchor/rollup.config.ts
@@ -30,7 +30,6 @@ export default {
         "process.env.ANCHOR_BROWSER": JSON.stringify(true),
       },
     }),
-    terser(),
   ],
   external: [
     "@project-serum/borsh",

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -4085,7 +4085,7 @@ rimraf@*, rimraf@=3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-terser@=7.0.2, rollup-plugin-terser@^7.0.2:
+rollup-plugin-terser@=7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
   integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==


### PR DESCRIPTION
## CHANGES 📲
- Removing `rollup-plugin-terser` for react-native support.

## Reasoning

The `anchor-ts` client uses rollup to bundle `ts` code for the browser. In the process of bundling, it passes the code through a `minification/uglification` plugin called `rollup-plugin-terser`.

The `terser` mangles the code in a way that the the variable assigned to the import of `@solana/web3.js` is reused.

Something similar to this is happening in the final output:
```
var s = require("@solana/web3.js")

function x() {
  var s, a, b; // ----> redefined s
  ...
  s.TransactionInstruction() // ----> calls method on original s
}
```

**Issues supporting this claim:**

https://github.com/coral-xyz/anchor/issues/1082
https://github.com/coral-xyz/anchor/issues/2054
https://github.com/coral-xyz/anchor/issues/1747
https://stackoverflow.com/questions/70652456/solanaweb-3-js-package-typeerror-s-transactioninstruction-is-not-a-constructor/70964609#70964609