### PR TITLE
Add Deactivate Feature Flag to CLI Local Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add priority fees to idl commands ([#2845](https://github.com/coral-xyz/anchor/pull/2845)).
 - ts: Add `prepend` option to MethodBuilder `preInstructions` method ([#2863](https://github.com/coral-xyz/anchor/pull/2863)).
 - lang: Add `declare_program!` macro ([#2857](https://github.com/coral-xyz/anchor/pull/2857)).
+- cli: Add `deactivate_feature` flag to `solana-test-validator` config in Anchor.toml ([#2872](https://github.com/coral-xyz/anchor/pull/2872)).
 
 ### Fixes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1059,6 +1059,9 @@ pub struct _Validator {
     // Warp the ledger to WARP_SLOT after starting the validator.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warp_slot: Option<String>,
+    // Deactivate one or more features.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deactivate_feature: Option<Vec<String>>
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -1094,6 +1097,8 @@ pub struct Validator {
     pub ticks_per_slot: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warp_slot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deactivate_feature: Option<Vec<String>>
 }
 
 impl From<_Validator> for Validator {
@@ -1122,6 +1127,7 @@ impl From<_Validator> for Validator {
             slots_per_epoch: _validator.slots_per_epoch,
             ticks_per_slot: _validator.ticks_per_slot,
             warp_slot: _validator.warp_slot,
+            deactivate_feature: _validator.deactivate_feature
         }
     }
 }
@@ -1146,6 +1152,7 @@ impl From<Validator> for _Validator {
             slots_per_epoch: validator.slots_per_epoch,
             ticks_per_slot: validator.ticks_per_slot,
             warp_slot: validator.warp_slot,
+            deactivate_feature: validator.deactivate_feature
         }
     }
 }
@@ -1235,6 +1242,7 @@ impl Merge for _Validator {
                 .or_else(|| self.slots_per_epoch.take()),
             ticks_per_slot: other.ticks_per_slot.or_else(|| self.ticks_per_slot.take()),
             warp_slot: other.warp_slot.or_else(|| self.warp_slot.take()),
+            deactivate_feature: other.deactivate_feature.or_else(|| self.deactivate_feature.take())
         };
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1061,7 +1061,7 @@ pub struct _Validator {
     pub warp_slot: Option<String>,
     // Deactivate one or more features.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub deactivate_feature: Option<Vec<String>>
+    pub deactivate_feature: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -1098,7 +1098,7 @@ pub struct Validator {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warp_slot: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub deactivate_feature: Option<Vec<String>>
+    pub deactivate_feature: Option<Vec<String>>,
 }
 
 impl From<_Validator> for Validator {
@@ -1127,7 +1127,7 @@ impl From<_Validator> for Validator {
             slots_per_epoch: _validator.slots_per_epoch,
             ticks_per_slot: _validator.ticks_per_slot,
             warp_slot: _validator.warp_slot,
-            deactivate_feature: _validator.deactivate_feature
+            deactivate_feature: _validator.deactivate_feature,
         }
     }
 }
@@ -1152,7 +1152,7 @@ impl From<Validator> for _Validator {
             slots_per_epoch: validator.slots_per_epoch,
             ticks_per_slot: validator.ticks_per_slot,
             warp_slot: validator.warp_slot,
-            deactivate_feature: validator.deactivate_feature
+            deactivate_feature: validator.deactivate_feature,
         }
     }
 }
@@ -1242,7 +1242,9 @@ impl Merge for _Validator {
                 .or_else(|| self.slots_per_epoch.take()),
             ticks_per_slot: other.ticks_per_slot.or_else(|| self.ticks_per_slot.take()),
             warp_slot: other.warp_slot.or_else(|| self.warp_slot.take()),
-            deactivate_feature: other.deactivate_feature.or_else(|| self.deactivate_feature.take())
+            deactivate_feature: other
+                .deactivate_feature
+                .or_else(|| self.deactivate_feature.take()),
         };
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3345,16 +3345,17 @@ fn validator_flags(
                         .unwrap()
                         .iter()
                         .map(|entry| {
-                            let feature_flag = entry.as_str().unwrap(); 
-                            Pubkey::from_str(feature_flag) 
-                                .map_err(|_| anyhow!("Invalid pubkey (feature flag) {}", feature_flag))
+                            let feature_flag = entry.as_str().unwrap();
+                            Pubkey::from_str(feature_flag).map_err(|_| {
+                                anyhow!("Invalid pubkey (feature flag) {}", feature_flag)
+                            })
                         })
                         .collect();
-                    let features = pubkeys_result?;                    
+                    let features = pubkeys_result?;
                     for feature in features {
                         flags.push("--deactivate-feature".to_string());
                         flags.push(feature.to_string());
-                    }                
+                    }
                 } else {
                     // Remaining validator flags are non-array types
                     flags.push(format!("--{}", key.replace('_', "-")));

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3338,6 +3338,23 @@ fn validator_flags(
                         flags.push("--clone".to_string());
                         flags.push(pubkey.to_string());
                     }
+                } else if key == "deactivate_feature" {
+                    // Verify that the feature flags are valid pubkeys
+                    let pubkeys_result: Result<Vec<Pubkey>, _> = value
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|entry| {
+                            let feature_flag = entry.as_str().unwrap(); 
+                            Pubkey::from_str(feature_flag) 
+                                .map_err(|_| anyhow!("Invalid pubkey (feature flag) {}", feature_flag))
+                        })
+                        .collect();
+                    let features = pubkeys_result?;                    
+                    for feature in features {
+                        flags.push("--deactivate-feature".to_string());
+                        flags.push(feature.to_string());
+                    }                
                 } else {
                     // Remaining validator flags are non-array types
                     flags.push(format!("--{}", key.replace('_', "-")));


### PR DESCRIPTION
### 
Adds support for `--deactivate-feature` flag to the `solana-test-validator` config in Anchor.toml. User must pass an array of feature pubkeys. 

Example Anchor.toml

```rust
[test.validator]
bind_address = "0.0.0.0"
url = "https://api.mainnet-beta.solana.com"
ledger = ".anchor/test-ledger"
rpc_port = 8899
slots_per_epoch = "32"
warp_slot = "18464"
deactivate_feature = ["GDH5TVdbTPUpRnXaRyQqiKUa7uZAbZ28Q2N9bhbKoMLm", "zkiTNuzBKxrCLMKehzuQeKZyLtX2yvFcEKMML8nExU8"]
```
After local validator is running you can run `solana feature status -ul` to check that features are deactivated.


### Changes
- add `deactivate_feature` to Validator struct and relevant impls in CLI config
- create pubkey validation parsing for `deactivate_feature` in `validator_flags` function

Fixes #2871 

### Ref
- [Solana Cookbook - parity testing](https://solanacookbook.com/guides/feature-parity-testing.html#feature-status)
- [Solana Validator CLI: Deactivate Features args](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/validator/src/cli.rs#L2727)