### PR TITLE
Remove IDL `path` field

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2381,12 +2381,14 @@ fn idl_build(no_docs: bool) -> Result<()> {
     }
 
     // Convert path to name if there are no conflicts
-    let path_regex = Regex::new(r#"\"((\w+::)+)(\w+)\""#).unwrap();
+    let path_regex = Regex::new(r#""((\w+::)+)(\w+)""#).unwrap();
     let idls = idls
         .into_iter()
         .map(|idl| {
             let mut modified_content = serde_json::to_string_pretty(&idl).unwrap();
 
+            // TODO: Remove. False positive https://github.com/rust-lang/rust-clippy/issues/10577
+            #[allow(clippy::redundant_clone)]
             for captures in path_regex.captures_iter(&modified_content.clone()) {
                 let path = captures.get(0).unwrap().as_str();
                 let name = captures.get(3).unwrap().as_str();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -17,7 +17,7 @@ use flate2::read::ZlibDecoder;
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
 use heck::{ToKebabCase, ToSnakeCase};
-use regex::RegexBuilder;
+use regex::{Regex, RegexBuilder};
 use reqwest::blocking::multipart::{Form, Part};
 use reqwest::blocking::Client;
 use semver::{Version, VersionReq};
@@ -2328,8 +2328,7 @@ fn idl_build(no_docs: bool) -> Result<()> {
                     }
 
                     let prog_ty = std::mem::take(&mut idl.types);
-                    defined_types
-                        .extend(prog_ty.into_iter().map(|ty| (ty.path.clone().unwrap(), ty)));
+                    defined_types.extend(prog_ty.into_iter().map(|ty| (ty.name.clone(), ty)));
                     idl.types = defined_types.into_values().collect::<Vec<_>>();
 
                     idls.push(idl);
@@ -2353,7 +2352,7 @@ fn idl_build(no_docs: bool) -> Result<()> {
                         event
                             .defined_types
                             .into_iter()
-                            .map(|ty| (ty.path.clone().unwrap(), ty)),
+                            .map(|ty| (ty.name.clone(), ty)),
                     );
                     state = State::Pass;
                     continue;
@@ -2381,13 +2380,35 @@ fn idl_build(no_docs: bool) -> Result<()> {
         }
     }
 
+    // Convert path to name if there are no conflicts
+    let path_regex = Regex::new(r#"\"((\w+::)+)(\w+)\""#).unwrap();
+    let idls = idls
+        .into_iter()
+        .map(|idl| {
+            let mut modified_content = serde_json::to_string_pretty(&idl).unwrap();
+
+            for captures in path_regex.captures_iter(&modified_content.clone()) {
+                let path = captures.get(0).unwrap().as_str();
+                let name = captures.get(3).unwrap().as_str();
+
+                // Replace path with name
+                let content_with_name = modified_content.replace(path, &format!(r#""{name}""#));
+
+                // Check whether there is a conflict
+                let has_conflict = content_with_name.contains(&format!("::{name}"));
+                if !has_conflict {
+                    modified_content = content_with_name;
+                }
+            }
+
+            modified_content
+        })
+        .collect::<Vec<_>>();
+
     if idls.len() == 1 {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&idls.first().unwrap()).unwrap()
-        );
-    } else if idls.len() >= 2 {
-        println!("{}", serde_json::to_string_pretty(&idls).unwrap());
+        println!("{}", idls[0]);
+    } else {
+        println!("{:?}", idls);
     };
 
     Ok(())
@@ -2670,7 +2691,7 @@ fn deserialize_idl_type_to_json(
         }
         IdlType::GenericLenArray(_, _) => todo!("Generic length arrays are not yet supported"),
         IdlType::Generic(_) => todo!("Generic types are not yet supported"),
-        IdlType::DefinedWithTypeArgs { path: _, args: _ } => {
+        IdlType::DefinedWithTypeArgs { name: _, args: _ } => {
             todo!("Defined types with type args are not yet supported")
         }
     })

--- a/lang/syn/src/idl/build.rs
+++ b/lang/syn/src/idl/build.rs
@@ -195,7 +195,7 @@ pub fn idl_type_ts_from_syn_type(
                     let params = quote! { vec![#(#params),*] };
                     Ok((
                         quote! { #idl::IdlType::DefinedWithTypeArgs {
-                            path: <#path>::__anchor_private_full_path(),
+                            name: <#path>::__anchor_private_full_path(),
                             args: #params
                         } },
                         defined,
@@ -283,7 +283,6 @@ pub fn idl_type_definition_ts_from_syn_struct(
 ) -> Result<(TokenStream, Vec<syn::TypePath>), ()> {
     let (idl, _) = get_module_paths();
 
-    let name = item_strct.ident.to_string();
     let docs = match docs::parse(&item_strct.attrs) {
         Some(docs) if !no_docs => quote! {Some(vec![#(#docs.into()),*])},
         _ => quote! {None},
@@ -324,8 +323,7 @@ pub fn idl_type_definition_ts_from_syn_struct(
     Ok((
         quote! {
             #idl::IdlTypeDefinition {
-                name: #name.into(),
-                path: Some(Self::__anchor_private_full_path()),
+                name: Self::__anchor_private_full_path(),
                 generics: #generics,
                 docs: #docs,
                 ty: #idl::IdlTypeDefinitionTy::Struct{
@@ -349,7 +347,6 @@ pub fn idl_type_definition_ts_from_syn_enum(
 ) -> Result<(TokenStream, Vec<syn::TypePath>), ()> {
     let (idl, _) = get_module_paths();
 
-    let name = enum_item.ident.to_string();
     let docs = match docs::parse(&enum_item.attrs) {
         Some(docs) if !no_docs => quote! {Some(vec![#(#docs.into()),*])},
         _ => quote! {None},
@@ -421,8 +418,7 @@ pub fn idl_type_definition_ts_from_syn_enum(
     Ok((
         quote! {
             #idl::IdlTypeDefinition {
-                name: #name.into(),
-                path: Some(Self::__anchor_private_full_path()),
+                name: Self::__anchor_private_full_path(),
                 generics: #generics,
                 docs: #docs,
                 ty: #idl::IdlTypeDefinitionTy::Enum{

--- a/lang/syn/src/idl/parse/file.rs
+++ b/lang/syn/src/idl/parse/file.rs
@@ -348,7 +348,6 @@ fn parse_ty_defs(ctx: &CrateContext, no_docs: bool) -> Result<Vec<IdlTypeDefinit
 
             Some(fields.map(|fields| IdlTypeDefinition {
                 name,
-                path: None,
                 generics: None,
                 docs: doc,
                 ty: IdlTypeDefinitionTy::Struct { fields },
@@ -408,7 +407,6 @@ fn parse_ty_defs(ctx: &CrateContext, no_docs: bool) -> Result<Vec<IdlTypeDefinit
                 .collect::<Vec<IdlEnumVariant>>();
             Some(Ok(IdlTypeDefinition {
                 name,
-                path: None,
                 generics: None,
                 docs: doc,
                 ty: IdlTypeDefinitionTy::Enum { variants },

--- a/lang/syn/src/idl/types.rs
+++ b/lang/syn/src/idl/types.rs
@@ -147,13 +147,16 @@ pub struct IdlEventField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlTypeDefinition {
+    /// - `idl-parse`: always the name of the type
+    /// - `idl-build`: full path if there is a name conflict, otherwise the name of the type
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub generics: Option<Vec<String>>,
+    /// Documentation comments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docs: Option<Vec<String>>,
+    /// Generics, only supported with `idl-build`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generics: Option<Vec<String>>,
+    /// Type definition, `struct` or `enum`
     #[serde(rename = "type")]
     pub ty: IdlTypeDefinitionTy,
 }
@@ -207,7 +210,7 @@ pub enum IdlType {
     GenericLenArray(Box<IdlType>, String),
     Generic(String),
     DefinedWithTypeArgs {
-        path: String,
+        name: String,
         args: Vec<IdlDefinedTypeArg>,
     },
 }

--- a/tests/idl-build/tests/testdata/generics_build_exp.json
+++ b/tests/idl-build/tests/testdata/generics_build_exp.json
@@ -29,7 +29,7 @@
           "name": "genericField",
           "type": {
             "definedWithTypeArgs": {
-              "path": "generics::GenericType",
+              "name": "GenericType",
               "args": [
                 {
                   "type": "u32"
@@ -50,7 +50,6 @@
   "accounts": [
     {
       "name": "GenericAccount",
-      "path": "generics::GenericAccount",
       "type": {
         "kind": "struct",
         "fields": [
@@ -58,7 +57,7 @@
             "name": "data",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericType",
+                "name": "GenericType",
                 "args": [
                   {
                     "type": "u32"
@@ -80,7 +79,6 @@
   "types": [
     {
       "name": "GenericEnum",
-      "path": "generics::GenericEnum",
       "generics": [
         "T",
         "U",
@@ -122,7 +120,7 @@
             "fields": [
               {
                 "definedWithTypeArgs": {
-                  "path": "generics::GenericNested",
+                  "name": "GenericNested",
                   "args": [
                     {
                       "type": {
@@ -157,7 +155,6 @@
     },
     {
       "name": "GenericNested",
-      "path": "generics::GenericNested",
       "generics": [
         "V",
         "Z"
@@ -182,7 +179,6 @@
     },
     {
       "name": "GenericType",
-      "path": "generics::GenericType",
       "generics": [
         "T",
         "U",
@@ -207,7 +203,7 @@
             "name": "gen3",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericNested",
+                "name": "GenericNested",
                 "args": [
                   {
                     "type": "u32"
@@ -225,7 +221,7 @@
             "name": "gen4",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericNested",
+                "name": "GenericNested",
                 "args": [
                   {
                     "type": {
@@ -234,7 +230,7 @@
                   },
                   {
                     "type": {
-                      "defined": "some_external_program::Baz"
+                      "defined": "Baz"
                     }
                   }
                 ]
@@ -245,7 +241,7 @@
             "name": "gen5",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericNested",
+                "name": "GenericNested",
                 "args": [
                   {
                     "type": {
@@ -265,7 +261,7 @@
             "name": "gen6",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericNested",
+                "name": "GenericNested",
                 "args": [
                   {
                     "type": "u32"
@@ -281,7 +277,7 @@
             "name": "gen7",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericNested",
+                "name": "GenericNested",
                 "args": [
                   {
                     "type": {
@@ -291,7 +287,7 @@
                   {
                     "type": {
                       "definedWithTypeArgs": {
-                        "path": "generics::GenericNested",
+                        "name": "GenericNested",
                         "args": [
                           {
                             "type": {
@@ -324,7 +320,7 @@
             "name": "warr",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::WrappedU8Array",
+                "name": "WrappedU8Array",
                 "args": [
                   {
                     "type": {
@@ -339,7 +335,7 @@
             "name": "warrval",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::WrappedU8Array",
+                "name": "WrappedU8Array",
                 "args": [
                   {
                     "value": "10"
@@ -352,7 +348,7 @@
             "name": "enm1",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericEnum",
+                "name": "GenericEnum",
                 "args": [
                   {
                     "type": {
@@ -377,12 +373,12 @@
             "name": "enm2",
             "type": {
               "definedWithTypeArgs": {
-                "path": "generics::GenericEnum",
+                "name": "GenericEnum",
                 "args": [
                   {
                     "type": {
                       "definedWithTypeArgs": {
-                        "path": "generics::GenericNested",
+                        "name": "GenericNested",
                         "args": [
                           {
                             "type": {
@@ -411,7 +407,6 @@
     },
     {
       "name": "Baz",
-      "path": "some_external_program::Baz",
       "type": {
         "kind": "struct",
         "fields": [

--- a/tests/idl-build/tests/testdata/idl_build_exp.json
+++ b/tests/idl-build/tests/testdata/idl_build_exp.json
@@ -187,7 +187,7 @@
           "name": "vecStructField",
           "type": {
             "vec": {
-              "defined": "idl::FooStruct"
+              "defined": "FooStruct"
             }
           }
         },
@@ -201,14 +201,14 @@
           "name": "optionStructField",
           "type": {
             "option": {
-              "defined": "idl::FooStruct"
+              "defined": "FooStruct"
             }
           }
         },
         {
           "name": "structField",
           "type": {
-            "defined": "idl::FooStruct"
+            "defined": "FooStruct"
           }
         },
         {
@@ -223,25 +223,25 @@
         {
           "name": "enumField1",
           "type": {
-            "defined": "idl::FooEnum"
+            "defined": "FooEnum"
           }
         },
         {
           "name": "enumField2",
           "type": {
-            "defined": "idl::FooEnum"
+            "defined": "FooEnum"
           }
         },
         {
           "name": "enumField3",
           "type": {
-            "defined": "idl::FooEnum"
+            "defined": "FooEnum"
           }
         },
         {
           "name": "enumField4",
           "type": {
-            "defined": "idl::FooEnum"
+            "defined": "FooEnum"
           }
         }
       ]
@@ -284,7 +284,7 @@
         }
       ],
       "returns": {
-        "defined": "idl::SomeRetStruct"
+        "defined": "SomeRetStruct"
       }
     },
     {
@@ -296,22 +296,20 @@
   "accounts": [
     {
       "name": "SomeZcAccount",
-      "path": "idl::SomeZcAccount",
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "field",
             "type": {
-              "defined": "idl::ZcStruct"
+              "defined": "ZcStruct"
             }
           }
         ]
       }
     },
     {
-      "name": "State",
-      "path": "idl::State",
+      "name": "idl::State",
       "docs": [
         "An account containing various fields"
       ],
@@ -395,7 +393,7 @@
             "name": "vecStructField",
             "type": {
               "vec": {
-                "defined": "idl::FooStruct"
+                "defined": "FooStruct"
               }
             }
           },
@@ -409,14 +407,14 @@
             "name": "optionStructField",
             "type": {
               "option": {
-                "defined": "idl::FooStruct"
+                "defined": "FooStruct"
               }
             }
           },
           {
             "name": "structField",
             "type": {
-              "defined": "idl::FooStruct"
+              "defined": "FooStruct"
             }
           },
           {
@@ -431,25 +429,25 @@
           {
             "name": "enumField1",
             "type": {
-              "defined": "idl::FooEnum"
+              "defined": "FooEnum"
             }
           },
           {
             "name": "enumField2",
             "type": {
-              "defined": "idl::FooEnum"
+              "defined": "FooEnum"
             }
           },
           {
             "name": "enumField3",
             "type": {
-              "defined": "idl::FooEnum"
+              "defined": "FooEnum"
             }
           },
           {
             "name": "enumField4",
             "type": {
-              "defined": "idl::FooEnum"
+              "defined": "FooEnum"
             }
           }
         ]
@@ -457,7 +455,6 @@
     },
     {
       "name": "State2",
-      "path": "idl::State2",
       "type": {
         "kind": "struct",
         "fields": [
@@ -480,7 +477,6 @@
   "types": [
     {
       "name": "BarStruct",
-      "path": "idl::BarStruct",
       "docs": [
         "Bar struct type"
       ],
@@ -503,7 +499,6 @@
     },
     {
       "name": "FooEnum",
-      "path": "idl::FooEnum",
       "docs": [
         "Enum type"
       ],
@@ -516,7 +511,7 @@
               "bool",
               "u8",
               {
-                "defined": "idl::BarStruct"
+                "defined": "BarStruct"
               }
             ]
           },
@@ -524,7 +519,7 @@
             "name": "UnnamedSingle",
             "fields": [
               {
-                "defined": "idl::BarStruct"
+                "defined": "BarStruct"
               }
             ]
           },
@@ -545,7 +540,7 @@
               {
                 "name": "nested",
                 "type": {
-                  "defined": "idl::BarStruct"
+                  "defined": "BarStruct"
                 }
               }
             ]
@@ -554,7 +549,7 @@
             "name": "Struct",
             "fields": [
               {
-                "defined": "idl::BarStruct"
+                "defined": "BarStruct"
               }
             ]
           },
@@ -563,7 +558,7 @@
             "fields": [
               {
                 "option": {
-                  "defined": "idl::BarStruct"
+                  "defined": "BarStruct"
                 }
               }
             ]
@@ -573,7 +568,7 @@
             "fields": [
               {
                 "vec": {
-                  "defined": "idl::BarStruct"
+                  "defined": "BarStruct"
                 }
               }
             ]
@@ -586,7 +581,6 @@
     },
     {
       "name": "FooStruct",
-      "path": "idl::FooStruct",
       "type": {
         "kind": "struct",
         "fields": [
@@ -601,14 +595,14 @@
           {
             "name": "nested",
             "type": {
-              "defined": "idl::BarStruct"
+              "defined": "BarStruct"
             }
           },
           {
             "name": "vecNested",
             "type": {
               "vec": {
-                "defined": "idl::BarStruct"
+                "defined": "BarStruct"
               }
             }
           },
@@ -616,14 +610,14 @@
             "name": "optionNested",
             "type": {
               "option": {
-                "defined": "idl::BarStruct"
+                "defined": "BarStruct"
               }
             }
           },
           {
             "name": "enumField",
             "type": {
-              "defined": "idl::FooEnum"
+              "defined": "FooEnum"
             }
           }
         ]
@@ -631,7 +625,6 @@
     },
     {
       "name": "SomeRetStruct",
-      "path": "idl::SomeRetStruct",
       "type": {
         "kind": "struct",
         "fields": [
@@ -644,7 +637,6 @@
     },
     {
       "name": "ZcStruct",
-      "path": "idl::ZcStruct",
       "type": {
         "kind": "struct",
         "fields": [
@@ -656,8 +648,7 @@
       }
     },
     {
-      "name": "Baz",
-      "path": "idl::some_other_module::Baz",
+      "name": "idl::some_other_module::Baz",
       "type": {
         "kind": "struct",
         "fields": [
@@ -669,8 +660,7 @@
       }
     },
     {
-      "name": "Baz",
-      "path": "some_external_program::Baz",
+      "name": "some_external_program::Baz",
       "type": {
         "kind": "struct",
         "fields": [

--- a/tests/idl-build/tests/testdata/relations_build_exp.json
+++ b/tests/idl-build/tests/testdata/relations_build_exp.json
@@ -64,7 +64,6 @@
   "accounts": [
     {
       "name": "MyAccount",
-      "path": "relations_derivation::MyAccount",
       "type": {
         "kind": "struct",
         "fields": [


### PR DESCRIPTION
#2011 adds `path` field to types and accounts to solve potential name conflicts but it also comes with a cost:

- Paths could get fairly large which would result in a much bigger IDL size.
- Some of the client functionality needs to implemented to take into account the `path` field instead of the `name` field.
- We store the `name` field to not cause a bigger breaking change but `name` field can be derived from `path` field, on-chain data should be as pure as possible, any derived data should be derived client side.

Given name conflicts don't occur in the vast majority of accounts/types, this PR removes the `path` field and uses `name` instead. `name` field will be the name of the account/type(exactly the same behavior as the current IDL) but if there is a conflict, item's path will be used as the `name` field.

This results in smaller IDL sizes and it also means there would be no difference between the old and the new IDL for the vast majority of programs. Old clients would be able to work with the IDLs generated by `idl build`.