### PR TITLE
syn: Fix `Hash::new_from_array` warning in non-bpf targets

### DIFF
--- a/lang/syn/src/hash.rs
+++ b/lang/syn/src/hash.rs
@@ -78,6 +78,7 @@ impl Hash {
         Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
     }
 
+    #[cfg(target_arch = "bpf")]
     pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
         Self(hash_array)
     }
@@ -102,7 +103,7 @@ pub fn hashv(vals: &[&[u8]]) -> Hash {
     {
         extern "C" {
             fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64;
-        };
+        }
         let mut hash_result = [0; HASH_BYTES];
         unsafe {
             sol_sha256(


### PR DESCRIPTION
### Problem

Compiling `anchor-lang` in non-bpf targets e.g. `anchor-cli` results in `#[warn(dead_code)]` warning after https://github.com/coral-xyz/anchor/pull/2682

```
warning: associated function `new_from_array` is never used
  --> /~/anchor/lang/syn/src/hash.rs:82:18
   |
76 | impl Hash {
   | --------- associated function in this implementation
...
82 |     pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
   |                  ^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `anchor-syn` (lib) generated 1 warning
```

### Summary of changes

Only include `Hash::new_from_array` function when `target_arch = "bpf"`.