### PR TITLE
idl: Add accounts resolution for associated token accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 - avm: Support customizing the installation location using `AVM_HOME` environment variable ([#2917](https://github.com/coral-xyz/anchor/pull/2917))
+- idl, ts: Add accounts resolution for associated token accounts ([#2927](https://github.com/coral-xyz/anchor/pull/2927))
 
 ### Fixes
 

--- a/tests/pda-derivation/programs/pda-derivation/Cargo.toml
+++ b/tests/pda-derivation/programs/pda-derivation/Cargo.toml
@@ -14,7 +14,8 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
-idl-build = ["anchor-lang/idl-build"]
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
+anchor-spl = { path = "../../../../spl" }

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -4,6 +4,10 @@
 mod other;
 
 use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{Mint, Token, TokenAccount},
+};
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
@@ -32,6 +36,10 @@ pub mod pda_derivation {
 
     pub fn init_my_account(ctx: Context<InitMyAccount>, _seed_a: u8) -> Result<()> {
         ctx.accounts.account.data = 1337;
+        Ok(())
+    }
+
+    pub fn associated_token_resolution(_ctx: Context<AssociatedTokenResolution>) -> Result<()> {
         Ok(())
     }
 }
@@ -113,6 +121,29 @@ pub struct Nested<'info> {
     )]
     /// CHECK: Not needed
     account_nested: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct AssociatedTokenResolution<'info> {
+    #[account(
+        init,
+        payer = payer,
+        mint::authority = payer,
+        mint::decimals = 9,
+    )]
+    pub mint: Account<'info, Mint>,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::authority = payer,
+        associated_token::mint = mint,
+    )]
+    pub ata: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -103,4 +103,13 @@ describe("typescript", () => {
 
     expect(called).is.true;
   });
+
+  it("Can resolve associated token accounts", async () => {
+    const mintKp = anchor.web3.Keypair.generate();
+    await program.methods
+      .associatedTokenResolution()
+      .accounts({ mint: mintKp.publicKey })
+      .signers([mintKp])
+      .rpc();
+  });
 });


### PR DESCRIPTION
### Problem

Associated token accounts are not automatically resolved in the client as described in https://github.com/coral-xyz/anchor/issues/2925.

### Summary of changes

- Using `associated_token::*` constraints now results in the account derivation information to be stored in the account's `pda` field in the IDL.
- Add a test case

Resolves #2925