### PR TITLE
fix missing filename in 'Unable to read keypair file' errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Eliminate variable allocations that build up stack space for token extension code generation ([#2913](https://github.com/coral-xyz/anchor/pull/2913)).
 - ts: Fix incorrect `maxSupportedTransactionVersion` in `AnchorProvider.send*()` methods ([#2922](https://github.com/coral-xyz/anchor/pull/2922)).
-- cli: Use npm's configured default license for new projects make with `anchor init` ([#2929](https://github.com/coral-xyz/anchor/pull/2929)).
+- cli: Use npm's configured default license for new projects made with `anchor init` ([#2929](https://github.com/coral-xyz/anchor/pull/2929)).
+- cli: add filename to 'Unable to read keypair file' errors ([#2932](https://github.com/coral-xyz/anchor/pull/2932)).
 
 ### Breaking
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::is_hidden;
+use crate::{get_keypair, is_hidden};
 use anchor_client::Cluster;
 use anchor_lang_idl::types::Idl;
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -531,8 +531,7 @@ impl Config {
     }
 
     pub fn wallet_kp(&self) -> Result<Keypair> {
-        solana_sdk::signature::read_keypair_file(&self.provider.wallet.to_string())
-            .map_err(|_| anyhow!("Unable to read keypair file"))
+        get_keypair(&self.provider.wallet.to_string())
     }
 }
 
@@ -1265,8 +1264,7 @@ impl Program {
 
     pub fn keypair(&self) -> Result<Keypair> {
         let file = self.keypair_file()?;
-        solana_sdk::signature::read_keypair_file(file.path())
-            .map_err(|_| anyhow!("failed to read keypair for program: {}", self.lib_name))
+        get_keypair(file.path().to_str().unwrap())
     }
 
     // Lazily initializes the keypair file with a new key if it doesn't exist.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -490,6 +490,11 @@ pub enum ClusterCommand {
     List,
 }
 
+fn get_keypair(path: &str) -> Result<Keypair> {
+    solana_sdk::signature::read_keypair_file(path)
+        .map_err(|_| anyhow!("Unable to read keypair file ({path})"))
+}
+
 pub fn entry(opts: Opts) -> Result<()> {
     let restore_cbs = override_toolchain(&opts.cfg_override)?;
     let result = process_command(opts);
@@ -2285,8 +2290,7 @@ fn idl_set_buffer(
     priority_fee: Option<u64>,
 ) -> Result<Pubkey> {
     with_workspace(cfg_override, |cfg| {
-        let keypair = solana_sdk::signature::read_keypair_file(&cfg.provider.wallet.to_string())
-            .map_err(|_| anyhow!("Unable to read keypair file"))?;
+        let keypair = get_keypair(&cfg.provider.wallet.to_string())?;
         let url = cluster_url(cfg, &cfg.test_validator);
         let client = create_client(url);
 
@@ -2404,8 +2408,7 @@ fn idl_set_authority(
             None => IdlAccount::address(&program_id),
             Some(addr) => addr,
         };
-        let keypair = solana_sdk::signature::read_keypair_file(&cfg.provider.wallet.to_string())
-            .map_err(|_| anyhow!("Unable to read keypair file"))?;
+        let keypair = get_keypair(&cfg.provider.wallet.to_string())?;
         let url = cluster_url(cfg, &cfg.test_validator);
         let client = create_client(url);
 
@@ -2488,8 +2491,7 @@ fn idl_close_account(
     print_only: bool,
     priority_fee: Option<u64>,
 ) -> Result<()> {
-    let keypair = solana_sdk::signature::read_keypair_file(&cfg.provider.wallet.to_string())
-        .map_err(|_| anyhow!("Unable to read keypair file"))?;
+    let keypair = get_keypair(&cfg.provider.wallet.to_string())?;
     let url = cluster_url(cfg, &cfg.test_validator);
     let client = create_client(url);
 
@@ -2541,8 +2543,7 @@ fn idl_write(
     priority_fee: Option<u64>,
 ) -> Result<()> {
     // Misc.
-    let keypair = solana_sdk::signature::read_keypair_file(&cfg.provider.wallet.to_string())
-        .map_err(|_| anyhow!("Unable to read keypair file"))?;
+    let keypair = get_keypair(&cfg.provider.wallet.to_string())?;
     let url = cluster_url(cfg, &cfg.test_validator);
     let client = create_client(url);
 
@@ -3631,12 +3632,7 @@ fn deploy(
             println!("Program path: {}...", binary_path);
 
             let (program_keypair_filepath, program_id) = match &program_keypair {
-                Some(path) => (
-                    path.clone(),
-                    solana_sdk::signature::read_keypair_file(path)
-                        .map_err(|_| anyhow!("Unable to read keypair file"))?
-                        .pubkey(),
-                ),
+                Some(path) => (path.clone(), get_keypair(path)?.pubkey()),
                 None => (
                     program.keypair_file()?.path().display().to_string(),
                     program.pubkey()?,
@@ -3725,8 +3721,7 @@ fn create_idl_account(
 ) -> Result<Pubkey> {
     // Misc.
     let idl_address = IdlAccount::address(program_id);
-    let keypair = solana_sdk::signature::read_keypair_file(keypair_path)
-        .map_err(|_| anyhow!("Unable to read keypair file"))?;
+    let keypair = get_keypair(keypair_path)?;
     let url = cluster_url(cfg, &cfg.test_validator);
     let client = create_client(url);
     let idl_data = serialize_idl(idl)?;
@@ -3807,8 +3802,7 @@ fn create_idl_buffer(
     idl: &Idl,
     priority_fee: Option<u64>,
 ) -> Result<Pubkey> {
-    let keypair = solana_sdk::signature::read_keypair_file(keypair_path)
-        .map_err(|_| anyhow!("Unable to read keypair file"))?;
+    let keypair = get_keypair(keypair_path)?;
     let url = cluster_url(cfg, &cfg.test_validator);
     let client = create_client(url);
 


### PR DESCRIPTION
Fixes #2884