### PR TITLE
fix:  used identifiers in handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 - ts: Narrowed `AccountClient` type to it's appropriate account type ([#2440](https://github.com/coral-xyz/anchor/pull/2440))
+- lang: Fix inability to use identifiers `program_id`, `accounts`, `ix_data`, `remaining_accounts` in instruction arguments ([#2464](https://github.com/coral-xyz/anchor/pull/2464))
 
 ### Breaking
+- lang: Identifiers that are intended for internal usage(`program_id`, `accounts`, `ix_data`, `remaining_accounts`) have been renamed with `__` prefix ([#2464](https://github.com/coral-xyz/anchor/pull/2464))
 
 ## [0.27.0] - 2023-03-08
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -480,7 +480,7 @@ fn generate_constraint_init_group(
                 quote! {
                     let (__pda_address, __bump) = Pubkey::find_program_address(
                         &[#maybe_seeds_plus_comma],
-                        program_id,
+                        __program_id,
                     );
                     __bumps.insert(#name_str.to_string(), __bump);
                     #validate_pda
@@ -754,7 +754,7 @@ fn generate_constraint_init_group(
             let (owner, owner_optional_check) = match owner {
                 None => (
                     quote! {
-                        program_id
+                        __program_id
                     },
                     quote! {},
                 ),
@@ -862,7 +862,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
             // If they specified a seeds::program to use when deriving the PDA, use it.
             .map(|program_id| quote! { #program_id.key() })
             // Otherwise fall back to the current program's program_id.
-            .unwrap_or(quote! { program_id });
+            .unwrap_or(quote! { __program_id });
 
         // If the seeds came with a trailing comma, we need to chop it off
         // before we interpolate them below.

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -113,13 +113,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 pub fn #ix_method_name(
                     __program_id: &Pubkey,
                     __accounts: &[AccountInfo],
-                    ix_data: &[u8],
+                    __ix_data: &[u8],
                 ) -> anchor_lang::Result<()> {
                     #[cfg(not(feature = "no-log-ix-name"))]
                     anchor_lang::prelude::msg!(#ix_name_log);
 
                     // Deserialize data.
-                    let ix = instruction::#ix_name::deserialize(&mut &ix_data[..])
+                    let ix = instruction::#ix_name::deserialize(&mut &__ix_data[..])
                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                     let instruction::#variant_arm = ix;
 
@@ -129,11 +129,11 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     let mut __reallocs = std::collections::BTreeSet::new();
 
                     // Deserialize accounts.
-                    let mut remaining_accounts: &[AccountInfo] = __accounts;
+                    let mut __remaining_accounts: &[AccountInfo] = __accounts;
                     let mut __accounts = #anchor::try_accounts(
                         __program_id,
-                        &mut remaining_accounts,
-                        ix_data,
+                        &mut __remaining_accounts,
+                        __ix_data,
                         &mut __bumps,
                         &mut __reallocs,
                     )?;
@@ -143,7 +143,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         anchor_lang::context::Context::new(
                             __program_id,
                             &mut __accounts,
-                            remaining_accounts,
+                            __remaining_accounts,
                             __bumps,
                         ),
                         #(#ix_arg_names),*

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -111,8 +111,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             quote! {
                 #[inline(never)]
                 pub fn #ix_method_name(
-                    program_id: &Pubkey,
-                    accounts: &[AccountInfo],
+                    __program_id: &Pubkey,
+                    __accounts: &[AccountInfo],
                     ix_data: &[u8],
                 ) -> anchor_lang::Result<()> {
                     #[cfg(not(feature = "no-log-ix-name"))]
@@ -129,9 +129,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     let mut __reallocs = std::collections::BTreeSet::new();
 
                     // Deserialize accounts.
-                    let mut remaining_accounts: &[AccountInfo] = accounts;
-                    let mut accounts = #anchor::try_accounts(
-                        program_id,
+                    let mut remaining_accounts: &[AccountInfo] = __accounts;
+                    let mut __accounts = #anchor::try_accounts(
+                        __program_id,
                         &mut remaining_accounts,
                         ix_data,
                         &mut __bumps,
@@ -141,8 +141,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     // Invoke user defined handler.
                     let result = #program_name::#ix_method_name(
                         anchor_lang::context::Context::new(
-                            program_id,
-                            &mut accounts,
+                            __program_id,
+                            &mut __accounts,
                             remaining_accounts,
                             __bumps,
                         ),
@@ -153,7 +153,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     #maybe_set_return_data
 
                     // Exit routine.
-                    accounts.exit(program_id)
+                    __accounts.exit(__program_id)
                 }
             }
         })

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -309,7 +309,7 @@ impl Field {
         let field_str = field.to_string();
         let container_ty = self.container_ty();
         let owner_addr = match &kind {
-            None => quote! { program_id },
+            None => quote! { __program_id },
             Some(InitKind::Program { .. }) => quote! {
                 __program_id
             },

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -311,7 +311,7 @@ impl Field {
         let owner_addr = match &kind {
             None => quote! { program_id },
             Some(InitKind::Program { .. }) => quote! {
-                program_id
+                __program_id
             },
             _ => quote! {
                 &anchor_spl::token::ID

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -725,3 +725,21 @@ pub struct TestAssociatedTokenWithTokenProgramConstraint<'info> {
     /// CHECK: ignore
     pub associated_token_token_program: AccountInfo<'info>,
 }
+
+#[derive(Accounts)]
+#[instruction(
+    program_id: u8,
+    accounts: u8,
+    ix_data: u8,
+    remaining_accounts: u8
+)]
+pub struct TestUsedIdentifiers<'info> {
+    #[account(
+        constraint = 1 == program_id,
+        constraint = 2 == accounts,
+        constraint = 3 == ix_data,
+        constraint = 4 == remaining_accounts,
+    )]
+    /// CHECK: ignore
+    pub authority: AccountInfo<'info>,
+}

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -741,5 +741,30 @@ pub struct TestUsedIdentifiers<'info> {
         constraint = 4 == remaining_accounts,
     )]
     /// CHECK: ignore
-    pub authority: AccountInfo<'info>,
+    pub test: AccountInfo<'info>,
+
+    #[account(
+        seeds = [&[program_id], &[accounts], &[ix_data], &[remaining_accounts]],
+        bump = program_id,
+    )]
+    /// CHECK: ignore
+    pub test1: AccountInfo<'info>,
+    #[account(
+        seeds = [&[program_id], &[accounts], &[ix_data], &[remaining_accounts]],
+        bump = accounts,
+    )]
+    /// CHECK: ignore
+    pub test2: AccountInfo<'info>,
+    #[account(
+        seeds = [&[program_id], &[accounts], &[ix_data], &[remaining_accounts]],
+        bump = ix_data,
+    )]
+    /// CHECK: ignore
+    pub test3: AccountInfo<'info>,
+    #[account(
+        seeds = [&[program_id], &[accounts], &[ix_data], &[remaining_accounts]],
+        bump = remaining_accounts,
+    )]
+    /// CHECK: ignore
+    pub test4: AccountInfo<'info>,
 }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -395,7 +395,7 @@ pub mod misc {
 
     #[allow(unused_variables)]
     pub fn test_used_identifiers(
-        _ctx: Context<Initialize>,
+        _ctx: Context<TestUsedIdentifiers>,
         program_id: u8,
         accounts: u8,
         ix_data: u8,

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -392,4 +392,15 @@ pub mod misc {
     pub fn test_associated_token_with_token_program_constraint(_ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>) -> Result<()> {
         Ok(())
     }
+
+    #[allow(unused_variables)]
+    pub fn test_used_identifiers(
+        _ctx: Context<Initialize>,
+        program_id: u8,
+        accounts: u8,
+        ix_data: u8,
+        remaining_accounts: u8
+    ) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tests/zero-copy/programs/zero-copy/src/lib.rs
+++ b/tests/zero-copy/programs/zero-copy/src/lib.rs
@@ -97,7 +97,7 @@ pub struct CreateBar<'info> {
         init,
         seeds = [authority.key().as_ref(), foo.key().as_ref()],
         bump,
-        payer = authority, owner = ID(),
+        payer = authority, owner = ID,
         space = Bar::LEN + 8
     )]
     bar: AccountLoader<'info, Bar>,

--- a/tests/zero-copy/programs/zero-copy/src/lib.rs
+++ b/tests/zero-copy/programs/zero-copy/src/lib.rs
@@ -97,7 +97,7 @@ pub struct CreateBar<'info> {
         init,
         seeds = [authority.key().as_ref(), foo.key().as_ref()],
         bump,
-        payer = authority, owner = *program_id,
+        payer = authority, owner = ID(),
         space = Bar::LEN + 8
     )]
     bar: AccountLoader<'info, Bar>,


### PR DESCRIPTION
This PR fixes the issue #55 

It is a bit old, I hope it is still relevant.
The `nonce` identifier does not seem to be used anymore.
