### PR TITLE
Enable all features for docs.rs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Show installation progress if Solana tools are not installed when using toolchain overrides ([#2757](https://github.com/coral-xyz/anchor/pull/2757)).
 - ts: Fix formatting enums ([#2763](https://github.com/coral-xyz/anchor/pull/2763)).
 - cli: Fix `migrate` command not working without global `ts-node` installation ([#2767](https://github.com/coral-xyz/anchor/pull/2767)).
+- client, lang, spl, syn: Enable all features for docs.rs build ([#2774](https://github.com/coral-xyz/anchor/pull/2774)).
 
 ### Breaking
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Rust client for Anchor programs"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 async = []
 debug = []

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! `anchor_client` provides an RPC client to send transactions and fetch
 //! deserialized accounts from Solana programs written in `anchor_lang`.
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Solana Sealevel eDSL"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 allow-missing-optionals = ["anchor-derive-accounts/allow-missing-optionals"]
 anchor-debug = [

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Anchor ⚓ is a framework for Solana's Sealevel runtime providing several
 //! convenient developer tools.
 //!

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -8,6 +8,10 @@ description = "Anchor syntax parsing and code generation tools"
 rust-version = "1.60"
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 allow-missing-optionals = []
 anchor-debug = []

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 pub mod codegen;
 pub mod parser;
 

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 license = "Apache-2.0"
 description = "CPI clients for SPL programs"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["associated_token", "mint", "token", "token_2022"]
 associated_token = ["spl-associated-token-account"]

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+//! Anchor CPI wrappers for popular programs in the Solana ecosystem.
+
 #[cfg(feature = "associated_token")]
 pub mod associated_token;
 

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[cfg(feature = "associated_token")]
 pub mod associated_token;
 


### PR DESCRIPTION
### Problem

[docs.rs](https://docs.rs) build only shows default features. For example, `metadata` module of [`anchor-spl`](https://docs.rs/anchor-spl/0.29.0/anchor_spl/) is not shown.

### Summary of changes

- Enable all features for docs.rs build
- Enable `doc_auto_cfg` feature for docs.rs build to automatically annote features. This feature is only enabled for `docs.rs` build because it's currently not stable(https://github.com/rust-lang/rust/issues/43781).