### PR TITLE
cli: Accept program lib name for `anchor deploy --program-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add `keys sync` command to sync program id declarations ([#2505](https://github.com/coral-xyz/anchor/pull/2505)).
 - cli: Create new programs with correct program ids ([#2509](https://github.com/coral-xyz/anchor/pull/2509)).
 - cli, client, lang, spl: Update Solana toolchain and dependencies to `1.16.0` and specify maximum version of `<1.17.0` ([#2512](https://github.com/coral-xyz/anchor/pull/2512)).
+- cli: `anchor deploy` command's `--program-name` argument accepts program lib names ([#2519](https://github.com/coral-xyz/anchor/pull/2519)).
 
 ### Fixes
 


### PR DESCRIPTION
`anchor deploy` command's `--program-name` argument only expected program directory name which is very confusing because other commands expects program lib name.

This PR allows `--program-name` to be the program lib name and the old behavior(program directory name) is kept to avoid introducing breaking changes.