### PR TITLE
lang: Remove `try_to_vec` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix commit based `anchor_version` override ([#2704](https://github.com/coral-xyz/anchor/pull/2704)).
 - spl: Fix compilation with `shmem` feature enabled ([#2722](https://github.com/coral-xyz/anchor/pull/2722)).
 - cli: Localhost default test validator address changes from `localhost` to `127.0.0.1`, NodeJS 17 IP resolution changes for IPv6 ([#2725](https://github.com/coral-xyz/anchor/pull/2725)).
-- lang: Eliminate temporary Vec allocations when serialising objects with discriminant ([#2691](https://github.com/coral-xyz/anchor/pull/2691)).
+- lang: Eliminate temporary Vec allocations when serializing data with discriminant and set the default capacity to 256 bytes ([#2691](https://github.com/coral-xyz/anchor/pull/2691)).
+- lang: Allow custom lifetime in Accounts structure ([#2741](https://github.com/coral-xyz/anchor/pull/2741)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Localhost default test validator address changes from `localhost` to `127.0.0.1`, NodeJS 17 IP resolution changes for IPv6 ([#2725](https://github.com/coral-xyz/anchor/pull/2725)).
 - lang: Eliminate temporary Vec allocations when serializing data with discriminant and set the default capacity to 256 bytes ([#2691](https://github.com/coral-xyz/anchor/pull/2691)).
 - lang: Allow custom lifetime in Accounts structure ([#2741](https://github.com/coral-xyz/anchor/pull/2741)).
+- lang: Remove `try_to_vec` usage while setting the return data in order to reduce heap memory usage ([#2744](https://github.com/coral-xyz/anchor/pull/2744))
 
 ### Breaking
 

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -107,7 +107,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let maybe_set_return_data = match ret_type.to_string().as_str() {
                 "()" => quote! {},
                 _ => quote! {
-                    anchor_lang::solana_program::program::set_return_data(&result.try_to_vec().unwrap());
+                    let mut return_data = Vec::with_capacity(256);
+                    result.serialize(&mut return_data).unwrap();
+                    anchor_lang::solana_program::program::set_return_data(&return_data);
                 },
             };
             quote! {

--- a/tests/cpi-returns/tsconfig.json
+++ b/tests/cpi-returns/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "types": ["mocha", "chai"],
-    "typeRoots": ["./node_modules/@types"],
     "lib": ["es2015"],
     "module": "commonjs",
     "target": "es6",


### PR DESCRIPTION
### Problem

[`try_to_vec`](https://docs.rs/borsh/0.10.3/borsh/ser/trait.BorshSerialize.html#method.try_to_vec) allocates 1024 bytes by default which is actually the [`MAX_RETURN_DATA`](https://docs.rs/solana-program/1.17.13/solana_program/program/constant.MAX_RETURN_DATA.html) for CPI. This is not necessary for the vast majority of programs so we've recently reduced the default capacity to 256 in https://github.com/coral-xyz/anchor/pull/2691 but [`set_return_data`](https://docs.rs/solana-program/1.17.13/solana_program/program/fn.set_return_data.html) still uses `try_to_vec`.

### Summary of changes

Remove the usage of `try_to_vec` and make the default allocation of 256 similar to other places in the codebase.

Related: https://github.com/coral-xyz/anchor/issues/2231