### PR TITLE
idl: Keep crate and `spec` version the same

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "anchor-idl"
-version = "0.29.0"
+version = "0.1.0"
 dependencies = [
  "anchor-syn",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ dev = []
 
 [dependencies]
 anchor-client = { path = "../client", version = "0.29.0" }
-anchor-idl = { path = "../idl", features = ["build"], version = "0.29.0" }
+anchor-idl = { path = "../idl", features = ["build"], version = "0.1.0" }
 anchor-lang = { path = "../lang", version = "0.29.0" }
 anyhow = "1.0.32"
 base64 = "0.21"

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor-idl"
-version = "0.29.0"
+version = "0.1.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 rust-version = "1.60"

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 
 /// IDL specification Semantic Version
-pub const IDL_SPEC: &str = "0.1.0";
+pub const IDL_SPEC: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Idl {

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -50,7 +50,7 @@ anchor-derive-serde = { path = "./derive/serde", version = "0.29.0" }
 anchor-derive-space = { path = "./derive/space", version = "0.29.0" }
 
 # `anchor-idl` should only be included with `idl-build` feature
-anchor-idl = { path = "../idl", version = "0.29.0", optional = true }
+anchor-idl = { path = "../idl", version = "0.1.0", optional = true }
 
 arrayref = "0.3"
 base64 = "0.21"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -17,7 +17,7 @@ idl-build = ["anchor-syn/idl-build"]
 interface-instructions = ["anchor-syn/interface-instructions"]
 
 [dependencies]
-anchor-idl = { path = "../../../idl", version = "0.29.0" }
+anchor-idl = { path = "../../../idl", version = "0.1.0" }
 anchor-syn = { path = "../../syn", version = "0.29.0" }
 anyhow = "1"
 bs58 = "0.5"


### PR DESCRIPTION
### Problem

There will be more and more IDL versions as the IDL continues to evolve, but we don't support older `spec`s.

For example, an area where it would be very useful to have backwards compatibility is the new [`declare_program!`](https://github.com/coral-xyz/anchor/pull/2894) macro. Having this support would allow much easier composibility, as the user wouldn't need to think about version/spec conflicts or support.

The simplest way to support various IDL versions is to add support for each of them based on their `metadata.spec` field. For this, it would be much easier to have the `spec` version and the IDL crate version the same, so that we can use different versions of the crate to handle each version separately.

Since the new IDL standard can also be used by non-anchor programs, there is no need to tie the release schedule of the IDL crate to the other Anchor crates.

### Summary of changes

- Set the IDL crate version to `0.1.0`
- Set the `metadata.spec` field of the IDL to the IDL crate's version instead of hardcoding it