### PR TITLE
cli: Add `anchor keys sync` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - bench: Add benchmarking for compute units usage ([#2466](https://github.com/coral-xyz/anchor/pull/2466))
 - cli: `idl set-buffer`, `idl set-authority` and `idl close` take an option `--print-only`. which prints transaction in a base64 Borsh compatible format but not sent to the cluster. It's helpful when managing authority under a multisig, e.g., a user can create a proposal for a `Custom Instruction` in SPL Governance ([#2486](https://github.com/coral-xyz/anchor/pull/2486)).
 - lang: Add `emit_cpi!` and `#[event_cpi]` macros(behind `event-cpi` feature flag) to store event logs in transaction metadata ([#2438](https://github.com/coral-xyz/anchor/pull/2438)).
+- cli: Add `keys sync` command to sync program id declarations ([#2505](https://github.com/coral-xyz/anchor/pull/2505)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -179,6 +179,7 @@ dependencies = [
  "heck 0.4.0",
  "pathdiff",
  "portpicker",
+ "regex",
  "reqwest",
  "semver 1.0.16",
  "serde",
@@ -2155,7 +2156,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.27",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3106,13 +3107,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3120,6 +3121,12 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remove_dir_all"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,6 +40,7 @@ dirs = "4.0"
 heck = "0.4.0"
 flate2 = "1.0.19"
 tar = "0.4.35"
+regex = "1.8.3"
 reqwest = { version = "0.11.4", default-features = false, features = ["multipart", "blocking", "rustls-tls"] }
 tokio = "1.24"
 pathdiff = "0.2.0"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3832,7 +3832,7 @@ fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Res
             }
 
             // Handle declaration in Anchor.toml
-            'outer: for (_, programs) in &mut cfg.programs {
+            'outer: for programs in cfg.programs.values_mut() {
                 for (name, mut deployment) in programs {
                     // Skip other programs
                     if name != &program.lib_name {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3828,6 +3828,7 @@ fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Res
                     fs::write(&path, content)?;
 
                     println!("Updated to {actual_program_id}\n");
+                    break;
                 }
             }
 


### PR DESCRIPTION
This PR adds `anchor keys sync` command to sync the program ids between the program files(including `Anchor.toml`) with the actual pubkey from the program keypair file.