### PR TITLE
Make the new IDL features explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Breaking
 
 - syn: `idl` feature has been replaced with `idl-build`, `idl-parse` and `idl-types` features ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
+- syn: IDL `parse` method now returns `Result<Idl>` instead of `Result<Option<Idl>>` ([#2582](https://github.com/coral-xyz/anchor/pull/2582)).
 
 ## [0.28.0] - 2023-06-09
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2292,7 +2292,6 @@ fn generate_idl_parse(
     safety_checks: bool,
 ) -> Result<Idl> {
     anchor_syn::idl::parse::file::parse(path, version, seeds_feature, no_docs, safety_checks)
-        .and_then(|maybe_idl| maybe_idl.ok_or_else(|| anyhow!("Failed to parse IDL")))
 }
 
 /// Generate IDL with the build method.

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -9,22 +9,22 @@ rust-version = "1.60"
 edition = "2021"
 
 [features]
-allow-missing-optionals = []
-init-if-needed = []
-idl-build = []
-idl-parse = []
-idl-types = []
-hash = []
 default = []
+allow-missing-optionals = []
 anchor-debug = []
-seeds = []
 event-cpi = []
+hash = []
+idl-build = ["idl-parse", "idl-types"]
+idl-parse = ["idl-types"]
+idl-types = []
+init-if-needed = []
+seeds = []
 
 [dependencies]
 anyhow = "1"
 bs58 = "0.5"
 heck = "0.3"
-proc-macro2 = { version = "1", features=["span-locations"]}
+proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "idl-build")]
 pub mod build;
-#[cfg(any(feature = "idl-parse", feature = "idl-build"))]
+
+#[cfg(feature = "idl-parse")]
 pub mod parse;
-#[cfg(any(feature = "idl-types", feature = "idl-build", feature = "idl-parse"))]
+
+#[cfg(feature = "idl-types")]
 pub mod types;


### PR DESCRIPTION
### Problem

1. `syn` crate's new IDL features are not explicit on what they enable.
2. IDL `parse` method returns `Result<Option<Idl>>` but `Ok(None)` is used as an error.

### Solution

1. Show which features new IDL features enable in `Cargo.toml`.
2. IDL `parse` method now returns `Result<Idl>` instead of `Result<Option<Idl>>`.