### PR TITLE
cli: Improve error handling of toolchain overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
+
 ### Fixes
 
 - syn: Add missing `new_from_array` method to `Hash` ([#2682](https://github.com/coral-xyz/anchor/pull/2682)).
 - cli: Switch to Cargo feature resolver(`resolver = "2"`) ([#2676](https://github.com/coral-xyz/anchor/pull/2676)).
 - cli: Fix using user specific path for `provider.wallet` in `Anchor.toml` ([#2696](https://github.com/coral-xyz/anchor/pull/2696)).
-- cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
+- cli: Display errors if toolchain override restoration fails ([#2700](https://github.com/coral-xyz/anchor/pull/2700)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

- If `solana_version` override restoration fails, it fails silently — there is no indication of failure
- `[toolchain]` override and restoration code is similar but they live in separate functions

### Summary of changes

- Show error if toolchain restoration fails
- Failure during one of the toolchain restoration steps no longer fails the entire function
- Set toolchain override and restoration in the same place