### PR TITLE
spl: Fix compilation with `shmem` feature enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - syn: Fix IDL constant seeds parsing ([#2699](https://github.com/coral-xyz/anchor/pull/2699)).
 - cli: Display errors if toolchain override restoration fails ([#2700](https://github.com/coral-xyz/anchor/pull/2700)).
 - cli: Fix commit based `anchor_version` override ([#2704](https://github.com/coral-xyz/anchor/pull/2704)).
+- spl: Fix compilation with `shmem` feature enabled ([#2722](https://github.com/coral-xyz/anchor/pull/2722)).
 
 ### Breaking
 

--- a/spl/src/shmem.rs
+++ b/spl/src/shmem.rs
@@ -1,7 +1,6 @@
 //! CPI API for interacting with the SPL shared memory
 //! [program](https://github.com/solana-labs/solana-program-library/tree/master/shared-memory).
 
-use anchor_lang::ToAccountInfo;
 use anchor_lang::{context::CpiContext, Accounts};
 use solana_program::account_info::AccountInfo;
 use solana_program::declare_id;

--- a/spl/src/shmem.rs
+++ b/spl/src/shmem.rs
@@ -8,6 +8,7 @@ use solana_program::declare_id;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::instruction::{AccountMeta, Instruction};
 use solana_program::program;
+use solana_program::pubkey::Pubkey;
 
 // TODO: update this once the final shared memory program gets released.
 //       shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL.


### PR DESCRIPTION
### Problem

`anchor-spl` crate doesn't compile with all features enabled because `shmem` feature is broken.

```
error[E0412]: cannot find type `Pubkey` in this scope
  --> spl/src/shmem.rs:36:10
   |
36 | #[derive(Accounts)]
   |          ^^^^^^^^ not found in this scope
   |
   = help: consider importing one of these items:
           anchor_lang::prelude::Pubkey
           solana_program::example_mocks::solana_sdk::Pubkey
   = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0412]: cannot find type `Pubkey` in this scope
  --> spl/src/shmem.rs:43:10
   |
43 | #[derive(Accounts)]
   |          ^^^^^^^^ not found in this scope
   |
   = help: consider importing one of these items:
           anchor_lang::prelude::Pubkey
           solana_program::example_mocks::solana_sdk::Pubkey
   = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)
```

### Summary of changes

Import `solana_program::pubkey::Pubkey`.

---

Might also remove this feature since the program doesn't seem to be [deployed](https://github.com/solana-labs/solana-program-library/blob/f3859bde06d79e5aff6f66b918d3fa637328f8af/shared-memory/program/program-id.md) so nobody is using it but let's keep it for now since the fix was easy.