### PR TITLE
client: Fix compilation with Solana `1.14`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Packages no longer depend on `assert` ([#2535](https://github.com/coral-xyz/anchor/pull/2535)).
 - lang: Support for `const` in the `InitSpace` macro ([#2555](https://github.com/coral-xyz/anchor/pull/2555)).
 - cli: Support workspace inheritence ([#2570](https://github.com/coral-xyz/anchor/pull/2570)).
+- client: Compile with Solana `1.14`([#2572](https://github.com/coral-xyz/anchor/pull/2572)).
 
 ### Breaking
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -279,9 +279,10 @@ impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
                     client.logs_subscribe(filter, config).await?;
 
                 tx.send(unsubscribe).map_err(|e| {
-                    ClientError::SolanaClientPubsubError(PubsubClientError::UnexpectedMessageError(
-                        e.to_string(),
-                    ))
+                    ClientError::SolanaClientPubsubError(PubsubClientError::RequestFailed {
+                        message: "Unsubscribe failed".to_string(),
+                        reason: e.to_string(),
+                    })
                 })?;
 
                 while let Some(logs) = notifications.next().await {


### PR DESCRIPTION
`anchor-client` uses an error variant that was added in `solana-client 1.16` which cause compilation errors when using `1.14`(https://github.com/coral-xyz/anchor/pull/2488#discussion_r1200952015). It was added in commit https://github.com/coral-xyz/anchor/pull/2488/commits/25a708eead151cc8f30cfef3dec8ef6ad6c38b7f and tests missed this issue because it's just after the `1.16` upgrade. We will most likely drop the `1.14` support after Metaplex crates upgrade to `1.16` but it doesn't hurt to make it compatible now.