### PR TITLE
ts: Remove `programId` parameter of the `Program` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Change `accounts` method to no longer accept resolvable accounts ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - ts: `Program` instances use camelCase for everything ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - ts: Remove discriminator functions ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
+- ts: Remove `programId` parameter of the `Program` constructor ([#2864](https://github.com/coral-xyz/anchor/pull/2864)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/tests/auction-house/tests/auction-house.ts
+++ b/tests/auction-house/tests/auction-house.ts
@@ -129,14 +129,9 @@ describe("auction-house", () => {
   });
 
   it("Creates auction house program clients representing the buyer and seller", async () => {
-    authorityClient = new Program<AuctionHouse>(
-      IDL,
-      AUCTION_HOUSE_PROGRAM_ID,
-      getProvider()
-    );
+    authorityClient = new Program<AuctionHouse>(IDL, getProvider());
     sellerClient = new Program<AuctionHouse>(
       IDL,
-      AUCTION_HOUSE_PROGRAM_ID,
       new AnchorProvider(
         getProvider().connection,
         new Wallet(sellerWallet),
@@ -145,7 +140,6 @@ describe("auction-house", () => {
     );
     buyerClient = new Program<AuctionHouse>(
       IDL,
-      AUCTION_HOUSE_PROGRAM_ID,
       new AnchorProvider(
         getProvider().connection,
         new Wallet(buyerWallet),

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -1182,7 +1182,11 @@ const miscTest = (
         new anchor.Wallet(anchor.web3.Keypair.generate()),
         { commitment: program.provider.connection.commitment }
       );
-      const anotherProgram = new anchor.Program(miscIdl, anotherProvider);
+
+      const anotherProgram = new anchor.Program(
+        { ...miscIdl, address: program.programId },
+        anotherProvider
+      );
       // Request airdrop for secondary wallet.
       const signature = await program.provider.connection.requestAirdrop(
         anotherProvider.wallet.publicKey,

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -1182,11 +1182,7 @@ const miscTest = (
         new anchor.Wallet(anchor.web3.Keypair.generate()),
         { commitment: program.provider.connection.commitment }
       );
-      const anotherProgram = new anchor.Program(
-        miscIdl,
-        program.programId,
-        anotherProvider
-      );
+      const anotherProgram = new anchor.Program(miscIdl, anotherProvider);
       // Request airdrop for secondary wallet.
       const signature = await program.provider.connection.requestAirdrop(
         anotherProvider.wallet.publicKey,

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -81,7 +81,6 @@ describe("typescript", () => {
     let called = false;
     const customProgram = new Program<PdaDerivation>(
       program.idl,
-      program.programId,
       program.provider,
       program.coder,
       (instruction) => {

--- a/tests/spl/token-proxy/tests/token-proxy.js
+++ b/tests/spl/token-proxy/tests/token-proxy.js
@@ -25,8 +25,9 @@ describe("program", () => {
   const program = anchor.workspace.TokenProxy;
 
   TOKEN_PROGRAMS.forEach((tokenProgram) => {
-    const name =
-      tokenProgram.programId === SPL_TOKEN_PROGRAM_ID ? "token" : "token-2022";
+    const name = tokenProgram.programId.equals(SPL_TOKEN_PROGRAM_ID)
+      ? "token"
+      : "token-2022";
     describe(name, () => {
       let mint = null;
       let from = null;

--- a/ts/packages/anchor/src/native/system.ts
+++ b/ts/packages/anchor/src/native/system.ts
@@ -3,10 +3,12 @@ import { Program } from "../program/index.js";
 import Provider from "../provider.js";
 import { SystemCoder } from "../coder/system/index.js";
 
-const SYSTEM_PROGRAM_ID = new PublicKey("11111111111111111111111111111111");
+export const SYSTEM_PROGRAM_ID = new PublicKey(
+  "11111111111111111111111111111111"
+);
 
 export function program(provider?: Provider): Program<SystemProgram> {
-  return new Program<SystemProgram>(IDL, SYSTEM_PROGRAM_ID, provider, coder());
+  return new Program<SystemProgram>(IDL, provider, coder());
 }
 
 export function coder(): SystemCoder {

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -558,7 +558,7 @@ class AccountStore<IDL extends Idl> {
     if (!this._idls[programIdStr]) {
       const idl = await Program.fetchIdl(programId, this._provider);
       if (idl) {
-        const program = new Program(idl, programId, this._provider);
+        const program = new Program(idl, this._provider);
         this._idls[programIdStr] = program.account;
       }
     }

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -272,7 +272,6 @@ export class Program<IDL extends Idl = Idl> {
 
   /**
    * @param idl       The interface definition.
-   * @param programId The on-chain address of the program.
    * @param provider  The network and wallet context to use. If not provided
    *                  then uses [[getProvider]].
    * @param getCustomResolver A function that returns a custom account resolver
@@ -281,22 +280,19 @@ export class Program<IDL extends Idl = Idl> {
    */
   public constructor(
     idl: IDL,
-    programId: Address,
     provider: Provider = getProvider(),
     coder?: Coder,
     getCustomResolver?: (
       instruction: IdlInstruction
     ) => CustomAccountResolver<IDL> | undefined
   ) {
-    programId = translateAddress(programId);
-
     const camelCasedIdl = convertIdlToCamelCase(idl);
 
     // Fields.
     this._idl = camelCasedIdl;
     this._rawIdl = idl;
     this._provider = provider;
-    this._programId = programId;
+    this._programId = translateAddress(idl.address);
     this._coder = coder ?? new BorshCoder(camelCasedIdl);
     this._events = new EventManager(this._programId, provider, this._coder);
 
@@ -305,7 +301,7 @@ export class Program<IDL extends Idl = Idl> {
       NamespaceFactory.build(
         camelCasedIdl,
         this._coder,
-        programId,
+        this._programId,
         provider,
         getCustomResolver
       );
@@ -338,7 +334,7 @@ export class Program<IDL extends Idl = Idl> {
       throw new Error(`IDL not found for program: ${address.toString()}`);
     }
 
-    return new Program(idl, programId, provider);
+    return new Program(idl, provider);
   }
 
   /**

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -68,15 +68,10 @@ const workspace = new Proxy(
       }
 
       const idl: Idl = JSON.parse(fs.readFileSync(idlPath));
-      if (!programId) {
-        if (!idl.address) {
-          throw new Error(
-            `IDL for program \`${programName}\` does not have \`address\` field.`
-          );
-        }
-        programId = idl.address;
+      if (programId) {
+        idl.address = programId;
       }
-      workspaceCache[programName] = new Program(idl, programId);
+      workspaceCache[programName] = new Program(idl);
 
       return workspaceCache[programName];
     },

--- a/ts/packages/spl-associated-token-account/src/program.ts
+++ b/ts/packages/spl-associated-token-account/src/program.ts
@@ -16,14 +16,14 @@ export function splAssociatedTokenAccountProgram(
   params?: GetProgramParams
 ): Program<SplAssociatedTokenAccount> {
   return new Program<SplAssociatedTokenAccount>(
-    IDL,
+    params?.programId ? { ...IDL, address: params.programId.toString() } : IDL,
     params?.provider,
     new SplAssociatedTokenAccountCoder(IDL)
   );
 }
 
 type SplAssociatedTokenAccount = {
-  address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+  address: string;
   metadata: {
     name: "splAssociatedTokenAccount";
     version: "1.1.1";

--- a/ts/packages/spl-associated-token-account/src/program.ts
+++ b/ts/packages/spl-associated-token-account/src/program.ts
@@ -17,7 +17,6 @@ export function splAssociatedTokenAccountProgram(
 ): Program<SplAssociatedTokenAccount> {
   return new Program<SplAssociatedTokenAccount>(
     IDL,
-    params?.programId ?? SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
     params?.provider,
     new SplAssociatedTokenAccountCoder(IDL)
   );

--- a/ts/packages/spl-token/src/program.ts
+++ b/ts/packages/spl-token/src/program.ts
@@ -13,12 +13,7 @@ interface GetProgramParams {
 }
 
 export function splTokenProgram(params?: GetProgramParams): Program<SplToken> {
-  return new Program<SplToken>(
-    IDL,
-    params?.programId ?? SPL_TOKEN_PROGRAM_ID,
-    params?.provider,
-    new SplTokenCoder(IDL)
-  );
+  return new Program<SplToken>(IDL, params?.provider, new SplTokenCoder(IDL));
 }
 
 type SplToken = {

--- a/ts/packages/spl-token/src/program.ts
+++ b/ts/packages/spl-token/src/program.ts
@@ -13,11 +13,15 @@ interface GetProgramParams {
 }
 
 export function splTokenProgram(params?: GetProgramParams): Program<SplToken> {
-  return new Program<SplToken>(IDL, params?.provider, new SplTokenCoder(IDL));
+  return new Program<SplToken>(
+    params?.programId ? { ...IDL, address: params.programId.toString() } : IDL,
+    params?.provider,
+    new SplTokenCoder(IDL)
+  );
 }
 
 type SplToken = {
-  address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+  address: string;
   metadata: {
     name: "splToken";
     version: "3.3.0";


### PR DESCRIPTION
### Problem

`address` field is now a required field for the IDL, making the `programId` parameter of `Program` constructor redundant.

### Solution

Remove the `programId` parameter of the `Program` constructor and use the program id from the IDL.