### PR TITLE
Fix npm warning by using configured default license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## Next release
+
+- cli: Use npm's configured default license for new projects make with `anchor init`. ([#2929](https://github.com/coral-xyz/anchor/pull/2929))
+
 ## [0.30.0] - 2024-04-15
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Eliminate variable allocations that build up stack space for token extension code generation ([#2913](https://github.com/coral-xyz/anchor/pull/2913)).
 - ts: Fix incorrect `maxSupportedTransactionVersion` in `AnchorProvider.send*()` methods ([#2922](https://github.com/coral-xyz/anchor/pull/2922)).
+- cli: Use npm's configured default license for new projects make with `anchor init` ([#2929](https://github.com/coral-xyz/anchor/pull/2929)).
 
 ### Breaking
-
-## Next release
-
-- cli: Use npm's configured default license for new projects make with `anchor init`. ([#2929](https://github.com/coral-xyz/anchor/pull/2929))
 
 ## [0.30.0] - 2024-04-15
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -392,10 +392,11 @@ describe("{}", () => {{
     )
 }
 
-pub fn package_json(jest: bool) -> String {
+pub fn package_json(jest: bool, license: String) -> String {
     if jest {
         format!(
             r#"{{
+  "license": "{license}",
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
@@ -413,6 +414,7 @@ pub fn package_json(jest: bool) -> String {
     } else {
         format!(
             r#"{{
+  "license": "{license}",
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
@@ -431,10 +433,11 @@ pub fn package_json(jest: bool) -> String {
     }
 }
 
-pub fn ts_package_json(jest: bool) -> String {
+pub fn ts_package_json(jest: bool, license: String) -> String {
     if jest {
         format!(
             r#"{{
+  "license": "{license}",              
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
@@ -456,6 +459,7 @@ pub fn ts_package_json(jest: bool) -> String {
     } else {
         format!(
             r#"{{
+  "license": "{license}",  
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"


### PR DESCRIPTION
Currently when a new project is made with `anchor init`, running `anchor test` will display a warning because the package.json is missing the `license` field:

```
warning package.json: No license field
```

This PR uses the system's configured default license (ie, what `npm init -y` would use) to set the license for the new project. 

People can set their system's default license with `npm config set init-license "<license name>"`. Eg

 - `npm config set init-license "MIT"` (if you prefer MIT to be the default)
 - `npm config set init-license "UNLICENSED"` (if you do not wish to make your code open source)

Note this is my first PR to a Rust project, so if you have any suggestions for the code please let me know!