### PR TITLE
Update to solang v0.3.2 and add simple test

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -10,7 +10,7 @@ runs:
         path: |
           ~/.cache/solana/
           ~/.local/share/solana/
-        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION }}
+        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION }}-${{ env.SOLANG_VERSION }}
     - uses: nick-fields/retry@v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:
@@ -20,6 +20,18 @@ runs:
         retry_on: error
         shell: bash
         command: sh -c "$(curl -sSfL https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install)"
+    - uses: nick-fields/retry@v2
+      if: steps.cache-solana.outputs.cache-hit != 'true'
+      with:
+        retry_wait_seconds: 300
+        timeout_minutes: 2
+        max_attempts: 10
+        retry_on: error
+        shell: bash
+        command: |
+          curl -sSL -o /home/runner/.local/share/solana/install/active_release/bin/solang \
+            https://github.com/hyperledger/solang/releases/download/v${{ env.SOLANG_VERSION }}/solang-linux-x86-64
+          chmod 755 /home/runner/.local/share/solana/install/active_release/bin/solang
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       cache: false
       solana_cli_version: 1.16.0
+      solang_version: 0.3.2
       node_version: 17.0.1
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -9,6 +9,9 @@ on:
       solana_cli_version:
         required: true
         type: string
+      solang_version:
+        required: true
+        type: string
       node_version:
         required: true
         type: string
@@ -21,6 +24,7 @@ on:
 env:
   CACHE: inputs.cache
   SOLANA_CLI_VERSION: ${{ inputs.solana_cli_version }}
+  SOLANG_VERSION: ${{ inputs.solang_version }}
   NODE_VERSION: ${{ inputs.node_version }}
   CARGO_PROFILE: ${{ inputs.cargo_profile }}
   ANCHOR_BINARY_NAME: ${{ inputs.anchor_binary_name }}
@@ -445,6 +449,8 @@ jobs:
             path: tests/bench
           - cmd: cd tests/idl && ./test.sh
             path: tests/idl
+          - cmd: cd tests/solang && anchor test
+            path: tests/solang
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
     with:
       cache: true
       solana_cli_version: 1.16.0
+      solang_version: 0.3.2
       node_version: 17.0.1
       cargo_profile: debug
       anchor_binary_name: anchor-binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,11 +4513,11 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c792fe9fae2a2f716846f214ca10d5a1e21133e0bf36cef34bcc4a852467b21"
