### PR TITLE
lang: Remove the unnecessary clone in `to_account_info().clone()`

### DIFF
--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -226,7 +226,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
                         accounts.system_program.to_account_info(),
                         anchor_lang::system_program::Transfer {
                             from: accounts.authority.to_account_info(),
-                            to: accounts.idl.to_account_info().clone(),
+                            to: accounts.idl.to_account_info(),
                         },
                     ),
                     new_rent_minimum

--- a/tests/cashiers-check/programs/cashiers-check/src/lib.rs
+++ b/tests/cashiers-check/programs/cashiers-check/src/lib.rs
@@ -22,8 +22,8 @@ pub mod cashiers_check {
     ) -> Result<()> {
         // Transfer funds to the check.
         let cpi_accounts = Transfer {
-            from: ctx.accounts.from.to_account_info().clone(),
-            to: ctx.accounts.vault.to_account_info().clone(),
+            from: ctx.accounts.from.to_account_info(),
+            to: ctx.accounts.vault.to_account_info(),
             authority: ctx.accounts.owner.clone(),
         };
         let cpi_program = ctx.accounts.token_program.clone();
@@ -50,8 +50,8 @@ pub mod cashiers_check {
         ];
         let signer = &[&seeds[..]];
         let cpi_accounts = Transfer {
-            from: ctx.accounts.vault.to_account_info().clone(),
-            to: ctx.accounts.to.to_account_info().clone(),
+            from: ctx.accounts.vault.to_account_info(),
+            to: ctx.accounts.to.to_account_info(),
             authority: ctx.accounts.check_signer.clone(),
         };
         let cpi_program = ctx.accounts.token_program.clone();
@@ -70,8 +70,8 @@ pub mod cashiers_check {
         ];
         let signer = &[&seeds[..]];
         let cpi_accounts = Transfer {
-            from: ctx.accounts.vault.to_account_info().clone(),
-            to: ctx.accounts.from.to_account_info().clone(),
+            from: ctx.accounts.vault.to_account_info(),
+            to: ctx.accounts.from.to_account_info(),
             authority: ctx.accounts.check_signer.clone(),
         };
         let cpi_program = ctx.accounts.token_program.clone();

--- a/tests/escrow/programs/escrow/src/lib.rs
+++ b/tests/escrow/programs/escrow/src/lib.rs
@@ -197,7 +197,7 @@ impl<'info> From<&mut InitializeEscrow<'info>>
                 .initializer_deposit_token_account
                 .to_account_info()
                 .clone(),
-            current_authority: accounts.initializer.to_account_info().clone(),
+            current_authority: accounts.initializer.to_account_info(),
         };
         let cpi_program = accounts.token_program.to_account_info();
         CpiContext::new(cpi_program, cpi_accounts)
