### PR TITLE
ts: Remove deprecated `associated` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `CLOSED_ACCOUNT_DISCRIMINATOR` ([#2726](https://github.com/coral-xyz/anchor/pull/2726)).
 - lang: Make bumps of optional accounts `Option<u8>` rather than `u8` ([#2730](https://github.com/coral-xyz/anchor/pull/2730)).
 - spl: Remove `shared-memory` program ([#2747](https://github.com/coral-xyz/anchor/pull/2747)).
+- ts: Remove `associated`, `account.associated` and `account.associatedAddress` methods ([#2749](https://github.com/coral-xyz/anchor/pull/2749)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -16,7 +16,6 @@ import { Idl, IdlAccountDef } from "../../idl.js";
 import { Coder, BorshCoder } from "../../coder/index.js";
 import { Subscription, Address, translateAddress } from "../common.js";
 import { AllAccountsMap, IdlAccounts } from "./types.js";
-import * as pubkeyUtil from "../../utils/pubkey.js";
 import * as rpcUtil from "../../utils/rpc.js";
 
 export default class AccountFactory {
@@ -370,29 +369,6 @@ export class AccountClient<
         ),
       programId: this._programId,
     });
-  }
-
-  /**
-   * @deprecated since version 14.0.
-   *
-   * Function returning the associated account. Args are keys to associate.
-   * Order matters.
-   */
-  async associated(...args: Array<PublicKey | Buffer>): Promise<T> {
-    const addr = await this.associatedAddress(...args);
-    return await this.fetch(addr);
-  }
-
-  /**
-   * @deprecated since version 14.0.
-   *
-   * Function returning the associated address. Args are keys to associate.
-   * Order matters.
-   */
-  async associatedAddress(
-    ...args: Array<PublicKey | Buffer>
-  ): Promise<PublicKey> {
-    return await pubkeyUtil.associated(this._programId, ...args);
   }
 
   async getAccountInfo(

--- a/ts/packages/anchor/src/utils/pubkey.ts
+++ b/ts/packages/anchor/src/utils/pubkey.ts
@@ -1,6 +1,5 @@
 import { Buffer } from "buffer";
 import { PublicKey } from "@solana/web3.js";
-import { Address, translateAddress } from "../program/common.js";
 import { sha256 } from "@noble/hashes/sha256";
 
 // Sync version of web3.PublicKey.createWithSeed.
@@ -15,19 +14,4 @@ export function createWithSeedSync(
     programId.toBuffer(),
   ]);
   return new PublicKey(sha256(buffer));
-}
-
-export function associated(
-  programId: Address,
-  ...args: Array<Address | Buffer>
-): PublicKey {
-  let seeds = [Buffer.from([97, 110, 99, 104, 111, 114])]; // b"anchor".
-  args.forEach((arg) => {
-    seeds.push(arg instanceof Buffer ? arg : translateAddress(arg).toBuffer());
-  });
-  const [assoc] = PublicKey.findProgramAddressSync(
-    seeds,
-    translateAddress(programId)
-  );
-  return assoc;
 }


### PR DESCRIPTION
### Problem

`associated` methods have been deprecated since `0.14.0` and they are taking unnecessary space.

### Summary of changes

Remove `associated`, `account.associated` and `account.associatedAddress` methods.

**NOTE:** [`associatedAdress`](https://github.com/coral-xyz/anchor/blob/52fbe55d52837667273b109d8e1e887854449d90/ts/packages/anchor/src/utils/token.ts#L10) function to get the associated token account address still remains, this removal is about the ancient `#[associated]` macro.