### PR TITLE
idl: Add `#[non_exhaustive]` to IDL enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Remove discriminator functions ([#2824](https://github.com/coral-xyz/anchor/pull/2824)).
 - ts: Remove `programId` parameter of the `Program` constructor ([#2864](https://github.com/coral-xyz/anchor/pull/2864)).
 - idl, syn: Move IDL types from the `anchor-syn` crate to the new IDL crate ([#2882](https://github.com/coral-xyz/anchor/pull/2882)).
+- idl: Add `#[non_exhaustive]` to IDL enums ([#2890](https://github.com/coral-xyz/anchor/pull/2890)).
 
 ## [0.29.0] - 2023-10-16
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2964,6 +2964,7 @@ fn deserialize_idl_type_to_json(
             deserialize_idl_defined_type_to_json(parent_idl, name, data)?
         }
         IdlType::Generic(generic) => json!(generic),
+        _ => unimplemented!("{idl_type:?}"),
     })
 }
 

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -178,6 +178,7 @@ pub struct IdlTypeDef {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum IdlSerialization {
     #[default]
     Borsh,
@@ -188,6 +189,7 @@ pub enum IdlSerialization {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum IdlRepr {
     Rust(IdlReprModifier),
     C(IdlReprModifier),
@@ -266,6 +268,7 @@ pub enum IdlGenericArg {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum IdlType {
     Bool,
     U8,

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -88,6 +88,7 @@ pub fn convert_idl_type_to_str(ty: &IdlType) -> String {
             .map(|generics| format!("{name}<{generics}>"))
             .unwrap_or(name.into()),
         IdlType::Generic(ty) => ty.into(),
+        _ => unimplemented!("{ty:?}"),
     }
 }
 
@@ -151,6 +152,7 @@ pub fn convert_idl_type_def_to_ts(
             IdlRepr::Rust(_) => "Rust",
             IdlRepr::C(_) => "C",
             IdlRepr::Transparent => "transparent",
+            _ => unimplemented!("{repr:?}"),
         };
         let kind = format_ident!("{kind}");
 


### PR DESCRIPTION
### Problem

Some of the IDL enums can be extended in the future, however, extending them would be a breaking change.

### Summary of changes

Add `#[non_exhaustive]` attribute to the `IdlSerialization`, `IdlRepr` and `IdlType` enum in order to be able to add new variants without causing a breaking change.