### PR TITLE
Implement TryFromIntError conversion for AnchorError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Support customizing the installation location using `AVM_HOME` environment variable ([#2917](https://github.com/coral-xyz/anchor/pull/2917)).
 - idl, ts: Add accounts resolution for associated token accounts ([#2927](https://github.com/coral-xyz/anchor/pull/2927)).
 - cli: Add `--no-install` option to the `init` command ([#2945](https://github.com/coral-xyz/anchor/pull/2945)).
-- lang: Implement `TryFromIntError` for `Error` to facilitate integers conversion.
+- lang: Implement `TryFromIntError` for `Error` to be able to propagate integer conversion errors ([#2950](https://github.com/coral-xyz/anchor/pull/2950)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - avm: Support customizing the installation location using `AVM_HOME` environment variable ([#2917](https://github.com/coral-xyz/anchor/pull/2917))
 - idl, ts: Add accounts resolution for associated token accounts ([#2927](https://github.com/coral-xyz/anchor/pull/2927))
+- lang: Implement `TryFromIntError` for `Error` to facilitate integers conversion.
 
 ### Fixes
 

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -2,6 +2,7 @@ use anchor_lang::error_code;
 use borsh::maybestd::io::Error as BorshIoError;
 use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 use std::fmt::{Debug, Display};
+use std::num::TryFromIntError;
 
 /// The starting point for user defined error codes.
 pub const ERROR_CODE_OFFSET: u32 = 6000;
@@ -263,7 +264,11 @@ pub enum ErrorCode {
     /// 4101 - You cannot/should not initialize the payer account as a program account
     #[msg("You cannot/should not initialize the payer account as a program account")]
     TryingToInitPayerAsProgramAccount = 4101,
+    /// 4102 - Invalid numeric conversion error
+    #[msg("Error during numeric conversion")]
+    InvalidNumericConversion = 4102,
 
+    
     // Deprecated
     /// 5000 - The API being used is deprecated and should no longer be used
     #[msg("The API being used is deprecated and should no longer be used")]
@@ -307,6 +312,18 @@ impl From<BorshIoError> for Error {
 impl From<ProgramErrorWithOrigin> for Error {
     fn from(pe: ProgramErrorWithOrigin) -> Self {
         Self::ProgramError(Box::new(pe))
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(e: TryFromIntError) -> Self {
+        Self::AnchorError(Box::new(AnchorError {
+            error_name: ErrorCode::InvalidNumericConversion.name(),
+            error_code_number: ErrorCode::InvalidNumericConversion.into(),
+            error_msg: format!("{}", e),
+            error_origin: None,
+            compared_values: None,
+        }))
     }
 }
 

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -268,7 +268,6 @@ pub enum ErrorCode {
     #[msg("Error during numeric conversion")]
     InvalidNumericConversion = 4102,
 
-    
     // Deprecated
     /// 5000 - The API being used is deprecated and should no longer be used
     #[msg("The API being used is deprecated and should no longer be used")]

--- a/tests/errors/programs/errors/src/lib.rs
+++ b/tests/errors/programs/errors/src/lib.rs
@@ -131,6 +131,10 @@ mod errors {
         require_gte!(5, 10);
         Ok(())
     }
+
+    pub fn try_into_integer(_ctx: Context<Hello>) -> Result<i64> {
+        Ok(u64::MAX.try_into()?)
+    }
 }
 
 #[derive(Accounts)]

--- a/tests/errors/tests/errors.ts
+++ b/tests/errors/tests/errors.ts
@@ -604,4 +604,21 @@ describe("errors", () => {
       "Program log: Right: 10",
     ]);
   });
+
+  it("Emits a InvalidNumericConversion error via try_into", async () => {
+    await withLogTest(async () => {
+      try {
+        const tx = await program.methods.tryIntoInteger().rpc();
+        assert.fail(
+          "Unexpected success in creating a transaction that should have failed with `InvalidNumericConversion` error"
+        );
+      } catch (_err) {
+        assert.isTrue(_err instanceof AnchorError);
+        const err: AnchorError = _err;
+        assert.strictEqual(err.error.errorCode.number, 4102);
+      }
+    }, [
+      "Program log: AnchorError occurred. Error Code: InvalidNumericConversion. Error Number: 4102. Error Message: out of range integral type conversion attempted.",
+    ]);
+  });
 });

--- a/ts/packages/anchor/src/error.ts
+++ b/ts/packages/anchor/src/error.ts
@@ -641,7 +641,7 @@ export const LangErrorMessage = new Map([
   ],
   [
     LangErrorCode.InvalidNumericConversion,
-    "The program could not perform the numeric conversion, out of range integral type conversion attempted"
+    "The program could not perform the numeric conversion, out of range integral type conversion attempted",
   ],
 
   // Deprecated

--- a/ts/packages/anchor/src/error.ts
+++ b/ts/packages/anchor/src/error.ts
@@ -394,6 +394,7 @@ export const LangErrorCode = {
   // Miscellaneous
   DeclaredProgramIdMismatch: 4100,
   TryingToInitPayerAsProgramAccount: 4101,
+  InvalidNumericConversion: 4102,
 
   // Used for APIs that shouldn't be used anymore.
   Deprecated: 5000,
@@ -637,6 +638,10 @@ export const LangErrorMessage = new Map([
   [
     LangErrorCode.TryingToInitPayerAsProgramAccount,
     "You cannot/should not initialize the payer account as a program account",
+  ],
+  [
+    LangErrorCode.InvalidNumericConversion,
+    "The program could not perform the numeric conversion, out of range integral type conversion attempted"
   ],
 
   // Deprecated


### PR DESCRIPTION
I noticed it was a bit painful to cast integers with `try_into` and `try_from` because you have to either `unwrap()` or `map_err(||)`.

What about implementing `TryFromIntError` for `Error` so we can use the `?` operator?