### PR TITLE
lang: `associated_token` constraints don't work when setting `token_program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Compile with Solana `1.14` ([#2572](https://github.com/coral-xyz/anchor/pull/2572)).
 - cli: Fix `anchor build --no-docs` adding docs to the IDL ([#2575](https://github.com/coral-xyz/anchor/pull/2575)).
 - ts: Load workspace programs on-demand rather than loading all of them at once ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
+- lang: Fix `associated_token::token_program` constraint ([#2603](https://github.com/coral-xyz/anchor/pull/2603)).
 
 ### Breaking
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -913,6 +913,7 @@ fn generate_constraint_associated_token(
     let name_str = name.to_string();
     let wallet_address = &c.wallet;
     let spl_token_mint_address = &c.mint;
+
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, name);
     let wallet_address_optional_check = optional_check_scope.generate_check(wallet_address);
     let spl_token_mint_address_optional_check =
@@ -921,6 +922,7 @@ fn generate_constraint_associated_token(
         #wallet_address_optional_check
         #spl_token_mint_address_optional_check
     };
+
     let token_program_check = match &c.token_program {
         Some(token_program) => {
             let token_program_optional_check = optional_check_scope.generate_check(token_program);
@@ -930,6 +932,14 @@ fn generate_constraint_associated_token(
             }
         }
         None => quote! {},
+    };
+    let get_associated_token_address = match &c.token_program {
+        Some(token_program) => quote! {
+            ::anchor_spl::associated_token::get_associated_token_address_with_program_id(&wallet_address, &#spl_token_mint_address.key(), &#token_program.key())
+        },
+        None => quote! {
+            ::anchor_spl::associated_token::get_associated_token_address(&wallet_address, &#spl_token_mint_address.key())
+        },
     };
 
     quote! {
@@ -942,7 +952,7 @@ fn generate_constraint_associated_token(
             if my_owner != wallet_address {
                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str).with_pubkeys((my_owner, wallet_address)));
             }
-            let __associated_token_address = ::anchor_spl::associated_token::get_associated_token_address(&wallet_address, &#spl_token_mint_address.key());
+            let __associated_token_address = #get_associated_token_address;
             let my_key = #name.key();
             if my_key != __associated_token_address {
                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintAssociated).with_account_name(#name_str).with_pubkeys((my_key, __associated_token_address)));

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -646,7 +646,7 @@ fn generate_constraint_init_group(
                             return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintAssociatedTokenTokenProgram).with_account_name(#name_str).with_pubkeys((*owner_program, #token_program.key())));
                         }
 
-                        if pa.key() != ::anchor_spl::associated_token::get_associated_token_address(&#owner.key(), &#mint.key()) {
+                        if pa.key() != ::anchor_spl::associated_token::get_associated_token_address_with_program_id(&#owner.key(), &#mint.key(), &#token_program.key()) {
                             return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount).with_account_name(#name_str));
                         }
                     }

--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -712,8 +712,8 @@ pub struct TestAssociatedTokenWithTokenProgramConstraint<'info> {
         associated_token::authority = authority,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Option<Account<'info, TokenAccount>>,
-    pub mint: Account<'info, Mint>,
+    pub token: Option<InterfaceAccount<'info, TokenAccountInterface>>,
+    pub mint: InterfaceAccount<'info, MintInterface>,
     /// CHECK: ignore
     pub authority: AccountInfo<'info>,
     /// CHECK: ignore

--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -2,6 +2,7 @@ use crate::account::*;
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
+use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAccountInterface};
 
 #[derive(Accounts)]
 pub struct TestTokenSeedsInit<'info> {
@@ -55,8 +56,8 @@ pub struct TestInitAssociatedTokenWithTokenProgram<'info> {
         associated_token::authority = payer,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Option<Account<'info, TokenAccount>>,
-    pub mint: Option<Account<'info, Mint>>,
+    pub token: Option<InterfaceAccount<'info, TokenAccountInterface>>,
+    pub mint: Option<InterfaceAccount<'info, MintInterface>>,
     #[account(mut)]
     pub payer: Option<Signer<'info>>,
     pub system_program: Option<Program<'info, System>>,
@@ -268,7 +269,7 @@ pub struct TestInitMintWithTokenProgram<'info> {
         mint::freeze_authority = payer,
         mint::token_program = mint_token_program,
     )]
-    pub mint: Option<Account<'info, Mint>>,
+    pub mint: Option<InterfaceAccount<'info, MintInterface>>,
     #[account(mut)]
     pub payer: Option<Signer<'info>>,
     pub system_program: Option<Program<'info, System>>,
@@ -465,8 +466,8 @@ pub struct TestInitAssociatedTokenIfNeededWithTokenProgram<'info> {
         associated_token::authority = authority,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Option<Account<'info, TokenAccount>>,
-    pub mint: Option<Account<'info, Mint>>,
+    pub token: Option<InterfaceAccount<'info, TokenAccountInterface>>,
+    pub mint: Option<InterfaceAccount<'info, MintInterface>>,
     #[account(mut)]
     pub payer: Option<Signer<'info>>,
     pub system_program: Option<Program<'info, System>>,

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -2,6 +2,7 @@ use crate::account::*;
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
+use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAccountInterface};
 
 #[derive(Accounts)]
 pub struct TestTokenSeedsInit<'info> {
@@ -47,6 +48,7 @@ pub struct TestInitAssociatedToken<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
 }
 
+
 #[derive(Accounts)]
 pub struct TestInitAssociatedTokenWithTokenProgram<'info> {
     #[account(
@@ -56,8 +58,8 @@ pub struct TestInitAssociatedTokenWithTokenProgram<'info> {
         associated_token::authority = payer,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Account<'info, TokenAccount>,
-    pub mint: Account<'info, Mint>,
+    pub token: InterfaceAccount<'info, TokenAccountInterface>,
+    pub mint: InterfaceAccount<'info, MintInterface>,
     #[account(mut)]
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,
@@ -267,7 +269,7 @@ pub struct TestInitMintWithTokenProgram<'info> {
         mint::freeze_authority = payer,
         mint::token_program = mint_token_program,
     )]
-    pub mint: Account<'info, Mint>,
+    pub mint: InterfaceAccount<'info, MintInterface>,
     #[account(mut)]
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,
@@ -472,8 +474,8 @@ pub struct TestInitAssociatedTokenIfNeededWithTokenProgram<'info> {
         associated_token::authority = authority,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Account<'info, TokenAccount>,
-    pub mint: Account<'info, Mint>,
+    pub token: InterfaceAccount<'info, TokenAccountInterface>,
+    pub mint: InterfaceAccount<'info, MintInterface>,
     #[account(mut)]
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -48,7 +48,6 @@ pub struct TestInitAssociatedToken<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
 }
 
