### PR TITLE
syn: Fix IDL named enum variant field being snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Load workspace programs on-demand rather than loading all of them at once ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
 - lang: Fix `associated_token::token_program` constraint ([#2603](https://github.com/coral-xyz/anchor/pull/2603)).
 - cli: Fix `anchor account` command panicking outside of workspace ([#2620](https://github.com/coral-xyz/anchor/pull/2620)).
+- lang: IDL named enum variant fields are now camelCase as opposed to snake_case, consistent with the other IDL types ([#2633](https://github.com/coral-xyz/anchor/pull/2633)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/parse/file.rs
+++ b/lang/syn/src/idl/parse/file.rs
@@ -384,7 +384,8 @@ fn parse_ty_defs(ctx: &CrateContext, no_docs: bool) -> Result<Vec<IdlTypeDefinit
                                 .named
                                 .iter()
                                 .map(|f: &syn::Field| {
-                                    let name = f.ident.as_ref().unwrap().to_string();
+                                    let name =
+                                        f.ident.as_ref().unwrap().to_string().to_mixed_case();
                                     let doc = if !no_docs {
                                         docs::parse(&f.attrs)
                                     } else {

--- a/tests/idl/idls/parse.json
+++ b/tests/idl/idls/parse.json
@@ -657,14 +657,14 @@
             "name": "Named",
             "fields": [
               {
-                "name": "bool_field",
+                "name": "boolField",
                 "docs": [
                   "A bool field inside a struct tuple kind"
                 ],
                 "type": "bool"
               },
               {
-                "name": "u8_field",
+                "name": "u8Field",
                 "type": "u8"
               },
               {

--- a/tests/idl/programs/client-interactions/src/lib.rs
+++ b/tests/idl/programs/client-interactions/src/lib.rs
@@ -81,7 +81,7 @@ pub struct EnumAccount {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MyEnum {
     Unit,
-    Named { x: u64, y: u64 },
+    Named { point_x: u64, point_y: u64 },
     Unnamed(u8, u8, u16, u16),
     UnnamedStruct(MyStruct),
 }

--- a/tests/idl/tests/client-interactions.ts
+++ b/tests/idl/tests/client-interactions.ts
@@ -81,11 +81,11 @@ describe("Client interactions", () => {
     assert.deepEqual(unit.enumField.unit, {});
 
     // Named
-    const x = new anchor.BN(1);
-    const y = new anchor.BN(2);
-    const named = await testAccountEnum({ named: { x, y } });
-    assert(named.enumField.named.x.eq(x));
-    assert(named.enumField.named.y.eq(y));
+    const pointX = new anchor.BN(1);
+    const pointY = new anchor.BN(2);
+    const named = await testAccountEnum({ named: { pointX, pointY } });
+    assert(named.enumField.named.pointX.eq(pointX));
+    assert(named.enumField.named.pointY.eq(pointY));
 
     // Unnamed
     const tupleArg = [1, 2, 3, 4] as const;


### PR DESCRIPTION
### Problem

Named enum variant fields are in snake_case as opposed to every other field being in camelCase in the IDL.

This has been addressed in the IDL build implementation(https://github.com/coral-xyz/anchor/pull/2011) but the issue still persists with the parse method.

### Summary of Changes

- Convert the named enum variant fields to camelCase
- Add a test case that uses an enum variant named field with multiple words(in snake_case)

It would be great if we could get rid of the case conversion in IDL but that would also have its own downsides(breaking change).

Closes https://github.com/coral-xyz/anchor/issues/1443.