### PR TITLE
Upgrade `cargo_toml` to 0.19.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,12 +983,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.3"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
+checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -5122,6 +5122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,6 +5147,19 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.0.2",
  "serde",

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/anchor/main.rs"
 [dependencies]
 anyhow = "1.0.32"
 cfg-if = "1.0.0"
-cargo_toml = "0.15.3"
+cargo_toml = "0.19.2"
 clap = { version = "4.2.4", features = ["derive"] }
 dirs = "4.0.0"
 once_cell = "1.8.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ anchor-lang = { path = "../lang", version = "0.29.0" }
 anyhow = "1.0.32"
 base64 = "0.21"
 bincode = "1.3.3"
-cargo_toml = "0.15.3"
+cargo_toml = "0.19.2"
 chrono = "0.4.19"
 clap = { version = "4.2.4", features = ["derive"] }
 dirs = "4.0"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -35,4 +35,4 @@ syn = { version = "1", features = ["full", "extra-traits", "parsing"] }
 thiserror = "1"
 
 # `idl-build` feature only
-cargo_toml = { version = "0.15", optional = true }
+cargo_toml = { version = "0.19", optional = true }


### PR DESCRIPTION
### Problem

[`cargo_toml`](https://crates.io/crates/cargo_toml) version is outdated which results in missing features such as better error handling for workspace inheritence (rather than panic).

### Solution

Upgrade to the latest version ([0.19.2](https://crates.io/crates/cargo_toml/0.19.2)).