### PR TITLE
cli: Fix `migrate` command not working without global `ts-node` installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `try_to_vec` usage while setting the return data in order to reduce heap memory usage ([#2744](https://github.com/coral-xyz/anchor/pull/2744))
 - cli: Show installation progress if Solana tools are not installed when using toolchain overrides ([#2757](https://github.com/coral-xyz/anchor/pull/2757)).
 - ts: Fix formatting enums ([#2763](https://github.com/coral-xyz/anchor/pull/2763)).
+- cli: Fix `migrate` command not working without global `ts-node` installation ([#2767](https://github.com/coral-xyz/anchor/pull/2767)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/parse/file.rs
+++ b/lang/syn/src/idl/parse/file.rs
@@ -107,7 +107,7 @@ pub fn parse(
                 .named
                 .iter()
                 .map(|f: &syn::Field| {
-                    let index = match f.attrs.get(0) {
+                    let index = match f.attrs.first() {
                         None => false,
                         Some(i) => parser::tts_to_string(&i.path) == "index",
                     };


### PR DESCRIPTION
Running `anchor migrate` without global `ts-node` installation results in:

```sh
$ anchor migrate
Running migration deploy script
Error: No such file or directory (os error 2)
```

### Summary of changes

Use the project's `ts-node` installation instead of global `ts-node` command.