### PR TITLE
ts: Use workspace dependencies and fix tests

### DIFF
--- a/ts/tests/package.json
+++ b/ts/tests/package.json
@@ -12,8 +12,5 @@
     "ts-node": "*",
     "typescript": "*"
   },
-  "dependencies": {
-    "@coral-xyz/anchor": "=0.28.1-beta.2",
-    "@solana/web3.js": "*"
-  }
+  "dependencies": {}
 }

--- a/ts/tests/src/spl/feature-proposal.ts
+++ b/ts/tests/src/spl/feature-proposal.ts
@@ -86,9 +86,9 @@ export async function featureProposalTests() {
   }
 
   async function fetchFeatureProposal() {
-    const featureProposal: { expired?: Buffer } =
-      await program.account.featureProposal.fetch(featureProposalPk);
-
+    const featureProposal = await program.account.featureProposal.fetch(
+      featureProposalPk
+    );
     if (!featureProposal.expired) {
       throw new Error("Feature should be expired.");
     }

--- a/ts/tests/src/spl/record.ts
+++ b/ts/tests/src/spl/record.ts
@@ -20,7 +20,7 @@ export async function recordTests() {
   });
   const kp = await loadKp();
 
-  const RECORD_DATA = new Uint8Array(8).fill(1);
+  const RECORD_DATA = Buffer.alloc(8).fill(1);
   const newAuthorityKp = new Keypair();
   let recordPk: PublicKey;
 

--- a/ts/tests/src/spl/stake-pool.ts
+++ b/ts/tests/src/spl/stake-pool.ts
@@ -454,7 +454,7 @@ export async function stakePoolTests() {
 
   async function setFee() {
     await program.methods
-      .setFee({ solReferral: 5 })
+      .setFee({ solReferral: [5] })
       .accounts({
         stakePool: stakePoolPk,
         manager: kp.publicKey,

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -880,7 +880,7 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/web3.js@*", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0":
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0":
   version "1.68.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.68.0.tgz#ded078d6e72f9f4b46e0f69925d4fe5c6cdcef54"
   integrity sha512-i41x4ArQrjdy/iQf75vKwZa+Mx1hOVquamHHe+5lNbObF4CT57oHOTvG9m9DTypuip3O9ucLoryywd6LfP2eEw==


### PR DESCRIPTION
### Problem

- Tests in `ts/tests` use npm packages instead of the workspace packages
- `feature-proposal`, `record` and `stake-pool` tests had TS error with the latest version

### Summary of changes

- Use the workspace packages instead of npm packages
- Fix the errors in tests