### PR TITLE
idl: Rename crate name to `anchor-lang-idl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 name = "anchor-attribute-program"
 version = "0.29.0"
 dependencies = [
- "anchor-idl",
+ "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
  "bs58 0.5.0",
@@ -186,8 +186,8 @@ name = "anchor-cli"
 version = "0.29.0"
 dependencies = [
  "anchor-client",
- "anchor-idl",
  "anchor-lang",
+ "anchor-lang-idl",
  "anyhow",
  "base64 0.21.7",
  "bincode",
@@ -264,17 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-idl"
-version = "0.1.0"
-dependencies = [
- "anchor-syn",
- "anyhow",
- "regex",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "anchor-lang"
 version = "0.29.0"
 dependencies = [
@@ -287,7 +276,7 @@ dependencies = [
  "anchor-derive-accounts",
  "anchor-derive-serde",
  "anchor-derive-space",
- "anchor-idl",
+ "anchor-lang-idl",
  "arrayref",
  "base64 0.21.7",
  "bincode",
@@ -296,6 +285,17 @@ dependencies = [
  "getrandom 0.2.10",
  "solana-program",
  "thiserror",
+]
+
+[[package]]
+name = "anchor-lang-idl"
+version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ dev = []
 
 [dependencies]
 anchor-client = { path = "../client", version = "0.29.0" }
-anchor-idl = { path = "../idl", features = ["build"], version = "0.1.0" }
+anchor-lang-idl = { path = "../idl", features = ["build"], version = "0.1.0" }
 anchor-lang = { path = "../lang", version = "0.29.0" }
 anyhow = "1.0.32"
 base64 = "0.21"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,6 +1,6 @@
 use crate::is_hidden;
 use anchor_client::Cluster;
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use anyhow::{anyhow, bail, Context, Error, Result};
 use clap::{Parser, ValueEnum};
 use dirs::home_dir;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,9 +6,9 @@ use crate::config::{
     DEFAULT_LEDGER_PATH, SHUTDOWN_WAIT, STARTUP_WAIT,
 };
 use anchor_client::Cluster;
-use anchor_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anchor_lang::idl::{IdlAccount, IdlInstruction, ERASED_AUTHORITY};
 use anchor_lang::{AccountDeserialize, AnchorDeserialize, AnchorSerialize};
+use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
 use checks::{check_anchor_version, check_overflow};
 use clap::Parser;
@@ -2609,7 +2609,7 @@ fn idl_build(
                 .path
         }
     };
-    let idl = anchor_idl::build::build_idl(
+    let idl = anchor_lang_idl::build::build_idl(
         program_path,
         cfg.features.resolution,
         cfg.features.skip_lint || skip_lint,
@@ -2655,7 +2655,7 @@ in `{path}`."#
         ));
     }
 
-    anchor_idl::build::build_idl(
+    anchor_lang_idl::build::build_idl(
         std::env::current_dir()?,
         cfg.features.resolution,
         cfg.features.skip_lint || skip_lint,

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -2,7 +2,7 @@ use crate::{
     config::ProgramWorkspace, create_files, override_or_create_files, solidity_template, Files,
     VERSION,
 };
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase};

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "anchor-idl"
+name = "anchor-lang-idl"
 version = "0.1.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -33,7 +33,7 @@ idl-build = [
     "anchor-attribute-program/idl-build",
     "anchor-derive-accounts/idl-build",
     "anchor-derive-serde/idl-build",
-    "anchor-idl/build",
+    "anchor-lang-idl/build",
 ]
 init-if-needed = ["anchor-derive-accounts/init-if-needed"]
 interface-instructions = ["anchor-attribute-program/interface-instructions"]
@@ -49,8 +49,8 @@ anchor-derive-accounts = { path = "./derive/accounts", version = "0.29.0" }
 anchor-derive-serde = { path = "./derive/serde", version = "0.29.0" }
 anchor-derive-space = { path = "./derive/space", version = "0.29.0" }
 
-# `anchor-idl` should only be included with `idl-build` feature
-anchor-idl = { path = "../idl", version = "0.1.0", optional = true }
+# `anchor-lang-idl` should only be included with `idl-build` feature
+anchor-lang-idl = { path = "../idl", version = "0.1.0", optional = true }
 
 arrayref = "0.3"
 base64 = "0.21"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -17,7 +17,7 @@ idl-build = ["anchor-syn/idl-build"]
 interface-instructions = ["anchor-syn/interface-instructions"]
 
 [dependencies]
-anchor-idl = { path = "../../../idl", version = "0.1.0" }
+anchor-lang-idl = { path = "../../../idl", version = "0.1.0" }
 anchor-syn = { path = "../../syn", version = "0.29.0" }
 anyhow = "1"
 bs58 = "0.5"

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::{
+use anchor_lang_idl::types::{
     Idl, IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlRepr, IdlSerialization,
     IdlType, IdlTypeDef, IdlTypeDefGeneric, IdlTypeDefTy,
 };

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -1,7 +1,7 @@
 mod common;
 mod mods;
 
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use anyhow::anyhow;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::{Idl, IdlSerialization};
+use anchor_lang_idl::types::{Idl, IdlSerialization};
 use quote::{format_ident, quote};
 
 use super::common::{convert_idl_type_def_to_ts, gen_discriminator, get_canonical_program_id};

--- a/lang/attribute/program/src/declare_program/mods/client.rs
+++ b/lang/attribute/program/src/declare_program/mods/client.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use quote::quote;
 
 use super::common::gen_accounts_common;

--- a/lang/attribute/program/src/declare_program/mods/constants.rs
+++ b/lang/attribute/program/src/declare_program/mods/constants.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::{Idl, IdlType};
+use anchor_lang_idl::types::{Idl, IdlType};
 use quote::{format_ident, quote, ToTokens};
 
 use super::common::convert_idl_type_to_str;

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use heck::CamelCase;
 use quote::{format_ident, quote};
 

--- a/lang/attribute/program/src/declare_program/mods/events.rs
+++ b/lang/attribute/program/src/declare_program/mods/events.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use quote::{format_ident, quote};
 
 use super::common::{convert_idl_type_def_to_ts, gen_discriminator};

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::{Idl, IdlInstructionAccountItem};
+use anchor_lang_idl::types::{Idl, IdlInstructionAccountItem};
 use anchor_syn::{
     codegen::accounts::{__client_accounts, __cpi_client_accounts},
     parser::accounts,

--- a/lang/attribute/program/src/declare_program/mods/types.rs
+++ b/lang/attribute/program/src/declare_program/mods/types.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use quote::quote;
 
 use super::common::convert_idl_type_def_to_ts;

--- a/lang/attribute/program/src/declare_program/mods/utils.rs
+++ b/lang/attribute/program/src/declare_program/mods/utils.rs
@@ -1,4 +1,4 @@
-use anchor_idl::types::Idl;
+use anchor_lang_idl::types::Idl;
 use quote::{format_ident, quote};
 
 use super::common::gen_discriminator;

--- a/lang/src/idl.rs
+++ b/lang/src/idl.rs
@@ -80,4 +80,4 @@ impl IdlAccount {
 }
 
 #[cfg(feature = "idl-build")]
-pub use anchor_idl::{build::IdlBuild, *};
+pub use anchor_lang_idl::{build::IdlBuild, *};


### PR DESCRIPTION
### Problem

[`anchor-idl`](https://crates.io/crates/anchor-idl) already exists in crates.io.

### Summary of changes

Rename the IDL crate to `anchor-lang-idl`.