### PR TITLE
cli: Accept package name as program name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add missing IDL PDA seed types ([#2752](https://github.com/coral-xyz/anchor/pull/2752)).
 - cli: `idl close` accepts optional `--idl-address` parameter ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
 - cli: Add support for simple wildcard patterns in Anchor.toml's `workspace.members` and `workspace.exclude`. ([#2785](https://github.com/coral-xyz/anchor/pull/2785)).
-- cli: Add new `test-template` option in `init` command  ([#2680](https://github.com/coral-xyz/anchor/issues/2680)).
+- cli: Add `--test-template` option for `init` command ([#2805](https://github.com/coral-xyz/anchor/pull/2805)).
 - cli: `anchor test` is able to run multiple commands ([#2799](https://github.com/coral-xyz/anchor/pull/2799)).
 - cli: Check `@coral-xyz/anchor` package and CLI version compatibility ([#2813](https://github.com/coral-xyz/anchor/pull/2813)).
+- cli: Accept package name as program name ([#2816](https://github.com/coral-xyz/anchor/pull/2816)).
 
 ### Fixes
 
@@ -54,6 +55,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Remove `shared-memory` program ([#2747](https://github.com/coral-xyz/anchor/pull/2747)).
 - ts: Remove `associated`, `account.associated` and `account.associatedAddress` methods ([#2749](https://github.com/coral-xyz/anchor/pull/2749)).
 - cli: `idl upgrade` command closes the IDL buffer account ([#2760](https://github.com/coral-xyz/anchor/pull/2760)).
+- cli: Remove `--jest` option from the `init` command ([#2805](https://github.com/coral-xyz/anchor/pull/2805)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1948,13 +1948,17 @@ fn cd_member(cfg_override: &ConfigOverride, program_name: &str) -> Result<()> {
                     program.path.display()
                 ));
             }
-            let p_lib_name = Manifest::from_path(&cargo_toml)?.lib_name()?;
-            if program_name == p_lib_name {
+
+            let manifest = Manifest::from_path(&cargo_toml)?;
+            let pkg_name = manifest.package().name();
+            let lib_name = manifest.lib_name()?;
+            if program_name == pkg_name || program_name == lib_name {
                 std::env::set_current_dir(&program.path)?;
                 return Ok(());
             }
         }
     }
+
     Err(anyhow!("{} is not part of the workspace", program_name,))
 }
 


### PR DESCRIPTION
### Problem

`--program-name` argument of various commands only accept program's lib name defined in `Cargo.toml`. This can be confusing since the directory name and the package name is in kebab-case while the lib name is in snake_case.

### Summary of changes

Accept both package name and lib name for the `--program-name` argument.