### PR TITLE
Fix match condition

### DIFF
--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -162,7 +162,7 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     ));
                 }
             }
-            match kind {
+            match &field.constraints.init.as_ref().unwrap().kind {
                 // This doesn't catch cases like account.key() or account.key.
                 // My guess is that doesn't happen often and we can revisit
                 // this if I'm wrong.


### PR DESCRIPTION
Hello,

I found an issue regarding the error message that is supposed to be raised when using a Pubkey for the `token::mint` constraint on a initialized token account.

the following code correctly raise the error: `the mint constraint has to be an account field for token initializations (not a public key)`.
```rs
#[derive(Accounts)]
pub struct TestInitConstraint<'info> {
    #[account(
        init,
        payer = payer,
        token::mint = crate::ID,
        token::authority = payer,
    )]
    pub token: Account<'info, TokenAccount>,

    #[account(mut)]
    pub payer: Signer<'info>,
    pub system_program: Program<'info, System>,
    pub token_program: Program<'info, Token>,
}
```

But not this one:
```rs
#[derive(Accounts)]
pub struct TestInitConstraint<'info> {
    #[account(
        init,
        payer = payer,
        mint::decimals = 0,
        mint::authority = payer,
    )]
    pub mint: Account<'info, Mint>,

    #[account(
        init,
        payer = payer,
        token::mint = crate::ID,
        token::authority = payer,
    )]
    pub token: Account<'info, TokenAccount>,
    #[account(mut)]
    pub payer: Signer<'info>,
    pub system_program: Program<'info, System>,
    pub token_program: Program<'info, Token>,
}
```

The guilty is the following match that seems to use the wrong variable.
https://github.com/coral-xyz/anchor/blob/ac86e15756b8bde5d15fde5ebe0f46f47bcb5049/lang/syn/src/parser/accounts/mod.rs#L165

https://github.com/coral-xyz/anchor/blob/ac86e15756b8bde5d15fde5ebe0f46f47bcb5049/lang/syn/src/parser/accounts/mod.rs#L91