### PR TITLE
spl: Remove `solana-program` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Add `docs` field for constants ([#2887](https://github.com/coral-xyz/anchor/pull/2887)).
 - idl: Store deployment addresses for other clusters ([#2892](https://github.com/coral-xyz/anchor/pull/2892)).
 - lang: Add `Event` utility type to get events from bytes ([#2897](https://github.com/coral-xyz/anchor/pull/2897)).
-- spl: Add support for [token extensions](https://solana.com/solutions/token-extensions) ([#2789](https://github.com/coral-xyz/anchor/pull/2789)).
+- lang, spl: Add support for [token extensions](https://solana.com/solutions/token-extensions) ([#2789](https://github.com/coral-xyz/anchor/pull/2789)).
 
 ### Fixes
 
@@ -70,6 +70,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Fix `parse_logs_response` to prevent panics when more than 1 outer instruction exists in logs ([#2856](https://github.com/coral-xyz/anchor/pull/2856)).
 - avm, cli: Fix `stdsimd` feature compilation error from `ahash` when installing the CLI using newer Rust versions ([#2867](https://github.com/coral-xyz/anchor/pull/2867)).
 - spl: Fix not being able to deserialize newer token 2022 extensions ([#2876](https://github.com/coral-xyz/anchor/pull/2876)).
+- spl: Remove `solana-program` dependency ([#2900](https://github.com/coral-xyz/anchor/pull/2900)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,6 @@ dependencies = [
  "borsh 0.10.3",
  "mpl-token-metadata",
  "serum_dex",
- "solana-program",
  "spl-associated-token-account 3.0.2",
  "spl-memo",
  "spl-pod 0.2.2",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -31,7 +31,6 @@ anchor-lang = { path = "../lang", version = "0.29.0", features = ["derive"] }
 borsh = { version = ">=0.9, <0.11", optional = true }
 mpl-token-metadata = { version = "4", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
-solana-program = "1.16"
 spl-associated-token-account = { version = "3", features = ["no-entrypoint"], optional = true }
 spl-memo = { version = "4", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "4", features = ["no-entrypoint"], optional = true }

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -14,7 +14,7 @@ pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Resul
         ctx.accounts.mint.key,
         ctx.accounts.token_program.key,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.payer,
@@ -38,7 +38,7 @@ pub fn create_idempotent<'info>(
         ctx.accounts.mint.key,
         ctx.accounts.token_program.key,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.payer,

--- a/spl/src/dex.rs
+++ b/spl/src/dex.rs
@@ -9,10 +9,10 @@ use std::num::NonZeroU64;
 pub use serum_dex;
 
 #[cfg(not(feature = "devnet"))]
-anchor_lang::solana_program::declare_id!("srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX");
+anchor_lang::declare_id!("srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX");
 
 #[cfg(feature = "devnet")]
-anchor_lang::solana_program::declare_id!("EoTcMgcDRTJVZDMZWBoU6rhYHZfkNTVEAfz3uUJRcYGj");
+anchor_lang::declare_id!("EoTcMgcDRTJVZDMZWBoU6rhYHZfkNTVEAfz3uUJRcYGj");
 
 #[allow(clippy::too_many_arguments)]
 pub fn new_order_v3<'info>(
@@ -52,7 +52,7 @@ pub fn new_order_v3<'info>(
         max_native_pc_qty_including_fees,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -77,7 +77,7 @@ pub fn cancel_order_v2<'info>(
         order_id,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -101,7 +101,7 @@ pub fn settle_funds<'info>(ctx: CpiContext<'_, '_, '_, 'info, SettleFunds<'info>
         ctx.accounts.vault_signer.key,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -120,7 +120,7 @@ pub fn init_open_orders<'info>(
         ctx.remaining_accounts.first().map(|acc| acc.key),
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -139,7 +139,7 @@ pub fn close_open_orders<'info>(
         ctx.accounts.market.key,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -158,7 +158,7 @@ pub fn sweep_fees<'info>(ctx: CpiContext<'_, '_, '_, 'info, SweepFees<'info>>) -
         ctx.accounts.token_program.key,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -194,7 +194,7 @@ pub fn initialize_market<'info>(
         pc_dust_threshold,
     )
     .map_err(|pe| ProgramError::from(pe))?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,

--- a/spl/src/governance.rs
+++ b/spl/src/governance.rs
@@ -12,7 +12,7 @@ macro_rules! vote_weight_record {
                 let vwr: spl_governance_addin_api::voter_weight::VoterWeightRecord =
                     anchor_lang::AnchorDeserialize::deserialize(&mut data)
                         .map_err(|_| anchor_lang::error::ErrorCode::AccountDidNotDeserialize)?;
-                if !solana_program::program_pack::IsInitialized::is_initialized(&vwr) {
+                if !anchor_lang::solana_program::program_pack::IsInitialized::is_initialized(&vwr) {
                     return Err(anchor_lang::error::ErrorCode::AccountDidNotSerialize.into());
                 }
                 Ok(VoterWeightRecord(vwr))

--- a/spl/src/memo.rs
+++ b/spl/src/memo.rs
@@ -13,8 +13,12 @@ pub fn build_memo<'info>(ctx: CpiContext<'_, '_, '_, 'info, BuildMemo>, memo: &[
             .map(|account| account.key)
             .collect::<Vec<_>>(),
     );
-    solana_program::program::invoke_signed(&ix, &ctx.remaining_accounts, ctx.signer_seeds)
-        .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(
+        &ix,
+        &ctx.remaining_accounts,
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
 }
 
 #[derive(Accounts)]

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -1,9 +1,9 @@
 use anchor_lang::context::CpiContext;
 use anchor_lang::error::ErrorCode;
+use anchor_lang::solana_program::account_info::AccountInfo;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::solana_program::sysvar;
 use anchor_lang::{system_program, Accounts, Result, ToAccountInfos};
-use solana_program::account_info::AccountInfo;
-use solana_program::pubkey::Pubkey;
-use solana_program::sysvar;
 use std::ops::Deref;
 
 pub use mpl_token_metadata;
@@ -23,7 +23,7 @@ pub fn approve_collection_authority<'info>(
         update_authority: *ctx.accounts.update_authority.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -48,7 +48,7 @@ pub fn bubblegum_set_collection_size<'info>(
             set_collection_size_args: mpl_token_metadata::types::SetCollectionSizeArgs { size },
         },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -72,7 +72,7 @@ pub fn burn_edition_nft<'info>(
         spl_token_program: *ctx.accounts.spl_token.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -109,7 +109,7 @@ pub fn burn_nft<'info>(
         token_account: *ctx.accounts.token.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -143,7 +143,7 @@ pub fn create_metadata_accounts_v3<'info>(
             is_mutable,
         },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -170,7 +170,7 @@ pub fn update_metadata_accounts_v2<'info>(
             is_mutable,
         },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -196,7 +196,7 @@ pub fn create_master_edition_v3<'info>(
     .instruction(
         mpl_token_metadata::instructions::CreateMasterEditionV3InstructionArgs { max_supply },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -230,7 +230,7 @@ pub fn mint_new_edition_from_master_edition_via_token<'info>(
                 mpl_token_metadata::types::MintNewEditionFromMasterEditionViaTokenArgs { edition },
         },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -249,7 +249,7 @@ pub fn revoke_collection_authority<'info>(
         revoke_authority: *ctx.accounts.revoke_authority.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -273,7 +273,7 @@ pub fn set_collection_size<'info>(
             set_collection_size_args: mpl_token_metadata::types::SetCollectionSizeArgs { size },
         },
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -295,7 +295,7 @@ pub fn verify_collection<'info>(
         payer: *ctx.accounts.payer.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -317,7 +317,7 @@ pub fn verify_sized_collection_item<'info>(
         payer: *ctx.accounts.payer.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -340,7 +340,7 @@ pub fn set_and_verify_collection<'info>(
         update_authority: *ctx.accounts.update_authority.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -363,7 +363,7 @@ pub fn set_and_verify_sized_collection_item<'info>(
         update_authority: *ctx.accounts.update_authority.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -382,7 +382,7 @@ pub fn freeze_delegated_account<'info>(
         token_program: *ctx.accounts.token_program.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -401,7 +401,7 @@ pub fn thaw_delegated_account<'info>(
         token_program: *ctx.accounts.token_program.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -418,7 +418,7 @@ pub fn update_primary_sale_happened_via_token<'info>(
         token: *ctx.accounts.token.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -437,7 +437,7 @@ pub fn set_token_standard<'info>(
         update_authority: *ctx.accounts.update_authority.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -451,7 +451,7 @@ pub fn sign_metadata<'info>(ctx: CpiContext<'_, '_, '_, 'info, SignMetadata<'inf
         metadata: *ctx.accounts.metadata.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -467,7 +467,7 @@ pub fn remove_creator_verification<'info>(
         metadata: *ctx.accounts.metadata.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -495,7 +495,7 @@ pub fn utilize<'info>(
         use_authority_record,
     }
     .instruction(mpl_token_metadata::instructions::UtilizeInstructionArgs { number_of_uses });
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -516,7 +516,7 @@ pub fn unverify_collection<'info>(
         metadata: *ctx.accounts.metadata.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,
@@ -538,7 +538,7 @@ pub fn unverify_sized_collection_item<'info>(
         payer: *ctx.accounts.payer.key,
     }
     .instruction();
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &ToAccountInfos::to_account_infos(&ctx),
         ctx.signer_seeds,

--- a/spl/src/mint.rs
+++ b/spl/src/mint.rs
@@ -1,4 +1,4 @@
-use anchor_lang::solana_program::declare_id;
+use anchor_lang::declare_id;
 
 pub use srm::ID as SRM;
 mod srm {

--- a/spl/src/stake.rs
+++ b/spl/src/stake.rs
@@ -36,7 +36,7 @@ pub fn authorize<'info>(
     if let Some(c) = custodian {
         account_infos.push(c);
     }
-    solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
         .map_err(Into::into)
 }
 
@@ -62,7 +62,7 @@ pub fn withdraw<'info>(
     if let Some(c) = custodian {
         account_infos.push(c);
     }
-    solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
         .map_err(Into::into)
 }
 
@@ -70,7 +70,7 @@ pub fn deactivate_stake<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, DeactivateStake<'info>>,
 ) -> Result<()> {
     let ix = stake::instruction::deactivate_stake(ctx.accounts.stake.key, ctx.accounts.staker.key);
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.stake, ctx.accounts.clock, ctx.accounts.staker],
         ctx.signer_seeds,

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -20,7 +20,7 @@ pub fn transfer<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.from, ctx.accounts.to, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -43,7 +43,7 @@ pub fn transfer_checked<'info>(
         amount,
         decimals,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.from,
@@ -68,7 +68,7 @@ pub fn mint_to<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.to, ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -85,7 +85,7 @@ pub fn burn<'info>(ctx: CpiContext<'_, '_, '_, 'info, Burn<'info>>, amount: u64)
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.from, ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -105,7 +105,7 @@ pub fn approve<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.to,
@@ -132,7 +132,7 @@ pub fn approve_checked<'info>(
         amount,
         decimals,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.to,
@@ -152,7 +152,7 @@ pub fn revoke<'info>(ctx: CpiContext<'_, '_, '_, 'info, Revoke<'info>>) -> Resul
         ctx.accounts.authority.key,
         &[],
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.source, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -169,7 +169,7 @@ pub fn initialize_account<'info>(
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -191,7 +191,7 @@ pub fn initialize_account3<'info>(
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.account, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -207,7 +207,7 @@ pub fn close_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, CloseAccount<'inf
         ctx.accounts.authority.key,
         &[], // TODO: support multisig
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -229,7 +229,7 @@ pub fn freeze_account<'info>(
         ctx.accounts.authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -249,7 +249,7 @@ pub fn thaw_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, ThawAccount<'info>
         ctx.accounts.authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -274,7 +274,7 @@ pub fn initialize_mint<'info>(
         freeze_authority,
         decimals,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.mint, ctx.accounts.rent],
         ctx.signer_seeds,
@@ -295,7 +295,7 @@ pub fn initialize_mint2<'info>(
         freeze_authority,
         decimals,
     )?;
-    solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
         .map_err(Into::into)
 }
 
@@ -317,7 +317,7 @@ pub fn set_authority<'info>(
         ctx.accounts.current_authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.account_or_mint, ctx.accounts.current_authority],
         ctx.signer_seeds,
@@ -327,8 +327,12 @@ pub fn set_authority<'info>(
 
 pub fn sync_native<'info>(ctx: CpiContext<'_, '_, '_, 'info, SyncNative<'info>>) -> Result<()> {
     let ix = spl_token::instruction::sync_native(&spl_token::ID, ctx.accounts.account.key)?;
-    solana_program::program::invoke_signed(&ix, &[ctx.accounts.account], ctx.signer_seeds)
-        .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.account],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
 }
 
 #[derive(Accounts)]

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -23,7 +23,7 @@ pub fn transfer<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.from, ctx.accounts.to, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -46,7 +46,7 @@ pub fn transfer_checked<'info>(
         amount,
         decimals,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.from,
