### PR TITLE
add optional prepend to preInstructions method builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Make `opts` parameter of `AnchorProvider` constructor optional ([#2843](https://github.com/coral-xyz/anchor/pull/2843)).
 - cli: Add `--no-idl` flag to the `build` command ([#2847](https://github.com/coral-xyz/anchor/pull/2847)).
 - cli: Add priority fees to idl commands ([#2845](https://github.com/coral-xyz/anchor/pull/2845)).
+- ts: Add `prepend` option to MethodBuilder `preInstructions` method ([#2863](https://github.com/coral-xyz/anchor/pull/2863)).
 
 ### Fixes
 

--- a/ts/packages/anchor/src/program/namespace/methods.ts
+++ b/ts/packages/anchor/src/program/namespace/methods.ts
@@ -247,8 +247,12 @@ export class MethodsBuilder<
     return this;
   }
 
-  public preInstructions(ixs: Array<TransactionInstruction>) {
-    this._preInstructions = this._preInstructions.concat(ixs);
+  public preInstructions(ixs: Array<TransactionInstruction>, prepend = false) {
+    if (prepend) {
+      this._preInstructions = ixs.concat(this._preInstructions);
+    } else {
+      this._preInstructions = this._preInstructions.concat(ixs);
+    }
     return this;
   }
 


### PR DESCRIPTION
With the recent need to calculate compute units by simulating the Transaction it's become desirable to prepend instructions to the `preInstructions`. Specifically instructions like `ComputeBudgetProgram.setComputeUnitPrice` and `ComputeBudgetProgram.setComputeUnitLimit` should be prepended to the `preInstructions` array after simulating the transaction.