### PR TITLE
cli: Check `anchor-lang` and CLI version compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `InstructionData::write_to` implementation ([#2733](https://github.com/coral-xyz/anchor/pull/2733)).
 - lang: Add `#[interface(..)]` attribute for instruction discriminator overrides ([#2728](https://github.com/coral-xyz/anchor/pull/2728)).
 - ts: Add `.interface(..)` method for instruction discriminator overrides ([#2728](https://github.com/coral-xyz/anchor/pull/2728)).
+- cli: Check `anchor-lang` and CLI version compatibility ([#2753](https://github.com/coral-xyz/anchor/pull/2753)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -39,8 +39,7 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
         .filter_map(|man| man.ok())
         .filter_map(|man| man.dependencies.get("anchor-lang").map(|d| d.to_owned()))
         .filter_map(|dep| Version::parse(dep.req()).ok())
-        .filter(|ver| ver != &cli_version)
-        .next(); // Only log the warning once
+        .find(|ver| ver != &cli_version); // Only log the warning once
 
     if let Some(ver) = mismatched_lang_version {
         eprintln!(

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,8 +1,12 @@
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
+use semver::Version;
 
-use crate::config::Manifest;
+use crate::{
+    config::{Config, Manifest, WithPath},
+    VERSION,
+};
 
 /// Check whether `overflow-checks` codegen option is enabled.
 ///
@@ -17,6 +21,37 @@ pub fn check_overflow(cargo_toml_path: impl AsRef<Path>) -> Result<bool> {
             "`overflow-checks` is not enabled. To enable, add:\n\n\
     [profile.release]\n\
     overflow-checks = true\n\n\
-    in workspace root Cargo.toml.",
+    in workspace root Cargo.toml",
         ))
+}
+
+/// Check whether there is a mismatch between the current CLI version and the `anchor-lang` crate
+/// version.
+///
+/// This function logs warnings in the case of a mismatch.
+pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
+    let cli_version = Version::parse(VERSION)?;
+    let mismatched_lang_version = cfg
+        .get_rust_program_list()?
+        .into_iter()
+        .map(|path| path.join("Cargo.toml"))
+        .map(cargo_toml::Manifest::from_path)
+        .filter_map(|man| man.ok())
+        .filter_map(|man| man.dependencies.get("anchor-lang").map(|d| d.to_owned()))
+        .filter_map(|dep| Version::parse(dep.req()).ok())
+        .filter(|ver| ver != &cli_version)
+        .next(); // Only log the warning once
+
+    if let Some(ver) = mismatched_lang_version {
+        eprintln!(
+            "WARNING: `anchor-lang` version({ver}) and the current CLI version({cli_version}) \
+                 don't match.\n\n\t\
+                 This can lead to unwanted behavior. To use the same CLI version, add:\n\n\t\
+                 [toolchain]\n\t\
+                 anchor_version = \"{ver}\"\n\n\t\
+                 to Anchor.toml\n"
+        );
+    }
+
+    Ok(())
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,7 +11,7 @@ use anchor_syn::idl::types::{
     IdlTypeDefinitionTy,
 };
 use anyhow::{anyhow, Context, Result};
-use checks::check_overflow;
+use checks::{check_anchor_version, check_overflow};
 use clap::Parser;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
@@ -1193,6 +1193,9 @@ pub fn build(
     if workspace_cargo_toml_path.exists() {
         check_overflow(workspace_cargo_toml_path)?;
     }
+
+    // Check whether there is a mismatch between CLI and lang crate versions
+    check_anchor_version(&cfg).ok();
 
     let idl_out = match idl {
         Some(idl) => Some(PathBuf::from(idl)),


### PR DESCRIPTION
### Problem

Using different version of program crate and the CLI can lead to unwanted behavior.

### Summary of changes

Print a warning when there is a mismatch between the versions. For example:

```
WARNING: `anchor-lang` version(0.28.0) and the current CLI version(0.29.0) don't match.

        This can lead to unwanted behavior. To use the same CLI version, add:

        [toolchain]
        anchor_version = "0.28.0"

        to Anchor.toml
```