@@ -71,7 +71,7 @@ pub fn mint_to<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.to, ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -88,7 +88,7 @@ pub fn burn<'info>(ctx: CpiContext<'_, '_, '_, 'info, Burn<'info>>, amount: u64)
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.from, ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -108,7 +108,7 @@ pub fn approve<'info>(
         &[],
         amount,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.to,
@@ -127,7 +127,7 @@ pub fn revoke<'info>(ctx: CpiContext<'_, '_, '_, 'info, Revoke<'info>>) -> Resul
         ctx.accounts.authority.key,
         &[],
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.source, ctx.accounts.authority],
         ctx.signer_seeds,
@@ -144,7 +144,7 @@ pub fn initialize_account<'info>(
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
     )?;
-    solana_program::program::invoke(
+    anchor_lang::solana_program::program::invoke(
         &ix,
         &[
             ctx.accounts.account,
@@ -165,7 +165,7 @@ pub fn initialize_account3<'info>(
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.account, ctx.accounts.mint])
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.account, ctx.accounts.mint])
         .map_err(Into::into)
 }
 
@@ -177,7 +177,7 @@ pub fn close_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, CloseAccount<'inf
         ctx.accounts.authority.key,
         &[], // TODO: support multisig
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -199,7 +199,7 @@ pub fn freeze_account<'info>(
         ctx.accounts.authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -219,7 +219,7 @@ pub fn thaw_account<'info>(ctx: CpiContext<'_, '_, '_, 'info, ThawAccount<'info>
         ctx.accounts.authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.account,
