### PR TITLE
Add error message when Mint and TokenAccount with `init` are not ordered correctly

### DIFF
--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -183,10 +183,14 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 InitKind::Mint { .. } => {
                     if init_fields.iter().enumerate().any(|(f_pos, f)| {
                         match &f.constraints.init.as_ref().unwrap().kind {
-                            InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. } => {
-                                mint.to_token_stream().to_string().starts_with(&field.ident.to_string()) && pos > f_pos
+                            InitKind::Token { mint, .. }
+                            | InitKind::AssociatedToken { mint, .. } => {
+                                mint.to_token_stream()
+                                    .to_string()
+                                    .starts_with(&field.ident.to_string())
+                                    && pos > f_pos
                             }
-                            _ => false
+                            _ => false,
                         }
                     }) {
                         return Err(ParseError::new(

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -185,17 +185,14 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                         match &f.constraints.init.as_ref().unwrap().kind {
                             InitKind::Token { mint, .. }
                             | InitKind::AssociatedToken { mint, .. } => {
-                                mint.to_token_stream()
-                                    .to_string()
-                                    .starts_with(&field.ident.to_string())
-                                    && pos > f_pos
+                                field.ident == mint.to_token_stream().to_string() && pos > f_pos
                             }
                             _ => false,
                         }
                     }) {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "because of the init constraint, the mint has to be declared before any corresponding token account",
+                            "because of the init constraint, the mint has to be declared before the corresponding token account",
                         ));
                     }
                 }


### PR DESCRIPTION
Hi,

Following the closed PR https://github.com/coral-xyz/anchor/pull/2467, here is another proposal for the issue https://github.com/coral-xyz/anchor/issues/2463.
Now, the following code will throw an error.
```rs
#[derive(Accounts)]
pub struct TestInitConstraint<'info> {
    #[account(
        init,
        payer = payer,
        token::mint = mint,
        token::authority = payer,
    )]
    pub token: Account<'info, TokenAccount>,

    #[account(
        init,
        payer = payer,
        mint::decimals = 0,
        mint::authority = payer,
    )]
    pub mint: Account<'info, Mint>,

    #[account(mut)]
    pub payer: Signer<'info>,
    pub system_program: Program<'info, System>,
    pub token_program: Program<'info, Token>,
}
```

What do you think?