+checksum = "7cb9fa2fa2fa6837be8a2495486ff92e3ffe68a99b6eeba288e139efdd842457"
 dependencies = [
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop",
  "lalrpop-util",
  "phf",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,7 @@ solana-cli-config = ">=1.14, <1.17"
 solana-faucet = ">=1.14, <1.17"
 solana-program = ">=1.14, <1.17"
 solana-sdk = ">=1.14, <1.17"
-solang-parser = "=0.3.1"
+solang-parser = "=0.3.2"
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 tar = "0.4.35"
 toml = "0.7.6"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -114,6 +114,8 @@ impl Manifest {
         let mut cwd_opt = Some(start_from.as_path());
 
         while let Some(cwd) = cwd_opt {
+            let mut anchor_toml = false;
+
             for f in fs::read_dir(cwd).with_context(|| {
                 format!("Error reading the directory with path: {}", cwd.display())
             })? {
@@ -127,10 +129,17 @@ impl Manifest {
                         let m = WithPath::new(Manifest::from_path(&p)?, p);
                         return Ok(Some(m));
                     }
+                    if filename.to_str() == Some("Anchor.toml") {
+                        anchor_toml = true;
+                    }
                 }
             }
 
-            // Not found. Go up a directory level.
+            // Not found. Go up a directory level, but don't go up from Anchor.toml
+            if anchor_toml {
+                break;
+            }
+
             cwd_opt = cwd.parent();
         }
 

--- a/cli/src/solidity_template.rs
+++ b/cli/src/solidity_template.rs
@@ -133,7 +133,7 @@ contract {} {{
     bool private value = true;
 
     @payer(payer)
-    constructor(address payer) {{
+    constructor() {{
         print("Hello, World!");
     }}
 
@@ -318,22 +318,27 @@ describe("{}", () => {{
 
   it("Is initialized!", async () => {{
     // Add your test here.
-    const tx = await program.methods.new(wallet.publicKey)
+    const tx = await program.methods
+      .new()
       .accounts({{ dataAccount: dataAccount.publicKey }})
-      .signers([dataAccount]).rpc();
+      .signers([dataAccount])
+      .rpc();
     console.log("Your transaction signature", tx);
 
-    const val1 = await program.methods.get()
+    const val1 = await program.methods
+      .get()
       .accounts({{ dataAccount: dataAccount.publicKey }})
       .view();
 
     console.log("state", val1);
 
-    await program.methods.flip()
+    await program.methods
+      .flip()
       .accounts({{ dataAccount: dataAccount.publicKey }})
       .rpc();
 
-    const val2 = await program.methods.get()
+    const val2 = await program.methods
+      .get()
       .accounts({{ dataAccount: dataAccount.publicKey }})
       .view();
 
@@ -366,9 +371,11 @@ describe("{}", () => {{
 
   it("Is initialized!", async () => {{
     // Add your test here.
-    const tx = await program.methods.new(wallet.publicKey)
+    const tx = await program.methods
+      .new()
       .accounts({{ dataAccount: dataAccount.publicKey }})
-      .signers([dataAccount]).rpc();
+      .signers([dataAccount])
+      .rpc();
     console.log("Your transaction signature", tx);
   }});
 }});

--- a/tests/package.json
+++ b/tests/package.json
@@ -43,7 +43,8 @@
     "cpi-returns",
     "multiple-suites",
     "multiple-suites-run-single",
-    "bpf-upgradeable-state"
+    "bpf-upgradeable-state",
+    "solang"
   ],
   "dependencies": {
     "@project-serum/common": "^0.0.1-beta.3",

--- a/tests/solang/.gitignore
+++ b/tests/solang/.gitignore
@@ -1,0 +1,8 @@
+
+.anchor
+.DS_Store
+target
+**/*.rs.bk
+node_modules
+test-ledger
+.yarn

--- a/tests/solang/.prettierignore
+++ b/tests/solang/.prettierignore
@@ -1,0 +1,8 @@
+
+.anchor
+.DS_Store
+target
+node_modules
+dist
+build
+test-ledger

--- a/tests/solang/Anchor.toml
+++ b/tests/solang/Anchor.toml
@@ -1,0 +1,13 @@
+[features]
+seeds = false
+skip-lint = false
+
+[programs.localnet]
+flipper = "F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC"
+
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/solang/migrations/deploy.ts
+++ b/tests/solang/migrations/deploy.ts
@@ -1,0 +1,12 @@
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@coral-xyz/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+};

--- a/tests/solang/package.json
+++ b/tests/solang/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "solang",
+  "version": "0.28.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=11"
+  },
+  "scripts": {
+    "test": "anchor run test-with-build"
+  }
+}

--- a/tests/solang/solidity/flipper.sol
+++ b/tests/solang/solidity/flipper.sol
@@ -1,0 +1,22 @@
+
+@program_id("F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC")
+contract flipper {
+    bool private value = true;
+
+    @payer(payer)
+    constructor() {
+        print("Hello, World!");
+    }
+
+    /// A message that can be called on instantiated contracts.
+    /// This one flips the value of the stored `bool` from `true`
+    /// to `false` and vice versa.
+    function flip() public {
+            value = !value;
+    }
+
+    /// Simply returns the current value of our `bool`.
+    function get() public view returns (bool) {
+            return value;
+    }
+}

--- a/tests/solang/tests/solang.ts
+++ b/tests/solang/tests/solang.ts
@@ -1,0 +1,43 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Flipper } from "../target/types/flipper";
+
+describe("flipper", () => {
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const dataAccount = anchor.web3.Keypair.generate();
+  const wallet = provider.wallet;
+
+  const program = anchor.workspace.Flipper as Program<Flipper>;
+
+  it("Is initialized!", async () => {
+    // Add your test here.
+    const tx = await program.methods
+      .new()
+      .accounts({ dataAccount: dataAccount.publicKey })
+      .signers([dataAccount])
+      .rpc();
+    console.log("Your transaction signature", tx);
+
+    const val1 = await program.methods
+      .get()
+      .accounts({ dataAccount: dataAccount.publicKey })
+      .view();
+
+    console.log("state", val1);
+
+    await program.methods
+      .flip()
+      .accounts({ dataAccount: dataAccount.publicKey })
+      .rpc();
+
+    const val2 = await program.methods
+      .get()
+      .accounts({ dataAccount: dataAccount.publicKey })
+      .view();
+
+    console.log("state", val2);
+  });
+});

--- a/tests/solang/tsconfig.json
+++ b/tests/solang/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
- Anchor looks for a `Cargo.toml` file in the project area, and walks the path all the way up to `/`. This causes problems with Solidity Anchor projects as they don't have their own `Cargo.toml` file, and then Anchor's own `Cargo.toml` file is found. So, stop walking when we find a `Anchor.toml` file.
- Update solang-parser to v0.3.2
- Add a simple solang test.