### PR TITLE
fix: remove skip preflight from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Narrowed `AccountClient` type to it's appropriate account type ([#2440](https://github.com/coral-xyz/anchor/pull/2440))
 - lang: Fix inability to use identifiers `program_id`, `accounts`, `ix_data`, `remaining_accounts` in instruction arguments ([#2464](https://github.com/coral-xyz/anchor/pull/2464))
 - cli: Fix incorrect `metadata.address` generation in IDL after deploying with a custom keypair ([#2485](https://github.com/coral-xyz/anchor/pull/2485))
+- cli: IDL commands no longer hang when the payer doesn't have funds to pay for the transaction fee ([#2492](https://github.com/coral-xyz/anchor/pull/2492))
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,7 +20,6 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value as JsonValue};
 use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_program::instruction::{AccountMeta, Instruction};
 use solana_sdk::account_utils::StateMut;
 use solana_sdk::bpf_loader;
@@ -1931,10 +1930,9 @@ fn idl_set_buffer(cfg_override: &ConfigOverride, program_id: Pubkey, buffer: Pub
         );
 
         // Send the transaction.
-        client.send_and_confirm_transaction_with_spinner_and_config(
+        client.send_and_confirm_transaction_with_spinner_and_commitment(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig::default(),
         )?;
 
         Ok(())
@@ -2017,10 +2015,9 @@ fn idl_set_authority(
             &[&keypair],
             latest_hash,
         );
-        client.send_and_confirm_transaction_with_spinner_and_config(
+        client.send_and_confirm_transaction_with_spinner_and_commitment(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig::default(),
         )?;
 
         println!("Authority update complete.");
@@ -2071,10 +2068,9 @@ fn idl_close_account(cfg: &Config, program_id: &Pubkey, idl_address: Pubkey) -> 
         &[&keypair],
         latest_hash,
     );
-    client.send_and_confirm_transaction_with_spinner_and_config(
+    client.send_and_confirm_transaction_with_spinner_and_commitment(
         &tx,
         CommitmentConfig::confirmed(),
-        RpcSendTransactionConfig::default(),
     )?;
 
     Ok(())
@@ -2132,10 +2128,9 @@ fn idl_write(cfg: &Config, program_id: &Pubkey, idl: &Idl, idl_address: Pubkey) 
             &[&keypair],
             latest_hash,
         );
-        client.send_and_confirm_transaction_with_spinner_and_config(
+        client.send_and_confirm_transaction_with_spinner_and_commitment(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig::default(),
         )?;
         offset += MAX_WRITE_SIZE;
     }
@@ -3163,10 +3158,9 @@ fn create_idl_account(
             &[&keypair],
             latest_hash,
         );
-        client.send_and_confirm_transaction_with_spinner_and_config(
+        client.send_and_confirm_transaction_with_spinner_and_commitment(
             &tx,
             CommitmentConfig::finalized(),
-            RpcSendTransactionConfig::default(),
         )?;
     }
 
@@ -3228,10 +3222,9 @@ fn create_idl_buffer(
     );
 
     // Send the transaction.
-    client.send_and_confirm_transaction_with_spinner_and_config(
+    client.send_and_confirm_transaction_with_spinner_and_commitment(
         &tx,
         CommitmentConfig::confirmed(),
-        RpcSendTransactionConfig::default(),
     )?;
 
     Ok(buffer.pubkey())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1934,10 +1934,7 @@ fn idl_set_buffer(cfg_override: &ConfigOverride, program_id: Pubkey, buffer: Pub
         client.send_and_confirm_transaction_with_spinner_and_config(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig {
-                skip_preflight: true,
-                ..RpcSendTransactionConfig::default()
-            },
+            RpcSendTransactionConfig::default(),
         )?;
 
         Ok(())
@@ -2023,10 +2020,7 @@ fn idl_set_authority(
         client.send_and_confirm_transaction_with_spinner_and_config(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig {
-                skip_preflight: true,
-                ..RpcSendTransactionConfig::default()
-            },
+            RpcSendTransactionConfig::default(),
         )?;
 
         println!("Authority update complete.");
@@ -2080,10 +2074,7 @@ fn idl_close_account(cfg: &Config, program_id: &Pubkey, idl_address: Pubkey) -> 
     client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
         CommitmentConfig::confirmed(),
-        RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        },
+        RpcSendTransactionConfig::default(),
     )?;
 
     Ok(())
@@ -2144,10 +2135,7 @@ fn idl_write(cfg: &Config, program_id: &Pubkey, idl: &Idl, idl_address: Pubkey) 
         client.send_and_confirm_transaction_with_spinner_and_config(
             &tx,
             CommitmentConfig::confirmed(),
-            RpcSendTransactionConfig {
-                skip_preflight: true,
-                ..RpcSendTransactionConfig::default()
-            },
+            RpcSendTransactionConfig::default(),
         )?;
         offset += MAX_WRITE_SIZE;
     }
@@ -3178,10 +3166,7 @@ fn create_idl_account(
         client.send_and_confirm_transaction_with_spinner_and_config(
             &tx,
             CommitmentConfig::finalized(),
-            RpcSendTransactionConfig {
-                skip_preflight: true,
-                ..RpcSendTransactionConfig::default()
-            },
+            RpcSendTransactionConfig::default(),
         )?;
     }
 
@@ -3246,10 +3231,7 @@ fn create_idl_buffer(
     client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
         CommitmentConfig::confirmed(),
-        RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        },
+        RpcSendTransactionConfig::default(),
     )?;
 
     Ok(buffer.pubkey())


### PR DESCRIPTION
I don't really see an argument as to why we need to skip preflight. But if there is please let me know.

Skipping preflight will cause zero balance fee payer TXs to "hang" until blockhash expiration providing no meaningful error message.

Example: Using a provider.wallet setup with balance for another cluster will easily cause the above