### PR TITLE
client: Add documentation for `RequestBuilder.accounts` method

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -541,6 +541,36 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> RequestBuilder<'a, C> {
         self
     }
 
+    /// Set the accounts to pass to the instruction.
+    ///
+    /// `accounts` argument can be:
+    ///
+    /// - Any type that implements [`ToAccountMetas`] trait
+    /// - A vector of [`AccountMeta`]s (for remaining accounts)
+    ///
+    /// Note that the given accounts are appended to the previous list of accounts instead of
+    /// overriding the existing ones (if any).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// program
+    ///     .request()
+    ///     // Regular accounts
+    ///     .accounts(accounts::Initialize {
+    ///         my_account: my_account_kp.pubkey(),
+    ///         payer: program.payer(),
+    ///         system_program: system_program::ID,
+    ///     })
+    ///     // Remaining accounts
+    ///     .accounts(vec![AccountMeta {
+    ///         pubkey: remaining,
+    ///         is_signer: true,
+    ///         is_writable: true,
+    ///     }])
+    ///     .args(instruction::Initialize { field: 42 })
+    ///     .send()?;
+    /// ```
     #[must_use]
     pub fn accounts(mut self, accounts: impl ToAccountMetas) -> Self {
         let mut metas = accounts.to_account_metas(None);


### PR DESCRIPTION
### Problem

It is not easy to tell that one can pass `Vec<AccountMeta>` to the `accounts` method by looking at the method signature:

https://github.com/coral-xyz/anchor/blob/253501aa898e6cac05a98b60225e32969f6f665c/client/src/lib.rs#L545

### Summary of changes

Document usage of the `accounts` method and provide an example with both regular and remaining accounts.

Closes https://github.com/coral-xyz/anchor/issues/2818