### PR TITLE
chore: Remove duplicate dependency and and alphabetize features

### DIFF
--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -15,9 +15,9 @@ path = "src/anchor/main.rs"
 [dependencies]
 anyhow = "1.0.32"
 cfg-if = "1.0.0"
-clap = { version = "4.2.4", features = ["derive"]}
+clap = { version = "4.2.4", features = ["derive"] }
 dirs = "4.0.0"
-once_cell = { version = "1.8.0" }
+once_cell = "1.8.0"
 reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/bin/main.rs"
 
 [features]
 dev = []
-default = []
 
 [dependencies]
 anchor-client = { path = "../client", version = "0.28.0" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,13 +8,13 @@ license = "Apache-2.0"
 description = "Rust client for Anchor programs"
 
 [features]
-debug = []
 async = []
+debug = []
 
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.28.0" }
 anyhow = "1"
-futures = { version = "0.3" }
+futures = "0.3"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 solana-client = ">=1.14, <1.17"

--- a/client/example/Cargo.toml
+++ b/client/example/Cargo.toml
@@ -17,8 +17,8 @@ basic-4 = { path = "../../examples/tutorial/basic-4/programs/basic-4", features 
 composite = { path = "../../tests/composite/programs/composite", features = ["no-entrypoint"] }
 optional = { path = "../../tests/optional/programs/optional", features = ["no-entrypoint"] }
 events = { path = "../../tests/events/programs/events", features = ["no-entrypoint"] }
-shellexpand = "2.1.0"
 anyhow = "1.0.32"
 clap = { version = "4.2.4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
+shellexpand = "2.1.0"
 solana-sdk = ">=1.14, <1.17"
+tokio = { version = "1", features = ["full"] }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -10,20 +10,6 @@ description = "Solana Sealevel eDSL"
 
 [features]
 allow-missing-optionals = ["anchor-derive-accounts/allow-missing-optionals"]
-init-if-needed = ["anchor-derive-accounts/init-if-needed"]
-derive = []
-default = []
-event-cpi = ["anchor-attribute-event/event-cpi"]
-idl-build = [
-    "anchor-syn/idl-build",
-    "anchor-derive-accounts/idl-build",
-    "anchor-derive-serde/idl-build",
-    "anchor-attribute-account/idl-build",
-    "anchor-attribute-constant/idl-build",
-    "anchor-attribute-event/idl-build",
-    "anchor-attribute-error/idl-build",
-    "anchor-attribute-program/idl-build",
-]
 anchor-debug = [
     "anchor-attribute-access-control/anchor-debug",
     "anchor-attribute-account/anchor-debug",
@@ -31,9 +17,21 @@ anchor-debug = [
     "anchor-attribute-error/anchor-debug",
     "anchor-attribute-event/anchor-debug",
     "anchor-attribute-program/anchor-debug",
-    "anchor-attribute-program/anchor-debug",
     "anchor-derive-accounts/anchor-debug"
 ]
+derive = []
+event-cpi = ["anchor-attribute-event/event-cpi"]
+idl-build = [
+    "anchor-attribute-account/idl-build",
+    "anchor-attribute-constant/idl-build",
+    "anchor-attribute-event/idl-build",
+    "anchor-attribute-error/idl-build",
+    "anchor-attribute-program/idl-build",
+    "anchor-derive-accounts/idl-build",
+    "anchor-derive-serde/idl-build",
+    "anchor-syn/idl-build",
+]
+init-if-needed = ["anchor-derive-accounts/init-if-needed"]
 
 [dependencies]
 anchor-attribute-access-control = { path = "./attribute/access-control", version = "0.28.0" }
@@ -45,8 +43,7 @@ anchor-attribute-program = { path = "./attribute/program", version = "0.28.0" }
 anchor-derive-accounts = { path = "./derive/accounts", version = "0.28.0" }
 anchor-derive-serde = { path = "./derive/serde", version = "0.28.0" }
 anchor-derive-space = { path = "./derive/space", version = "0.28.0" }
-# anchor-syn can and should only be included only for idl-build. It won't compile
-# for bpf due to proc-macro2 crate.
+# `anchor-syn` should only be included with `idl-build` feature
 anchor-syn = { path = "./syn", version = "0.28.0", optional = true }
 arrayref = "0.3"
 base64 = "0.13"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0", features = ["hash"] }

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0" }

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0" }

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
 event-cpi = ["anchor-syn/event-cpi"]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0", features = ["hash"] }

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0" }

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -13,12 +13,11 @@ proc-macro = true
 
 [features]
 allow-missing-optionals = ["anchor-syn/allow-missing-optionals"]
-init-if-needed = ["anchor-syn/init-if-needed"]
-default = []
-idl-build = ["anchor-syn/idl-build"]
 anchor-debug = ["anchor-syn/anchor-debug"]
+idl-build = ["anchor-syn/idl-build"]
+init-if-needed = ["anchor-syn/init-if-needed"]
 
 [dependencies]
+anchor-syn = { path = "../../syn", version = "0.28.0" }
 quote = "1"
 syn = { version = "1", features = ["full"] }
-anchor-syn = { path = "../../syn", version = "0.28.0" }

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -12,9 +12,7 @@ edition = "2021"
 proc-macro = true
 
 [features]
-idl-build = [
-    "anchor-syn/idl-build",
-]
+idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.28.0" }

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits"]}
+syn = { version = "1", features = ["extra-traits"] }

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -9,7 +9,6 @@ rust-version = "1.60"
 edition = "2021"
 
 [features]
-default = []
 allow-missing-optionals = []
 anchor-debug = []
 event-cpi = []

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -8,17 +8,17 @@ license = "Apache-2.0"
 description = "CPI clients for SPL programs"
 
 [features]
-default = ["mint", "token", "token_2022", "associated_token"]
-mint = []
-token = ["spl-token"]
-token_2022 = ["spl-token-2022"]
+default = ["associated_token", "mint", "token", "token_2022"]
 associated_token = ["spl-associated-token-account"]
+dex = ["serum_dex"]
+devnet = []
 governance = []
+metadata = ["mpl-token-metadata"]
+mint = []
 shmem = []
 stake = ["borsh"]
-devnet = []
-metadata = ["mpl-token-metadata"]
-dex = ["serum_dex"]
+token = ["spl-token"]
+token_2022 = ["spl-token-2022"]
 
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.28.0", features = ["derive"] }


### PR DESCRIPTION
`anchor-debug` feature has duplicate dependency for `anchor-attribute-program/anchor-debug`. Removed it and, while at it, alphabetized features in manifests.