### PR TITLE
ts: Make `opts` parameter of `AnchorProvider` constructor optional

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -414,8 +414,12 @@ jobs:
             path: tests/declare-id
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
-          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
-            path: tests/zero-copy
+          # zero-copy tests cause `/usr/bin/ld: final link failed: No space left on device`
+          # on GitHub runners. It is likely caused by `cargo test-sbf` since all other tests
+          # don't have this problem.
+          # TODO: Find a fix.
+          # - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
+          #   path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat
           - cmd: cd tests/ido-pool && anchor test --skip-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl, ts: Add unit and tuple struct support ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - idl, ts: Add generics support ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - ts: Add `accountsPartial` method to keep the old `accounts` method behavior ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
+- ts: Make `opts` parameter of `AnchorProvider` constructor optional ([#2843](https://github.com/coral-xyz/anchor/pull/2843)).
 
 ### Fixes
 
@@ -56,6 +57,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix IDL ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - idl, ts: Make casing consistent ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - ts: Fix not being able to use numbers in instruction, account, or event names in some cases due to case conversion ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
+- cli: Fix excessive test validator requests ([#2828](https://github.com/coral-xyz/anchor/pull/2828)).
 
 ### Breaking
 

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -63,7 +63,7 @@ export class AnchorProvider implements Provider {
   constructor(
     readonly connection: Connection,
     readonly wallet: Wallet,
-    readonly opts: ConfirmOptions
+    readonly opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ) {
     this.publicKey = wallet?.publicKey;
   }
@@ -83,11 +83,14 @@ export class AnchorProvider implements Provider {
    *
    * (This api is for Node only.)
    */
-  static local(url?: string, opts?: ConfirmOptions): AnchorProvider {
+  static local(
+    url?: string,
+    opts: ConfirmOptions = AnchorProvider.defaultOptions()
+  ): AnchorProvider {
     if (isBrowser) {
       throw new Error(`Provider local is not available on browser.`);
     }
-    opts = opts ?? AnchorProvider.defaultOptions();
+
     const connection = new Connection(
       url ?? "http://127.0.0.1:8899",
       opts.preflightCommitment


### PR DESCRIPTION
### Problem

`AnchorProvider` constructor takes in options that is required, and most examples use the default options (`AnchorProvider.defaultOptions`) anyway.

### Summary of changes

Make the `opts` parameter default to `AnchorProvider.defaultOptions`.