### PR TITLE
ts: Add support for unnamed(tuple) enum in accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Add support for the `.anchorversion` file to facilitate switching between different versions of the `anchor-cli` ([#2553](https://github.com/coral-xyz/anchor/pull/2553)).
 - ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
 - spl: Export `mpl-token-metadata` crate ([#2583](https://github.com/coral-xyz/anchor/pull/2583)).
+- spl: Add `TokenRecordAccount` for pNFTs ([#2597](https://github.com/coral-xyz/anchor/pull/2597)).
+- ts: Add support for unnamed(tuple) enum in accounts([#2601](https://github.com/coral-xyz/anchor/pull/2601)).
 
 ### Fixes
 

--- a/tests/misc/programs/misc-optional/src/account.rs
+++ b/tests/misc/programs/misc-optional/src/account.rs
@@ -36,6 +36,12 @@ pub struct DataI16 {
 }
 size!(DataI16, 2);
 
+#[account]
+pub struct DataEnum {
+    pub data: TestEnum, // 1 + 16
+}
+size!(DataEnum, 17);
+
 #[account(zero_copy)]
 pub struct DataZeroCopy {
     pub data: u16,    // 2
@@ -72,4 +78,20 @@ pub struct DataConstCastArraySize {
 #[account]
 pub struct DataMultidimensionalArrayConstSizes {
     pub data: [[u8; MAX_SIZE_U8 as usize]; MAX_SIZE],
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
+pub enum TestEnum {
+    First,
+    Second { x: u64, y: u64 },
+    TupleTest(u8, u8, u16, u16),
+    TupleStructTest(TestStruct),
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
+pub struct TestStruct {
+    pub data1: u8,
+    pub data2: u16,
+    pub data3: u32,
+    pub data4: u64,
 }

--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -209,6 +209,14 @@ pub struct TestI16<'info> {
 pub struct TestSimulate {}
 
 #[derive(Accounts)]
+pub struct TestAccountEnum<'info> {
+    #[account(init, payer = payer.as_ref().unwrap(), space = 8+ DataEnum::LEN )]
+    pub data: Option<Account<'info, DataEnum>>,
+    pub payer: Option<Signer<'info>>,
+    pub system_program: Option<Program<'info, System>>,
+}
+
+#[derive(Accounts)]
 pub struct TestI8<'info> {
     #[account(zero)]
     pub data: Option<Account<'info, DataI8>>,

--- a/tests/misc/programs/misc-optional/src/event.rs
+++ b/tests/misc/programs/misc-optional/src/event.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::*;
 
+use crate::account::*;
+
 pub const MAX_EVENT_SIZE: usize = 10;
 pub const MAX_EVENT_SIZE_U8: u8 = 11;
 
@@ -31,22 +33,6 @@ pub struct E5 {
 #[event]
 pub struct E6 {
     pub data: [u8; MAX_EVENT_SIZE_U8 as usize],
-}
-
-#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
-pub struct TestStruct {
-    pub data1: u8,
-    pub data2: u16,
-    pub data3: u32,
-    pub data4: u64,
-}
-
-#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
-pub enum TestEnum {
-    First,
-    Second { x: u64, y: u64 },
-    TupleTest(u8, u8, u16, u16),
-    TupleStructTest(TestStruct),
 }
 
 #[event]

--- a/tests/misc/programs/misc-optional/src/lib.rs
+++ b/tests/misc/programs/misc-optional/src/lib.rs
@@ -1,7 +1,7 @@
 //! Misc optional example is a catchall program for testing unrelated features.
 //! It's not too instructive/coherent by itself, so please see other examples.
 
-use account::MAX_SIZE;
+use account::*;
 use anchor_lang::prelude::*;
 use context::*;
 use event::*;
@@ -62,8 +62,13 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_input_enum(ctx: Context<TestSimulate>, data: TestEnum) -> Result<()> {
+    pub fn test_input_enum(_ctx: Context<TestSimulate>, data: TestEnum) -> Result<()> {
         emit!(E7 { data: data });
+        Ok(())
+    }
+
+    pub fn test_account_enum(ctx: Context<TestAccountEnum>, data: TestEnum) -> Result<()> {
+        ctx.accounts.data.as_mut().unwrap().data = data;
         Ok(())
     }
 
@@ -171,7 +176,9 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_init_mint_with_token_program(_ctx: Context<TestInitMintWithTokenProgram>) -> Result<()> {
+    pub fn test_init_mint_with_token_program(
+        _ctx: Context<TestInitMintWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -182,10 +189,11 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_init_token_with_token_program(_ctx: Context<TestInitTokenWithTokenProgram>) -> Result<()> {
+    pub fn test_init_token_with_token_program(
+        _ctx: Context<TestInitTokenWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
-
 
     pub fn test_composite_payer(ctx: Context<TestCompositePayer>) -> Result<()> {
         ctx.accounts.composite.data.as_mut().unwrap().data = 1;
@@ -201,7 +209,9 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_init_associated_token_with_token_program(ctx: Context<TestInitAssociatedTokenWithTokenProgram>) -> Result<()> {
+    pub fn test_init_associated_token_with_token_program(
+        _ctx: Context<TestInitAssociatedTokenWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -261,7 +271,9 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_init_token_if_needed_with_token_program(_ctx: Context<TestInitTokenIfNeededWithTokenProgram>) -> Result<()> {
+    pub fn test_init_token_if_needed_with_token_program(
+        _ctx: Context<TestInitTokenIfNeededWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -277,7 +289,7 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn init_with_space(_ctx: Context<InitWithSpace>, data: u16) -> Result<()> {
+    pub fn init_with_space(_ctx: Context<InitWithSpace>, _data: u16) -> Result<()> {
         Ok(())
     }
 
@@ -357,7 +369,9 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_only_token_program_constraint(_ctx: Context<TestOnlyTokenProgramConstraint>) -> Result<()> {
+    pub fn test_only_token_program_constraint(
+        _ctx: Context<TestOnlyTokenProgramConstraint>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -401,7 +415,9 @@ pub mod misc_optional {
         Ok(())
     }
 
-    pub fn test_associated_token_with_token_program_constraint(_ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>) -> Result<()> {
+    pub fn test_associated_token_with_token_program_constraint(
+        _ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/tests/misc/programs/misc/src/account.rs
+++ b/tests/misc/programs/misc/src/account.rs
@@ -36,6 +36,12 @@ pub struct DataI16 {
 }
 size!(DataI16, 2);
 
+#[account]
+pub struct DataEnum {
+    pub data: TestEnum, // 1 + 16
+}
+size!(DataEnum, 17);
+
 #[account(zero_copy)]
 pub struct DataZeroCopy {
     pub data: u16,    // 2
@@ -93,4 +99,20 @@ pub enum CoolEnum {
         user_2: Pubkey,
         some_slot: u64,
     },
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
+pub enum TestEnum {
+    First,
+    Second { x: u64, y: u64 },
+    TupleTest(u8, u8, u16, u16),
+    TupleStructTest(TestStruct),
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
+pub struct TestStruct {
+    pub data1: u8,
+    pub data2: u16,
+    pub data3: u32,
+    pub data4: u64,
 }

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -216,6 +216,15 @@ pub struct TestI16<'info> {
 pub struct TestSimulate {}
 
 #[derive(Accounts)]
+pub struct TestAccountEnum<'info> {
+    #[account(init, payer = payer, space = 8 + DataEnum::LEN)]
+    pub data: Account<'info, DataEnum>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 pub struct TestI8<'info> {
     #[account(zero)]
     pub data: Account<'info, DataI8>,

--- a/tests/misc/programs/misc/src/event.rs
+++ b/tests/misc/programs/misc/src/event.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::*;
 
+use crate::account::*;
+
 pub const MAX_EVENT_SIZE: usize = 10;
 pub const MAX_EVENT_SIZE_U8: u8 = 11;
 
@@ -33,23 +35,7 @@ pub struct E6 {
     pub data: [u8; MAX_EVENT_SIZE_U8 as usize],
 }
 
-#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
-pub struct TestStruct {
-    pub data1: u8,
-    pub data2: u16,
-    pub data3: u32,
-    pub data4: u64,
-}
-
-#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Eq)]
-pub enum TestEnum {
-    First,
-    Second {x: u64, y: u64},
-    TupleTest (u8, u8, u16, u16),
-    TupleStructTest (TestStruct),
-}
-
-#[event] 
+#[event]
 pub struct E7 {
     pub data: TestEnum,
 }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -1,7 +1,7 @@
 //! Misc example is a catchall program for testing unrelated features.
 //! It's not too instructive/coherent by itself, so please see other examples.
 
-use account::MAX_SIZE;
+use account::*;
 use anchor_lang::prelude::*;
 use context::*;
 use event::*;
@@ -68,6 +68,11 @@ pub mod misc {
 
     pub fn test_input_enum(_ctx: Context<TestSimulate>, data: TestEnum) -> Result<()> {
         emit!(E7 { data: data });
+        Ok(())
+    }
+
+    pub fn test_account_enum(ctx: Context<TestAccountEnum>, data: TestEnum) -> Result<()> {
+        ctx.accounts.data.data = data;
         Ok(())
     }
 
@@ -175,7 +180,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_mint_with_token_program(_ctx: Context<TestInitMintWithTokenProgram>) -> Result<()> {
+    pub fn test_init_mint_with_token_program(
+        _ctx: Context<TestInitMintWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -184,7 +191,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_token_with_token_program(_ctx: Context<TestInitTokenWithTokenProgram>) -> Result<()> {
+    pub fn test_init_token_with_token_program(
+        _ctx: Context<TestInitTokenWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -200,7 +209,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_associated_token_with_token_program(_ctx: Context<TestInitAssociatedTokenWithTokenProgram>) -> Result<()> {
+    pub fn test_init_associated_token_with_token_program(
+        _ctx: Context<TestInitAssociatedTokenWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -250,7 +261,7 @@ pub mod misc {
     }
 
     pub fn test_init_mint_if_needed_with_token_program(
-        _ctx: Context<TestInitMintIfNeededWithTokenProgram>
+        _ctx: Context<TestInitMintIfNeededWithTokenProgram>,
     ) -> Result<()> {
         Ok(())
     }
@@ -259,7 +270,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_init_token_if_needed_with_token_program(_ctx: Context<TestInitTokenIfNeededWithTokenProgram>) -> Result<()> {
+    pub fn test_init_token_if_needed_with_token_program(
+        _ctx: Context<TestInitTokenIfNeededWithTokenProgram>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -345,7 +358,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_only_token_program_constraint(_ctx: Context<TestOnlyTokenProgramConstraint>) -> Result<()> {
+    pub fn test_only_token_program_constraint(
+        _ctx: Context<TestOnlyTokenProgramConstraint>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -389,7 +404,9 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_associated_token_with_token_program_constraint(_ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>) -> Result<()> {
+    pub fn test_associated_token_with_token_program_constraint(
+        _ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -399,7 +416,7 @@ pub mod misc {
         program_id: u8,
         accounts: u8,
         ix_data: u8,
-        remaining_accounts: u8
+        remaining_accounts: u8,
     ) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
### Problem

Using unnamed(tuple) enum in accounts, e.g.

```rs
#[derive(Accounts)]
pub struct TestAccountEnum<'info> {
    pub enum_account: Account<'info, EnumAccount>,
}

#[account]
pub struct EnumAccount {
    pub data: EnumData,
}

#[derive(AnchorDeserialize, AnchorSerialize, Clone)]
pub enum TestEnum {
    Unnamed(u8),
}
```

results with: 

```
Error: Tuple enum variants not yet implemented.
```

This is happening because passing enum arguments was implemented in #2185 but account size calculation for unnamed enums was not.

### Summary of changes

- Add a test case for enum accounts(failing before this PR)
- Implement account size calculation for unnamed enums