### PR TITLE
ci: Remove manual downgrade of `index_list` to make `solana-program-test` compile

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -413,9 +413,7 @@ jobs:
             path: tests/declare-id
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
-            # `solana-program-test` crate doesn't compile because `index_list` crate had a breaking change with a patch release
-            # TODO: Remove the `cargo update` command after the issue is fixed
-          - cmd: cd tests/zero-copy && cargo update -p index_list --precise 0.2.7 && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
+          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
             path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat


### PR DESCRIPTION
### Problem

`solana-program-test` crate had a compile error due to an issue with one of it's dependencies(https://github.com/Fairglow/index-list/issues/5), it was fixed shortly after but we still downgrade it in CI.

### Summary of changes

Do not manually downgrade `index_list` crate version in CI.