### PR TITLE
spl: Remove `toml_edit` version requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,6 @@ dependencies = [
  "spl-memo",
  "spl-token 4.0.0",
  "spl-token-2022 3.0.2",
- "toml_edit 0.21.0",
 ]
 
 [[package]]

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -35,7 +35,3 @@ spl-associated-token-account = { version = "3", features = ["no-entrypoint"], op
 spl-memo = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token-2022 = { version = "3", features = ["no-entrypoint"], optional = true }
-
-# TODO: Remove after https://github.com/coral-xyz/anchor/pull/2795 is merged.
-# `toml_edit 0.21.1` has MSRV of `1.69.0` which is above `1.68.0` that comes from `solana-cli 1.17`.
-toml_edit = "=0.21.0"


### PR DESCRIPTION
### Problem

A fixed version requirement for `toml_edit` crate was added in https://github.com/coral-xyz/anchor/pull/2807 in order to fix an MSRV error. This is no longer necessary after Solana 1.18 https://github.com/coral-xyz/anchor/pull/2867.

### Summary of changes

Remove `toml_edit` version requirement.