### PR TITLE
Fixing breaking change where null or undefined wallet throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Update seeds inference to allow nested user defined structs within the seeds ([#2198](https://github.com/coral-xyz/anchor/pull/2198))
 - event: Fix multiple event listeners with the same name. ([#2165](https://github.com/coral-xyz/anchor/pull/2165))
 - lang: Prevent the payer account from being initialized as a program account. ([#2284](https://github.com/coral-xyz/anchor/pull/2284))
+- ts: Fixing breaking change where null or undefined wallet throws an error. ([#2303](https://github.com/coral-xyz/anchor/pull/2303))
 
 ### Breaking
 

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -60,7 +60,7 @@ export class AnchorProvider implements Provider {
     readonly wallet: Wallet,
     readonly opts: ConfirmOptions
   ) {
-    this.publicKey = wallet.publicKey;
+    this.publicKey = wallet?.publicKey;
   }
 
   static defaultOptions(): ConfirmOptions {


### PR DESCRIPTION
https://github.com/coral-xyz/anchor/pull/2084

It's such a small change and the original is too far out of whack from previous commits that it's just easier to merge this in a new PR.