### PR TITLE
ts: Remove usage of `assert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- ts: Packages no longer depend on `assert` ([#2535](https://github.com/coral-xyz/anchor/pull/2535)).
+
 ### Breaking
 
 ## [0.28.0] - 2023-06-09

--- a/ts/packages/anchor/rollup.config.ts
+++ b/ts/packages/anchor/rollup.config.ts
@@ -2,7 +2,6 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import replace from "@rollup/plugin-replace";
 import commonjs from "@rollup/plugin-commonjs";
-import { terser } from "rollup-plugin-terser";
 
 const env = process.env.NODE_ENV;
 
@@ -34,7 +33,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/anchor/src/program/event.ts
+++ b/ts/packages/anchor/src/program/event.ts
@@ -1,5 +1,4 @@
 import { PublicKey } from "@solana/web3.js";
-import * as assert from "assert";
 import { IdlEvent, IdlEventField } from "../idl.js";
 import { Coder } from "../coder/index.js";
 import { DecodeType } from "./namespace/types.js";
@@ -144,8 +143,13 @@ export class EventManager {
     }
 
     // Kill the websocket connection if all listeners have been removed.
-    if (this._eventCallbacks.size == 0) {
-      assert.ok(this._eventListeners.size === 0);
+    if (this._eventCallbacks.size === 0) {
+      if (this._eventListeners.size !== 0) {
+        throw new Error(
+          `Expected event listeners size to be 0 but got ${this._eventListeners.size}`
+        );
+      }
+
       if (this._onLogsSubscriptionId !== undefined) {
         await this._provider!.connection.removeOnLogsListener(
           this._onLogsSubscriptionId
@@ -273,7 +277,9 @@ class ExecutionContext {
   stack: string[] = [];
 
   program(): string {
-    assert.ok(this.stack.length > 0);
+    if (!this.stack.length) {
+      throw new Error("Expected the stack to have elements");
+    }
     return this.stack[this.stack.length - 1];
   }
 
@@ -282,7 +288,9 @@ class ExecutionContext {
   }
 
   pop() {
-    assert.ok(this.stack.length > 0);
+    if (!this.stack.length) {
+      throw new Error("Expected the stack to have elements");
+    }
     this.stack.pop();
   }
 }

--- a/ts/packages/spl-associated-token-account/rollup.config.ts
+++ b/ts/packages/spl-associated-token-account/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-binary-option/rollup.config.ts
+++ b/ts/packages/spl-binary-option/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-binary-oracle-pair/rollup.config.ts
+++ b/ts/packages/spl-binary-oracle-pair/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-feature-proposal/rollup.config.ts
+++ b/ts/packages/spl-feature-proposal/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-governance/rollup.config.ts
+++ b/ts/packages/spl-governance/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-memo/rollup.config.ts
+++ b/ts/packages/spl-memo/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-name-service/rollup.config.ts
+++ b/ts/packages/spl-name-service/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-record/rollup.config.ts
+++ b/ts/packages/spl-record/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-stake-pool/rollup.config.ts
+++ b/ts/packages/spl-stake-pool/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-stateless-asks/rollup.config.ts
+++ b/ts/packages/spl-stateless-asks/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-token-lending/rollup.config.ts
+++ b/ts/packages/spl-token-lending/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-token-swap/rollup.config.ts
+++ b/ts/packages/spl-token-swap/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",

--- a/ts/packages/spl-token/rollup.config.ts
+++ b/ts/packages/spl-token/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "assert",
     "base64-js",
     "bn.js",
     "bs58",


### PR DESCRIPTION
`assert` is a `node` module and is not available in browsers without a polyfill.

Removed `assert` in this PR but other polyfills for browser usage is still necessary because the library depends on other `node` modules.