### PR TITLE
fix: Allow polymorphic CPI calls matching an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Add `get_lamports`, `add_lamports` and `sub_lamports` methods for all account types ([#2552](https://github.com/coral-xyz/anchor/pull/2552)).
 - client: Add a helper struct `DynSigner` to simplify use of `Client<C> where <C: Clone + Deref<Target = impl Signer>>` with Solana clap CLI utils that loads `Signer` as `Box<dyn Signer>` ([#2550](https://github.com/coral-xyz/anchor/pull/2550)).
-- Allow CPI calls matching an interface without pinning program ID (https://github.com/coral-xyz/anchor/pull/2559)
+- lang: Allow CPI calls matching an interface without pinning program ID ([#2559](https://github.com/coral-xyz/anchor/pull/2559)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Add `get_lamports`, `add_lamports` and `sub_lamports` methods for all account types ([#2552](https://github.com/coral-xyz/anchor/pull/2552)).
 - client: Add a helper struct `DynSigner` to simplify use of `Client<C> where <C: Clone + Deref<Target = impl Signer>>` with Solana clap CLI utils that loads `Signer` as `Box<dyn Signer>` ([#2550](https://github.com/coral-xyz/anchor/pull/2550)).
+- Allow CPI calls matching an interface without pinning program ID (https://github.com/coral-xyz/anchor/pull/2559)
 
 ### Fixes
 

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -40,7 +40,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             data.append(&mut ix_data);
                             let accounts = ctx.to_account_metas(None);
                             anchor_lang::solana_program::instruction::Instruction {
-                                program_id: crate::ID,
+                                program_id: ctx.program.key(),
                                 accounts,
                                 data,
                             }


### PR DESCRIPTION
With the current implementation, CPIs can only call to the hardcoded crate program ID. With this change, you can create a base anchor program like this:

https://github.com/helium/modular-governance/blob/main/programs/vote_hook_interface/src/lib.rs

And then have a caller hit that interface with a context-dependent program ID