### PR TITLE
docs: Add tuple enum JS client documentation

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tailwindui-documentation",
+  "name": "anchor-docs",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindui-documentation",
+      "name": "anchor-docs",
       "version": "0.1.0",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
@@ -17,7 +17,7 @@
         "autoprefixer": "^10.4.7",
         "clsx": "^1.2.1",
         "focus-visible": "^5.2.0",
-        "gh-pages": "^4.0.0",
+        "gh-pages": "^5.0.0",
         "next": "12.2.1",
         "next-plausible": "^3.2.0",
         "postcss-focus-visible": "^6.0.4",
@@ -993,12 +993,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.7",
@@ -1398,9 +1395,9 @@
       "integrity": "sha512-lPHuHXBwpkr4RcfaZBKm6TKOWG/1N9mVggUpP4fY3l1JIUU2x4fkM8928smYdZ5lF+6KCTAxo1aK9JmqT+X71Q=="
     },
     "node_modules/email-addresses": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2187,13 +2184,13 @@
       }
     },
     "node_modules/gh-pages": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-4.0.0.tgz",
-      "integrity": "sha512-p8S0T3aGJc68MtwOcZusul5qPSNZCalap3NWbhRUZYu1YOdp+EjZ+4kPmRM8h3NNRdqw00yuevRjlkuSzCn7iQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-5.0.0.tgz",
+      "integrity": "sha512-Nqp1SjkPIB94Xw/3yYNTUL+G2dxlhjvv1zeN/4kMC1jfViTEqhtVz/Ba1zSXHuvXCN9ADNS1dN4r5/J/nZWEQQ==",
       "dependencies": {
-        "async": "^2.6.1",
+        "async": "^3.2.4",
         "commander": "^2.18.0",
-        "email-addresses": "^3.0.1",
+        "email-addresses": "^5.0.0",
         "filenamify": "^4.3.0",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "^8.1.0",
@@ -2749,11 +2746,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -4896,12 +4888,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "autoprefixer": {
       "version": "10.4.7",
@@ -5174,9 +5163,9 @@
       "integrity": "sha512-lPHuHXBwpkr4RcfaZBKm6TKOWG/1N9mVggUpP4fY3l1JIUU2x4fkM8928smYdZ5lF+6KCTAxo1aK9JmqT+X71Q=="
     },
     "email-addresses": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -5779,13 +5768,13 @@
       }
     },
     "gh-pages": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-4.0.0.tgz",
-      "integrity": "sha512-p8S0T3aGJc68MtwOcZusul5qPSNZCalap3NWbhRUZYu1YOdp+EjZ+4kPmRM8h3NNRdqw00yuevRjlkuSzCn7iQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-5.0.0.tgz",
+      "integrity": "sha512-Nqp1SjkPIB94Xw/3yYNTUL+G2dxlhjvv1zeN/4kMC1jfViTEqhtVz/Ba1zSXHuvXCN9ADNS1dN4r5/J/nZWEQQ==",
       "requires": {
-        "async": "^2.6.1",
+        "async": "^3.2.4",
         "commander": "^2.18.0",
-        "email-addresses": "^3.0.1",
+        "email-addresses": "^5.0.0",
         "filenamify": "^4.3.0",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "^8.1.0",
@@ -6180,11 +6169,6 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.castarray": {
       "version": "4.4.0",

--- a/docs/src/pages/docs/javascript-anchor-types.md
+++ b/docs/src/pages/docs/javascript-anchor-types.md
@@ -25,17 +25,17 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
 * `u64/u128/i64/i128`
 * `anchor.BN`
 * ```javascript
-    await program
+  await program
     .methods
     .init(new anchor.BN(99))
     .rpc();
     ```
-* [https://github.com/indutny/bn.js/](https://github.com/indutny/bn.js/ )
+* [https://github.com/indutny/bn.js](https://github.com/indutny/bn.js )
 ---
 * `u8/u16/u32/i8/i16/i32`
 * `number`
 * ```javascript
-    await program
+  await program
     .methods
     .init(99)
     .rpc();
@@ -44,69 +44,79 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
 * `f32/f64`
 * `number`
 * ```javascript
-    await program
+  await program
     .methods
     .init(1.0)
     .rpc();
     ```
 ---
 * `Enum`
-* `{ variantName: {} }`
-*   ```rust
-      enum MyEnum { One, Two };
-    ```
-    ```javascript
-    await program
+* `object`
+* ```rust
+  enum MyEnum {
+      One,
+      Two { val: u32 },
+      Three(u8, i16),
+  };
+  ```
+  ```javascript
+  // Unit variant
+  await program
     .methods
     .init({ one: {} })
     .rpc();
-    ```
-    ```rust
-    enum MyEnum { One: { val: u64 }, Two };
-    ```
-    ```javascript
-    await program
+
+  // Named variant
+  await program
     .methods
-    .init({ one: { val: 99 } })
+    .init({ two: { val: 99 } })
     .rpc();
-    ```
+
+  // Unnamed(tuple) variant
+  await program
+    .methods
+    .init({ three: [12, -34] })
+    .rpc();
+  ```
 ---
 * `Struct`
 * `{ val: {} }`
 * ```rust
-    struct MyStruct { val: u64 };
-    ```
+  struct MyStruct {
+    val: u16,
+  }
+  ```
   ```javascript
-    await program
+  await program
     .methods
     .init({ val: 99 })
     .rpc();
-    ```
+  ```
 ---
 * `[T; N]`
 * `[ T ]`
 * ```javascript
-    await program
+  await program
     .methods
-    .init([1,2,3])
+    .init([1, 2, 3])
     .rpc();
-    ```
+  ```
 ---
 * `String`
 * `string`
 * ```javascript
-    await program
+  await program
     .methods
     .init("hello")
     .rpc();
-    ```
+  ```
 ---
 * `Vec<T>`
 * `[ T ]`
 * ```javascript
-    await program
+  await program
     .methods
-    .init([1,2,3])
+    .init([1, 2, 3])
     .rpc();
-    ```
+  ```
 {% /table %}


### PR DESCRIPTION
### Problem

Unnamed(tuple) enum variant JS client interactions is not documented.

### Summary of Changes

- Add JS example for different enum variants; unit, named, unnamed(tuple)
- Fix code alignment of the code snippets
- Fix incorrect type in the `Struct` example