### PR TITLE
make idl enum fields which are snake case have proper typing to camel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Don't regenerate idl in read_all_programs(). ([#2332](https://github.com/coral-xyz/anchor/pull/2332)).
 - ts: `provider.simulate` will send the transaction with `sigVerify: false` if no `signers` are present ([#2331](https://github.com/coral-xyz/anchor/pull/2331)).
 - idl: Update the IDL program to use non-deprecated account types ([#2365](https://github.com/coral-xyz/anchor/pull/2365)).
+- ts: Enum fields weren't being converted from snake_case to camelCase ([#2378](https://github.com/coral-xyz/anchor/pull/2378)).
 
 ### Breaking
 

--- a/tests/misc/programs/init-if-needed/src/lib.rs
+++ b/tests/misc/programs/init-if-needed/src/lib.rs
@@ -56,6 +56,7 @@ pub struct SecondInitialize<'info> {
 pub struct Close<'info> {
     #[account(mut, close = receiver)]
     pub acc: Account<'info, MyData>,
+    /// CHECK: ignore
     #[account(mut)]
     pub receiver: UncheckedAccount<'info>,
 }

--- a/tests/misc/programs/misc/src/account.rs
+++ b/tests/misc/programs/misc/src/account.rs
@@ -73,3 +73,24 @@ pub struct DataConstCastArraySize {
 pub struct DataMultidimensionalArrayConstSizes {
     pub data: [[u8; MAX_SIZE_U8 as usize]; MAX_SIZE],
 }
+
+#[account]
+pub struct CoolEnumWrapperAccount {
+    pub my_enum: CoolEnum,
+}
+
+#[derive(Clone, AnchorSerialize, AnchorDeserialize)]
+pub enum CoolEnum {
+    Variant1,
+    Variant2 {
+        config: u8,
+        user_1: Pubkey,
+        some_slot: u64,
+    },
+    Variant3 {
+        config: u8,
+        user_1: Pubkey,
+        user_2: Pubkey,
+        some_slot: u64,
+    },
+}

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -487,6 +487,7 @@ pub struct TestAuthorityConstraint<'info> {
     )]
     pub token: Account<'info, TokenAccount>,
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub fake_authority: AccountInfo<'info>,
 }
 #[derive(Accounts)]
@@ -516,7 +517,9 @@ pub struct TestMintConstraint<'info> {
         mint::freeze_authority = freeze_authority
     )]
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub mint_authority: AccountInfo<'info>,
+    /// CHECK: ignore
     pub freeze_authority: AccountInfo<'info>,
 }
 
@@ -536,7 +539,9 @@ pub struct TestMintAuthorityConstraint<'info> {
         mint::freeze_authority = freeze_authority
     )]
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub mint_authority: AccountInfo<'info>,
+    /// CHECK: ignore
     pub freeze_authority: AccountInfo<'info>,
 }
 
@@ -546,6 +551,7 @@ pub struct TestMintOneAuthorityConstraint<'info> {
         mint::authority = mint_authority,
     )]
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub mint_authority: AccountInfo<'info>,
 }
 
@@ -557,6 +563,7 @@ pub struct TestMintMissMintAuthConstraint<'info> {
         mint::freeze_authority = freeze_authority,
     )]
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub freeze_authority: AccountInfo<'info>,
 }
 
@@ -568,5 +575,6 @@ pub struct TestAssociatedToken<'info> {
     )]
     pub token: Account<'info, TokenAccount>,
     pub mint: Account<'info, Mint>,
+    /// CHECK: ignore
     pub authority: AccountInfo<'info>,
 }

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -2253,6 +2253,22 @@ const miscTest = (
         );
         assert.isDefined(thisTx);
       });
+      it("Can access enum variant fields using camel case without throwing a type error", async () => {
+        const anotherProgram = new anchor.Program<Misc>(
+          miscIdl,
+          program.programId,
+          provider
+        );
+        const enumWrappers =
+          await anotherProgram.account.coolEnumWrapperAccount.all();
+        for (let enumWrapper of enumWrappers) {
+          // this code never gets run so just putting whatever
+          console.log(enumWrapper.account.myEnum.variant2?.someSlot);
+          console.log(enumWrapper.account.myEnum.variant2?.user1);
+          console.log(enumWrapper.account.myEnum.variant3?.someSlot);
+          console.log(enumWrapper.account.myEnum.variant3?.user2);
+        }
+      });
     });
   };
 };

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -163,11 +163,9 @@ type UnboxToUnion<T> = T extends (infer U)[]
   ? UnboxToUnion<V>
   : T;
 
-
-type SnakeToCamelCase<S extends string> =
-  S extends `${infer T}_${infer U}` ?
-  `${T}${Capitalize<SnakeToCamelCase<U>>}` :
-  S
+type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
+  ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
+  : S;
 
 /**
  * decode single enum.field
@@ -184,7 +182,10 @@ declare type DecodeEnumFields<
   Defined
 > = F extends IdlEnumFieldsNamed
   ? {
-      [F2 in F[number] as SnakeToCamelCase<F2["name"]>]: DecodeEnumField<F2["type"], Defined>;
+      [F2 in F[number] as SnakeToCamelCase<F2["name"]>]: DecodeEnumField<
+        F2["type"],
+        Defined
+      >;
     }
   : F extends IdlEnumFieldsTuple
   ? {

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -163,6 +163,12 @@ type UnboxToUnion<T> = T extends (infer U)[]
   ? UnboxToUnion<V>
   : T;
 
+
+type SnakeToCamelCase<S extends string> =
+  S extends `${infer T}_${infer U}` ?
+  `${T}${Capitalize<SnakeToCamelCase<U>>}` :
+  S
+
 /**
  * decode single enum.field
  */
@@ -178,7 +184,7 @@ declare type DecodeEnumFields<
   Defined
 > = F extends IdlEnumFieldsNamed
   ? {
-      [F2 in F[number] as F2["name"]]: DecodeEnumField<F2["type"], Defined>;
+      [F2 in F[number] as SnakeToCamelCase<F2["name"]>]: DecodeEnumField<F2["type"], Defined>;
     }
   : F extends IdlEnumFieldsTuple
   ? {


### PR DESCRIPTION
solves #2374

fixes:
ts: idl enum field types properly convert from snake case to camel case