@@ -244,7 +244,7 @@ pub fn initialize_mint<'info>(
         freeze_authority,
         decimals,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.mint, ctx.accounts.rent])
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.mint, ctx.accounts.rent])
         .map_err(Into::into)
 }
 
@@ -261,7 +261,7 @@ pub fn initialize_mint2<'info>(
         freeze_authority,
         decimals,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
 }
 
 pub fn set_authority<'info>(
@@ -282,7 +282,7 @@ pub fn set_authority<'info>(
         ctx.accounts.current_authority.key,
         &[], // TODO: Support multisig signers.
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.account_or_mint, ctx.accounts.current_authority],
         ctx.signer_seeds,
@@ -292,7 +292,7 @@ pub fn set_authority<'info>(
 
 pub fn sync_native<'info>(ctx: CpiContext<'_, '_, '_, 'info, SyncNative<'info>>) -> Result<()> {
     let ix = spl_token_2022::instruction::sync_native(ctx.program.key, ctx.accounts.account.key)?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
 }
 
 pub fn get_account_data_size<'info>(
@@ -304,15 +304,15 @@ pub fn get_account_data_size<'info>(
         ctx.accounts.mint.key,
         extension_types,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.mint])?;
-    solana_program::program::get_return_data()
-        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.mint])?;
+    anchor_lang::solana_program::program::get_return_data()
+        .ok_or(anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData)
         .and_then(|(key, data)| {
             if key != *ctx.program.key {
-                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+                Err(anchor_lang::solana_program::program_error::ProgramError::IncorrectProgramId)
             } else {
                 data.try_into().map(u64::from_le_bytes).map_err(|_| {
-                    solana_program::program_error::ProgramError::InvalidInstructionData
+                    anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData
                 })
             }
         })