@@ -207,7 +207,7 @@ impl<'info> From<&mut InitializeEscrow<'info>>
 impl<'info> CancelEscrow<'info> {
     fn into_set_authority_context(&self) -> CpiContext<'_, '_, '_, 'info, SetAuthority<'info>> {
         let cpi_accounts = SetAuthority {
-            account_or_mint: self.pda_deposit_token_account.to_account_info().clone(),
+            account_or_mint: self.pda_deposit_token_account.to_account_info(),
             current_authority: self.pda_account.clone(),
         };
         let cpi_program = self.token_program.to_account_info();
@@ -218,7 +218,7 @@ impl<'info> CancelEscrow<'info> {
 impl<'info> Exchange<'info> {
     fn into_set_authority_context(&self) -> CpiContext<'_, '_, '_, 'info, SetAuthority<'info>> {
         let cpi_accounts = SetAuthority {
-            account_or_mint: self.pda_deposit_token_account.to_account_info().clone(),
+            account_or_mint: self.pda_deposit_token_account.to_account_info(),
             current_authority: self.pda_account.clone(),
         };
         let cpi_program = self.receive_token_program.to_account_info();
@@ -231,9 +231,9 @@ impl<'info> Exchange<'info> {
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
         let cpi_accounts = TransferChecked {
-            from: self.pda_deposit_token_account.to_account_info().clone(),
-            mint: self.receive_mint.to_account_info().clone(),
-            to: self.taker_receive_token_account.to_account_info().clone(),
+            from: self.pda_deposit_token_account.to_account_info(),
+            mint: self.receive_mint.to_account_info(),
+            to: self.taker_receive_token_account.to_account_info(),
             authority: self.pda_account.clone(),
         };
         let cpi_program = self.receive_token_program.to_account_info();
@@ -246,8 +246,8 @@ impl<'info> Exchange<'info> {
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
         let cpi_accounts = TransferChecked {
-            from: self.taker_deposit_token_account.to_account_info().clone(),
-            mint: self.deposit_mint.to_account_info().clone(),
+            from: self.taker_deposit_token_account.to_account_info(),
+            mint: self.deposit_mint.to_account_info(),
             to: self
                 .initializer_receive_token_account
                 .to_account_info()

--- a/tests/lockup/programs/registry/src/lib.rs
+++ b/tests/lockup/programs/registry/src/lib.rs
@@ -1248,7 +1248,7 @@ impl<'a, 'b, 'c, 'info> From<&mut DepositLocked<'info>>
         let cpi_accounts = Transfer {
             from: accounts.vesting_vault.clone(),
             to: accounts.member_vault.to_account_info(),
-            authority: accounts.depositor_authority.to_account_info().clone(),
+            authority: accounts.depositor_authority.to_account_info(),
         };
         let cpi_program = accounts.token_program.clone();
         CpiContext::new(cpi_program, cpi_accounts)

--- a/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
+++ b/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
@@ -25,9 +25,9 @@ mod token_proxy {
         if let Some(token_program) = &ctx.accounts.token_program {
             if let Some(mint) = &ctx.accounts.mint {
                 let cpi_accounts = TransferChecked {
-                    from: ctx.accounts.from.to_account_info().clone(),
-                    mint: mint.to_account_info().clone(),
-                    to: ctx.accounts.to.to_account_info().clone(),
+                    from: ctx.accounts.from.to_account_info(),
+                    mint: mint.to_account_info(),
+                    to: ctx.accounts.to.to_account_info(),
                     authority: ctx.accounts.authority.clone(),
                 };
                 let cpi_program = token_program.to_account_info();
@@ -35,8 +35,8 @@ mod token_proxy {
                 token_interface::transfer_checked(cpi_context, amount, mint.decimals)
             } else {
                 let cpi_accounts = Transfer {
-                    from: ctx.accounts.from.to_account_info().clone(),
-                    to: ctx.accounts.to.to_account_info().clone(),
+                    from: ctx.accounts.from.to_account_info(),
+                    to: ctx.accounts.to.to_account_info(),
                     authority: ctx.accounts.authority.clone(),
                 };
                 let cpi_program = token_program.to_account_info();
@@ -208,8 +208,8 @@ impl<'a, 'b, 'c, 'info> From<&mut ProxyTransfer<'info>>
 {
     fn from(accounts: &mut ProxyTransfer<'info>) -> CpiContext<'a, 'b, 'c, 'info, Transfer<'info>> {
         let cpi_accounts = Transfer {
-            from: accounts.from.to_account_info().clone(),
-            to: accounts.to.to_account_info().clone(),
+            from: accounts.from.to_account_info(),
+            to: accounts.to.to_account_info(),
             authority: accounts.authority.clone(),
         };
         let cpi_program = accounts.token_program.to_account_info();
@@ -222,8 +222,8 @@ impl<'a, 'b, 'c, 'info> From<&mut ProxyMintTo<'info>>
 {
     fn from(accounts: &mut ProxyMintTo<'info>) -> CpiContext<'a, 'b, 'c, 'info, MintTo<'info>> {
         let cpi_accounts = MintTo {
-            mint: accounts.mint.to_account_info().clone(),
-            to: accounts.to.to_account_info().clone(),
+            mint: accounts.mint.to_account_info(),
+            to: accounts.to.to_account_info(),
             authority: accounts.authority.clone(),
         };
         let cpi_program = accounts.token_program.to_account_info();
@@ -234,8 +234,8 @@ impl<'a, 'b, 'c, 'info> From<&mut ProxyMintTo<'info>>
 impl<'a, 'b, 'c, 'info> From<&mut ProxyBurn<'info>> for CpiContext<'a, 'b, 'c, 'info, Burn<'info>> {
     fn from(accounts: &mut ProxyBurn<'info>) -> CpiContext<'a, 'b, 'c, 'info, Burn<'info>> {
         let cpi_accounts = Burn {
-            mint: accounts.mint.to_account_info().clone(),
-            from: accounts.from.to_account_info().clone(),
+            mint: accounts.mint.to_account_info(),
+            from: accounts.from.to_account_info(),
             authority: accounts.authority.clone(),
         };
         let cpi_program = accounts.token_program.to_account_info();


### PR DESCRIPTION
### Problem

`to_account_info().clone()` is an anti-pattern because `to_account_info` already returns an owned `AccountInfo`.

### Summary of changes

Remove the unnecessary `clone()` in `to_account_info().clone()`.