### PR TITLE
cli: Improve converting non-conflicting paths to names in IDL

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2458,7 +2458,7 @@ fn generate_idl_build(no_docs: bool) -> Result<Vec<Idl>> {
                 let replaced_idl = modified_idl.replace(path, &format!(r#""{name}""#));
 
                 // Check whether there is a conflict
-                let has_conflict = replaced_idl.contains(&format!("::{name}"));
+                let has_conflict = replaced_idl.contains(&format!(r#"::{name}""#));
                 if !has_conflict {
                     modified_idl = replaced_idl;
                 }

--- a/tests/idl/idls/build.json
+++ b/tests/idl/idls/build.json
@@ -309,7 +309,7 @@
       }
     },
     {
-      "name": "idl::State",
+      "name": "State",
       "docs": [
         "An account containing various fields"
       ],


### PR DESCRIPTION
### Problem

The step for converting non-conflicting full paths to names fails to filter all non-conflicting names if the name is also being used in documentation(`docs` field).

### Solution

Make sure the name is unique by checking whether `::<NAME>"` exists. It's extremely low probability for a documentation to end with that pattern.