### PR TITLE
cli: Add ability to force init and new commands via cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - syn: Add missing `new_from_array` method to `Hash` ([#2682](https://github.com/coral-xyz/anchor/pull/2682)).
 - cli: Switch to Cargo feature resolver(`resolver = "2"`) ([#2676](https://github.com/coral-xyz/anchor/pull/2676)).
 - cli: Fix using user specific path for `provider.wallet` in `Anchor.toml` ([#2696](https://github.com/coral-xyz/anchor/pull/2696)).
+- cli: Allow force init ([#2697](https://github.com/coral-xyz/anchor/pull/2697)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - syn: Add missing `new_from_array` method to `Hash` ([#2682](https://github.com/coral-xyz/anchor/pull/2682)).
 - cli: Switch to Cargo feature resolver(`resolver = "2"`) ([#2676](https://github.com/coral-xyz/anchor/pull/2676)).
 - cli: Fix using user specific path for `provider.wallet` in `Anchor.toml` ([#2696](https://github.com/coral-xyz/anchor/pull/2696)).
-- cli: Allow force init ([#2697](https://github.com/coral-xyz/anchor/pull/2697)).
+- cli: Allow force init ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - syn: Add missing `new_from_array` method to `Hash` ([#2682](https://github.com/coral-xyz/anchor/pull/2682)).
 - cli: Switch to Cargo feature resolver(`resolver = "2"`) ([#2676](https://github.com/coral-xyz/anchor/pull/2676)).
 - cli: Fix using user specific path for `provider.wallet` in `Anchor.toml` ([#2696](https://github.com/coral-xyz/anchor/pull/2696)).
-- cli: Allow force init ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
+- cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -760,7 +760,7 @@ fn init(
     template: ProgramTemplate,
     force: bool,
 ) -> Result<()> {
-    if Config::discover(cfg_override)?.is_some() && !force {
+    if !force && Config::discover(cfg_override)?.is_some() {
         return Err(anyhow!("Workspace already initialized"));
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -228,6 +228,9 @@ pub enum Command {
         /// Rust program template to use
         #[clap(value_enum, short, long, default_value = "single")]
         template: ProgramTemplate,
+        /// Create new program even if there is already one
+        #[clap(long, action)]
+        force: bool,
     },
     /// Commands for interacting with interface definitions.
     Idl {
@@ -610,7 +613,8 @@ fn process_command(opts: Opts) -> Result<()> {
             solidity,
             name,
             template,
-        } => new(&opts.cfg_override, solidity, name, template),
+            force,
+        } => new(&opts.cfg_override, solidity, name, template, force),
         Command::Build {
             idl,
             idl_ts,
@@ -933,6 +937,7 @@ fn new(
     solidity: bool,
     name: String,
     template: ProgramTemplate,
+    force: bool,
 ) -> Result<()> {
     with_workspace(cfg_override, |cfg| {
         match cfg.path().parent() {
@@ -944,7 +949,7 @@ fn new(
 
                 let cluster = cfg.provider.cluster.clone();
                 let programs = cfg.programs.entry(cluster).or_default();
-                if programs.contains_key(&name) {
+                if !force && programs.contains_key(&name) {
                     return Err(anyhow!("Program already exists"));
                 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -788,7 +788,9 @@ fn init(
         ));
     }
 
-    fs::create_dir(&project_name)?;
+    if !force {
+        fs::create_dir(&project_name)?;
+    }
     std::env::set_current_dir(&project_name)?;
     fs::create_dir("app")?;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -974,9 +974,11 @@ fn new(
 
                 let cluster = cfg.provider.cluster.clone();
                 let programs = cfg.programs.entry(cluster).or_default();
-                if !force && programs.contains_key(&name) {
-                    return Err(anyhow!("Program already exists"));
-                } else if force && programs.contains_key(&name) {
+                if programs.contains_key(&name) {
+                    if !force {
+                        return Err(anyhow!("Program already exists"));
+                    }
+
                     // Delete all files within the program folder
                     fs::remove_dir_all(
                         std::env::current_dir()?

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -88,6 +88,9 @@ pub enum Command {
         /// Rust program template to use
         #[clap(value_enum, short, long, default_value = "single")]
         template: ProgramTemplate,
+        /// Initialize even if there are files
+        #[clap(short, long, action)]
+        force: bool,
     },
     /// Builds the workspace.
     #[clap(name = "build", alias = "b")]
@@ -592,6 +595,7 @@ fn process_command(opts: Opts) -> Result<()> {
             no_git,
             jest,
             template,
+            force,
         } => init(
             &opts.cfg_override,
             name,
@@ -600,6 +604,7 @@ fn process_command(opts: Opts) -> Result<()> {
             no_git,
             jest,
             template,
+            force,
         ),
         Command::New {
             solidity,
@@ -753,8 +758,9 @@ fn init(
     no_git: bool,
     jest: bool,
     template: ProgramTemplate,
+    force: bool,
 ) -> Result<()> {
-    if Config::discover(cfg_override)?.is_some() {
+    if Config::discover(cfg_override)?.is_some() && !force {
         return Err(anyhow!("Workspace already initialized"));
     }
 
@@ -4416,6 +4422,7 @@ mod tests {
             false,
             false,
             ProgramTemplate::default(),
+            false,
         )
         .unwrap();
     }
@@ -4434,6 +4441,7 @@ mod tests {
             false,
             false,
             ProgramTemplate::default(),
+            false,
         )
         .unwrap();
     }
@@ -4452,6 +4460,7 @@ mod tests {
             false,
             false,
             ProgramTemplate::default(),
+            false,
         )
         .unwrap();
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -89,7 +89,7 @@ pub enum Command {
         #[clap(value_enum, short, long, default_value = "single")]
         template: ProgramTemplate,
         /// Initialize even if there are files
-        #[clap(short, long, action)]
+        #[clap(long, action)]
         force: bool,
     },
     /// Builds the workspace.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -795,11 +795,7 @@ fn init(
         fs::create_dir(&project_name)?;
     }
     std::env::set_current_dir(&project_name)?;
-    if force {
-        fs::create_dir_all("app")?;
-    } else {
-        fs::create_dir("app")?;
-    }
+    fs::create_dir_all("app")?;
 
     let mut cfg = Config::default();
     if jest {
@@ -861,17 +857,9 @@ fn init(
     }
 
     // Build the test suite.
-    if force {
-        fs::create_dir_all("tests")?;
-    } else {
-        fs::create_dir("tests")?;
-    }
+    fs::create_dir_all("tests")?;
     // Build the migrations directory.
-    if force {
-        fs::create_dir_all("migrations")?;
-    } else {
-        fs::create_dir("migrations")?;
-    }
+    fs::create_dir_all("migrations")?;
 
     if javascript {
         // Build javascript config

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -42,7 +42,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::fs::{self, File, remove_dir_all};
+use std::fs::{self, remove_dir_all, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Stdio};
@@ -846,9 +846,17 @@ fn init(
     // Build the program.
     if force {
         if solidity {
-            remove_dir_all(std::env::current_dir()?.join("solidity").join(&project_name))?;
+            remove_dir_all(
+                std::env::current_dir()?
+                    .join("solidity")
+                    .join(&project_name),
+            )?;
         } else {
-            remove_dir_all(std::env::current_dir()?.join("programs").join(&project_name))?;
+            remove_dir_all(
+                std::env::current_dir()?
+                    .join("programs")
+                    .join(&project_name),
+            )?;
         }
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -788,9 +788,17 @@ fn init(
         ));
     }
 
-    fs::create_dir_all(&project_name)?;
+    if force {
+        fs::create_dir_all(&project_name)?;
+    } else {
+        fs::create_dir(&project_name)?;
+    }
     std::env::set_current_dir(&project_name)?;
-    fs::create_dir_all("app")?;
+    if force {
+        fs::create_dir_all("app")?;
+    } else {
+        fs::create_dir("app")?;
+    }
 
     let mut cfg = Config::default();
     if jest {
@@ -836,6 +844,14 @@ fn init(
     fs::write(".prettierignore", rust_template::prettier_ignore())?;
 
     // Build the program.
+    if force {
+        if solidity {
+            remove_dir_all(std::env::current_dir()?.join("solidity").join(&project_name))?;
+        } else {
+            remove_dir_all(std::env::current_dir()?.join("programs").join(&project_name))?;
+        }
+    }
+
     if solidity {
         solidity_template::create_program(&project_name)?;
     } else {
@@ -843,9 +859,17 @@ fn init(
     }
 
     // Build the test suite.
-    fs::create_dir_all("tests")?;
+    if force {
+        fs::create_dir_all("tests")?;
+    } else {
+        fs::create_dir("tests")?;
+    }
     // Build the migrations directory.
-    fs::create_dir_all("migrations")?;
+    if force {
+        fs::create_dir_all("migrations")?;
+    } else {
+        fs::create_dir("migrations")?;
+    }
 
     if javascript {
         // Build javascript config

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -754,6 +754,7 @@ fn process_command(opts: Opts) -> Result<()> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn init(
     cfg_override: &ConfigOverride,
     name: String,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -42,7 +42,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::fs::{self, remove_dir_all, File};
+use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Stdio};
@@ -845,19 +845,11 @@ fn init(
 
     // Remove the default program if `--force` is passed
     if force {
-        if solidity {
-            remove_dir_all(
-                std::env::current_dir()?
-                    .join("solidity")
-                    .join(&project_name),
-            )?;
-        } else {
-            remove_dir_all(
-                std::env::current_dir()?
-                    .join("programs")
-                    .join(&project_name),
-            )?;
-        }
+        fs::remove_dir_all(
+            std::env::current_dir()?
+                .join(if solidity { "solidity" } else { "programs" })
+                .join(&project_name),
+        )?;
     }
 
     // Build the program.
@@ -986,11 +978,11 @@ fn new(
                     return Err(anyhow!("Program already exists"));
                 } else if force && programs.contains_key(&name) {
                     // Delete all files within the program folder
-                    if solidity {
-                        remove_dir_all(std::env::current_dir()?.join("solidity").join(&name))?;
-                    } else {
-                        remove_dir_all(std::env::current_dir()?.join("programs").join(&name))?;
-                    }
+                    fs::remove_dir_all(
+                        std::env::current_dir()?
+                            .join(if solidity { "solidity" } else { "programs" })
+                            .join(&name),
+                    )?;
                 }
 
                 if solidity {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -843,7 +843,7 @@ fn init(
     // Initialize .prettierignore file
     fs::write(".prettierignore", rust_template::prettier_ignore())?;
 
-    // Build the program.
+    // Remove the default program if `--force` is passed
     if force {
         if solidity {
             remove_dir_all(
@@ -860,6 +860,7 @@ fn init(
         }
     }
 
+    // Build the program.
     if solidity {
         solidity_template::create_program(&project_name)?;
     } else {


### PR DESCRIPTION
### Problem

Currently there's no way to force `init` and `new` commands via the cli. This is described at https://github.com/coral-xyz/anchor/issues/2669.

### Summary of changes
- Add a `--force` argument to the `init` command
- Update tests with new flag
- Update changelog

Fixes https://github.com/coral-xyz/anchor/issues/2669