### PR TITLE
ts: Lazy load workspace programs and improve program name accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Allow CPI calls matching an interface without pinning program ID ([#2559](https://github.com/coral-xyz/anchor/pull/2559)).
 - cli, lang: Add IDL generation through compilation. `anchor build` still uses parsing method to generate IDLs, use `anchor idl build` to generate IDLs with the build method ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
 - avm: Add support for the `.anchorversion` file to facilitate switching between different versions of the `anchor-cli` ([#2553](https://github.com/coral-xyz/anchor/pull/2553)).
+- ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2581](https://github.com/coral-xyz/anchor/pull/2581)).
 
 ### Fixes
 
@@ -25,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Support workspace inheritence ([#2570](https://github.com/coral-xyz/anchor/pull/2570)).
 - client: Compile with Solana `1.14` ([#2572](https://github.com/coral-xyz/anchor/pull/2572)).
 - cli: Fix `anchor build --no-docs` adding docs to the IDL ([#2575](https://github.com/coral-xyz/anchor/pull/2575)).
+- ts: Load workspace programs on-demand rather than loading all of them at once ([#2581](https://github.com/coral-xyz/anchor/pull/2581)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Allow CPI calls matching an interface without pinning program ID ([#2559](https://github.com/coral-xyz/anchor/pull/2559)).
 - cli, lang: Add IDL generation through compilation. `anchor build` still uses parsing method to generate IDLs, use `anchor idl build` to generate IDLs with the build method ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
 - avm: Add support for the `.anchorversion` file to facilitate switching between different versions of the `anchor-cli` ([#2553](https://github.com/coral-xyz/anchor/pull/2553)).
-- ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2581](https://github.com/coral-xyz/anchor/pull/2581)).
+- ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
 
 ### Fixes
 
@@ -26,7 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Support workspace inheritence ([#2570](https://github.com/coral-xyz/anchor/pull/2570)).
 - client: Compile with Solana `1.14` ([#2572](https://github.com/coral-xyz/anchor/pull/2572)).
 - cli: Fix `anchor build --no-docs` adding docs to the IDL ([#2575](https://github.com/coral-xyz/anchor/pull/2575)).
-- ts: Load workspace programs on-demand rather than loading all of them at once ([#2581](https://github.com/coral-xyz/anchor/pull/2581)).
+- ts: Load workspace programs on-demand rather than loading all of them at once ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
 
 ### Breaking
 

--- a/tests/idl/Anchor.toml
+++ b/tests/idl/Anchor.toml
@@ -6,6 +6,8 @@ external = "Externa1111111111111111111111111111111111111"
 generics = "Generics111111111111111111111111111111111111"
 idl = "id11111111111111111111111111111111111111111"
 relations_derivation = "Re1ationsDerivation111111111111111111111111"
+non_existent = { address = "NonExistent11111111111111111111111111111111", idl = "non-existent.json" }
+numbers_123 = { address = "Numbers111111111111111111111111111111111111", idl = "idls/relations_build_exp.json" }
 
 [provider]
 cluster = "localnet"

--- a/tests/idl/tests/idl.ts
+++ b/tests/idl/tests/idl.ts
@@ -1,9 +1,43 @@
 import * as anchor from "@coral-xyz/anchor";
+import { assert } from "chai";
 
-import { IDL } from "../target/types/idl";
-
-describe(IDL.name, () => {
+describe("IDL", () => {
   anchor.setProvider(anchor.AnchorProvider.env());
 
-  it("Builds", () => {});
+  it("Can lazy load workspace programs", () => {
+    assert.doesNotThrow(() => {
+      // Program exists, should not throw
+      anchor.workspace.relationsDerivation;
+    });
+
+    assert.throws(() => {
+      // IDL path in Anchor.toml doesn't exist but other tests still run
+      // successfully because workspace programs are getting loaded on-demand
+      anchor.workspace.nonExistent;
+    }, /non-existent\.json/);
+  });
+
+  it("Can get workspace programs by their name independent of casing", () => {
+    const camel = anchor.workspace.relationsDerivation;
+    const pascal = anchor.workspace.RelationsDerivation;
+    const kebab = anchor.workspace["relations-derivation"];
+    const snake = anchor.workspace["relations_derivation"];
+
+    const compareProgramNames = (...programs: anchor.Program[]) => {
+      return programs.every(
+        (program) => program.idl.name === "relations_derivation"
+      );
+    };
+
+    assert(compareProgramNames(camel, pascal, kebab, snake));
+  });
+
+  it("Can use numbers in program names", () => {
+    assert.doesNotThrow(() => {
+      anchor.workspace.numbers123;
+      anchor.workspace.Numbers123;
+      anchor.workspace["numbers-123"];
+      anchor.workspace["numbers_123"];
+    });
+  });
 });

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -29,25 +29,24 @@ const workspace = new Proxy(
       const fs = require("fs");
       const path = require("path");
 
-      const idlFolder = path.join("target", "idl");
-      if (!fs.existsSync(idlFolder)) {
-        throw new Error(
-          `${idlFolder} doesn't exist. Did you run \`anchor build\`?`
-        );
-      }
-
       // Override the workspace programs if the user put them in the config.
       const anchorToml = toml.parse(fs.readFileSync("Anchor.toml"));
       const clusterId = anchorToml.provider.cluster;
       const programEntry = anchorToml.programs?.[clusterId]?.[programName];
 
-      let idlPath;
+      let idlPath: string;
       let programId;
       if (typeof programEntry === "object" && programEntry.idl) {
         idlPath = programEntry.idl;
         programId = programEntry.address;
       } else {
-        idlPath = path.join(idlFolder, `${programName}.json`);
+        idlPath = path.join("target", "idl", `${programName}.json`);
+      }
+
+      if (!fs.existsSync(idlPath)) {
+        throw new Error(
+          `${idlPath} doesn't exist. Did you run \`anchor build\`?`
+        );
       }
 
       const idl = JSON.parse(fs.readFileSync(idlPath));

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -23,6 +23,23 @@ const workspace = new Proxy(
       // `workspace.myProgram`, `workspace.MyProgram`, `workspace["my-program"]`...
       programName = snakeCase(programName);
 
+      // Check whether the program name contains any digits
+      if (/\d/.test(programName)) {
+        // Numbers cannot be properly converted from camelCase to snake_case,
+        // e.g. if the `programName` is `myProgram2`, the actual program name could
+        // be `my_program2` or `my_program_2`. This implementation assumes the
+        // latter as the default and always converts to `_numbers`.
+        //
+        // A solution to the conversion of program names with numbers in them
+        // would be to always convert the `programName` to camelCase instead of
+        // snake_case. The problem with this approach is that it would require
+        // converting everything else e.g. program names in Anchor.toml and IDL
+        // file names which are both snake_case.
+        programName = programName
+          .replace(/\d+/g, (match) => "_" + match)
+          .replace("__", "_");
+      }
+
       // Return early if the program is in cache
       if (workspaceCache[programName]) return workspaceCache[programName];
 


### PR DESCRIPTION
### Problem

1. `anchor.workspace` loads all programs in the workspace even if a loaded program is not being used in code. This also cause issues when an IDL is missing - https://github.com/coral-xyz/anchor/issues/2562
2. Using PascalCase for property accessors in JS is unintuitive, e.g. `anchor.workspace.ProgramName`.

### Solution

1. Workspace programs only get loaded the first time they are used.

2. Workspace programs can now be accessed independent of their casing.

```ts
// All of the following works
const camel = anchor.workspace.myProgram;
const pascal = anchor.workspace.MyProgram;
const kebab = anchor.workspace["my-program"];
const snake = anchor.workspace["my_program"];
```