@@ -328,7 +328,7 @@ pub fn initialize_mint_close_authority<'info>(
         ctx.accounts.mint.key,
         close_authority,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
 }
 
 pub fn initialize_immutable_owner<'info>(
@@ -338,7 +338,7 @@ pub fn initialize_immutable_owner<'info>(
         ctx.program.key,
         ctx.accounts.account.key,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.account]).map_err(Into::into)
 }
 
 pub fn amount_to_ui_amount<'info>(
@@ -350,15 +350,15 @@ pub fn amount_to_ui_amount<'info>(
         ctx.accounts.account.key,
         amount,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
-    solana_program::program::get_return_data()
-        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
+    anchor_lang::solana_program::program::get_return_data()
+        .ok_or(anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData)
         .and_then(|(key, data)| {
             if key != *ctx.program.key {
-                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+                Err(anchor_lang::solana_program::program_error::ProgramError::IncorrectProgramId)
             } else {
                 String::from_utf8(data).map_err(|_| {
-                    solana_program::program_error::ProgramError::InvalidInstructionData
+                    anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData
                 })
             }
         })
@@ -374,15 +374,15 @@ pub fn ui_amount_to_amount<'info>(
         ctx.accounts.account.key,
         ui_amount,
     )?;
-    solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
-    solana_program::program::get_return_data()
-        .ok_or(solana_program::program_error::ProgramError::InvalidInstructionData)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.account])?;
+    anchor_lang::solana_program::program::get_return_data()
+        .ok_or(anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData)
         .and_then(|(key, data)| {
             if key != *ctx.program.key {
-                Err(solana_program::program_error::ProgramError::IncorrectProgramId)
+                Err(anchor_lang::solana_program::program_error::ProgramError::IncorrectProgramId)
             } else {
                 data.try_into().map(u64::from_le_bytes).map_err(|_| {
-                    solana_program::program_error::ProgramError::InvalidInstructionData
+                    anchor_lang::solana_program::program_error::ProgramError::InvalidInstructionData
                 })
             }
         })

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -1,7 +1,7 @@
+use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
-use solana_program::account_info::AccountInfo;
 
 pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(
@@ -10,7 +10,7 @@ pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info
         ctx.accounts.account.owner,
         &[],
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -30,7 +30,7 @@ pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'inf
         &[],
     )?;
 
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/default_account_state.rs
+++ b/spl/src/token_2022_extensions/default_account_state.rs
@@ -1,7 +1,7 @@
+use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
-use solana_program::account_info::AccountInfo;
 use spl_token_2022::state::AccountState;
 
 pub fn default_account_state_initialize<'info>(
