### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-The Anchor repository follows the Rust [Code of Conduct](https://www.rust-lang.org/conduct.html).
+The Anchor repository follows the Rust [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).


### PR DESCRIPTION
Old url: https://www.rust-lang.org/conduct.html is broken, new one is https://www.rust-lang.org/policies/code-of-conduct 