### PR TITLE
idl: Add `docs` field for constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add `prepend` option to MethodBuilder `preInstructions` method ([#2863](https://github.com/coral-xyz/anchor/pull/2863)).
 - lang: Add `declare_program!` macro ([#2857](https://github.com/coral-xyz/anchor/pull/2857)).
 - cli: Add `deactivate_feature` flag to `solana-test-validator` config in Anchor.toml ([#2872](https://github.com/coral-xyz/anchor/pull/2872)).
+- idl: Add `docs` field for constants ([#2887](https://github.com/coral-xyz/anchor/pull/2887)).
 
 ### Fixes
 

--- a/examples/tutorial/basic-0/package.json
+++ b/examples/tutorial/basic-0/package.json
@@ -14,6 +14,6 @@
     "node": ">=11"
   },
   "scripts": {
-    "test": "anchor test --skip-lint"
+    "test": "anchor test --skip-lint && anchor clean"
   }
 }

--- a/examples/tutorial/basic-1/package.json
+++ b/examples/tutorial/basic-1/package.json
@@ -14,6 +14,6 @@
     "node": ">=11"
   },
   "scripts": {
-    "test": "anchor test --skip-lint"
+    "test": "anchor test --skip-lint && anchor clean"
   }
 }

--- a/examples/tutorial/basic-2/package.json
+++ b/examples/tutorial/basic-2/package.json
@@ -14,6 +14,6 @@
     "node": ">=11"
   },
   "scripts": {
-    "test": "anchor test --skip-lint"
+    "test": "anchor test --skip-lint && anchor clean"
   }
 }

--- a/examples/tutorial/basic-3/package.json
+++ b/examples/tutorial/basic-3/package.json
@@ -14,6 +14,6 @@
     "node": ">=11"
   },
   "scripts": {
-    "test": "anchor test --skip-lint"
+    "test": "anchor test --skip-lint && anchor clean"
   }
 }

--- a/examples/tutorial/basic-4/package.json
+++ b/examples/tutorial/basic-4/package.json
@@ -14,6 +14,6 @@
     "node": ">=11"
   },
   "scripts": {
-    "test": "anchor test --skip-lint"
+    "test": "anchor test --skip-lint && anchor clean"
   }
 }

--- a/examples/tutorial/basic-5/package.json
+++ b/examples/tutorial/basic-5/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "basic-5",
-    "version": "0.29.0",
-    "license": "(MIT OR Apache-2.0)",
-    "homepage": "https://github.com/coral-xyz/anchor#readme",
-    "bugs": {
-      "url": "https://github.com/coral-xyz/anchor/issues"
-    },
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/coral-xyz/anchor.git"
-    },
-    "engines": {
-      "node": ">=11"
-    },
-    "scripts": {
-      "test": "anchor test --skip-lint"
-    }
+  "name": "basic-5",
+  "version": "0.29.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=11"
+  },
+  "scripts": {
+    "test": "anchor test --skip-lint && anchor clean"
   }
+}

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -137,6 +137,8 @@ pub struct IdlEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlConst {
     pub name: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub docs: Vec<String>,
     #[serde(rename = "type")]
     pub ty: IdlType,
     pub value: String,

--- a/lang/syn/src/idl/constant.rs
+++ b/lang/syn/src/idl/constant.rs
@@ -3,16 +3,23 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::{
-    common::{gen_print_section, get_idl_module_path},
+    common::{gen_print_section, get_idl_module_path, get_no_docs},
     defined::gen_idl_type,
 };
+use crate::parser::docs;
 
 pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
     let idl = get_idl_module_path();
+    let no_docs = get_no_docs();
 
     let name = item.ident.to_string();
     let expr = &item.expr;
     let fn_name = format_ident!("__anchor_private_print_idl_const_{}", name.to_snake_case());
+
+    let docs = match docs::parse(&item.attrs) {
+        Some(docs) if !no_docs => quote! { vec![#(#docs.into()),*] },
+        _ => quote! { vec![] },
+    };
 
     let fn_body = match gen_idl_type(&item.ty, &[]) {
         Ok((ty, _)) => gen_print_section(
@@ -20,6 +27,7 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
             quote! {
                 #idl::IdlConst {
                     name: #name.into(),
+                    docs: #docs,
                     ty: #ty,
                     value: format!("{:?}", #expr),
                 }

--- a/tests/idl/programs/docs/src/lib.rs
+++ b/tests/idl/programs/docs/src/lib.rs
@@ -4,6 +4,10 @@ use anchor_lang::prelude::*;
 
 declare_id!("Docs111111111111111111111111111111111111111");
 
+/// Documentation comment for constant
+#[constant]
+pub const MY_CONST: u8 = 42;
+
 /// This is a doc comment for the program
 #[program]
 pub mod docs {

--- a/tests/idl/tests/docs.ts
+++ b/tests/idl/tests/docs.ts
@@ -42,4 +42,9 @@ describe("Docs", () => {
       "Account attribute doc comment should appear in the IDL",
     ]);
   });
+
+  it("includes constant doc comment", () => {
+    const myConst = program.idl.constants.find((c) => c.name === "myConst")!;
+    assert.deepEqual(myConst.docs, ["Documentation comment for constant"]);
+  });
 });


### PR DESCRIPTION
### Problem

Constants in the IDL does not have a `docs` field unlike other types.

### Summary of changes

- Add `docs` field for `IdlConst`
- Adjust IDL generation to include documentation comments for constants
- Add a test case