### PR TITLE
Fix panic parsing seeds when account has qualified path

### DIFF
--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -197,7 +197,7 @@ impl AccountField {
     }
 
     pub fn ty_name(&self) -> Option<String> {
-        match self {
+        let qualified_ty_name = match self {
             AccountField::Field(field) => match &field.ty {
                 Ty::Account(account) => Some(parser::tts_to_string(&account.account_type_path)),
                 Ty::ProgramAccount(account) => {
@@ -206,7 +206,12 @@ impl AccountField {
                 _ => None,
             },
             AccountField::CompositeField(field) => Some(field.symbol.clone()),
-        }
+        };
+
+        qualified_ty_name.map(|name| match name.rsplit_once(" :: ") {
+            Some((_prefix, suffix)) => suffix.to_string(),
+            None => name,
+        })
     }
 }
 

--- a/tests/pda-derivation/programs/pda-derivation/src/other.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/other.rs
@@ -1,0 +1,6 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct AnotherBaseAccount {
+    pub data: u64,
+}

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -15,6 +15,8 @@ describe("typescript", () => {
   const base = Keypair.generate();
   const dataKey = Keypair.generate();
   const data = new BN(1);
+  const another = Keypair.generate();
+  const anotherData = new BN(2);
   const seedA = 4;
 
   it("Inits the base account", async () => {
@@ -24,6 +26,14 @@ describe("typescript", () => {
         base: base.publicKey,
       })
       .signers([base])
+      .rpc();
+
+    await program.methods
+      .initAnother(anotherData)
+      .accounts({
+        base: another.publicKey,
+      })
+      .signers([another])
       .rpc();
   });
 
@@ -47,6 +57,7 @@ describe("typescript", () => {
         new anchor.BN(MY_SEED_U64).toArrayLike(Buffer, "le", 8),
         new anchor.BN(data).toArrayLike(Buffer, "le", 8),
         dataKey.publicKey.toBuffer(),
+        new anchor.BN(anotherData).toArrayLike(Buffer, "le", 8),
       ],
       program.programId
     )[0];
@@ -54,6 +65,7 @@ describe("typescript", () => {
     const tx = program.methods.initMyAccount(seedA).accounts({
       base: base.publicKey,
       base2: base.publicKey,
+      anotherBase: another.publicKey,
     });
 
     const keys = await tx.pubkeys();
@@ -87,6 +99,7 @@ describe("typescript", () => {
       .accounts({
         base: base.publicKey,
         base2: base.publicKey,
+        anotherBase: another.publicKey,
       })
       .pubkeys();
 


### PR DESCRIPTION
This PR fixes a panic caused when Anchor parses seeds that reference an account imported from another file using its full path, eg in code like this:

```rs
    #[derive(Accounts)]
    pub struct LikePost<'info> {
        #[account(
            init,
            space = 448,
            payer = liker,
            seeds = [post.owner.as_ref() , post.id.to_le_bytes().as_ref()],
            bump
        )]
        pub like: Account<'info, dot::program::Like>,
        #[account(mut)]
        pub post: Account<'info, dot::program::Post>,
        #[account(mut)]
        pub liker: Signer<'info>,
        pub system_program: Program<'info, System>,
        pub rent: Sysvar<'info, Rent>,
    }
```

Here the `post.owner` and `post.id` seeds caused a panic.

The cause was: https://github.com/coral-xyz/anchor/blob/8ce18c36db10c6cb7a342e38ed7b5740bfa61c58/lang/syn/src/idl/pda.rs#L225

When this runs the struct idents are mapped to non-qualified type names: `["Like", "LoadedLike", "DeletePostEvent", "User", "LoadedUser", "LikeDislikePostEvent", "UpdatePostEvent", "Post", "LoadedPost", "NewPostEvent", "CreateUser", "DeletePost", "LikePost", "CreatePost", "DislikePost", "UpdatePost", "Mutable", "Empty", "ProgramsMap", "WithPrograms", "CpiAccount"]`

While the `account` was `dot :: program :: Post`. Since this doesn't match any of the unqualified struct names, it panics on the `unwrap`.

Here `account` comes from a call to: https://github.com/coral-xyz/anchor/blob/8ce18c36db10c6cb7a342e38ed7b5740bfa61c58/lang/syn/src/lib.rs#L199-L209

This PR updates the call to `ty_name` to remove any import path from the account. So `account` is returned as `Post` and correctly matches the imported struct name, fixing the panic. 