### PR TITLE
cli: Fix commit based `anchor_version` override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix using user specific path for `provider.wallet` in `Anchor.toml` ([#2696](https://github.com/coral-xyz/anchor/pull/2696)).
 - syn: Fix IDL constant seeds parsing ([#2699](https://github.com/coral-xyz/anchor/pull/2699)).
 - cli: Display errors if toolchain override restoration fails ([#2700](https://github.com/coral-xyz/anchor/pull/2700)).
+- cli: Fix commit based `anchor_version` override ([#2704](https://github.com/coral-xyz/anchor/pull/2704)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

`toolchain.anchor_version` override with commits after `0.29.0` doesn't work. This is because commit based installations do not have the correct version name inside the binary(they only have the tag version). For example

```toml
[toolchain]
anchor_version = "0.29.0-cded9de0a43302f8f51947405e0bf3bc6997b908"
```

doesn't work but

```toml
[toolchain]
anchor_version = "0.28.0-51578bcbc522d5398dbfa9d020f28fb797eb5815"
```

works(because no version compare logic).

### Summary of changes

Get the current version from the executing binary name or default to the crate version if the version doesn't exist in the binary name.