### PR TITLE
Replace unsafe arithmetic with checked_add

### DIFF
--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -273,7 +273,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             anchor_lang::prelude::msg!("Instruction: IdlWrite");
 
             let prev_len: usize = ::std::convert::TryInto::<usize>::try_into(accounts.idl.data_len).unwrap();
-            let new_len: usize = prev_len + idl_data.len() as usize;
+            let new_len: usize = prev_len.checked_add(idl_data.len()).unwrap() as usize;
             accounts.idl.data_len = accounts.idl.data_len.checked_add(::std::convert::TryInto::<u32>::try_into(idl_data.len()).unwrap()).unwrap();
 
             use IdlTrailingData;


### PR DESCRIPTION
We run an automated auditor on our contracts. After upgrading to 0.27.0, we started seeing this error show up in the reports. There is an unsafe arithmetic operation in the `__idl_write` function. This PR updates it to use `checked_sum` instead. 

```
Analyzing /home/ubuntu/clockwork/programs/thread/.coderrect/build/bpfel-unknown-unknown/release/all.ll ...
Cargo.toml: anchor_lang version: 0.27.0
anchor_lang_version: 0.27.0 anchorVersionTooOld: 0
Cargo.toml: anchor_lang version: 0.27.0
anchor_lang_version: 0.27.0 anchorVersionTooOld: 0
 - ✔ [00m:03s] Loading IR From File
 - ▘ [00m:00s] Running Compiler Optimization Passes
EntryPoints:
entrypoint
 - ✔ [00m:00s] Running Compiler Optimization Passes
 - ✔ [00m:01s] Running Pointer Analysis
=============This arithmetic operation may be UNSAFE!================
Found a potential vulnerability at line 23, column 1 in programs/thread/src/lib.rs
The add operation may result in overflows:

 17|use instructions::*;
 18|use state::*;
 19|
 20|declare_id!("CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh");
 21|
 22|/// Program for creating transaction threads on Solana.
>23|#[program]
 24|pub mod thread_program {
 25|    use super::*;
 26|
 27|    /// Return the crate information via `sol_set_return_data/sol_get_return_data`
 28|    pub fn get_crate_info(ctx: Context<GetCrateInfo>) -> Result<CrateInfo> {
 29|        get_crate_info::handler(ctx)
>>>Stack Trace:
>>>clockwork_thread_program::try_entry::hbb84678ed52dface [programs/thread/src/lib.rs:23]
>>>  clockwork_thread_program::dispatch::h293401d576feb4f4 [programs/thread/src/lib.rs:23]
>>>    clockwork_thread_program::__private::__idl::__idl_dispatch::haf1f701bdedf3b7b [programs/thread/src/lib.rs:23]
>>>      clockwork_thread_program::__private::__idl::__idl_write::hdbe58065e9110f8a [programs/thread/src/lib.rs:23]

 - ✔ [00m:02s] Building Static Happens-Before Graph
 - ✔ [00m:00s] Detecting Vulnerabilities
detected 0 untrustful accounts in total.
detected 1 unsafe math operations in total.

--------The summary of potential vulnerabilities in all.ll--------

(Note: Soteria checks 5 common vulnerabilities in Solana programs w/o Anchor;
for sec3's advanced X-ray scanner, please visit https://sec3.dev/x-ray)

	 1 unsafe arithmetic issues

```