### PR TITLE
bench: Fix number formatting due to locale difference

### DIFF
--- a/tests/bench/scripts/sync-markdown.ts
+++ b/tests/bench/scripts/sync-markdown.ts
@@ -1,6 +1,6 @@
 /** Sync Markdown files in /bench based on the data from bench.json */
 
-import { BenchData, BenchResult, Markdown } from "./utils";
+import { BenchData, BenchResult, Markdown, formatNumber } from "./utils";
 
 (async () => {
   const bench = await BenchData.open();
@@ -41,7 +41,7 @@ import { BenchData, BenchResult, Markdown } from "./utils";
             // New key
             changeText = "N/A";
           } else {
-            const delta = (newValue - oldValue).toLocaleString();
+            const delta = formatNumber(newValue - oldValue);
             const percentChange = ((newValue / oldValue - 1) * 100).toFixed(2);
 
             if (+percentChange > 0) {
@@ -51,10 +51,10 @@ import { BenchData, BenchResult, Markdown } from "./utils";
             }
           }
 
-          table.insert(name, newValue.toLocaleString(), changeText);
+          table.insert(name, formatNumber(newValue), changeText);
         },
         noChangeCb: ({ name, value }) => {
-          table.insert(name, value.toLocaleString(), +i === 0 ? "N/A" : "-");
+          table.insert(name, formatNumber(value), +i === 0 ? "N/A" : "-");
         },
       });
 

--- a/tests/bench/scripts/utils.ts
+++ b/tests/bench/scripts/utils.ts
@@ -527,11 +527,6 @@ export const getVersionFromArgs = () => {
     : (args[anchorVersionArgIndex + 1] as Version);
 };
 
-/** Run `anchor test` command. */
-export const runAnchorTest = () => {
-  return spawn("anchor", ["test", "--skip-lint"]);
-};
-
 /** Spawn a blocking process. */
 export const spawn = (
   cmd: string,
@@ -549,3 +544,9 @@ export const spawn = (
 
   return result;
 };
+
+/** Run `anchor test` command. */
+export const runAnchorTest = () => spawn("anchor", ["test", "--skip-lint"]);
+
+/** Format number with `en-US` locale. */
+export const formatNumber = (number: number) => number.toLocaleString("en-US");


### PR DESCRIPTION
### Problem

Bench results are formatted using the [`Number.prototype.toLocaleString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) method which produce [different results](https://github.com/coral-xyz/anchor/pull/2542/commits/d0efc1a5dc0c6c40d932fb9c46d8060dad36502b#diff-b712e855302beef466bedeb086f9fa2d0cc19bef95b70931105cb891214acf9b) based on the user's locale.

### Summary of changes

Always use `en-US` locale for number formating in order to produce the same result.