### PR TITLE
syn: Fix generic type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add strong type support for `Program.addEventListener` method ([#2627](https://github.com/coral-xyz/anchor/pull/2627)).
 - syn: Add `IdlBuild` trait to implement IDL support for custom types ([#2629](https://github.com/coral-xyz/anchor/pull/2629)).
 - spl: Add `idl-build` feature. IDL build method will not work without enabling this feature when using `anchor-spl` ([#2629](https://github.com/coral-xyz/anchor/pull/2629)).
+- lang: Add support for type aliases in IDLs ([#2637](https://github.com/coral-xyz/anchor/pull/2637)).
 
 ### Fixes
 
@@ -47,6 +48,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - syn: IDL `parse` method now returns `Result<Idl>` instead of `Result<Option<Idl>>` ([#2582](https://github.com/coral-xyz/anchor/pull/2582)).
 - spl: Update `mpl-token-metadata` dependency to use the client SDK instead of the program crate ([#2632](https://github.com/coral-xyz/anchor/pull/2632)).
 - ts: Remove `base64-js` dependency ([#2635](https://github.com/coral-xyz/anchor/pull/2635)).
+- syn: `IdlTypeDefinitionTy` enum has a new variant `Alias` ([#2637](https://github.com/coral-xyz/anchor/pull/2637)).
 
 ## [0.28.0] - 2023-06-09
 

--- a/tests/idl/programs/client-interactions/src/lib.rs
+++ b/tests/idl/programs/client-interactions/src/lib.rs
@@ -122,3 +122,10 @@ pub struct TypeAliasAccount {
 pub type TypeAliasU8 = u8;
 pub type TypeAliasU8Array = [TypeAliasU8; 8];
 pub type TypeAliasStruct = MyStruct;
+
+/// Generic type aliases should not get included in the IDL
+pub type TypeAliasNotSupported<'a, T> = NotSupported<'a, T>;
+pub struct NotSupported<'a, T> {
+    _t: T,
+    _s: &'a str,
+}

--- a/tests/idl/tests/client-interactions.ts
+++ b/tests/idl/tests/client-interactions.ts
@@ -141,9 +141,9 @@ describe("Client interactions", () => {
     const account = await program.account.typeAliasAccount.fetch(kp.publicKey);
     assert.strictEqual(account.typeAliasU8, typeAliasU8);
     assert.deepEqual(account.typeAliasU8Array, typeAliasU8Array);
-    assert.strictEqual(typeAliasStruct.u8, 1);
-    assert.strictEqual(typeAliasStruct.u16, 2);
-    assert.strictEqual(typeAliasStruct.u32, 3);
-    assert(typeAliasStruct.u64.eq(typeAliasStruct.u64));
+    assert.strictEqual(account.typeAliasStruct.u8, typeAliasStruct.u8);
+    assert.strictEqual(account.typeAliasStruct.u16, typeAliasStruct.u16);
+    assert.strictEqual(account.typeAliasStruct.u32, typeAliasStruct.u32);
+    assert(account.typeAliasStruct.u64.eq(typeAliasStruct.u64));
   });
 });


### PR DESCRIPTION
### Problem

Generics are not supported with type aliases but they get included in the IDL regardless which cause client side problems.

### Summary of changes

- Don't include generic types in the IDL
- Remove usage of `unwrap` on `IdlType` conversion, instead skip the types that return an error
- Add a test case