### PR TITLE
cli: Standardize Rust templates for "anchor init" generated JSON and ignore files

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -396,35 +396,35 @@ pub fn package_json(jest: bool) -> String {
     if jest {
         format!(
             r#"{{
-        "scripts": {{
-            "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
-            "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
-        }},
-        "dependencies": {{
-            "@coral-xyz/anchor": "^{VERSION}"
-        }},
-        "devDependencies": {{
-            "jest": "^29.0.3",
-            "prettier": "^2.6.2"
-        }}
-    }}
+  "scripts": {{
+    "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+    "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+  }},
+  "dependencies": {{
+    "@coral-xyz/anchor": "^{VERSION}"
+  }},
+  "devDependencies": {{
+    "jest": "^29.0.3",
+    "prettier": "^2.6.2"
+  }}
+}}
     "#
         )
     } else {
         format!(
             r#"{{
-    "scripts": {{
-        "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
-        "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
-    }},
-    "dependencies": {{
-        "@coral-xyz/anchor": "^{VERSION}"
-    }},
-    "devDependencies": {{
-        "chai": "^4.3.4",
-        "mocha": "^9.0.3",
-        "prettier": "^2.6.2"
-    }}
+  "scripts": {{
+    "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+    "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+  }},
+  "dependencies": {{
+    "@coral-xyz/anchor": "^{VERSION}"
+  }},
+  "devDependencies": {{
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3",
+    "prettier": "^2.6.2"
+  }}
 }}
 "#
         )
@@ -435,44 +435,44 @@ pub fn ts_package_json(jest: bool) -> String {
     if jest {
         format!(
             r#"{{
-        "scripts": {{
-            "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
-            "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
-        }},
-        "dependencies": {{
-            "@coral-xyz/anchor": "^{VERSION}"
-        }},
-        "devDependencies": {{
-            "@types/bn.js": "^5.1.0",
-            "@types/jest": "^29.0.3",
-            "jest": "^29.0.3",
-            "prettier": "^2.6.2",
-            "ts-jest": "^29.0.2",
-            "typescript": "^4.3.5"
-        }}
-    }}
-    "#
+  "scripts": {{
+    "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+    "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+  }},
+  "dependencies": {{
+    "@coral-xyz/anchor": "^{VERSION}"
+  }},
+  "devDependencies": {{
+    "@types/bn.js": "^5.1.0",
+    "@types/jest": "^29.0.3",
+    "jest": "^29.0.3",
+    "prettier": "^2.6.2",
+    "ts-jest": "^29.0.2",
+    "typescript": "^4.3.5"
+  }}
+}}
+"#
         )
     } else {
         format!(
             r#"{{
-    "scripts": {{
-        "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
-        "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
-    }},
-    "dependencies": {{
-        "@coral-xyz/anchor": "^{VERSION}"
-    }},
-    "devDependencies": {{
-        "chai": "^4.3.4",
-        "mocha": "^9.0.3",
-        "ts-mocha": "^10.0.0",
-        "@types/bn.js": "^5.1.0",
-        "@types/chai": "^4.3.0",
-        "@types/mocha": "^9.0.0",
-        "typescript": "^4.3.5",
-        "prettier": "^2.6.2"
-    }}
+  "scripts": {{
+    "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+    "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+  }},
+  "dependencies": {{
+    "@coral-xyz/anchor": "^{VERSION}"
+  }},
+  "devDependencies": {{
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3",
+    "ts-mocha": "^10.0.0",
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
+    "typescript": "^4.3.5",
+    "prettier": "^2.6.2"
+  }}
 }}
 "#
         )
@@ -536,28 +536,28 @@ describe("{}", () => {{
 pub fn ts_config(jest: bool) -> &'static str {
     if jest {
         r#"{
-            "compilerOptions": {
-              "types": ["jest"],
-              "typeRoots": ["./node_modules/@types"],
-              "lib": ["es2015"],
-              "module": "commonjs",
-              "target": "es6",
-              "esModuleInterop": true
-            }
-          }
-          "#
+  "compilerOptions": {
+    "types": ["jest"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}
+"#
     } else {
         r#"{
-            "compilerOptions": {
-              "types": ["mocha", "chai"],
-              "typeRoots": ["./node_modules/@types"],
-              "lib": ["es2015"],
-              "module": "commonjs",
-              "target": "es6",
-              "esModuleInterop": true
-            }
-          }
-          "#
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}
+"#
     }
 }
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -562,8 +562,7 @@ pub fn ts_config(jest: bool) -> &'static str {
 }
 
 pub fn git_ignore() -> &'static str {
