### PR TITLE
spl: Export `mpl-token-metadata` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli, lang: Add IDL generation through compilation. `anchor build` still uses parsing method to generate IDLs, use `anchor idl build` to generate IDLs with the build method ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
 - avm: Add support for the `.anchorversion` file to facilitate switching between different versions of the `anchor-cli` ([#2553](https://github.com/coral-xyz/anchor/pull/2553)).
 - ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
+- spl: Export `mpl-token-metadata` crate ([#2583](https://github.com/coral-xyz/anchor/pull/2583)).
 
 ### Fixes
 

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -2,10 +2,12 @@ use anchor_lang::context::CpiContext;
 use anchor_lang::error::ErrorCode;
 use anchor_lang::{Accounts, Result, ToAccountInfos};
 use mpl_token_metadata::state::{CollectionDetails, DataV2, TokenMetadataAccount};
-use mpl_token_metadata::ID;
 use solana_program::account_info::AccountInfo;
 use solana_program::pubkey::Pubkey;
 use std::ops::Deref;
+
+pub use mpl_token_metadata;
+pub use mpl_token_metadata::ID;
 
 pub fn approve_collection_authority<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, ApproveCollectionAuthority<'info>>,


### PR DESCRIPTION
### Problem

`anchor-spl` doesn't export `mpl-token-metadata` when `metadata` feature is activated. This causes people to add the dependency to their `Cargo.toml`.

```toml
anchor-spl = { version = "0.28.0", features = ["metadata"] }
mpl-token-metadata = "1.13.1"
```

### Solution

Export the `mpl-token-metadata` crate so that people can use it without adding it to their dependencies.

```toml
anchor-spl = { version = "0.28.0", features = ["metadata"] }
# mpl-token-metadata is not needed
```