### PR TITLE
:sparkles: Add support for simple wilcard Anchor.toml's workspace.members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Check `anchor-lang` and CLI version compatibility ([#2753](https://github.com/coral-xyz/anchor/pull/2753)).
 - ts: Add IdlSeed Type for IDL PDA seeds ([#2752](https://github.com/coral-xyz/anchor/pull/2752)).
 - cli: `idl close` accepts optional `--idl-address` parameter ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
+- cli: Add support for simple wildcard patterns in Anchor.toml's `workspace.members` and `workspace.exclude`. ([#2785](https://github.com/coral-xyz/anchor/pull/2785)).
 
 ### Fixes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -306,7 +306,7 @@ impl WithPath<Config> {
             .iter()
             .flat_map(|m| {
                 let path = self.path().parent().unwrap().join(m);
-                if m.ends_with('*') {
+                if m.ends_with("/*") {
                     let dir = path.parent().unwrap();
                     match fs::read_dir(dir) {
                         Ok(entries) => entries

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -314,8 +314,7 @@ impl WithPath<Config> {
                             .map(|entry| entry.path().canonicalize().unwrap_or_else(|_| {
                                 panic!("Error canonicalizing path {:?}", entry.path());
                             }))
-                            .collect::<Vec<_>>()
-                            .into_iter(),
+                            .collect(),
                         Err(_) => panic!("Error reading directory {:?}", dir),
                     }
                 } else {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -300,46 +300,43 @@ impl WithPath<Config> {
     }
 
     pub fn canonicalize_workspace(&self) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
-        let members = self
-            .workspace
-            .members
+        let members = self.process_paths(&self.workspace.members)?;
+        let exclude = self.process_paths(&self.workspace.exclude)?;
+        Ok((members, exclude))
+    }
+
+    fn process_paths(&self, paths: &[String]) -> Result<Vec<PathBuf>, Error> {
+        let base_path = self.path().parent().unwrap();
+        paths
             .iter()
             .flat_map(|m| {
-                let path = self.path().parent().unwrap().join(m);
+                let path = base_path.join(m);
                 if m.ends_with("/*") {
                     let dir = path.parent().unwrap();
                     match fs::read_dir(dir) {
                         Ok(entries) => entries
                             .filter_map(|entry| entry.ok())
-                            .map(|entry| entry.path().canonicalize().unwrap_or_else(|_| {
-                                panic!("Error canonicalizing path {:?}", entry.path());
-                            }))
+                            .map(|entry| self.process_single_path(&entry.path()))
                             .collect(),
-                        Err(_) => panic!("Error reading directory {:?}", dir),
+                        Err(e) => vec![Err(Error::new(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Error reading directory {:?}: {}", dir, e),
+                        )))],
                     }
                 } else {
-                    vec![path.canonicalize().unwrap_or_else(|_| {
-                        panic!("Error reading workspace.members. File {:?} does not exist at path {:?}.", m, self.path())
-                    })].into_iter()
+                    vec![self.process_single_path(&path)]
                 }
             })
-            .collect();
-        let exclude = self
-            .workspace
-            .exclude
-            .iter()
-            .map(|m| {
-                self.path()
-                    .parent()
-                    .unwrap()
-                    .join(m)
-                    .canonicalize()
-                    .unwrap_or_else(|_| {
-                        panic!("Error reading workspace.exclude. File {:?} does not exist at path {:?}.", m, self.path)
-                    })
-            })
-            .collect();
-        Ok((members, exclude))
+            .collect()
+    }
+
+    fn process_single_path(&self, path: &PathBuf) -> Result<PathBuf, Error> {
+        path.canonicalize().map_err(|e| {
+            Error::new(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Error canonicalizing path {:?}: {}", path, e),
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
# Add support for simple wilcard Anchor.toml's workspace.members

See #2784 and #2658 for context