### PR TITLE
Fix erroneous Cluster websocket ports

### DIFF
--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -87,8 +87,8 @@ impl Cluster {
             Cluster::Devnet => "wss://api.devnet.solana.com",
             Cluster::Testnet => "wss://api.testnet.solana.com",
             Cluster::Mainnet => "wss://api.mainnet-beta.solana.com",
-            Cluster::Localnet => "ws://127.0.0.1:9000",
-            Cluster::Debug => "ws://34.90.18.145:9000",
+            Cluster::Localnet => "ws://127.0.0.1:8900",
+            Cluster::Debug => "ws://34.90.18.145:8900",
             Cluster::Custom(_url, ws_url) => ws_url,
         }
     }


### PR DESCRIPTION
The default Solana validator websocket port is 8900, not 9000. Cluster should return websocket URLs with the default port.