### PR TITLE
lang: Fix using defined types in instruction parameters with `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: add filename to 'Unable to read keypair file' errors ([#2932](https://github.com/coral-xyz/anchor/pull/2932)).
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
+- lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -73,6 +73,9 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
         #docs
         pub mod #name {
             use anchor_lang::prelude::*;
+            use accounts::*;
+            use events::*;
+            use types::*;
 
             #id
             #program_mod

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -110,7 +110,7 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
     quote! {
         /// Program account type definitions.
         pub mod accounts {
-            use super::{*, types::*};
+            use super::*;
 
             #(#accounts)*
         }

--- a/lang/attribute/program/src/declare_program/mods/events.rs
+++ b/lang/attribute/program/src/declare_program/mods/events.rs
@@ -37,7 +37,7 @@ pub fn gen_events_mod(idl: &Idl) -> proc_macro2::TokenStream {
     quote! {
         /// Program event type definitions.
         pub mod events {
-            use super::{*, types::*};
+            use super::*;
 
             #(#events)*
         }

--- a/lang/attribute/program/src/declare_program/mods/utils.rs
+++ b/lang/attribute/program/src/declare_program/mods/utils.rs
@@ -32,7 +32,7 @@ fn gen_event(idl: &Idl) -> proc_macro2::TokenStream {
     });
 
     quote! {
-        use super::{*, events::*};
+        use super::*;
 
         /// An enum that includes all events of the declared program as a tuple variant.
         ///

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -82,6 +82,47 @@
       ]
     },
     {
+      "name": "update_all",
+      "discriminator": [
+        205,
+        139,
+        239,
+        66,
+        134,
+        131,
+        110,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "my_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "my_account",
+          "type": {
+            "defined": {
+              "name": "MyAccount"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "update_composite",
       "discriminator": [
         26,

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -19,6 +19,12 @@ pub mod external {
         ctx.accounts.update.my_account.field = value;
         Ok(())
     }
+
+    // Compilation test for whether a defined type (an account in this case) can be used in `cpi` client.
+    pub fn update_all(ctx: Context<Update>, my_account: MyAccount) -> Result<()> {
+        *ctx.accounts.my_account = my_account;
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
### Problem

Using the generated IDL from the following instruction

```rs
pub fn defined(ctx: Context<Defined>, my_type: MyType) -> Result<()> {
    Ok(())
}
```

with [`declare_program!`](https://github.com/coral-xyz/anchor/pull/2857) results in a compilation error due to `MyType` not being imported in the generated `cpi` module.

### Summary of changes

Globally import `accounts`, `events` and `types` modules in necessary places to not run into compilation errors which are difficult to debug.