### PR TITLE
ci: Add `declare-program` tests

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -412,7 +412,7 @@ jobs:
             path: tests/cashiers-check
           - cmd: cd tests/declare-id && anchor test --skip-lint && npx tsc --noEmit
             path: tests/declare-id
-          - cmd: cd tests/declare-program && anchor test --skip-lint && npx tsc --noEmit
+          - cmd: cd tests/declare-program && anchor test --skip-lint
             path: tests/declare-program
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -412,6 +412,8 @@ jobs:
             path: tests/cashiers-check
           - cmd: cd tests/declare-id && anchor test --skip-lint && npx tsc --noEmit
             path: tests/declare-id
+          - cmd: cd tests/declare-program && anchor test --skip-lint && npx tsc --noEmit
+            path: tests/declare-program
           - cmd: cd tests/typescript && anchor test --skip-lint && npx tsc --noEmit
             path: tests/typescript
           # zero-copy tests cause `/usr/bin/ld: final link failed: No space left on device`


### PR DESCRIPTION
### Problem

`declare-program!` tests was added in https://github.com/coral-xyz/anchor/pull/2857, but GitHub CI doesn't run them.

### Summary of changes

Add `declare-program!` tests to GitHub CI.