### PR TITLE
idl: Store deployment addresses for other clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `declare_program!` macro ([#2857](https://github.com/coral-xyz/anchor/pull/2857)).
 - cli: Add `deactivate_feature` flag to `solana-test-validator` config in Anchor.toml ([#2872](https://github.com/coral-xyz/anchor/pull/2872)).
 - idl: Add `docs` field for constants ([#2887](https://github.com/coral-xyz/anchor/pull/2887)).
+- idl: Store deployment addresses for other clusters ([#2892](https://github.com/coral-xyz/anchor/pull/2892)).
 
 ### Fixes
 

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -39,7 +39,7 @@ pub struct IdlMetadata {
     #[serde(skip_serializing_if = "is_default")]
     pub contact: Option<String>,
     #[serde(skip_serializing_if = "is_default")]
-    pub deployment: Option<IdlDeployment>,
+    pub deployments: Option<IdlDeployments>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -49,7 +49,7 @@ pub struct IdlDependency {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IdlDeployment {
+pub struct IdlDeployments {
     pub mainnet: Option<String>,
     pub testnet: Option<String>,
     pub devnet: Option<String>,

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -38,12 +38,22 @@ pub struct IdlMetadata {
     pub dependencies: Vec<IdlDependency>,
     #[serde(skip_serializing_if = "is_default")]
     pub contact: Option<String>,
+    #[serde(skip_serializing_if = "is_default")]
+    pub deployment: Option<IdlDeployment>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlDependency {
     pub name: String,
     pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IdlDeployment {
+    pub mainnet: Option<String>,
+    pub testnet: Option<String>,
+    pub devnet: Option<String>,
+    pub localnet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -119,7 +119,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                         .map(|r| r.into()),
                     dependencies: Default::default(),
                     contact: Default::default(),
-                    deployment: Default::default(),
+                    deployments: Default::default(),
                 },
                 docs: #docs,
                 instructions: vec![#(#instructions),*],

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -119,6 +119,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                         .map(|r| r.into()),
                     dependencies: Default::default(),
                     contact: Default::default(),
+                    deployment: Default::default(),
                 },
                 docs: #docs,
                 instructions: vec![#(#instructions),*],

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -23,11 +23,19 @@ export type IdlMetadata = {
   repository?: string;
   dependencies?: IdlDependency[];
   contact?: string;
+  deployment?: IdlDeployment;
 };
 
 export type IdlDependency = {
   name: string;
   version: string;
+};
+
+export type IdlDeployment = {
+  mainnet?: string;
+  testnet?: string;
+  devnet?: string;
+  localnet?: string;
 };
 
 export type IdlInstruction = {

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -23,7 +23,7 @@ export type IdlMetadata = {
   repository?: string;
   dependencies?: IdlDependency[];
   contact?: string;
-  deployment?: IdlDeployment;
+  deployments?: IdlDeployments;
 };
 
 export type IdlDependency = {
@@ -31,7 +31,7 @@ export type IdlDependency = {
   version: string;
 };
 
-export type IdlDeployment = {
+export type IdlDeployments = {
   mainnet?: string;
   testnet?: string;
   devnet?: string;


### PR DESCRIPTION
### Problem

It's currently not possible to store program address information for other clusters.

### Solution

Initially, I thought of making the top-level `address` field an enum:

```rs
pub enum IdlAddress {
    Multiple {
        mainnet: Option<String>,
        testnet: Option<String>,
        devnet: Option<String>,
        localnet: Option<String>,
    },
    #[untagged]
    Single(String),
}
```

This way, we could support both string address as a default and an object type for more detailed (cluster based) information. However, the program's IDL may also exist in other clusters, which makes the current IDL (the one we got the other deployment addresses from) useless (because the IDL in the cluster should be fetched). For this reason, it made more sense to store this information in the `metadata` field compared to the top-level `address` field:

```rs
pub struct IdlDeployments {
    pub mainnet: Option<String>,
    pub testnet: Option<String>,
    pub devnet: Option<String>,
    pub localnet: Option<String>,
}
```

### Summary of changes

Add `metadata.deployments` field that optionally stores deployment addresses in `mainnet`, `testnet`, `devnet` and `localnet`.