### PR TITLE
docker: Update org name and Ubuntu version

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -439,7 +439,7 @@ impl Config {
             .anchor_version
             .clone()
             .unwrap_or_else(|| crate::DOCKER_BUILDER_VERSION.to_string());
-        format!("projectserum/build:v{ver}")
+        format!("backpackapp/build:v{ver}")
     }
 
     pub fn discover(cfg_override: &ConfigOverride) -> Result<Option<WithPath<Config>>> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3432,7 +3432,6 @@ fn airdrop(cfg_override: &ConfigOverride) -> Result<()> {
 
 fn cluster(_cmd: ClusterCommand) -> Result<()> {
     println!("Cluster Endpoints:\n");
-    println!("* Mainnet - https://solana-api.projectserum.com");
     println!("* Mainnet - https://api.mainnet-beta.solana.com");
     println!("* Devnet  - https://api.devnet.solana.com");
     println!("* Testnet - https://api.testnet.solana.com");

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ SOLANA_CLI=v1.16.0
 #
 # Build version should match the Anchor cli version.
 #
-IMG_ORG ?= projectserum
+IMG_ORG ?= backpackapp
 IMG_VER ?= $(ANCHOR_CLI)
 
 .PHONY: build build-push build-shell publish

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -4,7 +4,7 @@
 # is released on GitHub.
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -87,7 +87,6 @@ This lists cluster endpoints:
 ```shell
 Cluster Endpoints:
 
-* Mainnet - https://solana-api.projectserum.com
 * Mainnet - https://api.mainnet-beta.solana.com
 * Devnet  - https://api.devnet.solana.com
 * Testnet - https://api.testnet.solana.com

--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -34,7 +34,7 @@ Example:
 
 ```
 [registry]
-url = "https://anchor.projectserum.com"
+url = "https://api.apr.dev"
 ```
 
 ## features

--- a/docs/src/pages/docs/verifiable-builds.md
+++ b/docs/src/pages/docs/verifiable-builds.md
@@ -37,10 +37,10 @@ If the program has an IDL, it will also check the IDL deployed on chain matches.
 
 ## Images
 
-A docker image for each version of Anchor is published on [Docker Hub](https://hub.docker.com/r/projectserum/build). They are tagged in the form `projectserum/build:<version>`. For example, to get the image for Anchor `v0.28.0` one can run
+A docker image for each version of Anchor is published on [Docker Hub](https://hub.docker.com/r/backpackapp/build). They are tagged in the form `backpackapp/build:<version>`. For example, to get the image for Anchor `v0.28.0` one can run
 
 ```shell
-docker pull projectserum/build:v0.28.0
+docker pull backpackapp/build:v0.28.0
 ```
 
 ## Removing an Image


### PR DESCRIPTION
Node LTS(18.16) doesn't seem to work with Ubuntu 18.04, bumped to Ubuntu LTS(22.04).