### PR TITLE
Add `anchor-derive-serde` crate to the publish script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- syn: Eliminate variable allocations that build up stack space for token extension code generation ([#2913](https://github.com/coral-xyz/anchor/pull/2913)).
+- lang: Eliminate variable allocations that build up stack space for token extension code generation ([#2913](https://github.com/coral-xyz/anchor/pull/2913)).
 
 ### Breaking
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ publish:
 	sleep 25
 	cd lang/derive/accounts/ && cargo publish && cd ../../../
 	sleep 25
+	cd lang/derive/serde/ && cargo publish && cd ../../../
+	sleep 25
 	cd lang/derive/space/ && cargo publish && cd ../../../
 	sleep 25
 	cd lang/attribute/access-control/ && cargo publish && cd ../../../


### PR DESCRIPTION
### Problem

[`anchor-derive-serde`](https://crates.io/crates/anchor-derive-serde) crate is not included in the publish script.

### Summary of changes

Add it.