### PR TITLE
ts: Remove `anchor-deprecated-state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - cli: Make `cargo build-sbf` the default build command ([#2694](https://github.com/coral-xyz/anchor/pull/2694)).
 - cli: Require explicit `overflow-checks` flag ([#2716](https://github.com/coral-xyz/anchor/pull/2716)).
+- ts: Remove `anchor-deprecated-state` feature ([#2717](https://github.com/coral-xyz/anchor/pull/2717)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/tests/lockup/programs/lockup/Cargo.toml
+++ b/tests/lockup/programs/lockup/Cargo.toml
@@ -12,8 +12,7 @@ name = "lockup"
 [features]
 no-entrypoint = []
 cpi = ["no-entrypoint"]
-anchor-deprecated-state = []
-default = ["anchor-deprecated-state"]
+default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }

--- a/tests/lockup/programs/registry/Cargo.toml
+++ b/tests/lockup/programs/registry/Cargo.toml
@@ -12,8 +12,7 @@ name = "registry"
 [features]
 no-entrypoint = []
 cpi = ["no-entrypoint"]
-anchor-deprecated-state = []
-default = ["anchor-deprecated-state"]
+default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }

--- a/tests/lockup/tests/lockup.js
+++ b/tests/lockup/tests/lockup.js
@@ -2,10 +2,8 @@ const anchor = require("@coral-xyz/anchor");
 const serumCmn = require("@project-serum/common");
 const { TOKEN_PROGRAM_ID } = require("@solana/spl-token");
 const utils = require("./utils");
-const { assert, expect } = require("chai");
+const { assert } = require("chai");
 const nativeAssert = require("assert");
-
-anchor.utils.features.set("anchor-deprecated-state");
 
 describe("Lockup and Registry", () => {
   // Read the provider from the configured environmnet.

--- a/ts/packages/anchor/src/utils/features.ts
+++ b/ts/packages/anchor/src/utils/features.ts
@@ -1,4 +1,4 @@
-const _AVAILABLE_FEATURES = new Set(["anchor-deprecated-state", "debug-logs"]);
+const _AVAILABLE_FEATURES = new Set(["debug-logs"]);
 
 const _FEATURES = new Map();
 


### PR DESCRIPTION
### Problem

`anchor-deprecated-state` feature in TS package is no longer being used because `state` attribute was removed in https://github.com/coral-xyz/anchor/pull/2285.

### Summary of changes

Remove the `anchor-deprecated-state` feature in TS `features` and in `tests/lockup`.