### PR TITLE
Fix zero-copy tests

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -403,7 +403,7 @@ jobs:
             path: tests/declare-id
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
-          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-bpf
+          - cmd: cd tests/zero-copy && rustup toolchain install 1.66.1-x86_64-unknown-linux-gnu && anchor test --skip-lint && cd programs/zero-copy && cargo test-bpf
             path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat

--- a/tests/zero-copy/rust-toolchain.toml
+++ b/tests/zero-copy/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.66.1-x86_64-unknown-linux-gnu"

--- a/tests/zero-copy/rust-toolchain.toml
+++ b/tests/zero-copy/rust-toolchain.toml
@@ -1,2 +1,3 @@
+# TODO: Remove when `cargo-test-sbf` works with stable Rust
 [toolchain]
 channel = "1.66.1-x86_64-unknown-linux-gnu"


### PR DESCRIPTION
`cargo-test-bpf`(or `cargo-test-sbf`) does not work with stable Rust version. This PR adds `rust-toolchain.toml` to zero-copy tests and specifies the latest compatible Rust version(1.66.1).