### PR TITLE
spl: Pin version of `toml_edit` crate to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "spl-memo",
  "spl-token 4.0.0",
  "spl-token-2022",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -2982,7 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -5105,14 +5106,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -5126,6 +5127,17 @@ dependencies = [
  "indexmap 2.0.2",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.0.2",
  "toml_datetime",
  "winnow",
 ]

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -36,3 +36,6 @@ spl-memo = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token-2022 = { version = "0.9", features = ["no-entrypoint"], optional = true }
 
+# TODO: Remove after https://github.com/coral-xyz/anchor/pull/2795 is merged.
+# `toml_edit 0.21.1` has MSRV of `1.69.0` which is above `1.68.0` that comes from `solana-cli 1.17`.
+toml_edit = "=0.21.0"


### PR DESCRIPTION
### Problem

New installations of `anchor-spl` come with `toml_edit 0.21.1` which has a MSRV of `1.69` which results in the following error when using `solana-cli 1.17`:

```
error: package `toml_edit v0.21.1` cannot be built because it requires rustc 1.69 or newer, while the currently active rustc version is 1.68.0-dev
```

There is also no good reason for a program to depend on `toml_edit` crate but that's not something we have control over since it's a transitive dependency of `spl-token-2022`.

Related: https://github.com/solana-labs/solana/issues/33504

### Summary of changes

Use fixed version `toml_edit = "=0.21.0"` in `anchor-spl` to block `cargo` from fetching the newest version.

This is necessary until https://github.com/coral-xyz/anchor/pull/2795 is merged but that also has its own problems.