### PR TITLE
cli: Fix excessive test validator requests

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1131,7 +1131,7 @@ impl From<Validator> for _Validator {
     }
 }
 
-const DEFAULT_LEDGER_PATH: &str = ".anchor/test-ledger";
+pub const DEFAULT_LEDGER_PATH: &str = ".anchor/test-ledger";
 const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0";
 
 impl Merge for _Validator {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3561,7 +3561,7 @@ fn start_test_validator(
         std::thread::sleep(std::time::Duration::from_millis(100));
         count += 100;
     }
-    if count == ms_wait {
+    if count >= ms_wait {
         eprintln!(
             "Unable to get latest blockhash. Test validator does not look started. \
             Check {test_ledger_log_filename:?} for errors. Consider increasing [test.startup_wait] in Anchor.toml."


### PR DESCRIPTION
### Problem

Anchor sends thousands of network requests in order to decide whether the test validator is initialized. Even though this is only for localnet, the amount of network requests is unnecessary.

### Summary of changes

- Check whether the test validator is initialized every 100ms (instead of 1ms)
- Remove usage of `unwrap` in `test_validator_file_paths` function, propagate errors instead