### PR TITLE
ts: Add strong type support for `addEventListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add support for unnamed(tuple) enum in accounts ([#2601](https://github.com/coral-xyz/anchor/pull/2601)).
 - cli: Add program template with multiple files for instructions, state... ([#2602](https://github.com/coral-xyz/anchor/pull/2602)).
 - lang: `Box` the inner enums of `anchor_lang::error::Error` to optimize `anchor_lang::Result` ([#2600](https://github.com/coral-xyz/anchor/pull/2600)).
+- ts: Add strong type support for `Program.addEventListener` method ([#2627](https://github.com/coral-xyz/anchor/pull/2627)).
 
 ### Fixes
 

--- a/tests/events/Anchor.toml
+++ b/tests/events/Anchor.toml
@@ -6,4 +6,4 @@ wallet = "~/.config/solana/id.json"
 events = "2dhGsWUzy5YKUsjZdLHLmkNpUDAXkNa9MYWsPc4Ziqzy"
 
 [scripts]
-test = "yarn run mocha -t 1000000 tests/"
+test = "yarn run ts-mocha -t 1000000 -p ./tsconfig.json tests/**/*.ts"

--- a/tests/events/tsconfig.json
+++ b/tests/events/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -11,6 +11,7 @@ import NamespaceFactory, {
   SimulateNamespace,
   MethodsNamespace,
   ViewNamespace,
+  IdlEvents,
 } from "./namespace/index.js";
 import { utf8 } from "../utils/bytes/index.js";
 import { EventManager } from "./event.js";
@@ -357,9 +358,13 @@ export class Program<IDL extends Idl = Idl> {
    * @param callback  The function to invoke whenever the event is emitted from
    *                  program logs.
    */
-  public addEventListener(
-    eventName: string,
-    callback: (event: any, slot: number, signature: string) => void
+  public addEventListener<E extends keyof IdlEvents<IDL>>(
+    eventName: E,
+    callback: (
+      event: IdlEvents<IDL>[E],
+      slot: number,
+      signature: string
+    ) => void
   ): number {
     return this._events.addEventListener(eventName, callback);
   }


### PR DESCRIPTION
### Problem

`Program.addEventListener` method is not strongly typed.

https://github.com/coral-xyz/anchor/blob/cec9946111a1c651fd21235c2a554eda05c3ffa3/ts/packages/anchor/src/program/index.ts#L360-L363

`eventName` is a `string`, and `event` is `any`.

### Summary of Changes

- Add strong type support for `addEventListener` method. Both `eventName` and `event` is now strongly typed.
- Convert and refactor the event tests from JavaScript to TypeScript to test types properly.