### PR TITLE
spl: implement try_deserialize for Metaplex accounts to ensure initialization

### DIFF
--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -813,7 +813,8 @@ impl anchor_lang::AccountDeserialize for MetadataAccount {
     }
 
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        Ok(Self(mpl_token_metadata::state::Metadata::safe_deserialize(buf)?))
+        let md = mpl_token_metadata::state::Metadata::safe_deserialize(buf)?;
+        Ok(Self(md))
     }
 }
 
@@ -841,15 +842,16 @@ impl MasterEditionAccount {
 
 impl anchor_lang::AccountDeserialize for MasterEditionAccount {
     fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        let md = Self::try_deserialize_unchecked(buf)?;
-        if md.key != mpl_token_metadata::state::MasterEditionV2::key() {
+        let me = Self::try_deserialize_unchecked(buf)?;
+        if me.key != mpl_token_metadata::state::MasterEditionV2::key() {
             return Err(ErrorCode::AccountNotInitialized.into());
         }
-        Ok(md)
+        Ok(me)
     }
 
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        Ok(Self(mpl_token_metadata::state::MasterEditionV2::safe_deserialize(buf)?))
+        let result = mpl_token_metadata::state::MasterEditionV2::safe_deserialize(buf)?;
+        Ok(Self(result))
     }
 }
 

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -1,5 +1,5 @@
 use anchor_lang::context::CpiContext;
-use anchor_lang::{Accounts, Result, ToAccountInfos};
+use anchor_lang::{Accounts, ErrorCode, Result, ToAccountInfos};
 use mpl_token_metadata::state::{CollectionDetails, DataV2, TokenMetadataAccount};
 use mpl_token_metadata::ID;
 use solana_program::account_info::AccountInfo;
@@ -804,9 +804,16 @@ impl MetadataAccount {
 }
 
 impl anchor_lang::AccountDeserialize for MetadataAccount {
+    fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        let md = Self::try_deserialize_unchecked(buf)?;
+        if md.key != mpl_token_metadata::state::Metadata::key() {
+            return Err(ErrorCode::AccountNotInitialized.into());
+        }
+        Ok(md)
+    }
+
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        let result = mpl_token_metadata::state::Metadata::safe_deserialize(buf)?;
-        Ok(MetadataAccount(result))
+        Ok(Self(mpl_token_metadata::state::Metadata::safe_deserialize(buf)?))
     }
 }
 
@@ -833,9 +840,16 @@ impl MasterEditionAccount {
 }
 
 impl anchor_lang::AccountDeserialize for MasterEditionAccount {
+    fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        let md = Self::try_deserialize_unchecked(buf)?;
+        if md.key != mpl_token_metadata::state::MasterEditionV2::key() {
+            return Err(ErrorCode::AccountNotInitialized.into());
+        }
+        Ok(md)
+    }
+
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        let result = mpl_token_metadata::state::MasterEditionV2::safe_deserialize(buf)?;
-        Ok(MasterEditionAccount(result))
+        Ok(Self(mpl_token_metadata::state::MasterEditionV2::safe_deserialize(buf)?))
     }
 }
 


### PR DESCRIPTION
Currently Metaplex accounts are deserialized using [`safe_deserialize()`](https://github.com/metaplex-foundation/metaplex-program-library/blob/a649ba070d8adc58bbe4868feb8758fe194195b3/token-metadata/program/src/state/mod.rs#L100).

This is unsafe however, because `safe_deserialize` in turn calls [`is_correct_account_type()`](https://github.com/metaplex-foundation/metaplex-program-library/blob/a649ba070d8adc58bbe4868feb8758fe194195b3/token-metadata/program/src/state/mod.rs#L78) which also accepts uninitialized accounts (checks that the discriminator is either the expected key or `Key::uninitialized`).

This PR fixes this by implementing `try_deserialize` for both `Metadata` and `MasterEdition` account wrappers and introducing the required manual check.