### PR TITLE
cli: idl close to directly an idl address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- cli: `idl close` accepts optinal `--idl-address` parameter, `idl upgrade` closes the buffer ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 - cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
 - cli: Add verifiable option when `deploy` ([#2705](https://github.com/coral-xyz/anchor/pull/2705)).
 - cli: Add support for passing arguments to the underlying `solana program deploy` command with `anchor deploy` ([#2709](https://github.com/coral-xyz/anchor/pull/2709)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- cli: `idl close` accepts optinal `--idl-address` parameter, `idl upgrade` closes the buffer ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 - cli: Allow force `init` and `new` ([#2698](https://github.com/coral-xyz/anchor/pull/2698)).
 - cli: Add verifiable option when `deploy` ([#2705](https://github.com/coral-xyz/anchor/pull/2705)).
 - cli: Add support for passing arguments to the underlying `solana program deploy` command with `anchor deploy` ([#2709](https://github.com/coral-xyz/anchor/pull/2709)).
@@ -21,6 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add `.interface(..)` method for instruction discriminator overrides ([#2728](https://github.com/coral-xyz/anchor/pull/2728)).
 - cli: Check `anchor-lang` and CLI version compatibility ([#2753](https://github.com/coral-xyz/anchor/pull/2753)).
 - ts: Add IdlSeed Type for IDL PDA seeds ([#2752](https://github.com/coral-xyz/anchor/pull/2752)).
+- cli: `idl close` accepts optional `--idl-address` parameter ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 
 ### Fixes
 
@@ -49,6 +49,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Make bumps of optional accounts `Option<u8>` rather than `u8` ([#2730](https://github.com/coral-xyz/anchor/pull/2730)).
 - spl: Remove `shared-memory` program ([#2747](https://github.com/coral-xyz/anchor/pull/2747)).
 - ts: Remove `associated`, `account.associated` and `account.associatedAddress` methods ([#2749](https://github.com/coral-xyz/anchor/pull/2749)).
+- cli: `idl upgrade` command closes the IDL buffer account ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2068,16 +2068,26 @@ fn idl(cfg_override: &ConfigOverride, subcmd: IdlCommand) -> Result<()> {
             program_id,
             idl_address,
             print_only,
-        } => idl_close(cfg_override, program_id, idl_address, print_only),
+        } => {
+            let closed_address = idl_close(cfg_override, program_id, idl_address, print_only)?;
+            if !print_only {
+                println!("Idl account closed: {closed_address}");
+            }
+            Ok(())
+        }
         IdlCommand::WriteBuffer {
             program_id,
             filepath,
-        } => idl_write_buffer(cfg_override, program_id, filepath).map(|_| ()),
+        } => {
+            let idl_buffer = idl_write_buffer(cfg_override, program_id, filepath)?;
+            println!("Idl buffer created: {idl_buffer}");
+            Ok(())
+        }
         IdlCommand::SetBuffer {
             program_id,
             buffer,
             print_only,
-        } => idl_set_buffer(cfg_override, program_id, buffer, print_only),
+        } => idl_set_buffer(cfg_override, program_id, buffer, print_only).map(|_| ()),
         IdlCommand::Upgrade {
             program_id,
             filepath,
@@ -2167,16 +2177,12 @@ fn idl_close(
     program_id: Pubkey,
     idl_address: Option<Pubkey>,
     print_only: bool,
-) -> Result<()> {
+) -> Result<Pubkey> {
     with_workspace(cfg_override, |cfg| {
         let idl_address = idl_address.unwrap_or_else(|| IdlAccount::address(&program_id));
         idl_close_account(cfg, &program_id, idl_address, print_only)?;
 
-        if !print_only {
-            println!("Idl account closed: {idl_address:?}");
-        }
-
-        Ok(())
+        Ok(idl_address)
     })
 }
 
@@ -2194,8 +2200,6 @@ fn idl_write_buffer(
         let idl_buffer = create_idl_buffer(cfg, &keypair, &program_id, &idl)?;
         idl_write(cfg, &program_id, &idl, idl_buffer)?;
 
-        println!("Idl buffer created: {idl_buffer:?}");
-
         Ok(idl_buffer)
     })
 }
@@ -2205,7 +2209,7 @@ fn idl_set_buffer(
     program_id: Pubkey,
     buffer: Pubkey,
     print_only: bool,
-) -> Result<()> {
+) -> Result<Pubkey> {
     with_workspace(cfg_override, |cfg| {
         let keypair = solana_sdk::signature::read_keypair_file(&cfg.provider.wallet.to_string())
             .map_err(|_| anyhow!("Unable to read keypair file"))?;
@@ -2250,7 +2254,7 @@ fn idl_set_buffer(
             client.send_and_confirm_transaction_with_spinner(&tx)?;
         }
 
-        Ok(())
+        Ok(idl_address)
     })
 }
 
@@ -2259,9 +2263,11 @@ fn idl_upgrade(
     program_id: Pubkey,
     idl_filepath: String,
 ) -> Result<()> {
-    let buffer = idl_write_buffer(cfg_override, program_id, idl_filepath)?;
-    idl_set_buffer(cfg_override, program_id, buffer, false)?;
-    idl_close(cfg_override, program_id, Some(buffer), false)
+    let buffer_address = idl_write_buffer(cfg_override, program_id, idl_filepath)?;
+    let idl_address = idl_set_buffer(cfg_override, program_id, buffer_address, false)?;
+    idl_close(cfg_override, program_id, Some(buffer_address), false).map(|_| ())?;
+    println!("Idl account {idl_address} successfully upgraded");
+    Ok(())
 }
 
 fn idl_authority(cfg_override: &ConfigOverride, program_id: Pubkey) -> Result<()> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2265,7 +2265,7 @@ fn idl_upgrade(
 ) -> Result<()> {
     let buffer_address = idl_write_buffer(cfg_override, program_id, idl_filepath)?;
     let idl_address = idl_set_buffer(cfg_override, program_id, buffer_address, false)?;
-    idl_close(cfg_override, program_id, Some(buffer_address), false).map(|_| ())?;
+    idl_close(cfg_override, program_id, Some(buffer_address), false)?;
     println!("Idl account {idl_address} successfully upgraded");
     Ok(())
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -376,7 +376,7 @@ pub enum IdlCommand {
     Close {
         program_id: Pubkey,
         /// The IDL account to close. If none is given, then the IDL account derived from program_id is used.
-        #[clap(short, long)]
+        #[clap(long)]
         idl_address: Option<Pubkey>,
         /// When used, the content of the instruction will only be printed in base64 form and not executed.
         /// Useful for multisig execution when the local wallet keypair is not available.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -375,6 +375,9 @@ pub enum IdlCommand {
     },
     Close {
         program_id: Pubkey,
+        /// The IDL account to close. If none is given, then the IDL account derived from program_id is used.
+        #[clap(short, long)]
+        idl_address: Option<Pubkey>,
         /// When used, the content of the instruction will only be printed in base64 form and not executed.
         /// Useful for multisig execution when the local wallet keypair is not available.
         #[clap(long)]
@@ -2063,8 +2066,9 @@ fn idl(cfg_override: &ConfigOverride, subcmd: IdlCommand) -> Result<()> {
         } => idl_init(cfg_override, program_id, filepath),
         IdlCommand::Close {
             program_id,
+            idl_address,
             print_only,
-        } => idl_close(cfg_override, program_id, print_only),
+        } => idl_close(cfg_override, program_id, idl_address, print_only),
         IdlCommand::WriteBuffer {
             program_id,
             filepath,
@@ -2158,9 +2162,14 @@ fn idl_init(cfg_override: &ConfigOverride, program_id: Pubkey, idl_filepath: Str
     })
 }
 
-fn idl_close(cfg_override: &ConfigOverride, program_id: Pubkey, print_only: bool) -> Result<()> {
+fn idl_close(
+    cfg_override: &ConfigOverride,
+    program_id: Pubkey,
+    idl_address: Option<Pubkey>,
+    print_only: bool,
+) -> Result<()> {
     with_workspace(cfg_override, |cfg| {
-        let idl_address = IdlAccount::address(&program_id);
+        let idl_address = idl_address.unwrap_or_else(|| IdlAccount::address(&program_id));
         idl_close_account(cfg, &program_id, idl_address, print_only)?;
 
         if !print_only {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2260,7 +2260,8 @@ fn idl_upgrade(
     idl_filepath: String,
 ) -> Result<()> {
     let buffer = idl_write_buffer(cfg_override, program_id, idl_filepath)?;
-    idl_set_buffer(cfg_override, program_id, buffer, false)
+    idl_set_buffer(cfg_override, program_id, buffer, false)?;
+    idl_close(cfg_override, program_id, Some(buffer), false)
 }
 
 fn idl_authority(cfg_override: &ConfigOverride, program_id: Pubkey) -> Result<()> {


### PR DESCRIPTION
On upgrading the IDL account 

```
anchor --provider.cluster devnet idl \
  --provider.wallet <fee-payer> upgrade <program-id> -f ./target/idl/program.json
```

It creates the IDL buffer and then it writes the buffer to the program IDL account.
The IDL buffer is still opened. It's not possible to use `anchor idl close` with specific IDL address (e.g., address of the buffer) to close it and get back the rent for the account.
Adding the optional argument of providing the IDL address directly makes possible to close the buffer account as well.