### PR TITLE
Update `spl-token-2022` to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.6.1",
  "toml_datetime",
  "winnow",
 ]
@@ -3727,7 +3727,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -4219,7 +4219,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -4397,7 +4397,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -4546,7 +4546,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -4579,6 +4579,24 @@ name = "spl-token-2022"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -26,7 +26,7 @@ borsh = { version = "^0.9", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = "1.14.16"
 spl-token = { version = "3.5.0", features = ["no-entrypoint"], optional = true }
-spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"], optional = true }
+spl-token-2022 = { version = "0.6.1", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"], optional = true }
 mpl-token-metadata = { version = "^1.11.0", optional = true, features = ["no-entrypoint"] }
 

--- a/tests/escrow/programs/escrow/Cargo.toml
+++ b/tests/escrow/programs/escrow/Cargo.toml
@@ -18,4 +18,3 @@ default = []
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
 anchor-spl = { path = "../../../../spl" }
-spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"] }

--- a/tests/escrow/programs/escrow/src/lib.rs
+++ b/tests/escrow/programs/escrow/src/lib.rs
@@ -16,10 +16,10 @@
 //! - Initializer will get back ownership of their token X account
 
 use anchor_lang::prelude::*;
-use anchor_spl::token_interface::{
-    self, Mint, SetAuthority, TokenAccount, TokenInterface, TransferChecked,
+use anchor_spl::{
+    token_2022::spl_token_2022::instruction::AuthorityType,
+    token_interface::{self, Mint, SetAuthority, TokenAccount, TokenInterface, TransferChecked},
 };
-use spl_token_2022::instruction::AuthorityType;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 

--- a/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
+++ b/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
@@ -16,4 +16,3 @@ cpi = ["no-entrypoint"]
 [dependencies]
 anchor-lang = { path = "../../../../../lang" }
 anchor-spl = { path = "../../../../../spl" }
-spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"] }

--- a/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
+++ b/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
@@ -1,9 +1,13 @@
 //! This example demonstrates the use of the `anchor_spl::token` CPI client.
 
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token_interface::{
-    self, Burn, Mint, MintTo, SetAuthority, TokenAccount, TokenInterface, Transfer, TransferChecked,
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token_2022::spl_token_2022,
+    token_interface::{
+        self, Burn, Mint, MintTo, SetAuthority, TokenAccount, TokenInterface, Transfer,
+        TransferChecked,
+    },
 };
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

--- a/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
+++ b/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
@@ -18,4 +18,3 @@ default = []
 [dependencies]
 anchor-lang = { path = "../../../../../lang" }
 anchor-spl = { path = "../../../../../spl" }
-spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"] }


### PR DESCRIPTION
Version 0.5.0 started to cause issues in CI, updating it to the latest version with this PR.

Also, tests no longer specify `spl-token-2022` as a dependency in Cargo.toml since `anchor-spl` already exports it.