### PR TITLE
spl: Update dependencies to their latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
  "mpl-token-metadata",
  "serum_dex",
  "solana-program",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
+ "spl-associated-token-account",
+ "spl-token 4.0.0",
+ "spl-token-2022",
 ]
 
 [[package]]
@@ -3778,7 +3778,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "spl-token-metadata-interface",
  "thiserror",
  "zstd",
@@ -3905,7 +3905,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "spl-memo 4.0.0",
+ "spl-memo",
  "thiserror",
  "tokio",
 ]
@@ -4243,7 +4243,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4416,10 +4416,10 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account 2.2.0",
- "spl-memo 4.0.0",
+ "spl-associated-token-account",
+ "spl-memo",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4556,22 +4556,6 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
-dependencies = [
- "assert_matches",
- "borsh 0.9.3",
- "num-derive 0.3.3",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385e31c29981488f2820b2022d8e731aae3b02e6e18e2fd854e4c9a94dc44fc3"
@@ -4582,7 +4566,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4619,15 +4603,6 @@ dependencies = [
  "sha2 0.10.8",
  "syn 2.0.37",
  "thiserror",
-]
-
-[[package]]
-name = "spl-memo"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
-dependencies = [
- "solana-program",
 ]
 
 [[package]]
@@ -4723,24 +4698,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1",
- "spl-token 3.5.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
@@ -4752,7 +4709,7 @@ dependencies = [
  "num_enum 0.7.0",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo 4.0.0",
+ "spl-memo",
  "spl-pod",
  "spl-token 4.0.0",
  "spl-token-metadata-interface",

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1118,7 +1118,7 @@ fn generate_get_token_account_space(mint: &Expr) -> proc_macro2::TokenStream {
                 let mint_state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
                 let mint_extensions = mint_state.get_extension_types()?;
                 let required_extensions = ExtensionType::get_required_init_account_extensions(&mint_extensions);
-                ExtensionType::get_account_len::<Account>(&required_extensions)
+                ExtensionType::try_calculate_account_len::<Account>(&required_extensions)?
             } else {
                 ::anchor_spl::token::TokenAccount::LEN
             }

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -27,6 +27,6 @@ borsh = { version = ">=0.9, <0.11", optional = true }
 mpl-token-metadata = { version = "3.1.0", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = ">=1.16, <1.18"
-spl-associated-token-account = { version = "^1.1", features = ["no-entrypoint"], optional = true }
-spl-token = { version = "3.5", features = ["no-entrypoint"], optional = true }
-spl-token-2022 = { version = "0.6", features = ["no-entrypoint"], optional = true }
+spl-associated-token-account = { version = "2.2", features = ["no-entrypoint"], optional = true }
+spl-token = { version = "4", features = ["no-entrypoint"], optional = true }
+spl-token-2022 = { version = "0.9", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
### Summary of changes

- Upgrade `spl-token` to `4`
- Upgrade `spl-token-2022` to `0.9`
- Upgrade `spl-associated-token` to `2.2`.