### PR TITLE
Make the return type of `AccountClient.fetchMultiple` consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- ts: Make the return type of `AccountClient.fetchMultiple` match the account type being fetched ([#2390](https://github.com/coral-xyz/anchor/pull/2390))
 - cli: Don't regenerate idl in read_all_programs(). ([#2332](https://github.com/coral-xyz/anchor/pull/2332)).
 - ts: `provider.simulate` will send the transaction with `sigVerify: false` if no `signers` are present ([#2331](https://github.com/coral-xyz/anchor/pull/2331)).
 - cli: Failing commands will return the correct exit status. ([#2370](https://github.com/coral-xyz/anchor/pull/2370)).

--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -211,7 +211,7 @@ export class AccountClient<
   async fetchMultiple(
     addresses: Address[],
     commitment?: Commitment
-  ): Promise<(Object | null)[]> {
+  ): Promise<(T | null)[]> {
     const accounts = await this.fetchMultipleAndContext(addresses, commitment);
     return accounts.map((account) => (account ? account.data : null));
   }
@@ -225,7 +225,7 @@ export class AccountClient<
   async fetchMultipleAndContext(
     addresses: Address[],
     commitment?: Commitment
-  ): Promise<({ data: Object; context: Context } | null)[]> {
+  ): Promise<({ data: T; context: Context } | null)[]> {
     const accounts = await rpcUtil.getMultipleAccountsAndContext(
       this._provider.connection,
       addresses.map((address) => translateAddress(address)),


### PR DESCRIPTION
`fetchMultiple` currently returns `(Object | null)[]`, but it should return the account type similarly to `fetch` and `fetchNullable`, which would be `(T | null)[]`