### PR TITLE
fix(ts): correctly construct field layout for type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Fix formatting enums ([#2763](https://github.com/coral-xyz/anchor/pull/2763)).
 - cli: Fix `migrate` command not working without global `ts-node` installation ([#2767](https://github.com/coral-xyz/anchor/pull/2767)).
 - client, lang, spl, syn: Enable all features for docs.rs build ([#2774](https://github.com/coral-xyz/anchor/pull/2774)).
+- ts: Fix construction of field layouts for type aliased instruction arguments ([#2821](https://github.com/coral-xyz/anchor/pull/2821))
 
 ### Breaking
 

--- a/ts/packages/anchor/src/coder/borsh/idl.ts
+++ b/ts/packages/anchor/src/coder/borsh/idl.ts
@@ -164,10 +164,7 @@ export class IdlCoder {
       }
 
       case "alias": {
-        return IdlCoder.fieldLayout(
-          { type: typeDef.type.value, name: typeDef.name },
-          types
-        );
+        return IdlCoder.fieldLayout({ type: typeDef.type.value, name }, types);
       }
     }
   }

--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -1,0 +1,49 @@
+import * as assert from "assert";
+import { BorshCoder } from "../src";
+import { IdlType } from "../src/idl";
+import { toInstruction } from "../src/program/common";
+
+describe("coder.instructions", () => {
+  test("Can encode and decode type aliased instruction arguments (byte array)", () => {
+    const idl = {
+      version: "0.1.0",
+      name: "test",
+      instructions: [
+        {
+          name: "initialize",
+          accounts: [],
+          args: [
+            {
+              name: "arg",
+              type: {
+                defined: "AliasTest",
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "AliasTest",
+          type: {
+            kind: "alias" as const,
+            value: {
+              array: ["u8", 3] as [IdlType, number],
+            },
+          },
+        },
+      ],
+    };
+
+    const idlIx = idl.instructions[0];
+    const expected = [1, 2, 3];
+
+    const coder = new BorshCoder(idl);
+    const ix = toInstruction(idlIx, expected);
+
+    const encoded = coder.instruction.encode(idlIx.name, ix);
+    const decoded = coder.instruction.decode(encoded, "hex", idlIx.name);
+
+    assert.deepStrictEqual(decoded?.data[idlIx.args[0].name], expected);
+  });
+});


### PR DESCRIPTION
## Problem

Field layouts for type aliased instruction arguments were being constructed using the type alias name as the field name instead of the instruction name (#2820).

## Summary of changes

Alters `IdlCoder` such that it now uses the field (ix) name instead of the type alias name when constructing field layouts.

## Fixes
Fixes #2820