### PR TITLE
cli: Add ability to build and test only a specified program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: `anchor test` is able to run multiple commands ([#2799](https://github.com/coral-xyz/anchor/pull/2799)).
 - cli: Check `@coral-xyz/anchor` package and CLI version compatibility ([#2813](https://github.com/coral-xyz/anchor/pull/2813)).
 - cli: Accept package name as program name ([#2816](https://github.com/coral-xyz/anchor/pull/2816)).
+- cli: Add ability to build and test only a specified program ([#2823](https://github.com/coral-xyz/anchor/pull/2823)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -109,6 +109,7 @@ pub enum Command {
         /// True if the build artifact needs to be deterministic and verifiable.
         #[clap(short, long)]
         verifiable: bool,
+        /// Name of the program to build
         #[clap(short, long)]
         program_name: Option<String>,
         /// Version of the Solana toolchain to use. For --verifiable builds
@@ -183,8 +184,11 @@ pub enum Command {
         skip_build: bool,
     },
     #[clap(name = "test", alias = "t")]
-    /// Runs integration tests against a localnetwork.
+    /// Runs integration tests.
     Test {
+        /// Build and test only this program
+        #[clap(short, long)]
+        program_name: Option<String>,
         /// Use this flag if you want to run tests against previously deployed
         /// programs.
         #[clap(long)]
@@ -746,6 +750,7 @@ fn process_command(opts: Opts) -> Result<()> {
         Command::Idl { subcmd } => idl(&opts.cfg_override, subcmd),
         Command::Migrate => migrate(&opts.cfg_override),
         Command::Test {
+            program_name,
             skip_deploy,
             skip_local_validator,
             skip_build,
@@ -758,6 +763,7 @@ fn process_command(opts: Opts) -> Result<()> {
             arch,
         } => test(
             &opts.cfg_override,
+            program_name,
             skip_deploy,
             skip_local_validator,
             skip_build,
@@ -3048,6 +3054,7 @@ enum OutFile {
 #[allow(clippy::too_many_arguments)]
 fn test(
     cfg_override: &ConfigOverride,
+    program_name: Option<String>,
     skip_deploy: bool,
     skip_local_validator: bool,
     skip_build: bool,
@@ -3077,7 +3084,7 @@ fn test(
                 None,
                 false,
                 skip_lint,
-                None,
+                program_name.clone(),
                 None,
                 None,
                 BootstrapMode::None,
@@ -3104,12 +3111,40 @@ fn test(
             deploy(cfg_override, None, None, false, vec![])?;
         }
         let mut is_first_suite = true;
-        if cfg.scripts.get("test").is_some() {
+        if let Some(test_script) = cfg.scripts.get_mut("test") {
             is_first_suite = false;
-            println!("\nFound a 'test' script in the Anchor.toml. Running it as a test suite!");
+
+            match program_name {
+                Some(program_name) => {
+                    if let Some((from, to)) = Regex::new("\\s(tests/\\S+\\.(js|ts))")
+                        .unwrap()
+                        .captures_iter(&test_script.clone())
+                        .last()
+                        .and_then(|captures| {
+                            captures
+                                .get(1)
+                                .and_then(|mtch| captures.get(2).and_then(|ext| Some((mtch, ext))))
+                        })
+                        .map(|(mtch, ext)| {
+                            (
+                                mtch.as_str(),
+                                format!("tests/{program_name}.{}", ext.as_str()),
+                            )
+                        })
+                    {
+                        println!("\nRunning tests of program `{program_name}`!");
+                        // Replace the last path to the program name's path
+                        *test_script = test_script.replace(from, &to);
+                    }
+                }
+                _ => println!(
+                    "\nFound a 'test' script in the Anchor.toml. Running it as a test suite!"
+                ),
+            }
+
             run_test_suite(
-                cfg.path(),
                 cfg,
+                cfg.path(),
                 is_localnet,
                 skip_local_validator,
                 skip_deploy,
@@ -3135,8 +3170,8 @@ fn test(
                 }
 
                 run_test_suite(
-                    test_suite.0,
                     cfg,
+                    test_suite.0,
                     is_localnet,
                     skip_local_validator,
                     skip_deploy,
@@ -3153,8 +3188,8 @@ fn test(
 
 #[allow(clippy::too_many_arguments)]
 fn run_test_suite(
-    test_suite_path: impl AsRef<Path>,
     cfg: &WithPath<Config>,
+    test_suite_path: impl AsRef<Path>,
     is_localnet: bool,
     skip_local_validator: bool,
     skip_deploy: bool,
@@ -3191,7 +3226,7 @@ fn run_test_suite(
     let log_streams = stream_logs(cfg, &url);
 
     // Run the tests.
-    let test_result: Result<_> = {
+    let test_result = {
         let cmd = scripts
             .get("test")
             .expect("Not able to find script for `test`")

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3120,11 +3120,7 @@ fn test(
                         .unwrap()
                         .captures_iter(&test_script.clone())
                         .last()
-                        .and_then(|captures| {
-                            captures
-                                .get(1)
-                                .and_then(|mtch| captures.get(2).map(|ext| ((mtch, ext))))
-                        })
+                        .and_then(|c| c.get(1).and_then(|mtch| c.get(2).map(|ext| (mtch, ext))))
                         .map(|(mtch, ext)| {
                             (
                                 mtch.as_str(),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3123,7 +3123,7 @@ fn test(
                         .and_then(|captures| {
                             captures
                                 .get(1)
-                                .and_then(|mtch| captures.get(2).and_then(|ext| Some((mtch, ext))))
+                                .and_then(|mtch| captures.get(2).map(|ext| ((mtch, ext))))
                         })
                         .map(|(mtch, ext)| {
                             (


### PR DESCRIPTION
### Problem

There is no easy way to test a single program without doing an extra setup with either custom scripts or adding test suites (https://github.com/coral-xyz/anchor/pull/1864).

### Summary of changes

Add `--program-name` option to the `test` command that allows building and testing only the program specified without requiring any additional setup.