### PR TITLE
tests: Fix non-path `anchor-lang` dep in tests

### DIFF
--- a/tests/misc/programs/overflow-checks/Cargo.toml
+++ b/tests/misc/programs/overflow-checks/Cargo.toml
@@ -16,4 +16,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.29.0"
+anchor-lang = { path = "../../../../lang" }


### PR DESCRIPTION
### Problem

`anchor-lang` dependency in `overflow-checks` test depend on the published version rather than the local version.

### Summary of changes

Use the local `anchor-lang` dependency.