### PR TITLE
spl: Upgrade `spl-associated-token-account` to 3.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "mpl-token-metadata",
  "serum_dex",
  "solana-program",
- "spl-associated-token-account",
+ "spl-associated-token-account 3.0.2",
  "spl-memo",
  "spl-token 4.0.0",
  "spl-token-2022 3.0.2",
@@ -4523,7 +4523,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account",
+ "spl-associated-token-account 2.3.0",
  "spl-memo",
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
@@ -4680,6 +4680,22 @@ dependencies = [
  "solana-program",
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e688554bac5838217ffd1fab7845c573ff106b6336bf7d290db7c98d5a8efd"
+dependencies = [
+ "assert_matches",
+ "borsh 1.3.1",
+ "num-derive 0.4.0",
+ "num-traits",
+ "solana-program",
+ "spl-token 4.0.0",
+ "spl-token-2022 3.0.2",
  "thiserror",
 ]
 

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -31,7 +31,7 @@ borsh = { version = ">=0.9, <0.11", optional = true }
 mpl-token-metadata = { version = "3.1.0", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = "1.16"
-spl-associated-token-account = { version = "2.2", features = ["no-entrypoint"], optional = true }
+spl-associated-token-account = { version = "3", features = ["no-entrypoint"], optional = true }
 spl-memo = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token-2022 = { version = "3", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
### Problem

The latest version of [`spl-associated-token-account`](https://crates.io/crates/spl-associated-token-account/3.0.2) is on v3, meanwhile we're still on v2.

### Summary of changes

Upgrade `spl-associated-token-account` dependency to v3.