### PR TITLE
cli: [Bug] Fix incorrect metadata.address generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - ts: Narrowed `AccountClient` type to it's appropriate account type ([#2440](https://github.com/coral-xyz/anchor/pull/2440))
 - lang: Fix inability to use identifiers `program_id`, `accounts`, `ix_data`, `remaining_accounts` in instruction arguments ([#2464](https://github.com/coral-xyz/anchor/pull/2464))
+- cli: Fix incorrect `metadata.address` generation in IDL after deploying with a custom keypair ([#2485](https://github.com/coral-xyz/anchor/pull/2485))
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3024,14 +3024,19 @@ fn deploy(
 
             println!("Program path: {binary_path}...");
 
-            let program_keypair_filepath = match &program_keypair {
-                Some(program_keypair) => program_keypair.clone(),
-                None => program.keypair_file()?.path().display().to_string(),
+            let (program_keypair_filepath, program_id) = match &program_keypair {
+                Some(path) => (
+                    path.clone(),
+                    solana_sdk::signature::read_keypair_file(path)
+                        .map_err(|_| anyhow!("Unable to read keypair file"))?
+                        .pubkey(),
+                ),
+                None => (
+                    program.keypair_file()?.path().display().to_string(),
+                    program.pubkey()?,
+                ),
             };
-            let program_id = solana_sdk::signature::read_keypair_file(program_keypair_filepath.clone()).map_err(
-                |_| anyhow!("Unable to read keypair file")
-            ).unwrap().pubkey();
-            
+
             // Send deploy transactions.
             let exit = std::process::Command::new("solana")
                 .arg("program")
@@ -3052,11 +3057,10 @@ fn deploy(
                 std::process::exit(exit.status.code().unwrap_or(1));
             }
 
-            let program_pubkey = program_id;
             if let Some(mut idl) = program.idl.as_mut() {
                 // Add program address to the IDL.
                 idl.metadata = Some(serde_json::to_value(IdlTestMetadata {
-                    address: program_pubkey.to_string(),
+                    address: program_id.to_string(),
                 })?);
 
                 // Persist it.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3028,7 +3028,10 @@ fn deploy(
                 Some(program_keypair) => program_keypair.clone(),
                 None => program.keypair_file()?.path().display().to_string(),
             };
-
+            let program_id = solana_sdk::signature::read_keypair_file(program_keypair_filepath.clone()).map_err(
+                |_| anyhow!("Unable to read keypair file")
+            ).unwrap().pubkey();
+            
             // Send deploy transactions.
             let exit = std::process::Command::new("solana")
                 .arg("program")
@@ -3049,7 +3052,7 @@ fn deploy(
                 std::process::exit(exit.status.code().unwrap_or(1));
             }
 
-            let program_pubkey = program.pubkey()?;
+            let program_pubkey = program_id;
             if let Some(mut idl) = program.idl.as_mut() {
                 // Add program address to the IDL.
                 idl.metadata = Some(serde_json::to_value(IdlTestMetadata {


### PR DESCRIPTION
Currently when running `anchor deploy --program-name <name> --program-keypair <specified keypair>` the cli still uses the auto-generated keypair when fetching the program id to add to the IDL metadata at the end. It should instead use the address from the specified keypair.