### PR TITLE
allow toolchain overriding in idl build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- idl: Allow overriding the idl build toolchain with the `RUSTUP_TOOLCHAIN` environment variable ([#2941](https://github.com/coral-xyz/anchor/pull/2941]))
 - avm: Support customizing the installation location using `AVM_HOME` environment variable ([#2917](https://github.com/coral-xyz/anchor/pull/2917))
 - idl, ts: Add accounts resolution for associated token accounts ([#2927](https://github.com/coral-xyz/anchor/pull/2927))
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -70,12 +70,15 @@ pub fn build_idl(
 /// Build IDL.
 fn build(program_path: &Path, resolution: bool, no_docs: bool) -> Result<Idl> {
     // `nightly` toolchain is currently required for building the IDL.
-    const TOOLCHAIN: &str = "+nightly";
-    install_toolchain_if_needed(TOOLCHAIN)?;
+    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
+        .map(|toolchain| format!("+{}", toolchain))
+        .unwrap_or_else(|_| "+nightly".to_string());
+
+    install_toolchain_if_needed(&toolchain)?;
 
     let output = Command::new("cargo")
         .args([
-            TOOLCHAIN,
+            &toolchain,
             "test",
             "__anchor_private_print_idl",
             "--features",


### PR DESCRIPTION
in order to build the idl, `nightly` toolchain is currently hardcoded in the code
https://github.com/coral-xyz/anchor/blob/9761ea60088a73a660c2f02d1151782174d0913e/idl/src/build.rs#L73

However, sometimes latest nightly may be incompatible with a given program. This pr allows to override the toolchain used by the idl  build command via `RUSTUP_TOOLCHAIN` env, e.g. 
```
RUSTUP_TOOLCHAIN=”nightly-2023-04-01" anchor idl build
```