### PR TITLE
cli: Add program template with multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
 - spl: Export `mpl-token-metadata` crate ([#2583](https://github.com/coral-xyz/anchor/pull/2583)).
 - spl: Add `TokenRecordAccount` for pNFTs ([#2597](https://github.com/coral-xyz/anchor/pull/2597)).
-- ts: Add support for unnamed(tuple) enum in accounts([#2601](https://github.com/coral-xyz/anchor/pull/2601)).
+- ts: Add support for unnamed(tuple) enum in accounts ([#2601](https://github.com/coral-xyz/anchor/pull/2601)).
+- cli: Add program template with multiple files for instructions, state... ([#2602](https://github.com/coral-xyz/anchor/pull/2602)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -856,8 +856,9 @@ pub type Files = Vec<(PathBuf, String)>;
 /// Create files from the given (path, content) tuple array.
 ///
 /// # Example
-/// ```
-/// crate_files(&[("programs/my_program/src/lib.rs".into(), "// Content".into())])?;
+///
+/// ```ignore
+/// crate_files(vec![("programs/my_program/src/lib.rs".into(), "// Content".into())])?;
 /// ```
 pub fn create_files(files: &Files) -> Result<()> {
     for (path, content) in files {

--- a/cli/src/solidity_template.rs
+++ b/cli/src/solidity_template.rs
@@ -1,10 +1,20 @@
-use crate::config::ProgramWorkspace;
 use crate::VERSION;
+use crate::{config::ProgramWorkspace, create_files};
 use anchor_syn::idl::types::Idl;
 use anyhow::Result;
 use heck::{ToLowerCamelCase, ToSnakeCase, ToUpperCamelCase};
 use solana_sdk::pubkey::Pubkey;
 use std::fmt::Write;
+use std::path::Path;
+
+/// Create a solidity program.
+pub fn create_program(name: &str) -> Result<()> {
+    let files = vec![(
+        Path::new("solidity").join(name).with_extension("sol"),
+        solidity(name),
+    )];
+    create_files(&files)
+}
 
 pub fn default_program_id() -> Pubkey {
     "F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC"


### PR DESCRIPTION
Added `--template` argument(short `-t`) to choose a program template with `anchor init` and `anchor new` commands.

```
-t, --template <TEMPLATE>
        Rust program template to use
        
        [default: single]

        Possible values:
        - single:   Program with a single `lib.rs` file
        - multiple: Program with multiple files for instructions, state...
```

### Example usage

```
anchor init my-program -t multiple
```