### PR TITLE
[testing] changing default local test-validator address from localhost to 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Display errors if toolchain override restoration fails ([#2700](https://github.com/coral-xyz/anchor/pull/2700)).
 - cli: Fix commit based `anchor_version` override ([#2704](https://github.com/coral-xyz/anchor/pull/2704)).
 - spl: Fix compilation with `shmem` feature enabled ([#2722](https://github.com/coral-xyz/anchor/pull/2722)).
+- cli: Localhost default test validator address changes from `localhost` to `127.0.0.1`, NodeJS 17 IP resolution changes for IPv6 ([#2725](https://github.com/coral-xyz/anchor/pull/2725)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3514,7 +3514,7 @@ fn test_validator_rpc_url(test_validator: &Option<TestValidator>) -> String {
             validator: Some(validator),
             ..
         }) => format!("http://{}:{}", validator.bind_address, validator.rpc_port),
-        _ => "http://localhost:8899".to_string(),
+        _ => "http://127.0.0.1:8899".to_string(),
     }
 }
 

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -89,7 +89,7 @@ export class AnchorProvider implements Provider {
     }
     opts = opts ?? AnchorProvider.defaultOptions();
     const connection = new Connection(
-      url ?? "http://localhost:8899",
+      url ?? "http://127.0.0.1:8899",
       opts.preflightCommitment
     );
     const NodeWallet = require("./nodewallet.js").default;


### PR DESCRIPTION
I'm inspired with the change of the solana labs example here https://github.com/solana-labs/example-helloworld/issues/375
From the newer nodejs servers the `localhost` is resolved to ipv6 `::1` and when I use the `AnchorProvider.env()` then the `ANCHOR_PROVIDER_URL` by `anchor test` is setup to `http://localhost:8899`.
But the test validator is running on ipv4 as far as I can see.

When I want to use a new instance of `Connection` that's created with the `provider.connection.rpcEndpoint` then I'm getting errors like `Error: failed to get recent blockhash: TypeError: fetch failed`.

Would that be reasonable to change the default local connection url to test validator from localhost to 127.0.0.1?