### PR TITLE
spl: Fix compilation error and warnings

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -379,6 +379,8 @@ jobs:
             path: tests/composite
           - cmd: cd tests/errors && anchor test --skip-lint && npx tsc --noEmit
             path: tests/errors
+          - cmd: cd tests/spl/metadata && anchor test --skip-lint
+            path: spl/metadata
           - cmd: cd tests/spl/token-proxy && anchor test --skip-lint
             path: spl/token-proxy
           - cmd: cd tests/spl/token-wrapper && anchor test --skip-lint

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -106,18 +106,8 @@ pub fn create_metadata_accounts_v3<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, CreateMetadataAccountsV3<'info>>,
     data: mpl_token_metadata::types::DataV2,
     is_mutable: bool,
-    update_authority_is_signer: bool,
-    details: Option<mpl_token_metadata::types::CollectionDetails>,
+    collection_details: Option<mpl_token_metadata::types::CollectionDetails>,
 ) -> Result<()> {
-    let mpl_token_metadata::types::DataV2 {
-        name,
-        symbol,
-        uri,
-        creators,
-        seller_fee_basis_points,
-        collection,
-        uses,
-    } = data;
     let ix = mpl_token_metadata::instructions::CreateMetadataAccountV3 {
         metadata: *ctx.accounts.metadata.key,
         mint: *ctx.accounts.mint.key,
@@ -129,7 +119,7 @@ pub fn create_metadata_accounts_v3<'info>(
     }
     .instruction(
         mpl_token_metadata::instructions::CreateMetadataAccountV3InstructionArgs {
-            collection_details: details,
+            collection_details,
             data,
             is_mutable,
         },
@@ -468,7 +458,7 @@ pub fn remove_creator_verification<'info>(
 
 pub fn utilize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Utilize<'info>>,
-    use_authority_record_pda: Option<Pubkey>,
+    use_authority_record: Option<Pubkey>,
     burner: Option<Pubkey>,
     number_of_uses: u64,
 ) -> Result<()> {
@@ -483,7 +473,7 @@ pub fn utilize<'info>(
         token_account: *ctx.accounts.token_account.key,
         token_program: spl_token::ID,
         use_authority: *ctx.accounts.use_authority.key,
-        use_authority_record: None,
+        use_authority_record,
     }
     .instruction(mpl_token_metadata::instructions::UtilizeInstructionArgs { number_of_uses });
     solana_program::program::invoke_signed(

--- a/tests/package.json
+++ b/tests/package.json
@@ -30,6 +30,7 @@
     "relations-derivation",
     "pyth",
     "realloc",
+    "spl/metadata",
     "spl/token-proxy",
     "spl/token-wrapper",
     "swap",

--- a/tests/spl/metadata/Anchor.toml
+++ b/tests/spl/metadata/Anchor.toml
@@ -1,0 +1,9 @@
+[programs.localnet]
+metadata = "Metadata11111111111111111111111111111111111"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/spl/metadata/Cargo.toml
+++ b/tests/spl/metadata/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = [
+    "programs/*"
+]
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tests/spl/metadata/package.json
+++ b/tests/spl/metadata/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "metadata",
+  "version": "0.28.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  }
+}

--- a/tests/spl/metadata/programs/metadata/Cargo.toml
+++ b/tests/spl/metadata/programs/metadata/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "metadata"
+version = "0.1.0"
+description = "Created with Anchor"
+rust-version = "1.60"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "metadata"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = { path = "../../../../../lang" }
+anchor-spl = { path = "../../../../../spl", features = ["metadata"] }

--- a/tests/spl/metadata/programs/metadata/Xargo.toml
+++ b/tests/spl/metadata/programs/metadata/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/spl/metadata/programs/metadata/src/lib.rs
+++ b/tests/spl/metadata/programs/metadata/src/lib.rs
@@ -1,0 +1,8 @@
+//! Only tests whether `anchor-spl` builds with `metadata` feature enabled.
+
+use anchor_lang::prelude::*;
+
+declare_id!("Metadata11111111111111111111111111111111111");
+
+#[program]
+pub mod metadata {}

--- a/tests/spl/metadata/tests/metadata.ts
+++ b/tests/spl/metadata/tests/metadata.ts
@@ -1,0 +1,12 @@
+import * as anchor from "@coral-xyz/anchor";
+
+import { Metadata } from "../target/types/metadata";
+
+describe("Client interactions", () => {
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const program = anchor.workspace.metadata as anchor.Program<Metadata>;
+
+  it("Builds and deploys", () => {
+    console.log("Program ID:", program.programId.toBase58());
+  });
+});

--- a/tests/spl/metadata/tsconfig.json
+++ b/tests/spl/metadata/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
### Problem

`anchor-spl` with `metadata` feature has a compile error and a few warnings after the recent upgrade(https://github.com/coral-xyz/anchor/pull/2632).

```
warning: unused variable: `name`
   --> src/metadata.rs:113:9
    |
113 |         name,
    |         ^^^^ help: try ignoring the field: `name: _`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `symbol`
   --> src/metadata.rs:114:9
    |
114 |         symbol,
    |         ^^^^^^ help: try ignoring the field: `symbol: _`

warning: unused variable: `uri`
   --> src/metadata.rs:115:9
    |
115 |         uri,
    |         ^^^ help: try ignoring the field: `uri: _`

warning: unused variable: `creators`
   --> src/metadata.rs:116:9
    |
116 |         creators,
    |         ^^^^^^^^ help: try ignoring the field: `creators: _`

warning: unused variable: `seller_fee_basis_points`
   --> src/metadata.rs:117:9
    |
117 |         seller_fee_basis_points,
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `seller_fee_basis_points: _`

warning: unused variable: `collection`
   --> src/metadata.rs:118:9
    |
118 |         collection,
    |         ^^^^^^^^^^ help: try ignoring the field: `collection: _`

warning: unused variable: `uses`
   --> src/metadata.rs:119:9
    |
119 |         uses,
    |         ^^^^ help: try ignoring the field: `uses: _`

warning: unused variable: `update_authority_is_signer`
   --> src/metadata.rs:109:5
    |
109 |     update_authority_is_signer: bool,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_update_authority_is_signer`

warning: unused variable: `use_authority_record_pda`
   --> src/metadata.rs:471:5
    |
471 |     use_authority_record_pda: Option<Pubkey>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_use_authority_record_pda`

error[E0382]: use of partially moved value: `data`
   --> src/metadata.rs:133:13
    |
119 |         uses,
    |         ---- value partially moved here
...
133 |             data,
    |             ^^^^ value used here after partial move
    |
    = note: partial move occurs because `data.uses` has type `Option<Uses>`, which does not implement the `Copy` trait
help: borrow this binding in the pattern to avoid moving the value
    |
119 |         ref uses,
    |         +++

For more information about this error, try `rustc --explain E0382`.
warning: `anchor-spl` (lib) generated 9 warnings
error: could not compile `anchor-spl` due to previous error; 9 warnings emitted
```

### Summary of changes

- Fix the compile error and warnings
- Add a test case to build `anchor-spl` with `metadata` feature enabled