### PR TITLE
fix: Fix bytes being converted incorrectly in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
+- lang: Fix bytes being incorrectly converted from IDL to Rust with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
 - lang: Fix using const generics with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2965)).
-- lang: Fix bytes being incorrectly converted from IDL to Rust with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
+- lang: Fix using `Vec<u8>` type with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
+- lang: Fix using const generics with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2965)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -38,10 +38,7 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
 }
 
 pub fn convert_idl_type_to_syn_type(ty: &IdlType) -> syn::Type {
-    match ty {
-        IdlType::Bytes => syn::parse_str("Vec<u8>").unwrap(),
-        _ => syn::parse_str(&convert_idl_type_to_str(ty)).unwrap(),
-    }
+    syn::parse_str(&convert_idl_type_to_str(ty)).unwrap()
 }
 
 // TODO: Impl `ToString` for `IdlType`
@@ -62,7 +59,7 @@ pub fn convert_idl_type_to_str(ty: &IdlType) -> String {
         IdlType::I128 => "i128".into(),
         IdlType::U256 => "u256".into(),
         IdlType::I256 => "i256".into(),
-        IdlType::Bytes => "bytes".into(),
+        IdlType::Bytes => "Vec<u8>".into(),
         IdlType::String => "String".into(),
         IdlType::Pubkey => "Pubkey".into(),
         IdlType::Option(ty) => format!("Option<{}>", convert_idl_type_to_str(ty)),

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -104,8 +104,15 @@ pub fn convert_idl_type_def_to_ts(
             .generics
             .iter()
             .map(|generic| match generic {
-                IdlTypeDefGeneric::Type { name } => format_ident!("{name}"),
-                IdlTypeDefGeneric::Const { name, ty } => format_ident!("{name}: {ty}"),
+                IdlTypeDefGeneric::Type { name } => {
+                    let name = format_ident!("{}", name);
+                    quote! { #name }
+                }
+                IdlTypeDefGeneric::Const { name, ty } => {
+                    let name = format_ident!("{}", name);
+                    let ty = format_ident!("{}", ty);
+                    quote! { const #name: #ty }
+                }
             })
             .collect::<Vec<_>>();
         if generics.is_empty() {

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -38,7 +38,10 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
 }
 
 pub fn convert_idl_type_to_syn_type(ty: &IdlType) -> syn::Type {
-    syn::parse_str(&convert_idl_type_to_str(ty)).unwrap()
+    match ty {
+        IdlType::Bytes => syn::parse_str("Vec<u8>").unwrap(),
+        _ => syn::parse_str(&convert_idl_type_to_str(ty)).unwrap(),
+    }
 }
 
 // TODO: Impl `ToString` for `IdlType`


### PR DESCRIPTION
`declare_program!` converts `bytes` in the idl to the type `bytes` in rust. This type doesn't exist, so we switch to converting it to a `Vec<u8>`