### PR TITLE
lang: Allow custom lifetime for Accounts structure

### DIFF
--- a/lang/syn/src/codegen/accounts/to_account_infos.rs
+++ b/lang/syn/src/codegen/accounts/to_account_infos.rs
@@ -23,7 +23,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
     quote! {
         #[automatically_derived]
         impl<#combined_generics> anchor_lang::ToAccountInfos<#trait_generics> for #name <#struct_generics> #where_clause{
-            fn to_account_infos(&self) -> Vec<anchor_lang::solana_program::account_info::AccountInfo<'info>> {
+            fn to_account_infos(&self) -> Vec<anchor_lang::solana_program::account_info::AccountInfo<#trait_generics>> {
                 let mut account_infos = vec![];
 
                 #(#to_acc_infos)*

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -120,7 +120,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
             #[inline(never)]
             fn try_accounts(
                 __program_id: &anchor_lang::solana_program::pubkey::Pubkey,
-                __accounts: &mut &'info [anchor_lang::solana_program::account_info::AccountInfo<'info>],
+                __accounts: &mut &#trait_generics [anchor_lang::solana_program::account_info::AccountInfo<#trait_generics>],
                 __ix_data: &[u8],
                 __bumps: &mut #bumps_struct_name,
                 __reallocs: &mut std::collections::BTreeSet<anchor_lang::solana_program::pubkey::Pubkey>,

--- a/lang/tests/generics_test.rs
+++ b/lang/tests/generics_test.rs
@@ -9,6 +9,11 @@ use solana_program::pubkey::Pubkey;
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[derive(Accounts)]
+pub struct CustomLifetime<'a> {
+    pub non_generic: UncheckedAccount<'a>,
+}
+
+#[derive(Accounts)]
 pub struct GenericsTest<'info, T, U, const N: usize>
 where
     T: AccountSerialize + AccountDeserialize + Owner + Clone,


### PR DESCRIPTION
### Problem

Currently, we can't write a syntax like this:
```rust
#[derive(Accounts)]
pub struct CustomLifetime<'a> {
    pub non_generic: UncheckedAccount<'a>,
}
```

### Summary of changes

- Use `trait_generics` in `to_account_infos` macro generation.
- Use `trait_generics` in `try_accounts` macro generation.


