### PR TITLE
syn: Fix having access to empty `idl` module by default

### DIFF
--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -1,8 +1,7 @@
+pub mod types;
+
 #[cfg(feature = "idl-build")]
 pub mod build;
 
 #[cfg(feature = "idl-parse")]
 pub mod parse;
-
-#[cfg(feature = "idl-types")]
-pub mod types;

--- a/lang/syn/src/idl/types.rs
+++ b/lang/syn/src/idl/types.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Idl {
@@ -19,7 +18,7 @@ pub struct Idl {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub errors: Option<Vec<IdlErrorCode>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub metadata: Option<JsonValue>,
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -1,3 +1,14 @@
+pub mod codegen;
+pub mod parser;
+
+#[cfg(feature = "idl-types")]
+pub mod idl;
+
+#[cfg(feature = "hash")]
+pub mod hash;
+#[cfg(not(feature = "hash"))]
+pub(crate) mod hash;
+
 use crate::parser::tts_to_string;
 use codegen::accounts as accounts_codegen;
 use codegen::program as program_codegen;
@@ -17,14 +28,6 @@ use syn::{
     Expr, Generics, Ident, ItemEnum, ItemFn, ItemMod, ItemStruct, LitInt, PatType, Token, Type,
     TypePath,
 };
-
-pub mod codegen;
-#[cfg(feature = "hash")]
-pub mod hash;
-#[cfg(not(feature = "hash"))]
-pub(crate) mod hash;
-pub mod idl;
-pub mod parser;
 
 #[derive(Debug)]
 pub struct Program {


### PR DESCRIPTION
### Problem

`anchor_syn::idl` is available by default(as empty) without enabling any IDL related features.

### Summary of changes

- Only compile `idl` module when `idl-types` feature is enabled since all other IDL features also enable this feature.