### PR TITLE
PDA payers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Don't regenerate idl in read_all_programs(). ([#2332](https://github.com/coral-xyz/anchor/pull/2332)).
 - ts: `provider.simulate` will send the transaction with `sigVerify: false` if no `signers` are present ([#2331](https://github.com/coral-xyz/anchor/pull/2331)).
 - idl: Update the IDL program to use non-deprecated account types ([#2365](https://github.com/coral-xyz/anchor/pull/2365)).
+- lang: Allow PDA account to be payers, i.e. `payer = `, without needing to pass in a signature ([#2371](https://github.com/coral-xyz/anchor/pull/2371)).
 
 ### Breaking
 


### PR DESCRIPTION
There was a previous PR that attempted to add this but it is out of date now and it was also a little incomplete at the time. I'm going to attempt to cover all the cases correctly but we'll see how it goes

- [ ] PDAs that are system program owned
- [ ] PDAs that are program owned (and have no data on them)
- [ ] paying for token accounts / associated token account 
            - this is a separate part because the code for token account payers might live in a different place.