### PR TITLE
cli: Add support for passing arguments to `solana program deploy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
 - cli: Add verifiable option when `deploy` ([#2705](https://github.com/coral-xyz/anchor/pull/2705)).
+- cli: Add support for passing arguments to the underlying `solana program deploy` command with `anchor deploy` ([#2709](https://github.com/coral-xyz/anchor/pull/2709)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

There is no way to pass arguments to the underlying `solana program deploy` command with `anchor deploy`.

### Summary of changes

Add ability to pass arguments to `solana program deploy` command, e.g.

```
anchor deploy -- --final
```

Fixes https://github.com/coral-xyz/anchor/issues/1836