### PR TITLE
Specify `solana-program` version range to not include 1.18.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,11 +36,11 @@ semver = "1.0.4"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "2.1.0"
-solana-client = "1.16"
-solana-cli-config = "1.16"
-solana-faucet = "1.16"
-solana-program = "1.16"
-solana-sdk = "1.16"
+solana-client = ">=1.16, <1.18"
+solana-cli-config = ">=1.16, <1.18"
+solana-faucet = ">=1.16, <1.18"
+solana-program = ">=1.16, <1.18"
+solana-sdk = ">=1.16, <1.18"
 # Pin solang-parser because it may break in a backwards incompatible way in minor versions
 solang-parser = "=0.3.3"
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,9 +21,9 @@ anyhow = "1"
 futures = "0.3"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-solana-account-decoder = "1.16"
-solana-client = "1.16"
-solana-sdk = "1.16"
+solana-account-decoder = ">=1.16, <1.18"
+solana-client = ">=1.16, <1.18"
+solana-sdk = ">=1.16, <1.18"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 url = "2"

--- a/client/example/Cargo.toml
+++ b/client/example/Cargo.toml
@@ -20,5 +20,5 @@ events = { path = "../../tests/events/programs/events", features = ["no-entrypoi
 anyhow = "1.0.32"
 clap = { version = "4.2.4", features = ["derive"] }
 shellexpand = "2.1.0"
-solana-sdk = "1.16"
+solana-sdk = ">=1.16, <1.18"
 tokio = { version = "1", features = ["full"] }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -57,7 +57,7 @@ base64 = "0.21"
 bincode = "1"
 borsh = ">=0.9, <0.11"
 bytemuck = "1"
-solana-program = "1.16"
+solana-program = ">=1.16, <1.18"
 thiserror = "1"
 
 # TODO: Remove. This crate has been added to fix a build error with the 1.16.0 release.

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -30,7 +30,7 @@ anchor-lang = { path = "../lang", version = "0.29.0", features = ["derive"] }
 borsh = { version = ">=0.9, <0.11", optional = true }
 mpl-token-metadata = { version = "3.1.0", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
-solana-program = "1.16"
+solana-program = ">=1.16, <1.18"
 spl-associated-token-account = { version = "2.2", features = ["no-entrypoint"], optional = true }
 spl-memo = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "4", features = ["no-entrypoint"], optional = true }

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -22,4 +22,4 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 
 [dev-dependencies]
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
-solana-program-test = "1.16"
+solana-program-test = ">=1.16, <1.18"


### PR DESCRIPTION
### Problem

CI is currently broken because of the `1.18` release of Solana. The solution is to upgrade Solana tools to use `1.18` but I've run into some unexpected behavior while upgrading the repo to use `1.18` in https://github.com/coral-xyz/anchor/pull/2795. Further debugging is needed in order to identify the root cause of the issues.

### Summary of changes

Specify `>=1.16, <1.18` version range for Solana dependencies in order to fix CI.