### PR TITLE
spl: Upgrade `mpl-token-metadata` to 4.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "3.1.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177204bbe7486b22ac35af2c91a82630f830a6ddd3392651aefde1ef346aba3d"
+checksum = "caf0f61b553e424a6234af1268456972ee66c2222e1da89079242251fa7479e5"
 dependencies = [
  "borsh 0.10.3",
  "num-derive 0.3.3",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -28,7 +28,7 @@ token_2022 = ["spl-token-2022"]
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.29.0", features = ["derive"] }
 borsh = { version = ">=0.9, <0.11", optional = true }
-mpl-token-metadata = { version = "3.1.0", optional = true }
+mpl-token-metadata = { version = "4", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 solana-program = "1.16"
 spl-associated-token-account = { version = "3", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
### Problem

The latest version of [`mpl-token-metadata`](https://crates.io/crates/mpl-token-metadata/4.1.2) is on v4, meanwhile `anchor-spl` is on v3.

### Summary of changes

Upgrade `mpl-token-metadata` to `4.1.2`.