### PR TITLE
Fix unsafe math operation in idl generation

### DIFF
--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -273,7 +273,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             anchor_lang::prelude::msg!("Instruction: IdlWrite");
 
             let prev_len: usize = ::std::convert::TryInto::<usize>::try_into(accounts.idl.data_len).unwrap();
-            let new_len: usize = prev_len + idl_data.len();
+            let new_len: usize = prev_len + idl_data.len() as usize;
             accounts.idl.data_len = accounts.idl.data_len.checked_add(::std::convert::TryInto::<u32>::try_into(idl_data.len()).unwrap()).unwrap();
 
             use IdlTrailingData;


### PR DESCRIPTION
The soteria automated code auditor is now flagging all programs that use anchor 0.27.0 with an unsafe add. For example, in a program called staking_options, the output is below. This is new behavior in 0.27.0, the same program passes the auditor with 0.26.0.


=============This arithmetic operation may be UNSAFE!================
Found a potential vulnerability at line 16, column 1 in programs/staking-options/src/lib.rs
The add operation may result in overflows:

 10|pub use crate::common::*;
 11|pub use crate::errors::SOErrorCode;
 12|pub use crate::instructions::*;
 13|
 14|declare_id!("4yx1NJ4Vqf2zT1oVLk4SySBhhDJXmXFt88ncm4gPxtL7");
 15|
>16|#[program]
 17|pub mod staking_options {
 18|    use super::*;
 19|
 20| 
 21|    pub fn add_tokens(ctx: Context<AddTokens>, num_tokens_to_add: u64) -> Result<()> {
 22|        add_tokens::add_tokens(ctx, num_tokens_to_add)
>>>Stack Trace:
>>>staking_options::try_entry::hb8cf534d59117bf4 [programs/staking-options/src/lib.rs:16]
>>>  staking_options::dispatch::hebac4e8e8d499657 [programs/staking-options/src/lib.rs:16]
>>>    staking_options::__private::__idl::__idl_dispatch::h3d0da0ec994a9706 [programs/staking-options/src/lib.rs:16]
>>>      staking_options::__private::__idl::__idl_write::h51bca92fd7f3e0d7 [programs/staking-options/src/lib.rs:16]

 - ✔ [00m:00s] Building Static Happens-Before Graph                                    
 - ✔ [00m:00s] Detecting Vulnerabilities                         
detected 0 untrustful accounts in total.
detected 1 unsafe math operations in total.

--------The summary of potential vulnerabilities in all.ll--------

(Note: Soteria checks 5 common vulnerabilities in Solana programs w/o Anchor;
for sec3's advanced X-ray scanner, please visit https://sec3.dev/x-ray)

         1 unsafe arithmetic issues
