### PR TITLE
Add master edition account deserialization to spl metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- spl: Add `MasterEditionAccount` account deserialization to spl metadata ([#2393](https://github.com/coral-xyz/anchor/pull/2393)).
 - lang: Add the `InitSpace` derive macro to automatically calculate the space at the initialization of an account ([#2346](https://github.com/coral-xyz/anchor/pull/2346)).
 - cli: Add `env` option to verifiable builds ([#2325](https://github.com/coral-xyz/anchor/pull/2325)).
 - cli: Add `idl close` command to close a program's IDL account ([#2329](https://github.com/coral-xyz/anchor/pull/2329)).

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -543,6 +543,35 @@ impl Deref for MetadataAccount {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct MasterEditionAccount(mpl_token_metadata::state::MasterEditionV2);
+
+impl MasterEditionAccount {
+    pub const LEN: usize = mpl_token_metadata::state::MAX_MASTER_EDITION_LEN;
+}
+
+impl anchor_lang::AccountDeserialize for MasterEditionAccount {
+    fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        let result = mpl_token_metadata::state::MasterEditionV2::safe_deserialize(buf)?;
+        Ok(MasterEditionAccount(result))
+    }
+}
+
+impl Deref for MasterEditionAccount {
+    type Target = mpl_token_metadata::state::MasterEditionV2;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl anchor_lang::AccountSerialize for MasterEditionAccount {}
+
+impl anchor_lang::Owner for MasterEditionAccount {
+    fn owner() -> Pubkey {
+        ID
+    }
+}
+
 #[derive(Clone)]
 pub struct Metadata;
 


### PR DESCRIPTION
## Changes
- Include MasterEditionAccount to spl metadata to deserialize master edition v2 accounts

```rust
pub struct CreateDrop<'info> {
    /// authority over and payer for the drop
    #[account(mut)]
    pub authority: Signer<'info>,

    #[account(
        seeds = [state::PREFIX.as_bytes(), Metadata::id().as_ref(), metadata_mint.key().as_ref(), state::EDITION.as_bytes()],
        seeds::program = Metadata::id(),
        bump,
    )]

    #[account(constraint = master_edition.supply > 0)]
    pub master_edition: Account<'info, MasterEditionAccount>,
    
    ...
}
```