### PR TITLE
cli: Make `cargo build-sbf` the default build command

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -411,7 +411,9 @@ jobs:
             path: tests/declare-id
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
-          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
+            # `solana-program-test` crate doesn't compile because `index_list` crate had a breaking change with a patch release
+            # TODO: Remove the `cargo update` command after the issue is fixed
+          - cmd: cd tests/zero-copy && cargo update -p index_list --precise 0.2.7 && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
             path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -411,7 +411,7 @@ jobs:
             path: tests/declare-id
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
-          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-bpf
+          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
             path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+- cli: Make `cargo build-sbf` the default build command ([#2694](https://github.com/coral-xyz/anchor/pull/2694)).
+
 ## [0.29.0] - 2023-10-16
 
 ### Features

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -122,14 +122,14 @@ pub enum Command {
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command
+        /// Arguments to pass to the underlying `cargo build-sbf` command
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
         /// Suppress doc strings in IDL output
         #[clap(long)]
         no_docs: bool,
         /// Architecture to use when building the program
-        #[clap(value_enum, long, default_value = "bpf")]
+        #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
     },
     /// Expands macros (wrapper around cargo expand)
@@ -166,12 +166,12 @@ pub enum Command {
         #[clap(value_enum, short, long, default_value = "none")]
         bootstrap: BootstrapMode,
         /// Architecture to use when building the program
-        #[clap(value_enum, long, default_value = "bpf")]
+        #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command.
+        /// Arguments to pass to the underlying `cargo build-sbf` command.
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
         /// Flag to skip building the program in the workspace,
@@ -199,7 +199,7 @@ pub enum Command {
         #[clap(long)]
         skip_build: bool,
         /// Architecture to use when building the program
-        #[clap(value_enum, long, default_value = "bpf")]
+        #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
         /// Flag to keep the local validator running after tests
         /// to be able to check the transactions.
@@ -212,7 +212,7 @@ pub enum Command {
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command.
+        /// Arguments to pass to the underlying `cargo build-sbf` command.
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
     },
@@ -289,7 +289,7 @@ pub enum Command {
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command.
+        /// Arguments to pass to the underlying `cargo build-sbf` command.
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
         /// Flag to skip building the program in the workspace,
@@ -297,7 +297,7 @@ pub enum Command {
         #[clap(long)]
         skip_build: bool,
         /// Architecture to use when building the program
-        #[clap(value_enum, long, default_value = "bpf")]
+        #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
     },
     /// Keypair commands.
@@ -320,12 +320,12 @@ pub enum Command {
         #[clap(long)]
         skip_lint: bool,
         /// Architecture to use when building the program
-        #[clap(value_enum, long, default_value = "bpf")]
+        #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
-        /// Arguments to pass to the underlying `cargo build-bpf` command.
+        /// Arguments to pass to the underlying `cargo build-sbf` command.
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
     },

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -14,7 +14,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
-test-bpf = []
+test-sbf = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-bpf")]
+#![cfg(feature = "test-sbf")]
 
 use {
     anchor_client::{


### PR DESCRIPTION
### Problem

`cargo build-bpf` has been deprecated for a while but Anchor still uses it by default.

### Summary of changes

Make the `cargo build-sbf` the default build command. The `--arch` argument that was added in https://github.com/coral-xyz/anchor/pull/2398 still exists but now defaults to `sbf`.