### PR TITLE
ts: Remove `base64-js` dependency

### DIFF
--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -36,7 +36,6 @@
     "@coral-xyz/borsh": "^0.28.0",
     "@noble/hashes": "^1.3.1",
     "@solana/web3.js": "^1.68.0",
-    "base64-js": "^1.5.1",
     "bn.js": "^5.1.2",
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.2",

--- a/ts/packages/anchor/rollup.config.ts
+++ b/ts/packages/anchor/rollup.config.ts
@@ -33,7 +33,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/anchor/src/coder/borsh/event.ts
+++ b/ts/packages/anchor/src/coder/borsh/event.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "buffer";
-import * as base64 from "base64-js";
 import { Layout } from "buffer-layout";
+import * as base64 from "../../utils/bytes/base64.js";
 import { Idl, IdlEvent, IdlTypeDef } from "../../idl.js";
 import { Event, EventData } from "../../program/event.js";
 import { IdlCoder } from "./idl.js";
@@ -41,7 +41,7 @@ export class BorshEventCoder implements EventCoder {
       idl.events === undefined
         ? []
         : idl.events.map((e) => [
-            base64.fromByteArray(eventDiscriminator(e.name)),
+            base64.encode(eventDiscriminator(e.name)),
             e.name,
           ])
     );
@@ -53,11 +53,11 @@ export class BorshEventCoder implements EventCoder {
     let logArr: Buffer;
     // This will throw if log length is not a multiple of 4.
     try {
-      logArr = Buffer.from(base64.toByteArray(log));
+      logArr = base64.decode(log);
     } catch (e) {
       return null;
     }
-    const disc = base64.fromByteArray(logArr.slice(0, 8));
+    const disc = base64.encode(logArr.slice(0, 8));
 
     // Only deserialize if the discriminator implies a proper event.
     const eventName = this.discriminators.get(disc);

--- a/ts/packages/anchor/src/utils/bytes/base64.ts
+++ b/ts/packages/anchor/src/utils/bytes/base64.ts
@@ -1,10 +1,9 @@
 import { Buffer } from "buffer";
-import * as base64 from "base64-js";
 
 export function encode(data: Buffer): string {
-  return base64.fromByteArray(data);
+  return data.toString("base64");
 }
 
 export function decode(data: string): Buffer {
-  return Buffer.from(base64.toByteArray(data));
+  return Buffer.from(data, "base64");
 }

--- a/ts/packages/spl-associated-token-account/rollup.config.ts
+++ b/ts/packages/spl-associated-token-account/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-binary-option/rollup.config.ts
+++ b/ts/packages/spl-binary-option/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-binary-oracle-pair/rollup.config.ts
+++ b/ts/packages/spl-binary-oracle-pair/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-feature-proposal/rollup.config.ts
+++ b/ts/packages/spl-feature-proposal/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-governance/rollup.config.ts
+++ b/ts/packages/spl-governance/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-memo/rollup.config.ts
+++ b/ts/packages/spl-memo/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-name-service/rollup.config.ts
+++ b/ts/packages/spl-name-service/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-record/rollup.config.ts
+++ b/ts/packages/spl-record/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-stake-pool/rollup.config.ts
+++ b/ts/packages/spl-stake-pool/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-stateless-asks/rollup.config.ts
+++ b/ts/packages/spl-stateless-asks/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-token-lending/rollup.config.ts
+++ b/ts/packages/spl-token-lending/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-token-swap/rollup.config.ts
+++ b/ts/packages/spl-token-swap/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/packages/spl-token/rollup.config.ts
+++ b/ts/packages/spl-token/rollup.config.ts
@@ -35,7 +35,6 @@ export default {
   external: [
     "@coral-xyz/borsh",
     "@solana/web3.js",
-    "base64-js",
     "bn.js",
     "bs58",
     "buffer",

--- a/ts/tests/package.json
+++ b/ts/tests/package.json
@@ -13,7 +13,7 @@
     "typescript": "*"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "*",
+    "@coral-xyz/anchor": "=0.28.1-beta.2",
     "@solana/web3.js": "*"
   }
 }

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1417,7 +1417,7 @@ base-x@^3.0.2, base-x@^3.0.6:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==


### PR DESCRIPTION
### Problem

`Buffer` supports base64 encoding which makes the explicit `base64-js` dependency redundant.

### Summary of Changes

- Remove the `base64-js` dependency from all packages