### PR TITLE
lang: Remove `CLOSED_ACCOUNT_DISCRIMINATOR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Make `cargo build-sbf` the default build command ([#2694](https://github.com/coral-xyz/anchor/pull/2694)).
 - cli: Require explicit `overflow-checks` flag ([#2716](https://github.com/coral-xyz/anchor/pull/2716)).
 - ts: Remove `anchor-deprecated-state` feature ([#2717](https://github.com/coral-xyz/anchor/pull/2717)).
+- lang: Remove `CLOSED_ACCOUNT_DISCRIMINATOR` ([#2726](https://github.com/coral-xyz/anchor/pull/2726)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/docs/src/pages/docs/account-constraints.md
+++ b/docs/src/pages/docs/account-constraints.md
@@ -214,9 +214,11 @@ Minimal reference examples for Anchor account [constraints](https://docs.rs/anch
 
 - [Github](https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/close)
   [Solpg](https://beta.solpg.io/https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/close)
-- Marks the account as closed at the end of the instruction’s execution (sets its discriminator to the CLOSED_ACCOUNT_DISCRIMINATOR) and sends its lamports to the specified account.
+- Closes the account by:
 
-  Setting the discriminator to a special variant makes account revival attacks (where a subsequent instruction adds the rent exemption lamports again) impossible.
+  - Sending the lamports to the specified account
+  - Assigning the owner to the System Program
+  - Resetting the data of the account
 
   Requires mut to exist on the account.
 

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -386,12 +386,10 @@ use syn::parse_macro_input;
 ///                 <code>#[account(close = &lt;target_account&gt;)]</code>
 ///             </td>
 ///             <td>
-///                 Marks the account as closed at the end of the instruction’s execution
-///                 (sets its discriminator to the <code>CLOSED_ACCOUNT_DISCRIMINATOR</code>)
-///                 and sends its lamports to the specified account.<br>
-///                 Setting the discriminator to a special variant
-///                 makes account revival attacks (where a subsequent instruction
-///                 adds the rent exemption lamports again) impossible.<br>
+///                 Closes the account by:<br>
+///                 &nbsp;&nbsp;&nbsp;&nbsp;- Sending the lamports to the specified account<br>
+///                 &nbsp;&nbsp;&nbsp;&nbsp;- Assigning the owner to the System Program<br>
+///                 &nbsp;&nbsp;&nbsp;&nbsp;- Resetting the data of the account<br><br>
 ///                 Requires <code>mut</code> to exist on the account.
 ///                 <br><br>
 ///                 Example:

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -412,9 +412,6 @@ pub mod prelude {
 /// Internal module used by macros and unstable apis.
 #[doc(hidden)]
 pub mod __private {
-    /// The discriminator anchor uses to mark an account as closed.
-    pub const CLOSED_ACCOUNT_DISCRIMINATOR: [u8; 8] = [255, 255, 255, 255, 255, 255, 255, 255];
-
     pub use anchor_attribute_account::ZeroCopyAccessor;
 
     pub use anchor_attribute_event::EventIndex;


### PR DESCRIPTION
### Problem

`CLOSED_ACCOUNT_DISCRIMINATOR` is no longer being used in the codebase after https://github.com/coral-xyz/anchor/pull/2169 but it's still kept in `anchor-lang` and docs.

### Summary of changes

- Remove `CLOSED_ACCOUNT_DISCRIMINATOR`
- Update outdated `close` constraint documentation