### PR TITLE
cli: Check `@coral-xyz/anchor` package and CLI version compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `#[interface(..)]` attribute for instruction discriminator overrides ([#2728](https://github.com/coral-xyz/anchor/pull/2728)).
 - ts: Add `.interface(..)` method for instruction discriminator overrides ([#2728](https://github.com/coral-xyz/anchor/pull/2728)).
 - cli: Check `anchor-lang` and CLI version compatibility ([#2753](https://github.com/coral-xyz/anchor/pull/2753)).
-- ts: Add IdlSeed Type for IDL PDA seeds ([#2752](https://github.com/coral-xyz/anchor/pull/2752)).
+- ts: Add missing IDL PDA seed types ([#2752](https://github.com/coral-xyz/anchor/pull/2752)).
 - cli: `idl close` accepts optional `--idl-address` parameter ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 - cli: Add support for simple wildcard patterns in Anchor.toml's `workspace.members` and `workspace.exclude`. ([#2785](https://github.com/coral-xyz/anchor/pull/2785)).
 - cli: `anchor test` is able to run multiple commands ([#2799](https://github.com/coral-xyz/anchor/pull/2799)).
+- cli: Check `@coral-xyz/anchor` package and CLI version compatibility ([#2813](https://github.com/coral-xyz/anchor/pull/2813)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use anyhow::{anyhow, Result};
-use semver::Version;
+use semver::{Version, VersionReq};
 
 use crate::{
     config::{Config, Manifest, WithPath},
@@ -25,12 +25,16 @@ pub fn check_overflow(cargo_toml_path: impl AsRef<Path>) -> Result<bool> {
         ))
 }
 
-/// Check whether there is a mismatch between the current CLI version and the `anchor-lang` crate
-/// version.
+/// Check whether there is a mismatch between the current CLI version and:
+///
+/// - `anchor-lang` crate version
+/// - `@coral-xyz/anchor` package version
 ///
 /// This function logs warnings in the case of a mismatch.
 pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
     let cli_version = Version::parse(VERSION)?;
+
+    // Check lang crate
     let mismatched_lang_version = cfg
         .get_rust_program_list()?
         .into_iter()
@@ -49,6 +53,28 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
                  [toolchain]\n\t\
                  anchor_version = \"{ver}\"\n\n\t\
                  to Anchor.toml\n"
+        );
+    }
+
+    // Check TS package
+    let package_json = {
+        let package_json_path = cfg.path().parent().unwrap().join("package.json");
+        let package_json_content = fs::read_to_string(package_json_path)?;
+        serde_json::from_str::<serde_json::Value>(&package_json_content)?
+    };
+    let mismatched_ts_version = package_json
+        .get("dependencies")
+        .and_then(|deps| deps.get("@coral-xyz/anchor"))
+        .and_then(|ver| ver.as_str())
+        .and_then(|ver| VersionReq::parse(ver).ok())
+        .filter(|ver| !ver.matches(&cli_version));
+
+    if let Some(ver) = mismatched_ts_version {
+        eprintln!(
+            "WARNING: `@coral-xyz/anchor` version({ver}) and the current CLI version\
+                ({cli_version}) don't match.\n\n\t\
+                This can lead to unwanted behavior. To fix, upgrade the package by running:\n\n\t\
+                yarn upgrade @coral-xyz/anchor@{cli_version}\n"
         );
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1220,7 +1220,7 @@ pub fn build(
         check_overflow(workspace_cargo_toml_path)?;
     }
 
-    // Check whether there is a mismatch between CLI and lang crate versions
+    // Check whether there is a mismatch between CLI and crate/package versions
     check_anchor_version(&cfg).ok();
 
     let idl_out = match idl {


### PR DESCRIPTION
### Problem

Similar to https://github.com/coral-xyz/anchor/pull/2753, using different version of TS package and the CLI can result in unwanted behavior.

### Summary of changes

Print a warning when there is a mismatch between TS package and the current CLI version:

```
WARNING: `@coral-xyz/anchor` version(^0.28.0) and the current CLI version(0.29.0) don't match.

	This can lead to unwanted behavior. To fix, upgrade the package by running:

	yarn upgrade @coral-xyz/anchor@0.29.0
```
