### PR TITLE
fix: recursive idl gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Fix incorrect `maxSupportedTransactionVersion` in `AnchorProvider.send*()` methods ([#2922](https://github.com/coral-xyz/anchor/pull/2922)).
 - cli: Use npm's configured default license for new projects made with `anchor init` ([#2929](https://github.com/coral-xyz/anchor/pull/2929)).
 - cli: add filename to 'Unable to read keypair file' errors ([#2932](https://github.com/coral-xyz/anchor/pull/2932)).
+- idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 
 ### Breaking
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -95,6 +95,10 @@ fn build(program_path: &Path, resolution: bool, no_docs: bool) -> Result<Idl> {
             "ANCHOR_IDL_BUILD_RESOLUTION",
             if resolution { "TRUE" } else { "FALSE" },
         )
+        .env(
+            "ANCHOR_IDL_BUILD_PROGRAM_PATH",
+            program_path.to_str().unwrap(),
+        )
         .env("RUSTFLAGS", "--cfg procmacro2_semver_exempt")
         .current_dir(program_path)
         .stderr(Stdio::inherit())

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -95,10 +95,7 @@ fn build(program_path: &Path, resolution: bool, no_docs: bool) -> Result<Idl> {
             "ANCHOR_IDL_BUILD_RESOLUTION",
             if resolution { "TRUE" } else { "FALSE" },
         )
-        .env(
-            "ANCHOR_IDL_BUILD_PROGRAM_PATH",
-            program_path.to_str().unwrap(),
-        )
+        .env("ANCHOR_IDL_BUILD_PROGRAM_PATH", program_path)
         .env("RUSTFLAGS", "--cfg procmacro2_semver_exempt")
         .current_dir(program_path)
         .stderr(Stdio::inherit())

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -18,7 +18,7 @@ pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<sy
 
     // Get crate name and version from lock file
     let program_path = std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH").expect("Failed to get program path");
-    let lock_path = find_path("Cargo.lock", lib_path)?;
+    let lock_path = find_path("Cargo.lock", program_path)?;
     let lock_file = parse_lock_file(lock_path)?;
     let registry_path = get_registry_path()?;
 

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -17,7 +17,7 @@ pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<sy
         .ok_or_else(|| anyhow!("`{name}` not found in use statements"))?;
 
     // Get crate name and version from lock file
-    let lib_path = find_path("lib.rs", path)?;
+    let program_path = std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH").expect("Failed to get program path");
     let lock_path = find_path("Cargo.lock", lib_path)?;
     let lock_file = parse_lock_file(lock_path)?;
     let registry_path = get_registry_path()?;

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -17,7 +17,8 @@ pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<sy
         .ok_or_else(|| anyhow!("`{name}` not found in use statements"))?;
 
     // Get crate name and version from lock file
-    let program_path = std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH").expect("Failed to get program path");
+    let program_path =
+        std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH").expect("Failed to get program path");
     let lock_path = find_path("Cargo.lock", program_path)?;
     let lock_file = parse_lock_file(lock_path)?;
     let registry_path = get_registry_path()?;


### PR DESCRIPTION
There's a bug in the logic for adding external types from other crates into the idl.

The way it works is a macro that :
- first checks `use` statements to see which crate the type is imported from'
- looks for the Cargo.lock of the project
- then finds the name and version of the crate in Cargo.lock
- then looks for the type definition in the cargo registry for that crate locally

The bug I'm trying to fix appears in a recursive situation where a program A imports a type from crate B which uses a type from crate C.
When the macro gets expanded in crate B, it is incapable of finding the `Cargo.lock` of the project and panics (this is because at that point the working directory is the `~/.cargo/registry` and not the anchor workspace ).

I propose to update the code so Cargo.lock is searched from the program path.

Here's a reproducible example:
https://github.com/diyahir/minimal-pyth-version-error
- Program is `tic_tac_toe`, it imports the Anchor type `PriceUpdateV2` from Crate B
- Crate B is `pyth-solana-receiver-sdk`, it imports the Anchor type`PriceFeedMessage` from Crate C.
- Crate C is `pythnet-sdk`
