### PR TITLE
Fix `1.79.0-nightly` warnings

### DIFF
--- a/lang/attribute/account/src/id.rs
+++ b/lang/attribute/account/src/id.rs
@@ -10,7 +10,6 @@ extern crate proc_macro;
 
 use proc_macro2::{Delimiter, Span, TokenTree};
 use quote::{quote, ToTokens};
-use std::convert::TryFrom;
 use syn::{
     bracketed,
     parse::{Parse, ParseStream, Result},

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -9,7 +9,6 @@ use solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 use std::collections::BTreeSet;
-use std::convert::TryFrom;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -2,11 +2,7 @@
 
 use crate::error::ErrorCode;
 use crate::*;
-use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
-use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
-use std::collections::BTreeSet;
 use std::ops::Deref;
 
 /// Type validating that the account is owned by the system program

--- a/lang/src/idl.rs
+++ b/lang/src/idl.rs
@@ -18,7 +18,6 @@
 //! Anchor programs. To remove them, one can use the `no-idl` feature.
 
 use crate::prelude::*;
-use solana_program::pubkey::Pubkey;
 
 // The first 8 bytes of an instruction to create or modify the IDL account. This
 // instruction is defined outside the main program's instruction enum, so that

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1,6 +1,5 @@
 use quote::quote;
 use std::collections::HashSet;
-use syn::Expr;
 
 use crate::*;
 

--- a/lang/syn/src/hash.rs
+++ b/lang/syn/src/hash.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{convert::TryFrom, fmt, mem, str::FromStr};
+use std::{fmt, mem, str::FromStr};
 use thiserror::Error;
 
 pub const HASH_BYTES: usize = 32;

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -1,10 +1,6 @@
 use crate::*;
-use syn::ext::IdentExt;
-use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token::Comma;
-use syn::{bracketed, Expr, Ident, Token};
+use syn::parse::{Error as ParseError, Result as ParseResult};
+use syn::{bracketed, Token};
 
 pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -5,10 +5,6 @@ pub mod event_cpi;
 use crate::parser::docs;
 use crate::*;
 use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token::Comma;
-use syn::Expr;
 use syn::Path;
 
 pub fn parse(accounts_struct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -1,9 +1,8 @@
 use anchor_lang::solana_program::account_info::AccountInfo;
-
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
-use anchor_lang::{solana_program, Result};
 use std::ops::Deref;
 
 pub use spl_token;

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -1,8 +1,7 @@
 use anchor_lang::solana_program::account_info::AccountInfo;
-
 use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
-use anchor_lang::{solana_program, Result};
 
 pub use spl_token_2022;
 pub use spl_token_2022::ID;


### PR DESCRIPTION
### Problem

`rustc 1.79.0-nightly` introduces many compilation warnings in the repository:

```
   Compiling anchor-syn v0.29.0 (/anchor/lang/syn)
warning: the item `Expr` is imported redundantly
 --> /anchor/lang/syn/src/codegen/accounts/constraints.rs:3:5
  |
3 | use syn::Expr;
  |     ^^^^^^^^^
4 |
5 | use crate::*;
  |     -------- the item `Expr` is already imported here
  |
  = note: `#[warn(unused_imports)]` on by default

warning: the item `IdentExt` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:2:5
  |
1 | use crate::*;
  |     -------- the item `IdentExt` is already imported here
2 | use syn::ext::IdentExt;
  |     ^^^^^^^^^^^^^^^^^^

warning: the item `Parse` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:3:39
  |
1 | use crate::*;
  |     -------- the item `Parse` is already imported here
2 | use syn::ext::IdentExt;
3 | use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
  |                                       ^^^^^

warning: the item `ParseStream` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:3:46
  |
1 | use crate::*;
  |     -------- the item `ParseStream` is already imported here
2 | use syn::ext::IdentExt;
3 | use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
  |                                              ^^^^^^^^^^^

warning: the item `Punctuated` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:4:5
  |
1 | use crate::*;
  |     -------- the item `Punctuated` is already imported here
...
4 | use syn::punctuated::Punctuated;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `Spanned` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:5:5
  |
1 | use crate::*;
  |     -------- the item `Spanned` is already imported here
...
5 | use syn::spanned::Spanned;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: the item `Comma` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:6:5
  |
1 | use crate::*;
  |     -------- the item `Comma` is already imported here
...
6 | use syn::token::Comma;
  |     ^^^^^^^^^^^^^^^^^

warning: the item `Expr` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:7:22
  |
1 | use crate::*;
  |     -------- the item `Expr` is already imported here
...
7 | use syn::{bracketed, Expr, Ident, Token};
  |                      ^^^^

warning: the item `Ident` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/constraints.rs:7:28
  |
1 | use crate::*;
  |     -------- the item `Ident` is already imported here
...
7 | use syn::{bracketed, Expr, Ident, Token};
  |                            ^^^^^

warning: the item `Punctuated` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/mod.rs:8:5
  |
6 | use crate::*;
  |     -------- the item `Punctuated` is already imported here
7 | use syn::parse::{Error as ParseError, Result as ParseResult};
8 | use syn::punctuated::Punctuated;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `Spanned` is imported redundantly
 --> /anchor/lang/syn/src/parser/accounts/mod.rs:9:5
  |
6 | use crate::*;
  |     -------- the item `Spanned` is already imported here
...
9 | use syn::spanned::Spanned;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: the item `Comma` is imported redundantly
  --> /anchor/lang/syn/src/parser/accounts/mod.rs:10:5
   |
6  | use crate::*;
   |     -------- the item `Comma` is already imported here
...
10 | use syn::token::Comma;
   |     ^^^^^^^^^^^^^^^^^

warning: the item `Expr` is imported redundantly
  --> /anchor/lang/syn/src/parser/accounts/mod.rs:11:5
   |
6  | use crate::*;
   |     -------- the item `Expr` is already imported here
...
11 | use syn::Expr;
   |     ^^^^^^^^^

warning: the item `TryFrom` is imported redundantly
 --> /anchor/lang/syn/src/hash.rs:6:11
  |
6 | use std::{convert::TryFrom, fmt, mem, str::FromStr};
  |           ^^^^^^^^^^^^^^^^
 --> /rustc/9d5cdf75aa42faaf0b58ba21a510117e8d0051a3/library/std/src/prelude/mod.rs:148:13
  |
  = note: the item `TryFrom` is already defined here

   Compiling aes-gcm-siv v0.10.3
   Compiling merlin v3.0.0
   Compiling sha3 v0.9.1
   Compiling spl-program-error-derive v0.4.0
   Compiling spl-discriminator-syn v0.2.0
   Compiling spl-discriminator-derive v0.2.0
   Compiling anchor-idl v0.29.0 (/anchor/idl)
   Compiling solana-security-txt v1.1.1
   Compiling anchor-derive-space v0.29.0 (/anchor/lang/derive/space)
warning: `anchor-syn` (lib) generated 14 warnings
   Compiling anchor-attribute-account v0.29.0 (/anchor/lang/attribute/account)
warning: the item `TryFrom` is imported redundantly
  --> /anchor/lang/attribute/account/src/id.rs:13:5
   |
13 | use std::convert::TryFrom;
   |     ^^^^^^^^^^^^^^^^^^^^^
  --> /rustc/9d5cdf75aa42faaf0b58ba21a510117e8d0051a3/library/std/src/prelude/mod.rs:148:13
   |
   = note: the item `TryFrom` is already defined here
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `anchor-attribute-account` (lib) generated 1 warning
   Compiling spl-program-error v0.4.0
   Compiling spl-discriminator v0.2.2
   Compiling spl-memo v4.0.1
   Compiling spl-token v4.0.1
   Compiling anchor-attribute-event v0.29.0 (/anchor/lang/attribute/event)
   Compiling solana-zk-token-sdk v1.18.10
warning: `anchor-syn` (lib) generated 14 warnings (14 duplicates)
   Compiling anchor-attribute-access-control v0.29.0 (/anchor/lang/attribute/access-control)
   Compiling anchor-derive-accounts v0.29.0 (/anchor/lang/derive/accounts)
   Compiling anchor-attribute-program v0.29.0 (/anchor/lang/attribute/program)
   Compiling anchor-derive-serde v0.29.0 (/anchor/lang/derive/serde)
   Compiling anchor-attribute-error v0.29.0 (/anchor/lang/attribute/error)
   Compiling anchor-attribute-constant v0.29.0 (/anchor/lang/attribute/constant)
   Compiling anchor-lang v0.29.0 (/anchor/lang)
warning: the item `TryFrom` is imported redundantly
  --> /anchor/lang/src/accounts/program.rs:12:5
   |
12 | use std::convert::TryFrom;
   |     ^^^^^^^^^^^^^^^^^^^^^
  --> /rustc/9d5cdf75aa42faaf0b58ba21a510117e8d0051a3/library/std/src/prelude/mod.rs:148:13
   |
   = note: the item `TryFrom` is already defined here
   |
   = note: `#[warn(unused_imports)]` on by default

warning: the item `AccountInfo` is imported redundantly
 --> /anchor/lang/src/accounts/system_account.rs:5:5
  |
4 | use crate::*;
  |     -------- the item `AccountInfo` is already imported here
5 | use solana_program::account_info::AccountInfo;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `AccountMeta` is imported redundantly
 --> /anchor/lang/src/accounts/system_account.rs:6:5
  |
4 | use crate::*;
  |     -------- the item `AccountMeta` is already imported here
5 | use solana_program::account_info::AccountInfo;
6 | use solana_program::instruction::AccountMeta;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `Pubkey` is imported redundantly
 --> /anchor/lang/src/accounts/system_account.rs:7:5
  |
4 | use crate::*;
  |     -------- the item `Pubkey` is already imported here
...
7 | use solana_program::pubkey::Pubkey;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `BTreeSet` is imported redundantly
 --> /anchor/lang/src/accounts/system_account.rs:9:5
  |
4 | use crate::*;
  |     -------- the item `BTreeSet` is already imported here
...
9 | use std::collections::BTreeSet;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `Pubkey` is imported redundantly
  --> /anchor/lang/src/idl.rs:21:5
   |
20 | use crate::prelude::*;
   |     ----------------- the item `Pubkey` is already imported here
21 | use solana_program::pubkey::Pubkey;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

   Compiling spl-pod v0.2.2
warning: `anchor-lang` (lib) generated 6 warnings
   Compiling spl-type-length-value v0.4.3
   Compiling spl-token-group-interface v0.2.3
   Compiling spl-tlv-account-resolution v0.6.3
   Compiling spl-token-metadata-interface v0.3.3
   Compiling spl-transfer-hook-interface v0.6.3
   Compiling spl-token-2022 v3.0.2
   Compiling spl-associated-token-account v3.0.2
   Compiling anchor-spl v0.29.0 (/anchor/spl)
warning: the item `solana_program` is imported redundantly
 --> /anchor/spl/src/token.rs:6:19
  |
6 | use anchor_lang::{solana_program, Result};
  |                   ^^^^^^^^^^^^^^ the item `solana_program` is already defined by prelude
  |
  = note: `#[warn(unused_imports)]` on by default

warning: the item `solana_program` is imported redundantly
 --> /anchor/spl/src/token_2022.rs:5:19
  |
5 | use anchor_lang::{solana_program, Result};
  |                   ^^^^^^^^^^^^^^ the item `solana_program` is already defined by prelude
```

### Summary of changes

Fix all warnings.