@@ -13,7 +13,7 @@ pub fn default_account_state_initialize<'info>(
         ctx.accounts.mint.key,
         state
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -39,7 +39,7 @@ pub fn default_account_state_update<'info>(
         state
     )?;
 
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/group_member_pointer.rs
+++ b/spl/src/token_2022_extensions/group_member_pointer.rs
@@ -14,7 +14,7 @@ pub fn group_member_pointer_initialize<'info>(
         authority,
         member_address,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -39,7 +39,7 @@ pub fn group_member_pointer_update<'info>(
         &[],
         member_address,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -14,7 +14,7 @@ pub fn group_pointer_initialize<'info>(
         authority,
         group_address,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -39,7 +39,7 @@ pub fn group_pointer_update<'info>(
         &[&ctx.accounts.authority.key],
         group_address,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/immutable_owner.rs
+++ b/spl/src/token_2022_extensions/immutable_owner.rs
@@ -10,7 +10,7 @@ pub fn immutable_owner_initialize<'info>(
         ctx.accounts.token_program_id.key,
         ctx.accounts.token_account.key,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.token_account],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl/src/token_2022_extensions/interest_bearing_mint.rs
@@ -14,7 +14,7 @@ pub fn interest_bearing_mint_initialize<'info>(
         rate_authority,
         rate,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -39,7 +39,7 @@ pub fn interest_bearing_mint_update_rate<'info>(
         &[],
         rate,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/memo_transfer.rs
+++ b/spl/src/token_2022_extensions/memo_transfer.rs
@@ -12,7 +12,7 @@ pub fn memo_transfer_initialize<'info>(
         ctx.accounts.owner.key,
         &[],
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -34,7 +34,7 @@ pub fn memo_transfer_disable<'info>(
             ctx.accounts.owner.key,
             &[],
         )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl/src/token_2022_extensions/metadata_pointer.rs
@@ -14,7 +14,7 @@ pub fn metadata_pointer_initialize<'info>(
         authority,
         metadata_address,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/mint_close_authority.rs