-
 #[derive(Accounts)]
 pub struct TestInitAssociatedTokenWithTokenProgram<'info> {
     #[account(
@@ -729,8 +728,8 @@ pub struct TestAssociatedTokenWithTokenProgramConstraint<'info> {
         associated_token::authority = authority,
         associated_token::token_program = associated_token_token_program,
     )]
-    pub token: Account<'info, TokenAccount>,
-    pub mint: Account<'info, Mint>,
+    pub token: InterfaceAccount<'info, TokenAccountInterface>,
+    pub mint: InterfaceAccount<'info, MintInterface>,
     /// CHECK: ignore
     pub authority: AccountInfo<'info>,
     /// CHECK: ignore

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -1195,31 +1195,31 @@ const miscTest = (
 
       it("associated_token constraints (no init) - Can make with associated_token::token_program", async () => {
         const mint = anchor.web3.Keypair.generate();
-        await program.rpc.testInitMint({
+        await program.rpc.testInitMintWithTokenProgram({
           accounts: {
             mint: mint.publicKey,
             payer: provider.wallet.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
+            mintTokenProgram: TOKEN_2022_PROGRAM_ID,
           },
           signers: [mint],
         });
 
         const associatedToken = await Token.getAssociatedTokenAddress(
           ASSOCIATED_TOKEN_PROGRAM_ID,
-          TOKEN_PROGRAM_ID,
+          TOKEN_2022_PROGRAM_ID,
           mint.publicKey,
           provider.wallet.publicKey
         );
 
-        await program.rpc.testInitAssociatedToken({
+        await program.rpc.testInitAssociatedTokenWithTokenProgram({
           accounts: {
             token: associatedToken,
             mint: mint.publicKey,
             payer: provider.wallet.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
             associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            associatedTokenTokenProgram: TOKEN_2022_PROGRAM_ID,
           },
           signers: [],
         });
@@ -1228,7 +1228,7 @@ const miscTest = (
             token: associatedToken,
             mint: mint.publicKey,
             authority: provider.wallet.publicKey,
-            associatedTokenTokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenTokenProgram: TOKEN_2022_PROGRAM_ID,
           },
         });
 
@@ -1237,7 +1237,7 @@ const miscTest = (
         );
         assert.strictEqual(
           account.owner.toString(),
-          TOKEN_PROGRAM_ID.toString()
+          TOKEN_2022_PROGRAM_ID.toString()
         );
       });
 

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -1004,7 +1004,7 @@ const miscTest = (
       );
       const ataAccount = AccountLayout.decode(rawAccount.data);
       assert.strictEqual(ataAccount.state, 1);
-      assert.strictEqual(new BN(ataAccount.amount).toNumber(), 0);
+      assert.strictEqual(new anchor.BN(ataAccount.amount).toNumber(), 0);
       assert.strictEqual(
         new PublicKey(ataAccount.owner).toString(),
         provider.wallet.publicKey.toString()
@@ -1091,7 +1091,7 @@ const miscTest = (
         );
         const ataAccount = AccountLayout.decode(rawAta.data);
         assert.strictEqual(ataAccount.state, 1);
-        assert.strictEqual(new BN(ataAccount.amount).toNumber(), 0);
+        assert.strictEqual(new anchor.BN(ataAccount.amount).toNumber(), 0);
         assert.strictEqual(
           new PublicKey(ataAccount.owner).toString(),
           provider.wallet.publicKey.toString()
@@ -1679,7 +1679,7 @@ const miscTest = (
         newToken.publicKey
       );
       const ataAccount = AccountLayout.decode(rawAccount.data);
-      assert.strictEqual(new BN(ataAccount.amount).toNumber(), 0);
+      assert.strictEqual(new anchor.BN(ataAccount.amount).toNumber(), 0);
       assert.strictEqual(
         new PublicKey(ataAccount.mint).toString(),
         newMint.publicKey.toString()
@@ -1786,7 +1786,7 @@ const miscTest = (
         associatedToken
       );
       const ataAccount = AccountLayout.decode(rawAccount.data);
-      assert.strictEqual(new BN(ataAccount.amount).toNumber(), 0);
+      assert.strictEqual(new anchor.BN(ataAccount.amount).toNumber(), 0);
       assert.strictEqual(
         new PublicKey(ataAccount.mint).toString(),
         newMint.publicKey.toString()

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -967,7 +967,9 @@ const miscTest = (
         },
         signers: [newMint],
       });
-      const rawAccount = await provider.connection.getAccountInfo(newMint.publicKey)
+      const rawAccount = await provider.connection.getAccountInfo(
+        newMint.publicKey
+      );
       const mintAccount = MintLayout.decode(rawAccount.data);
       assert.strictEqual(mintAccount.decimals, 6);
       assert.strictEqual(
@@ -978,7 +980,10 @@ const miscTest = (
         new PublicKey(mintAccount.freezeAuthority).toString(),
         provider.wallet.publicKey.toString()
       );
-      assert.strictEqual(rawAccount.owner.toString(), TOKEN_2022_PROGRAM_ID.toString());
+      assert.strictEqual(
+        rawAccount.owner.toString(),
+        TOKEN_2022_PROGRAM_ID.toString()
+      );
     });
 
     it("Can create a random token account with token program", async () => {
@@ -994,7 +999,9 @@ const miscTest = (
         signers: [token],
       });
 
-      const rawAccount = await provider.connection.getAccountInfo(token.publicKey)
+      const rawAccount = await provider.connection.getAccountInfo(
+        token.publicKey
+      );
       const ataAccount = AccountLayout.decode(rawAccount.data);
       assert.strictEqual(ataAccount.state, 1);
       assert.strictEqual(new BN(ataAccount.amount).toNumber(), 0);
@@ -1002,7 +1009,10 @@ const miscTest = (
         new PublicKey(ataAccount.owner).toString(),
         provider.wallet.publicKey.toString()
       );
-      assert.strictEqual(new PublicKey(ataAccount.mint).toString(), mint.publicKey.toString());
+      assert.strictEqual(
+        new PublicKey(ataAccount.mint).toString(),
+        mint.publicKey.toString()
+      );
     });
 
     describe("associated_token constraints", () => {

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -22,6 +22,10 @@ const { assert, expect } = require("chai");
 const nativeAssert = require("assert");
 const miscIdl = require("../../target/idl/misc.json");
 
+const TOKEN_2022_PROGRAM_ID = new anchor.web3.PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+);
+
 const miscTest = (
   program: anchor.Program<Misc> | anchor.Program<MiscOptional>
 ) => {
@@ -1060,14 +1064,14 @@ const miscTest = (
             mint: newMint.publicKey,
             payer: provider.wallet.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
+            tokenProgram: TOKEN_2022_PROGRAM_ID,
           },
           signers: [newMint],
         });
 
         const associatedToken = await Token.getAssociatedTokenAddress(
           ASSOCIATED_TOKEN_PROGRAM_ID,
-          TOKEN_PROGRAM_ID,
+          TOKEN_2022_PROGRAM_ID,
           newMint.publicKey,
           provider.wallet.publicKey
         );
@@ -1078,7 +1082,7 @@ const miscTest = (
             mint: newMint.publicKey,
             payer: provider.wallet.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
-            associatedTokenTokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenTokenProgram: TOKEN_2022_PROGRAM_ID,
             associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
           },
         });
@@ -1086,7 +1090,7 @@ const miscTest = (
         const token = new Token(
           program.provider.connection,
           newMint.publicKey,
-          TOKEN_PROGRAM_ID,
+          TOKEN_2022_PROGRAM_ID,
           wallet.payer
         );
         const ataAccount = await token.getAccountInfo(associatedToken);
@@ -1767,14 +1771,14 @@ const miscTest = (
           mint: newMint.publicKey,
           payer: provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-          tokenProgram: TOKEN_PROGRAM_ID,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
         },
         signers: [newMint],
       });
 
       const associatedToken = await Token.getAssociatedTokenAddress(
         ASSOCIATED_TOKEN_PROGRAM_ID,
-        TOKEN_PROGRAM_ID,
+        TOKEN_2022_PROGRAM_ID,
         newMint.publicKey,
         provider.wallet.publicKey
       );
