### PR TITLE
Add type alias support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli, lang: Add IDL generation through compilation. `anchor build` still uses parsing method to generate IDLs, use `anchor idl build` to generate IDLs with the build method ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
 - avm: Add support for the `.anchorversion` file to facilitate switching between different versions of the `anchor-cli` ([#2553](https://github.com/coral-xyz/anchor/pull/2553)).
 - ts: Add ability to access workspace programs independent of the casing used, e.g. `anchor.workspace.myProgram`, `anchor.workspace.MyProgram`... ([#2579](https://github.com/coral-xyz/anchor/pull/2579)).
+- bench: Add benchmarking for program binary size ([#2591](https://github.com/coral-xyz/anchor/pull/2591)).
 - spl: Export `mpl-token-metadata` crate ([#2583](https://github.com/coral-xyz/anchor/pull/2583)).
 - spl: Add `TokenRecordAccount` for pNFTs ([#2597](https://github.com/coral-xyz/anchor/pull/2597)).
 - ts: Add support for unnamed(tuple) enum in accounts ([#2601](https://github.com/coral-xyz/anchor/pull/2601)).
 - cli: Add program template with multiple files for instructions, state... ([#2602](https://github.com/coral-xyz/anchor/pull/2602)).
+- bench: Add benchmarking for stack memory usage ([#2617](https://github.com/coral-xyz/anchor/pull/2617)).
 - lang: `Box` the inner enums of `anchor_lang::error::Error` to optimize `anchor_lang::Result` ([#2600](https://github.com/coral-xyz/anchor/pull/2600)).
 - ts: Add strong type support for `Program.addEventListener` method ([#2627](https://github.com/coral-xyz/anchor/pull/2627)).
+- syn: Add `IdlBuild` trait to implement IDL support for custom types ([#2629](https://github.com/coral-xyz/anchor/pull/2629)).
+- spl: Add `idl-build` feature. IDL build method will not work without enabling this feature when using `anchor-spl` ([#2629](https://github.com/coral-xyz/anchor/pull/2629)).
 
 ### Fixes
 
@@ -41,7 +45,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - syn: `idl` feature has been replaced with `idl-build`, `idl-parse` and `idl-types` features ([#2011](https://github.com/coral-xyz/anchor/pull/2011)).
 - syn: IDL `parse` method now returns `Result<Idl>` instead of `Result<Option<Idl>>` ([#2582](https://github.com/coral-xyz/anchor/pull/2582)).
-- spl: Update Token Metadata dependency to use the client SDK instead of the program crate ([#2632](https://github.com/coral-xyz/anchor/pull/2632))
+- spl: Update `mpl-token-metadata` dependency to use the client SDK instead of the program crate ([#2632](https://github.com/coral-xyz/anchor/pull/2632)).
+- ts: Remove `base64-js` dependency ([#2635](https://github.com/coral-xyz/anchor/pull/2635)).
 
 ## [0.28.0] - 2023-06-09
 

--- a/lang/syn/src/idl/types.rs
+++ b/lang/syn/src/idl/types.rs
@@ -166,6 +166,7 @@ pub struct IdlTypeDefinition {
 pub enum IdlTypeDefinitionTy {
     Struct { fields: Vec<IdlField> },
     Enum { variants: Vec<IdlEnumVariant> },
+    Alias { value: IdlType },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -28,6 +28,10 @@ impl CrateContext {
         self.modules.iter().flat_map(|(_, ctx)| ctx.enums())
     }
 
+    pub fn type_aliases(&self) -> impl Iterator<Item = &syn::ItemType> {
+        self.modules.iter().flat_map(|(_, ctx)| ctx.type_aliases())
+    }
+
     pub fn modules(&self) -> impl Iterator<Item = ModuleContext> {
         self.modules.values().map(|detail| ModuleContext { detail })
     }
@@ -292,5 +296,12 @@ impl ParsedModule {
                 _ => None,
             })
             .flatten()
+    }
+
+    fn type_aliases(&self) -> impl Iterator<Item = &syn::ItemType> {
+        self.items.iter().filter_map(|i| match i {
+            syn::Item::Type(item) => Some(item),
+            _ => None,
+        })
     }
 }

--- a/tests/idl/programs/client-interactions/src/lib.rs
+++ b/tests/idl/programs/client-interactions/src/lib.rs
@@ -35,6 +35,18 @@ pub mod client_interactions {
         ctx.accounts.account.enum_field = enum_arg;
         Ok(())
     }
+
+    pub fn type_alias(
+        ctx: Context<TypeAlias>,
+        type_alias_u8: TypeAliasU8,
+        type_alias_u8_array: TypeAliasU8Array,
+        type_alias_struct: TypeAliasStruct,
+    ) -> Result<()> {
+        ctx.accounts.account.type_alias_u8 = type_alias_u8;
+        ctx.accounts.account.type_alias_u8_array = type_alias_u8_array;
+        ctx.accounts.account.type_alias_struct = type_alias_struct;
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -93,3 +105,20 @@ pub struct MyStruct {
     pub u32: u32,
     pub u64: u64,
 }
+
+#[derive(Accounts)]
+pub struct TypeAlias<'info> {
+    #[account(zero)]
+    pub account: Account<'info, TypeAliasAccount>,
+}
+
+#[account]
+pub struct TypeAliasAccount {
+    pub type_alias_u8: TypeAliasU8,
+    pub type_alias_u8_array: TypeAliasU8Array,
+    pub type_alias_struct: TypeAliasStruct,
+}
+
+pub type TypeAliasU8 = u8;
+pub type TypeAliasU8Array = [TypeAliasU8; 8];
+pub type TypeAliasStruct = MyStruct;

--- a/tests/idl/tests/client-interactions.ts
+++ b/tests/idl/tests/client-interactions.ts
@@ -118,4 +118,32 @@ describe("Client interactions", () => {
       unnamedStruct.enumField.unnamedStruct[0].u64.eq(tupleStructArg[0].u64)
     );
   });
+
+  it("Can use type aliases", async () => {
+    const kp = anchor.web3.Keypair.generate();
+
+    const typeAliasU8 = 42;
+    const typeAliasU8Array = [1, 2, 3, 4, 5, 6, 7, 8];
+    const typeAliasStruct = {
+      u8: 1,
+      u16: 2,
+      u32: 3,
+      u64: new anchor.BN(4),
+    };
+
+    await program.methods
+      .typeAlias(typeAliasU8, typeAliasU8Array, typeAliasStruct)
+      .accounts({ account: kp.publicKey })
+      .signers([kp])
+      .preInstructions([await program.account.intAccount.createInstruction(kp)])
+      .rpc();
+
+    const account = await program.account.typeAliasAccount.fetch(kp.publicKey);
+    assert.strictEqual(account.typeAliasU8, typeAliasU8);
+    assert.deepEqual(account.typeAliasU8Array, typeAliasU8Array);
+    assert.strictEqual(typeAliasStruct.u8, 1);
+    assert.strictEqual(typeAliasStruct.u16, 2);
+    assert.strictEqual(typeAliasStruct.u32, 3);
+    assert(typeAliasStruct.u64.eq(typeAliasStruct.u64));
+  });
 });

--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -264,56 +264,66 @@ class InstructionFormatter {
     data: Object,
     types: IdlTypeDef[]
   ): string {
-    if (typeDef.type.kind === "struct") {
-      const struct: IdlTypeDefTyStruct = typeDef.type;
-      const fields = Object.keys(data)
-        .map((k) => {
-          const f = struct.fields.filter((f) => f.name === k)[0];
-          if (f === undefined) {
-            throw new Error("Unable to find type");
-          }
-          return (
-            k + ": " + InstructionFormatter.formatIdlData(f, data[k], types)
-          );
-        })
-        .join(", ");
-      return "{ " + fields + " }";
-    } else {
-      if (typeDef.type.variants.length === 0) {
-        return "{}";
-      }
-      // Struct enum.
-      if (typeDef.type.variants[0].name) {
-        const variants = typeDef.type.variants;
-        const variant = Object.keys(data)[0];
-        const enumType = data[variant];
-        const namedFields = Object.keys(enumType)
-          .map((f) => {
-            const fieldData = enumType[f];
-            const idlField = variants[variant]?.filter(
-              (v: IdlField) => v.name === f
-            )[0];
-            if (idlField === undefined) {
-              throw new Error("Unable to find variant");
+    switch (typeDef.type.kind) {
+      case "struct": {
+        const struct: IdlTypeDefTyStruct = typeDef.type;
+        const fields = Object.keys(data)
+          .map((k) => {
+            const field = struct.fields.find((f) => f.name === k);
+            if (!field) {
+              throw new Error("Unable to find type");
             }
             return (
-              f +
+              k +
               ": " +
-              InstructionFormatter.formatIdlData(idlField, fieldData, types)
+              InstructionFormatter.formatIdlData(field, data[k], types)
             );
           })
           .join(", ");
-
-        const variantName = camelCase(variant, { pascalCase: true });
-        if (namedFields.length === 0) {
-          return variantName;
-        }
-        return `${variantName} { ${namedFields} }`;
+        return "{ " + fields + " }";
       }
-      // Tuple enum.
-      else {
-        // TODO.
-        return "Tuple formatting not yet implemented";
+
+      case "enum": {
+        if (typeDef.type.variants.length === 0) {
+          return "{}";
+        }
+        // Struct enum.
+        if (typeDef.type.variants[0].name) {
+          const variants = typeDef.type.variants;
+          const variant = Object.keys(data)[0];
+          const enumType = data[variant];
+          const namedFields = Object.keys(enumType)
+            .map((f) => {
+              const fieldData = enumType[f];
+              const idlField = variants[variant]?.find(
+                (v: IdlField) => v.name === f
+              );
+              if (!idlField) {
+                throw new Error("Unable to find variant");
+              }
+              return (
+                f +
+                ": " +
+                InstructionFormatter.formatIdlData(idlField, fieldData, types)
+              );
+            })
+            .join(", ");
+
+          const variantName = camelCase(variant, { pascalCase: true });
+          if (namedFields.length === 0) {
+            return variantName;
+          }
+          return `${variantName} { ${namedFields} }`;
+        }
+        // Tuple enum.
+        else {
+          // TODO.
+          return "Tuple formatting not yet implemented";
+        }
+      }
+
+      case "alias": {
+        return InstructionFormatter.formatIdlType(typeDef.type.value);
       }
     }
   }

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -104,7 +104,15 @@ export type IdlTypeDefTyEnum = {
   variants: IdlEnumVariant[];
 };
 
-export type IdlTypeDefTy = IdlTypeDefTyEnum | IdlTypeDefTyStruct;
+export type IdlTypeDefTyAlias = {
+  kind: "alias";
+  value: IdlType;
+};
+
+export type IdlTypeDefTy =
+  | IdlTypeDefTyEnum
+  | IdlTypeDefTyStruct
+  | IdlTypeDefTyAlias;
 
 export type IdlTypeDefStruct = Array<IdlField>;
 

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -11,6 +11,7 @@ import {
   IdlInstruction,
   IdlType,
   IdlTypeDef,
+  IdlTypeDefTyAlias,
   IdlTypeDefTyEnum,
   IdlTypeDefTyStruct,
 } from "../../idl";
@@ -214,6 +215,11 @@ type DecodeStruct<I extends IdlTypeDefTyStruct, Defined> = {
   [F in I["fields"][number] as F["name"]]: DecodeType<F["type"], Defined>;
 };
 
+type DecodeAlias<I extends IdlTypeDefTyAlias, Defined> = DecodeType<
+  I["value"],
+  Defined
+>;
+
 export type TypeDef<
   I extends IdlTypeDef,
   Defined
@@ -221,6 +227,8 @@ export type TypeDef<
   ? DecodeEnum<I["type"], Defined>
   : I["type"] extends IdlTypeDefTyStruct
   ? DecodeStruct<I["type"], Defined>
+  : I["type"] extends IdlTypeDefTyAlias
+  ? DecodeAlias<I["type"], Defined>
   : never;
 
 type TypeDefDictionary<T extends IdlTypeDef[], Defined> = {


### PR DESCRIPTION
### Problem

Type aliases are not supported.

### Summary of Changes

- Add type alias support for the IDL, TS client, and the CLI
- Add tests for type aliases

### Example

**Program:**

```rs
use anchor_lang::prelude::*;

declare_id!("TypeA1ias1111111111111111111111111111111111");

#[program]
pub mod type_alias {
    use super::*;

    pub fn type_alias(ctx: Context<TypeAlias>, u8_array: U8Array) -> Result<()> {
        ctx.accounts.account.u8_array = u8_array;
        Ok(())
    }
}

#[derive(Accounts)]
pub struct TypeAlias<'info> {
    #[account(zero)]
    pub account: Account<'info, TypeAliasAccount>,
}

#[account]
pub struct TypeAliasAccount {
    pub u8_array: U8Array,
}

pub type U8Array = [u8; 8];

```

**IDL:**

```json
{
  "version": "0.1.0",
  "name": "type_alias",
  "instructions": [
    {
      "name": "typeAlias",
      "accounts": [
        {
          "name": "account",
          "isMut": true,
          "isSigner": false
        }
      ],
      "args": [
        {
          "name": "u8Array",
          "type": {
            "defined": "U8Array"
          }
        }
      ]
    }
  ],
  "accounts": [
    {
      "name": "TypeAliasAccount",
      "type": {
        "kind": "struct",
        "fields": [
          {
            "name": "u8Array",
            "type": {
              "defined": "U8Array"
            }
          }
        ]
      }
    }
  ],
  "types": [
    {
      "name": "U8Array",
      "type": {
        "kind": "alias",
        "value": {
          "array": [
            "u8",
            8
          ]
        }
      }
    }
  ]
}
```

**TypeScript:**

```ts
import * as anchor from "@coral-xyz/anchor";
import { assert } from "chai";

import type { TypeAlias } from "../target/types/type_alias";

describe("Type alias", () => {
  anchor.setProvider(anchor.AnchorProvider.env());
  const program = anchor.workspace.typeAlias as anchor.Program<TypeAlias>;

  it("Can use type aliases", async () => {
    const kp = anchor.web3.Keypair.generate();

    const u8Array = [1, 2, 3, 4, 5, 6, 7, 8];
    await program.methods
      .typeAlias(u8Array)
      .accounts({ account: kp.publicKey })
      .signers([kp])
      .preInstructions([
        await program.account.typeAliasAccount.createInstruction(kp),
      ])
      .rpc();

    const account = await program.account.typeAliasAccount.fetch(kp.publicKey);
    assert.deepEqual(account.u8Array, u8Array);
  });
});
```

Closes https://github.com/coral-xyz/anchor/issues/1300, resolves https://github.com/coral-xyz/anchor/issues/1632.