### PR TITLE
Update token metadata crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eefd9179d205bfedf07eb243959ae33ff6f76488f791f2d1cb1f895f17d0824"
+checksum = "177204bbe7486b22ac35af2c91a82630f830a6ddd3392651aefde1ef346aba3d"
 dependencies = [
  "borsh 0.10.3",
  "num-derive",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -24,7 +24,7 @@ token_2022 = ["spl-token-2022"]
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.28.0", features = ["derive"] }
 borsh = { version = ">=0.9, <0.11", optional = true }
-mpl-token-metadata = { version = "3.0.2", optional = true }
+mpl-token-metadata = { version = "3.1.0", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = ">=1.14, <1.17"
 spl-associated-token-account = { version = "^1.1", features = ["no-entrypoint"], optional = true }

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -106,6 +106,7 @@ pub fn create_metadata_accounts_v3<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, CreateMetadataAccountsV3<'info>>,
     data: mpl_token_metadata::types::DataV2,
     is_mutable: bool,
+    update_authority_is_signer: bool,
     collection_details: Option<mpl_token_metadata::types::CollectionDetails>,
 ) -> Result<()> {
     let ix = mpl_token_metadata::instructions::CreateMetadataAccountV3 {
@@ -115,7 +116,10 @@ pub fn create_metadata_accounts_v3<'info>(
         payer: *ctx.accounts.payer.key,
         rent: None,
         system_program: system_program::ID,
-        update_authority: *ctx.accounts.update_authority.key,
+        update_authority: (
+            *ctx.accounts.update_authority.key,
+            update_authority_is_signer,
+        ),
     }
     .instruction(
         mpl_token_metadata::instructions::CreateMetadataAccountV3InstructionArgs {


### PR DESCRIPTION
This PR updates Token Metadata to `3.1.0` to address an issue with the `create_metadata_accounts_v3` – now it is possible to indicate whether the update authority should be a signer or not.

The issue was mentioned on #2647 