### PR TITLE
feat: Add account-dir test-validator argument support

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2536,14 +2536,19 @@ fn validator_flags(
                         flags.push(entry["address"].as_str().unwrap().to_string());
                         flags.push(entry["filename"].as_str().unwrap().to_string());
                     }
+                } else if key == "account_dir" {
+                    for entry in value.as_array().unwrap() {
+                        flags.push("--account-dir".to_string());
+                        flags.push(entry["directory"].as_str().unwrap().to_string());
+                    }
                 } else if key == "clone" {
                     // Client for fetching accounts data
                     let client = if let Some(url) = entries["url"].as_str() {
                         RpcClient::new(url.to_string())
                     } else {
                         return Err(anyhow!(
-                    "Validator url for Solana's JSON RPC should be provided in order to clone accounts from it"
-                ));
+                            "Validator url for Solana's JSON RPC should be provided in order to clone accounts from it"
+                        ));
                     };
 
                     let mut pubkeys = value

--- a/tests/validator-clone/Anchor.toml
+++ b/tests/validator-clone/Anchor.toml
@@ -36,3 +36,9 @@ address = "mv3ekLzLbnVPNxjSKvqBpU3ZeZXPQdEC3bp5MDEBG68"
 
 [[test.validator.clone]]
 address = "8DKwAVrCEVStDYNPCsmxHtUj8LH9oXNtkVRrBfpNKvhp"
+
+[[test.validator.clone]]
+address = "8DKwAVrCEVStDYNPCsmxHtUj8LH9oXNtkVRrBfpNKvhp"
+
+[[test.validator.account_dir]]
+directory = "accounts-snapshot"

--- a/tests/validator-clone/accounts-snapshot/usdc-mint.json
+++ b/tests/validator-clone/accounts-snapshot/usdc-mint.json
@@ -1,0 +1,13 @@
+{
+  "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "account": {
+    "lamports": 182698617139,
+    "data": [
+      "AQAAABzjWe1aAS4E+hQrnHUaHF6Hz9CgFhuchf/TG3jN/Nj2pIW9lUPjEQAGAQEAAAAqnl7btTwEZ5CY/3sSZRcUQ0/AjFYqmjuGEQXmctQicw==",
+      "base64"
+    ],
+    "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "executable": false,
+    "rentEpoch": 361
+  }
+}

--- a/tests/validator-clone/tests/validator-clone.ts
+++ b/tests/validator-clone/tests/validator-clone.ts
@@ -67,4 +67,13 @@ describe("validator-clone", () => {
       assert.isNotNull(acc, "Account " + accounts[i] + " not found");
     });
   });
+
+  it("Load accounts from account-dir directory", async () => {
+    // USDC mint
+    const account = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const accountInfo = await connection.getAccountInfo(
+      new anchor.web3.PublicKey(account)
+    );
+    assert.isNotNull(accountInfo, "Account " + account + " not found");
+  });
 });


### PR DESCRIPTION
account-dir is a lot more convenient if there is a snapshot of multiple accounts.
As it would be cumbersome to add them one by one to the Anchor.toml file

I hijacked the validator-clone test but maybe it should be removed and host all sorts of test-validator simple tests?