### PR TITLE
examples: Fix passing `programId` to `Program` constructor

### DIFF
--- a/examples/tutorial/basic-0/client.js
+++ b/examples/tutorial/basic-0/client.js
@@ -10,15 +10,10 @@ anchor.setProvider(anchor.AnchorProvider.local());
 async function main() {
   // #region main
   // Read the generated IDL.
-  const idl = JSON.parse(
-    require("fs").readFileSync("./target/idl/basic_0.json", "utf8")
-  );
-
-  // Address of the deployed program.
-  const programId = new anchor.web3.PublicKey("<YOUR-PROGRAM-ID>");
+  const idl = require("./target/idl/basic_0.json");
 
   // Generate the program client from IDL.
-  const program = new anchor.Program(idl, programId);
+  const program = new anchor.Program(idl);
 
   // Execute the RPC.
   await program.rpc.initialize();


### PR DESCRIPTION
### Problem

There is a rather unusual [`client.js`](https://github.com/coral-xyz/anchor/blob/ede69e67ef7ebbae51bc624040dfab1acfddd269/examples/tutorial/basic-0/client.js) file in [`basic-0`](https://github.com/coral-xyz/anchor/tree/ede69e67ef7ebbae51bc624040dfab1acfddd269/examples/tutorial/basic-0) tutorial directory which is not updated to be compatible with https://github.com/coral-xyz/anchor/pull/2864 as described in https://github.com/coral-xyz/anchor/issues/2947.

### Summary of changes

Remove the `programId` argument when constructing `Program` instance.

Closes #2947