### PR TITLE
docs.rs docs patch: token_program override example

### DIFF
--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -591,16 +591,16 @@ use syn::parse_macro_input;
 ///                 <br><br>
 ///                 Example:
 ///                 <pre>
-/// use anchor_spl::{mint, token::{TokenAccount, Mint, Token}};
+/// use anchor_spl::token_interface::{TokenInterface, TokenAccount, Mint};
 /// ...&#10;
 /// #[account(
 ///     mint::token_program = token_a_token_program,
 /// )]
-/// pub token_a_mint: Box<InterfaceAccount<'info, Mint>>,
+/// pub token_a_mint: InterfaceAccount<'info, Mint>,
 /// #[account(
 ///     mint::token_program = token_b_token_program,
 /// )]
-/// pub token_b_mint: Box<InterfaceAccount<'info, Mint>>,
+/// pub token_b_mint: InterfaceAccount<'info, Mint>,
 /// #[account(
 ///     init,
 ///     payer = payer,
@@ -608,7 +608,7 @@ use syn::parse_macro_input;
 ///     token::authority = payer,
 ///     token::token_program = token_a_token_program,
 /// )]
-/// pub token_a_account: Box<InterfaceAccount<'info, TokenAccount>>,
+/// pub token_a_account: InterfaceAccount<'info, TokenAccount>,
 /// #[account(
 ///     init,
 ///     payer = payer,
@@ -616,7 +616,7 @@ use syn::parse_macro_input;
 ///     token::authority = payer,
 ///     token::token_program = token_b_token_program,
 /// )]
-/// pub token_b_account: Box<InterfaceAccount<'info, TokenAccount>>,
+/// pub token_b_account: InterfaceAccount<'info, TokenAccount>,
 /// pub token_a_token_program: Interface<'info, TokenInterface>,
 /// pub token_b_token_program: Interface<'info, TokenInterface>,
 /// #[account(mut)]


### PR DESCRIPTION
I've been working with interfaces recently and this example was very confusing.

1. Updated imports to imports from `anchor_spl::token_interface`

2. I removed Box<> because docs.rs currently displays them incorrectly for some reason:
![image](https://github.com/coral-xyz/anchor/assets/109175575/d36625a1-e5dd-4105-9bf7-c62aa279f887)
Boxing accs here isn't necessary for educational purposes of this example, and hopefully removing them will fix what docs.rs builds.


Attaching link to this example on docs.rs so u could see how confusing it is right now:
https://docs.rs/anchor-lang/latest/anchor_lang/derive.Accounts.html#:~:text=%23%5Baccount(*%3A%3Atoken_program%20%3D%20%3Ctarget_account%3E)%5D
