### PR TITLE
ts: Bump packages to `0.28.1-beta.2`

### DIFF
--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coral-xyz/anchor",
-  "version": "0.28.1-beta.1",
+  "version": "0.28.1-beta.2",
   "description": "Anchor client",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",

--- a/ts/packages/spl-associated-token-account/package.json
+++ b/ts/packages/spl-associated-token-account/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-binary-option/package.json
+++ b/ts/packages/spl-binary-option/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-binary-oracle-pair/package.json
+++ b/ts/packages/spl-binary-oracle-pair/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-feature-proposal/package.json
+++ b/ts/packages/spl-feature-proposal/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-governance/package.json
+++ b/ts/packages/spl-governance/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-memo/package.json
+++ b/ts/packages/spl-memo/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1"
+    "@coral-xyz/anchor": "=0.28.1-beta.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "=21.0.2",

--- a/ts/packages/spl-name-service/package.json
+++ b/ts/packages/spl-name-service/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-record/package.json
+++ b/ts/packages/spl-record/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-stake-pool/package.json
+++ b/ts/packages/spl-stake-pool/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-stateless-asks/package.json
+++ b/ts/packages/spl-stateless-asks/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-token-lending/package.json
+++ b/ts/packages/spl-token-lending/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-token-swap/package.json
+++ b/ts/packages/spl-token-swap/package.json
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {

--- a/ts/packages/spl-token/package.json
+++ b/ts/packages/spl-token/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coral-xyz/spl-token",
   "description": "Anchor client for Solana Program Library Token",
-  "version": "0.28.1-beta.1",
+  "version": "0.28.1-beta.2",
   "author": "acheron <acheroncrypto@gmail.com>",
   "license": "Apache-2.0",
   "repository": {
@@ -27,7 +27,7 @@
     "watch": "tsc -p tsconfig.cjs.json --watch"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.1",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@native-to-anchor/buffer-layout": "=0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pre release with `@noble/hashes` instead of `js-sha256`(https://github.com/coral-xyz/anchor/pull/2580) to fix inconsistent discriminator issue on some Chrome versions.