### PR TITLE
DynSigner struct: for Solana CLI usage to wrap Box<dyn Signer> to align with Client<C>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 - lang: Add `get_lamports`, `add_lamports` and `sub_lamports` methods for all account types ([#2552](https://github.com/coral-xyz/anchor/pull/2552)).
+- client: Add a helper struct `DynSigner` to simplify use of `Client<C> where <C: Clone + Deref<Target = impl Signer>>` with Solana clap CLI utils that loads `Signer` as `Box<dyn Signer>` ([#2550](https://github.com/coral-xyz/anchor/pull/2550)).
 
 ### Fixes
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -98,6 +98,36 @@ impl<C: Clone + Deref<Target = impl Signer>> Client<C> {
     }
 }
 
+/// Auxiliary data structure to align the types of the Solana CLI utils with Anchor client.
+/// Client<C> implementation requires <C: Clone + Deref<Target = impl Signer>> which does not comply with Box<dyn Signer>
+/// that's used when loaded Signer from keypair file. This struct is used to wrap the usage.
+pub struct DynSigner(pub Arc<dyn Signer>);
+
+impl Signer for DynSigner {
+    fn pubkey(&self) -> Pubkey {
+        self.0.pubkey()
+    }
+
+    fn try_pubkey(&self) -> Result<Pubkey, solana_sdk::signer::SignerError> {
+        self.0.try_pubkey()
+    }
+
+    fn sign_message(&self, message: &[u8]) -> solana_sdk::signature::Signature {
+        self.0.sign_message(message)
+    }
+
+    fn try_sign_message(
+        &self,
+        message: &[u8],
+    ) -> Result<solana_sdk::signature::Signature, solana_sdk::signer::SignerError> {
+        self.0.try_sign_message(message)
+    }
+
+    fn is_interactive(&self) -> bool {
+        self.0.is_interactive()
+    }
+}
+
 // Internal configuration for a client.
 #[derive(Debug)]
 pub struct Config<C> {


### PR DESCRIPTION
When using Solana labs CLI utilities (solana-clap-utils, https://github.com/solana-labs/solana/tree/master/clap-utils -> https://github.com/solana-labs/solana/blob/6b013f46ebd30c82f7fa9c50c5a0e9ae32df3c44/clap-utils/src/keypair.rs#L357) the loaded signer of type `Box<dyn Signer>` is not aligned to the expected `Client<C>` type of `<C: Clone + Deref<Target = impl Signer>>`. Using the `dyn Signer` fails with error:

```
the size for values of type `dyn solana_sdk::signature::Signer` cannot be known at compilation time [E0277] doesn't have a size known at compile-time Help: the trait `Sized` is not implemented for `dyn solana_sdk::signature::Signer` Note: required by a bound in `anchor_client::Client::<C>::new_with_options`
```

Adding the helper `DynSigner` makes possible to match those types and use the Signer loded from the Solana utils with the Anchor client.

```
let fee_payer: Arc<dyn Signer> = ...
let anchor_client: Client<Arc<DynSigner>> = Client::new_with_options(
  anchor_cluster,
  Arc::new(DynSigner(fee_payer.clone())),
    CommitmentConfig::confirmed(),
);
```