+++ b/spl/src/token_2022_extensions/mint_close_authority.rs
@@ -12,7 +12,7 @@ pub fn mint_close_authority_initialize<'info>(
         ctx.accounts.mint.key,
         authority,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/non_transferable.rs
+++ b/spl/src/token_2022_extensions/non_transferable.rs
@@ -10,7 +10,7 @@ pub fn non_transferable_mint_initialize<'info>(
         ctx.accounts.token_program_id.key,
         ctx.accounts.mint.key,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/permanent_delegate.rs
+++ b/spl/src/token_2022_extensions/permanent_delegate.rs
@@ -12,7 +12,7 @@ pub fn permanent_delegate_initialize<'info>(
         ctx.accounts.mint.key,
         permanent_delegate,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,

--- a/spl/src/token_2022_extensions/token_group.rs
+++ b/spl/src/token_2022_extensions/token_group.rs
@@ -16,7 +16,7 @@ pub fn token_group_initialize<'info>(
         update_authority,
         max_size,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -48,7 +48,7 @@ pub fn token_member_initialize<'info>(
         ctx.accounts.group.key,
         ctx.accounts.group_update_authority.key,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -22,7 +22,7 @@ pub fn token_metadata_initialize<'info>(
         symbol,
         uri,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -55,7 +55,7 @@ pub fn token_metadata_update_authority<'info>(
         ctx.accounts.current_authority.key,
         new_authority,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -87,7 +87,7 @@ pub fn token_metadata_update_field<'info>(
         field,
         value,
     );
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -18,7 +18,7 @@ pub fn transfer_fee_initialize<'info>(
         transfer_fee_basis_points,
         maximum_fee,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -45,7 +45,7 @@ pub fn transfer_fee_set<'info>(
         transfer_fee_basis_points,
         maximum_fee,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -81,7 +81,7 @@ pub fn transfer_checked_with_fee<'info>(
         decimals,
         fee,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,
@@ -117,7 +117,7 @@ pub fn harvest_withheld_tokens_to_mint<'info>(
     let mut account_infos = vec![ctx.accounts.token_program_id, ctx.accounts.mint];
     account_infos.extend_from_slice(&sources);
 
-    solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
         .map_err(Into::into)
 }
 
@@ -138,7 +138,7 @@ pub fn withdraw_withheld_tokens_from_mint<'info>(
             ctx.accounts.authority.key,
             &[],
         )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_2022_extensions/transfer_hook.rs
+++ b/spl/src/token_2022_extensions/transfer_hook.rs
@@ -14,7 +14,7 @@ pub fn transfer_hook_initialize<'info>(
         authority,
         transfer_hook_program_id,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[ctx.accounts.token_program_id, ctx.accounts.mint],
         ctx.signer_seeds,
@@ -39,7 +39,7 @@ pub fn transfer_hook_update<'info>(
         &[],
         transfer_hook_program_id,
     )?;
-    solana_program::program::invoke_signed(
+    anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
             ctx.accounts.token_program_id,

--- a/spl/src/token_interface.rs
+++ b/spl/src/token_interface.rs
@@ -1,5 +1,5 @@
+use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::solana_program::pubkey::Pubkey;
-use solana_program::program_pack::Pack;
 use spl_token_2022::extension::ExtensionType;
 use spl_token_2022::{
     extension::{BaseStateWithExtensions, Extension, StateWithExtensions},
@@ -91,7 +91,7 @@ pub fn find_mint_account_size(extensions: Option<&ExtensionsVec>) -> anchor_lang
 }
 
 pub fn get_mint_extension_data<T: Extension + Pod>(
-    account: &solana_program::account_info::AccountInfo,
+    account: &anchor_lang::solana_program::account_info::AccountInfo,
 ) -> anchor_lang::Result<T> {
     let mint_data = account.data.borrow();
     let mint_with_extension =


### PR DESCRIPTION
### Problem

`solana-program` dependency is exported from `anchor-lang`, but in `anchor-spl`, we sometimes use `solana_program` and sometimes `anchor_lang::solana_program` which makes it inconsistent.

### Summary of changes

Replace all `solana_program` usage with `anchor_lang::solana_program` and remove the `solana-program` dependency.