-    r#"
-.anchor
+    r#".anchor
 .DS_Store
 target
 **/*.rs.bk
@@ -574,8 +573,7 @@ test-ledger
 }
 
 pub fn prettier_ignore() -> &'static str {
-    r#"
-.anchor
+    r#".anchor
 .DS_Store
 target
 node_modules


### PR DESCRIPTION
These changes improve the style and consistency of generated config files when running `anchor init`.

## Summary of Changes
- For `.gitignore` and `.prettierignore`, I removed the empty line on `line 1`.
- For `package.json`, I adjusted the indentation tab size to `2`, then fixed indentation when using `jest`.
- For `tsconfig.json`, I fixed the indentation.

Snippets for generate file changes before and after the fixes are shown below.

## `.ignore` files

### Old
```

.anchor
.DS_Store
target
**/*.rs.bk
node_modules
test-ledger
.yarn
```

### New
```
.anchor
.DS_Store
target
**/*.rs.bk
node_modules
test-ledger
.yarn
```

## `package.json`

### Default (mocha, chai)

#### Old 
```json
{
    "scripts": {
        "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
        "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
    },
    "dependencies": {
        "@coral-xyz/anchor": "^0.29.0"
    },
    "devDependencies": {
        "chai": "^4.3.4",
        "mocha": "^9.0.3",
        "ts-mocha": "^10.0.0",
        "@types/bn.js": "^5.1.0",
        "@types/chai": "^4.3.0",
        "@types/mocha": "^9.0.0",
        "typescript": "^4.3.5",
        "prettier": "^2.6.2"
    }
}
```

#### New
```json
{
  "scripts": {
    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
  },
  "dependencies": {
    "@coral-xyz/anchor": "^0.29.0"
  },
  "devDependencies": {
    "chai": "^4.3.4",
    "mocha": "^9.0.3",
    "ts-mocha": "^10.0.0",
    "@types/bn.js": "^5.1.0",
    "@types/chai": "^4.3.0",
    "@types/mocha": "^9.0.0",
    "typescript": "^4.3.5",
    "prettier": "^2.6.2"
  }
}
```

### Jest

#### Old 
```json
{
        "scripts": {
            "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
            "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
        },
        "dependencies": {
            "@coral-xyz/anchor": "^0.29.0"
        },
        "devDependencies": {
            "@types/bn.js": "^5.1.0",
            "@types/jest": "^29.0.3",
            "jest": "^29.0.3",
            "prettier": "^2.6.2",
            "ts-jest": "^29.0.2",
            "typescript": "^4.3.5"
        }
    }
    
```

#### New
```json
{
  "scripts": {
    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
  },
  "dependencies": {
    "@coral-xyz/anchor": "^0.29.0"
  },
  "devDependencies": {
    "@types/bn.js": "^5.1.0",
    "@types/jest": "^29.0.3",
    "jest": "^29.0.3",
    "prettier": "^2.6.2",
    "ts-jest": "^29.0.2",
    "typescript": "^4.3.5"
  }
}
```

## `tsconfig.json`

### Default (mocha, chai)

#### Old 
```json
{
            "compilerOptions": {
              "types": ["mocha", "chai"],
              "typeRoots": ["./node_modules/@types"],
              "lib": ["es2015"],
              "module": "commonjs",
              "target": "es6",
              "esModuleInterop": true
            }
          }
          
```

#### New
```json
{
  "compilerOptions": {
    "types": ["mocha", "chai"],
    "typeRoots": ["./node_modules/@types"],
    "lib": ["es2015"],
    "module": "commonjs",
    "target": "es6",
    "esModuleInterop": true
  }
}
```

### Jest

#### Old 
```json
{
            "compilerOptions": {
              "types": ["jest"],
              "typeRoots": ["./node_modules/@types"],
              "lib": ["es2015"],
              "module": "commonjs",
              "target": "es6",
              "esModuleInterop": true
            }
          }
          
```

#### New
```json
{
  "compilerOptions": {
    "types": ["jest"],
    "typeRoots": ["./node_modules/@types"],
    "lib": ["es2015"],
    "module": "commonjs",
    "target": "es6",
    "esModuleInterop": true
  }
}
```