### PR TITLE
Only add public enums to the IDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Prevent the payer account from being initialized as a program account ([#2284](https://github.com/coral-xyz/anchor/pull/2284)).
 - ts: Fixing breaking change where null or undefined wallet throws an error ([#2303](https://github.com/coral-xyz/anchor/pull/2303)).
 - ts: Fixed `.fetchNullable()` to be robust towards accounts only holding a balance ([#2301](https://github.com/coral-xyz/anchor/pull/2301)).
+- lang: Only add public enums to the IDL ([#2309](https://github.com/coral-xyz/anchor/pull/2309)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -484,7 +484,12 @@ fn parse_ty_defs(ctx: &CrateContext, no_docs: bool) -> Result<Vec<IdlTypeDefinit
                 ty: IdlTypeDefinitionTy::Struct { fields },
             }))
         })
-        .chain(ctx.enums().map(|enm| {
+        .chain(ctx.enums().filter_map(|enm| {
+            // Only take public types
+            match &enm.vis {
+                syn::Visibility::Public(_) => (),
+                _ => return None,
+            }
             let name = enm.ident.to_string();
             let doc = if !no_docs {
                 docs::parse(&enm.attrs)
@@ -531,11 +536,11 @@ fn parse_ty_defs(ctx: &CrateContext, no_docs: bool) -> Result<Vec<IdlTypeDefinit
                     IdlEnumVariant { name, fields }
                 })
                 .collect::<Vec<IdlEnumVariant>>();
-            Ok(IdlTypeDefinition {
+            Some(Ok(IdlTypeDefinition {
                 name,
                 docs: doc,
                 ty: IdlTypeDefinitionTy::Enum { variants },
-            })
+            }))
         }))
         .collect()
 }


### PR DESCRIPTION
Closes https://github.com/coral-xyz/anchor/issues/2188

This PR is simpler version of https://github.com/coral-xyz/anchor/pull/2042, here we only filter out private enums and don't add the extra logic for checking if an enum is serializable. For now, just make the enum private if it's not serializable and you don't want it to show up in the IDL.