@@ -1786,7 +1790,7 @@ const miscTest = (
           payer: provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
           associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-          associatedTokenTokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenTokenProgram: TOKEN_2022_PROGRAM_ID,
           authority: provider.wallet.publicKey,
         },
       });
@@ -1794,7 +1798,7 @@ const miscTest = (
       const mintClient = new Token(
         provider.connection,
         newMint.publicKey,
-        TOKEN_PROGRAM_ID,
+        TOKEN_2022_PROGRAM_ID,
         wallet.payer
       );
       const ataAccount = await mintClient.getAccountInfo(associatedToken);
@@ -2439,14 +2443,14 @@ const miscTest = (
           mint: mint.publicKey,
           payer: provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-          tokenProgram: TOKEN_PROGRAM_ID,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
         },
         signers: [mint],
       });
 
       const associatedToken = await Token.getAssociatedTokenAddress(
         ASSOCIATED_TOKEN_PROGRAM_ID,
-        TOKEN_PROGRAM_ID,
+        TOKEN_2022_PROGRAM_ID,
         mint.publicKey,
         provider.wallet.publicKey
       );
@@ -2457,7 +2461,7 @@ const miscTest = (
           mint: mint.publicKey,
           payer: provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-          tokenProgram: TOKEN_PROGRAM_ID,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
           associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         },
       });
@@ -2468,7 +2472,7 @@ const miscTest = (
           mint: mint.publicKey,
           payer: provider.wallet.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
-          associatedTokenTokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenTokenProgram: TOKEN_2022_PROGRAM_ID,
           associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
           authority: provider.wallet.publicKey,
         },


### PR DESCRIPTION
supersedes and resolves #2541

When setting `associated_token` constraints using a specified `token_program` other than the standard token program. A constraint fails because it relies on a hardcoded version of `token_program` instead of the user-specified one. This makes it impossible to use `associated_token` constraints that use the Token2022 token program.

This PR fixes the check by using `get_associated_token_address_with_program_id` instead of `get_associated_token_address` which it was using previously.

This PR also adds a new test program that uses the `associated_token` constraints both with and without specifying a `token_program`. This test would throw an `AccountNotAssociatedTokenAccount` before the changes introduced in this PR.

tl;dr: This PR fixes a bug that makes using a custom `token_program` impossible with the `associated_token` constraints.