### PR TITLE
Unpin `nightly` version

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -9,12 +9,3 @@ runs:
       shell: bash
     - run: git submodule update --init --recursive --depth 1
       shell: bash
-    # `nightly` toolchain is currently required for building the IDL.
-    #
-    # Pinning the toolchain to an older date in order to fix
-    # `error[E0635]: unknown feature stdsimd` error from `ahash`.
-    # See: https://github.com/tkaitchuck/aHash/issues/200
-    #
-    # TODO: Unpin `nightly` release after upgrading Solana to `1.18`.
-    - run: rustup toolchain install nightly-2024-01-30
-      shell: bash

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -67,19 +67,10 @@ pub fn build_idl(
     Ok(idl)
 }
 
-// Build IDL.
+/// Build IDL.
 fn build(program_path: &Path, resolution: bool, no_docs: bool) -> Result<Idl> {
     // `nightly` toolchain is currently required for building the IDL.
-    //
-    // Pinning the toolchain to an older date in order to fix
-    // `error[E0635]: unknown feature stdsimd` error from `ahash`.
-    // See: https://github.com/tkaitchuck/aHash/issues/200
-    //
-    // There is also another error when using a date after 2024-01-30
-    // `error[E0412]: cannot find type `T` in this scope``
-    //
-    // TODO: Unpin `nightly` release after upgrading Solana to `1.18`.
-    const TOOLCHAIN: &str = "+nightly-2024-01-30";
+    const TOOLCHAIN: &str = "+nightly";
     install_toolchain_if_needed(TOOLCHAIN)?;
 
     let output = Command::new("cargo")

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -543,9 +543,12 @@ pub fn gen_idl_type(
                                     .enumerate()
                                     .fold(outer, |acc, (i, cur)| {
                                         let inner = &inners[i];
-                                        acc.replace(&format!(" {cur}"), &format!(" {inner} "))
+                                        // The spacing of the `outer` variable can differ between
+                                        // versions, e.g. `[T; N]` and `[T ; N]`
+                                        acc.replace(&format!(" {cur} "), &format!(" {inner} "))
                                             .replace(&format!(" {cur},"), &format!(" {inner},"))
-                                            .replace(&format!("[{cur} "), &format!("[{inner} ",))
+                                            .replace(&format!("[{cur} "), &format!("[{inner} "))
+                                            .replace(&format!("[{cur};"), &format!("[{inner};"))
                                             .replace(&format!(" {cur}]"), &format!(" {inner}]"))
                                     });
                                 if let Ok(ty) = syn::parse_str(&resolved_alias) {


### PR DESCRIPTION
### Problem

The current IDL build process uses a pinned `nightly` version to make it work due to the problems such as `error[E0635]: unknown feature stdsimd` error from `ahash`.

We should now be able to unpin it after https://github.com/coral-xyz/anchor/pull/2867, which includes a newer Rust version that fixes some of the problems that blocked us from using the latest `nightly` version.

### Summary of changes

Unpin the `nightly` version used in CI and when generating the IDL.