### PR TITLE
docs: minor fixes to JS Anchor types

### DIFF
--- a/docs/src/pages/docs/javascript-anchor-types.md
+++ b/docs/src/pages/docs/javascript-anchor-types.md
@@ -3,7 +3,7 @@ title: Javascript Anchor Types Reference
 description: Anchor - Javascript Anchor Types Reference
 ---
 
-This reference shows you how Anchor maps Tust types to JavaScript/TypeScript types in the client.
+This reference shows you how Anchor maps Rust types to JavaScript/TypeScript types in the client.
 
 ---
 

--- a/docs/src/pages/docs/javascript-anchor-types.md
+++ b/docs/src/pages/docs/javascript-anchor-types.md
@@ -9,7 +9,7 @@ This reference shows you how Anchor maps Rust types to JavaScript/TypeScript typ
 
 {% table %}
 * Rust Type
-* Javascript Type
+* JavaScript Type
 * Example
 * Note
 ---

--- a/docs/src/pages/docs/javascript-anchor-types.md
+++ b/docs/src/pages/docs/javascript-anchor-types.md
@@ -3,7 +3,7 @@ title: Javascript Anchor Types Reference
 description: Anchor - Javascript Anchor Types Reference
 ---
 
-This reference shows you how anchor maps rust types to javascript/typescript types in the client.
+This reference shows you how Anchor maps Tust types to JavaScript/TypeScript types in the client.
 
 ---
 
@@ -14,7 +14,7 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
 * Note
 ---
 * `bool`
-* `bool`
+* `boolean`
 * ```javascript
   await program
     .methods
@@ -72,7 +72,7 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
     .init({ two: { val: 99 } })
     .rpc();
 
-  // Unnamed(tuple) variant
+  // Unnamed (tuple) variant
   await program
     .methods
     .init({ three: [12, -34] })
@@ -94,7 +94,7 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
   ```
 ---
 * `[T; N]`
-* `[ T ]`
+* `Array<T>`
 * ```javascript
   await program
     .methods
@@ -112,7 +112,7 @@ This reference shows you how anchor maps rust types to javascript/typescript typ
   ```
 ---
 * `Vec<T>`
-* `[ T ]`
+* `Array<T>`
 * ```javascript
   await program
     .methods


### PR DESCRIPTION
Originally just wanted to fix that JS Booleans are booleans (not bools) but added some minor capitalisation fixes and used the more modern generic type syntax for JS arrays.