### PR TITLE
Clean up `parse_account` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+### Features
+
+- cli: Add `env` option to verifiable builds ([#2325](https://github.com/coral-xyz/anchor/pull/2325)).
+
 ## [0.26.0] - 2022-12-15
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ The minor version will be incremented upon a breaking change and the patch versi
 ## [Unreleased]
 
 ### Features
-
 - cli: Add `env` option to verifiable builds ([#2325](https://github.com/coral-xyz/anchor/pull/2325)).
+
+### Fixes
+
+### Breaking
 
 ## [0.26.0] - 2022-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
+- create an intentional merge conflict
+
 ## [0.26.0] - 2022-12-15
 
 ### Features

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -350,10 +350,21 @@ fn option_to_inner_path(path: &Path) -> ParseResult<Path> {
 }
 
 fn ident_string(f: &syn::Field) -> ParseResult<(String, bool, Path)> {
+    // TODO support parsing references to account infos
     let mut path = match &f.ty {
         syn::Type::Path(ty_path) => ty_path.path.clone(),
-        _ => return Err(ParseError::new(f.ty.span(), "invalid account type given")),
+        _ => {
+            return Err(ParseError::new_spanned(
+                f,
+                format!(
+                    "Field {} has a non-path type",
+                    f.ident.as_ref().expect("named fields only")
+                ),
+            ))
+        }
     };
+
+    // TODO replace string matching with helper functions using syn type match statments
     let mut optional = false;
     if parser::tts_to_string(&path)
         .replace(' ', "")

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -44,14 +44,14 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
     let message = |constraint: &str, field: &str, required: bool| {
         if required {
             format! {
-                "a non-optional {} constraint requires \
-                a non-optional {} field to exist in the account \
+                "The {} constraint requires \
+                a {} field to exist in the account \
                 validation struct. Use the Program type to add \
                 the {} field to your validation struct.", constraint, field, field
             }
         } else {
             format! {
-                "an optional {} constraint requires \
+                "An optional {} constraint requires \
                 an optional or required {} field to exist \
                 in the account validation struct. Use the Program type \
                 to add the {} field to your validation struct.", constraint, field, field
@@ -301,6 +301,7 @@ fn is_field_primitive(f: &syn::Field) -> ParseResult<bool> {
     Ok(r)
 }
 
+// TODO call `account_parse` a single time at the start of this function and then init each of the types
 fn parse_ty(f: &syn::Field) -> ParseResult<(Ty, bool)> {
     let (ident, optional, path) = ident_string(f)?;
     let ty = match ident.as_str() {

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -453,20 +453,16 @@ fn parse_account(path: &syn::Path) -> ParseResult<syn::TypePath> {
                     syn::GenericArgument::Type(syn::Type::Path(ty_path)) => {
                         parse_account(&ty_path.path)
                     }
-                    _ => {
-                        Err(ParseError::new(
-                            args.args[1].span(),
-                            "Expected a path containing: [AccountType]<'info, T>",
-                        ))
-                    }
+                    _ => Err(ParseError::new(
+                        args.args[1].span(),
+                        "Expected a path containing: [AccountType]<'info, T>",
+                    )),
                 }
             }
-            _ => {
-                Err(ParseError::new(
-                    segment.arguments.span(),
-                    "Expected angle brackets with a type: Box<[AccountType]<'info, T>",
-                ))
-            }
+            _ => Err(ParseError::new(
+                segment.arguments.span(),
+                "Expected angle brackets with a type: Box<[AccountType]<'info, T>",
+            )),
         },
         _ => match &segment.arguments {
             syn::PathArguments::AngleBracketed(args) => {
@@ -491,12 +487,10 @@ fn parse_account(path: &syn::Path) -> ParseResult<syn::TypePath> {
                     }
                 }
             }
-            _ => {
-                Err(ParseError::new(
-                    segment.arguments.span(),
-                    "Expected angle brackets with a type: [AccountType]<'info, T>",
-                ))
-            }
+            _ => Err(ParseError::new(
+                segment.arguments.span(),
+                "Expected angle brackets with a type: [AccountType]<'info, T>",
+            )),
         },
     }
 }
@@ -587,5 +581,8 @@ fn test_parse_account() {
 
     let path = syn::parse_quote! { Box<Account> };
     let err = parse_account(&path).unwrap_err();
-    assert_eq!(err.to_string(), "Expected angle brackets with a type: [AccountType]<'info, T>");
+    assert_eq!(
+        err.to_string(),
+        "Expected angle brackets with a type: [AccountType]<'info, T>"
+    );
 }


### PR DESCRIPTION
Not changing functionality or anything just cleaning up messy code with some incorrect error messages.

```
// TODO: this whole method is a hack. Do something more idiomatic.
```
Just addressing this comment 