### PR TITLE
fix unused variable warning on new projects

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -62,6 +62,7 @@ pub mod {} {{
     use super::*;
 
     pub fn initialize(ctx: Context<Initialize>) -> Result<()> {{
+        msg!("Greetings from: {{:?}}", ctx.program_id);
         Ok(())
     }}
 }}
@@ -145,6 +146,7 @@ pub use initialize::*;
 pub struct Initialize {}
 
 pub fn handler(ctx: Context<Initialize>) -> Result<()> {
+    msg!("Greetings from: {{:?}}", ctx.program_id);
     Ok(())
 }
 "#


### PR DESCRIPTION
Running `anchor init` and then `anchor build` always returns:

```
warning: unused variable: `ctx`
 --> programs/deleteme/src/lib.rs:9:23
  |
9 |     pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
  |                       ^^^ help: if this is intentional, prefix it with an underscore: `_ctx`
  |
  = note: `#[warn(unused_variables)]` on by default

warning: `deleteme` (lib) generated 1 warning (run `cargo fix --lib -p deleteme` to apply 1 suggestion)
```

This is a bit of an unnecessary distraction. This PR silences the warning by simply logging the program ID in the default function handler. 

Additionally, `context` is spelt `context` to be consistent with the rest of Anchor. Right now `prelude`, `program`, `initialize`, `handler`, `wallet`, are all full words without contractions but `ctx` is contracted, and when discussing Anchor we have to consistently remind people of this by saying "context, spelled 'see tee ecks'". It's a change, but people that already know anchor should easily understand that `context` is `ctx` and people new to anchor can save some unnecessary confusion.

