### PR TITLE
Fix workspace `resolver` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- syn: Add missing `new_from_array` method to `Hash` ([#2682](https://github.com/coral-xyz/anchor/pull/2682)).
+- cli: Switch to Cargo feature resolver(`resolver = "2"`) ([#2676](https://github.com/coral-xyz/anchor/pull/2676)).
+
 ### Breaking
 
 ## [0.29.0] - 2023-10-16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ exclude = [
     "tests/swap/deps/openbook-dex",
     "tests/cfo/deps/openbook-dex",
 ]
+resolver = "2"

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -149,6 +149,7 @@ const fn workspace_manifest() -> &'static str {
 members = [
     "programs/*"
 ]
+resolver = "2"
 
 [profile.release]
 overflow-checks = true

--- a/tests/anchor-cli-account/Cargo.toml
+++ b/tests/anchor-cli-account/Cargo.toml
@@ -5,3 +5,4 @@ overflow-checks = true
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/anchor-cli-idl/Cargo.toml
+++ b/tests/anchor-cli-idl/Cargo.toml
@@ -5,3 +5,4 @@ overflow-checks = true
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/auction-house/Cargo.toml
+++ b/tests/auction-house/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/bench/Cargo.toml
+++ b/tests/bench/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/bpf-upgradeable-state/Cargo.toml
+++ b/tests/bpf-upgradeable-state/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/cashiers-check/Cargo.toml
+++ b/tests/cashiers-check/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/cfo/Cargo.toml
+++ b/tests/cfo/Cargo.toml
@@ -7,3 +7,4 @@ exclude = [
     "deps/stake",
     "deps/swap"
 ]
+resolver = "2"

--- a/tests/chat/Cargo.toml
+++ b/tests/chat/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/composite/Cargo.toml
+++ b/tests/composite/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/cpi-returns/Cargo.toml
+++ b/tests/cpi-returns/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/custom-coder/Cargo.toml
+++ b/tests/custom-coder/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/declare-id/Cargo.toml
+++ b/tests/declare-id/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/docs/Cargo.toml
+++ b/tests/docs/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/errors/Cargo.toml
+++ b/tests/errors/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/escrow/Cargo.toml
+++ b/tests/escrow/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/events/Cargo.toml
+++ b/tests/events/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/floats/Cargo.toml
+++ b/tests/floats/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/idl/Cargo.toml
+++ b/tests/idl/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "programs/*"
 ]
+resolver = "2"
 
 [profile.release]
 overflow-checks = true

--- a/tests/ido-pool/Cargo.toml
+++ b/tests/ido-pool/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/lockup/Cargo.toml
+++ b/tests/lockup/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/misc/Cargo.toml
+++ b/tests/misc/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/multiple-suites-run-single/Cargo.toml
+++ b/tests/multiple-suites-run-single/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/multiple-suites/Cargo.toml
+++ b/tests/multiple-suites/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/multisig/Cargo.toml
+++ b/tests/multisig/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/optional/Cargo.toml
+++ b/tests/optional/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/pda-derivation/Cargo.toml
+++ b/tests/pda-derivation/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/pyth/Cargo.toml
+++ b/tests/pyth/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/realloc/Cargo.toml
+++ b/tests/realloc/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/relations-derivation/Cargo.toml
+++ b/tests/relations-derivation/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/safety-checks/Cargo.toml
+++ b/tests/safety-checks/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/spl/metadata/Cargo.toml
+++ b/tests/spl/metadata/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "programs/*"
 ]
+resolver = "2"
 
 [profile.release]
 overflow-checks = true

--- a/tests/spl/token-proxy/Cargo.toml
+++ b/tests/spl/token-proxy/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/spl/token-wrapper/Cargo.toml
+++ b/tests/spl/token-wrapper/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/swap/Cargo.toml
+++ b/tests/swap/Cargo.toml
@@ -5,3 +5,4 @@ members = [
 exclude = [
     "deps/openbook-dex"
 ]
+resolver = "2"

--- a/tests/system-accounts/Cargo.toml
+++ b/tests/system-accounts/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/sysvars/Cargo.toml
+++ b/tests/sysvars/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/tictactoe/Cargo.toml
+++ b/tests/tictactoe/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/typescript/Cargo.toml
+++ b/tests/typescript/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/validator-clone/Cargo.toml
+++ b/tests/validator-clone/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"

--- a/tests/zero-copy/Cargo.toml
+++ b/tests/zero-copy/Cargo.toml
@@ -2,3 +2,4 @@
 members = [
     "programs/*"
 ]
+resolver = "2"


### PR DESCRIPTION
### Problem

`cargo` commands give a warning about the workspace `resolver` in newer versions of Rust.

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

### Summary of changes

Specify `resolver = "2"` in:
- Repository `Cargo.toml`
- Workspace `Cargo.toml` crated using `anchor init`
- `tests/*/Cargo.toml`