### PR TITLE
Use fixed version for `winnow` crate to fix new builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-token",
  "spl-token-2022",
+ "winnow",
 ]
 
 [[package]]
@@ -5488,6 +5489,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -29,3 +29,8 @@ spl-token = { version = "3.5.0", features = ["no-entrypoint"], optional = true }
 spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"], optional = true }
 mpl-token-metadata = { version = "^1.9.0", optional = true, features = ["no-entrypoint"] }
+
+# TODO: Remove after updating to latest version of platform-tools.
+# Latest solana version(1.14.17) as of 2023-05-01 comes with rustc 1.62.0-dev but MSRV for latest
+# version of this crate is 1.64.0. See https://github.com/solana-labs/solana/pull/31418
+winnow = "=0.4.1"


### PR DESCRIPTION
The latest release of Solana(1.14.17) comes with rustc 1.62.0-dev which causes issues with `winnow` crate's latest version(MSRV 1.64.0).

Any new build without a lock file that uses `spl-token-2022` crate fails including [CI](https://github.com/coral-xyz/anchor/actions/runs/4839989051/jobs/8625367091?pr=2477).

This PR adds a temporary entry for `anchor-spl` that fixates `winnow`'s version to 0.4.1(MSRV 1.60.0).

Also made this PR for v.14 branch on Solana repo to use the latest version of platform-tools(rustc 1.68.0) https://github.com/solana-labs/solana/pull/31418