### PR TITLE
cli: Add arch option to use `build-sbf` or `build-bpf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Add support for multithreading to the rust client: use flag `--multithreaded` ([#2321](https://github.com/coral-xyz/anchor/pull/2321)).
 - client: Add `async_rpc` a method which returns a nonblocking solana rpc client ([2322](https://github.com/coral-xyz/anchor/pull/2322)).
 - avm, cli: Use the `rustls-tls` feature of `reqwest` so that users don't need OpenSSL installed ([#2385](https://github.com/coral-xyz/anchor/pull/2385)).
+- cli: Add `--arch sbf` option to compile programs using `cargo build-sbf` ([#2398](https://github.com/coral-xyz/anchor/pull/2398)).
 
 ### Fixes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -330,6 +330,20 @@ pub enum BootstrapMode {
     Debian,
 }
 
+#[derive(ValueEnum, Parser, Clone, PartialEq, Eq, Debug)]
+pub enum ProgramArch {
+    Bpf,
+    Sbf,
+}
+impl ProgramArch {
+    pub fn build_subcommand(&self) -> &str {
+        match self {
+            Self::Bpf => "build-bpf",
+            Self::Sbf => "build-sbf",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BuildConfig {
     pub verifiable: bool,


### PR DESCRIPTION
#### Problem

Some programs use `cargo build-sbf`, like the solana-program-library, but the verifiable builds through Anchor default to `cargo build-bpf`. I noticed this while performing a verifiable build of token-2022.

#### Solution

This adds an `--arch` flag to control using `build-sbf` if you pass in `--arch sbf`, defaults to `bpf`. This way, it'll be possible to support SBFv2 and any other format that might come out. I initially had this as a simple bool flag, but the arch flag makes more sense to me. Let me know what you think!