### PR TITLE
spl: update spl-associated-token-account version requirements

### DIFF
--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -26,6 +26,6 @@ borsh = { version = ">=0.9, <0.11", optional = true }
 mpl-token-metadata = { version = "1.11", optional = true, features = ["no-entrypoint"] }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = ">=1.14, <1.17"
-spl-associated-token-account = { version = "1", features = ["no-entrypoint"], optional = true }
+spl-associated-token-account = { version = "^1.1", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "3.5", features = ["no-entrypoint"], optional = true }
 spl-token-2022 = { version = "0.6", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
`anchor-spl` builds with `spl-associated-token-account` below version `1.1` fail with the following compile errors due to the use of functions added in after v1.1 and other breaking changes solana made to the package:

```
error[E0432]: unresolved import `spl_associated_token_account::get_associated_token_address_with_program_id`
 --> src/associated_token.rs:7:35
  |
7 |     get_associated_token_address, get_associated_token_address_with_program_id, ID,
  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |                                   |
  |                                   no `get_associated_token_address_with_program_id` in the root
  |                                   help: a similar name exists in the module: `get_associated_token_address_and_bump_seed`

error[E0425]: cannot find function `create_associated_token_account_idempotent` in module `spl_associated_token_account::instruction`
  --> src/associated_token.rs:35:57
   |
35 |       let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
   |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `create_associated_token_account`

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
  --> src/associated_token.rs:11:14
   |
11 |     let ix = spl_associated_token_account::instruction::create_associated_token_account(
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 arguments
12 |         ctx.accounts.payer.key,
   |         ----------------------
13 |         ctx.accounts.authority.key,
   |         --------------------------
14 |         ctx.accounts.mint.key,
   |         ---------------------
15 |         ctx.accounts.token_program.key,
   |         ------------------------------ supplied 4 arguments
   |
note: function defined here
```