### PR TITLE
Relax the mpl metadata package constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docker-target
 .rollup.cache/
 test-keypair.json
 tsconfig.tsbuildinfo
+.vscode

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -26,4 +26,4 @@ serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2",
 solana-program = "1.13.5"
 spl-token = { version = "3.5.0", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"], optional = true }
-mpl-token-metadata = { version = "1.4.3", optional = true, features = ["no-entrypoint"] }
+mpl-token-metadata = { version = "1.*", optional = true, features = ["no-entrypoint"] }

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -26,4 +26,4 @@ serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2",
 solana-program = "1.13.5"
 spl-token = { version = "3.5.0", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"], optional = true }
-mpl-token-metadata = { version = "1.*", optional = true, features = ["no-entrypoint"] }
+mpl-token-metadata = { version = "^1.4.3", optional = true, features = ["no-entrypoint"] }


### PR DESCRIPTION
Prepare some new changes from 
https://crates.io/crates/mpl-token-metadata/versions, and wait for the 1.7.0 public release

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/89176731/213889490-8b11fe05-34d7-4ce9-9fb1-7aaf955832cc.png">
