### PR TITLE
lang: Return overflow error from `Lamports` trait operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Store deployment addresses for other clusters ([#2892](https://github.com/coral-xyz/anchor/pull/2892)).
 - lang: Add `Event` utility type to get events from bytes ([#2897](https://github.com/coral-xyz/anchor/pull/2897)).
 - lang, spl: Add support for [token extensions](https://solana.com/solutions/token-extensions) ([#2789](https://github.com/coral-xyz/anchor/pull/2789)).
+- lang: Return overflow error from `Lamports` trait operations ([#2907](https://github.com/coral-xyz/anchor/pull/2907)).
 
 ### Fixes
 

--- a/tests/misc/tests/lamports/lamports.ts
+++ b/tests/misc/tests/lamports/lamports.ts
@@ -8,16 +8,13 @@ describe("lamports", () => {
 
   const program = anchor.workspace.Lamports as anchor.Program<Lamports>;
 
-  it("Can use the Lamports trait", async () => {
-    const signer = program.provider.publicKey!;
-    const [pda] = anchor.web3.PublicKey.findProgramAddressSync(
-      [Buffer.from("lamports")],
-      program.programId
-    );
-
+  it("Can transfer from/to PDA", async () => {
     await program.methods
-      .testLamportsTrait(new anchor.BN(anchor.web3.LAMPORTS_PER_SOL))
-      .accounts({ signer, pda })
+      .transfer(new anchor.BN(anchor.web3.LAMPORTS_PER_SOL))
       .rpc();
+  });
+
+  it("Returns an error on overflow", async () => {
+    await program.methods.overflow().rpc();
   });
 });


### PR DESCRIPTION
### Problem

Currently, the default behavior of the [`Lamports`](https://github.com/coral-xyz/anchor/pull/2552) methods is to panic on overflow (due to [`overflow-checks`](https://doc.rust-lang.org/cargo/reference/profiles.html#overflow-checks) flag).

### Summary of changes

Return `ProgramError::ArithmeticOverflow` in the case of an overflow of `Lamports` trait methods instead of panicking, giving more flexibility to the developer to gracefully handle overflow situations.