### PR TITLE
fix branch name for example link

### DIFF
--- a/docs/src/pages/release-notes/0.30.0.md
+++ b/docs/src/pages/release-notes/0.30.0.md
@@ -68,7 +68,7 @@ declare_program!(program_name);
 
 `program_name` is based on the file name of the IDL in `idls` directory, e.g. `idls/program_name.json` is required to exist in order for the above example to work.
 
-This works for both on-chain (CPI) and off-chain (RPC) usage, allowing program interactions without creating a [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). Check out [this](https://github.com/coral-xyz/anchor/blob/0.30.0/tests/declare-program/programs/declare-program/src/lib.rs) example for on-chain CPI usage.
+This works for both on-chain (CPI) and off-chain (RPC) usage, allowing program interactions without creating a [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). Check out [this](https://github.com/coral-xyz/anchor/blob/master/tests/declare-program/programs/declare-program/src/lib.rs) example for on-chain CPI usage.
 
 For more information, see the macro's [documentation](https://docs.rs/anchor-lang/0.30.0/anchor_lang/macro.declare_program.html).
 

--- a/docs/src/pages/release-notes/0.30.0.md
+++ b/docs/src/pages/release-notes/0.30.0.md
@@ -68,7 +68,7 @@ declare_program!(program_name);
 
 `program_name` is based on the file name of the IDL in `idls` directory, e.g. `idls/program_name.json` is required to exist in order for the above example to work.
 
-This works for both on-chain (CPI) and off-chain (RPC) usage, allowing program interactions without creating a [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). Check out [this](https://github.com/coral-xyz/anchor/blob/master/tests/declare-program/programs/declare-program/src/lib.rs) example for on-chain CPI usage.
+This works for both on-chain (CPI) and off-chain (RPC) usage, allowing program interactions without creating a [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell). Check out [this](https://github.com/coral-xyz/anchor/blob/v0.30.0/tests/declare-program/programs/declare-program/src/lib.rs) example for on-chain CPI usage.
 
 For more information, see the macro's [documentation](https://docs.rs/anchor-lang/0.30.0/anchor_lang/macro.declare_program.html).
 


### PR DESCRIPTION
the link in the docs is leading to example code on branch 0.30.0 which isn't there anymore so its a 404, hence fixed the branch name to master in link url