### PR TITLE
fix: Fix optional accounts in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
+- lang: Fix bytes being incorrectly converted from IDL to Rust with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
+- lang: Fix using optional accounts with `declare_program!` ([#2967](https://github.com/coral-xyz/anchor/pull/2967)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix path resolution of the `Cargo.lock` of the project when generating idls for external types ([#2946](https://github.com/coral-xyz/anchor/pull/2946)).
 - idl: Fix potential panic on external type resolution ([#2954](https://github.com/coral-xyz/anchor/pull/2954)).
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
+- lang: Fix using const generics with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2965)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -104,8 +104,15 @@ pub fn convert_idl_type_def_to_ts(
             .generics
             .iter()
             .map(|generic| match generic {
-                IdlTypeDefGeneric::Type { name } => format_ident!("{name}"),
-                IdlTypeDefGeneric::Const { name, ty } => format_ident!("{name}: {ty}"),
+                IdlTypeDefGeneric::Type { name } => {
+                    let name = format_ident!("{}", name);
+                    quote! { #name }
+                }
+                IdlTypeDefGeneric::Const { name, ty } => {
+                    let name = format_ident!("{}", name);
+                    let ty = format_ident!("{}", ty);
+                    quote! { const #name: #ty }
+                }
             })
             .collect::<Vec<_>>();
         if generics.is_empty() {

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -38,10 +38,7 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
 }
 
 pub fn convert_idl_type_to_syn_type(ty: &IdlType) -> syn::Type {
-    match ty {
-        IdlType::Bytes => syn::parse_str("Vec<u8>").unwrap(),
-        _ => syn::parse_str(&convert_idl_type_to_str(ty)).unwrap(),
-    }
+    syn::parse_str(&convert_idl_type_to_str(ty)).unwrap()
 }
 
 // TODO: Impl `ToString` for `IdlType`

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -38,7 +38,10 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
 }
 
 pub fn convert_idl_type_to_syn_type(ty: &IdlType) -> syn::Type {
-    syn::parse_str(&convert_idl_type_to_str(ty)).unwrap()
+    match ty {
+        IdlType::Bytes => syn::parse_str("Vec<u8>").unwrap(),
+        _ => syn::parse_str(&convert_idl_type_to_str(ty)).unwrap(),
+    }
 }
 
 // TODO: Impl `ToString` for `IdlType`

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -107,7 +107,7 @@ fn gen_internal_accounts(idl: &Idl) -> proc_macro2::TokenStream {
 
 fn gen_internal_accounts_common(
     idl: &Idl,
-    gen_accounts: impl Fn(&AccountsStruct) -> proc_macro2::TokenStream,
+    gen_accounts: impl Fn(&AccountsStruct, proc_macro2::TokenStream) -> proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let accounts = idl
         .instructions
@@ -171,7 +171,7 @@ fn gen_internal_accounts_common(
             let accs_struct = syn::parse2(accs_struct).expect("Failed to parse as syn::ItemStruct");
             let accs_struct =
                 accounts::parse(&accs_struct).expect("Failed to parse accounts struct");
-            gen_accounts(&accs_struct)
+            gen_accounts(&accs_struct, quote!(super::__ID))
         });
 
     quote! { #(#accounts)* }

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -171,7 +171,7 @@ fn gen_internal_accounts_common(
             let accs_struct = syn::parse2(accs_struct).expect("Failed to parse as syn::ItemStruct");
             let accs_struct =
                 accounts::parse(&accs_struct).expect("Failed to parse accounts struct");
-            gen_accounts(&accs_struct, quote!(super::__ID))
+            gen_accounts(&accs_struct, get_canonical_program_id())
         });
 
     quote! { #(#accounts)* }

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -6,7 +6,10 @@ use std::str::FromStr;
 // Generates the private `__client_accounts` mod implementation, containing
 // a generated struct mapping 1-1 to the `Accounts` struct, except with
 // `Pubkey`s as the types. This is generated for Rust *clients*.
-pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
+pub fn generate(
+    accs: &AccountsStruct,
+    program_id: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     let name = &accs.ident;
     let account_mod_name: proc_macro2::TokenStream = format!(
         "__client_accounts_{}",
@@ -103,7 +106,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         if let Some(#name) = &self.#name {
                             account_metas.push(#meta(*#name, #is_signer));
                         } else {
-                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(crate::ID, false));
+                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(#program_id, false));
                         }
                     }
                 } else {

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -7,7 +7,10 @@ use quote::quote;
 // Generates the private `__cpi_client_accounts` mod implementation, containing
 // a generated struct mapping 1-1 to the `Accounts` struct, except with
 // `AccountInfo`s as the types. This is generated for CPI clients.
-pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
+pub fn generate(
+    accs: &AccountsStruct,
+    program_id: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     let name = &accs.ident;
     let account_mod_name: proc_macro2::TokenStream = format!(
         "__cpi_client_accounts_{}",
@@ -104,7 +107,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         if let Some(#name) = &self.#name {
                             account_metas.push(#meta(anchor_lang::Key::key(#name), #is_signer));
                         } else {
-                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(crate::ID, false));
+                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(#program_id, false));
                         }
                     }
                 } else {

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -21,8 +21,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
     let impl_exit = exit::generate(accs);
     let bumps_struct = bumps::generate(accs);
 
-    let __client_accounts_mod = __client_accounts::generate(accs);
-    let __cpi_client_accounts_mod = __cpi_client_accounts::generate(accs);
+    let __client_accounts_mod = __client_accounts::generate(accs, quote!(crate::ID));
+    let __cpi_client_accounts_mod = __cpi_client_accounts::generate(accs, quote!(crate::ID));
 
     let ret = quote! {
         #impl_try_accounts


### PR DESCRIPTION
When using optional accounts with `declare_program!` the generated code results in the account being set to `crate::ID` when the account is `None`. This means we get two scenarios:

- If our program A is called from another program B via CPI, it will set the optional account to B if it's none because from that scope the current `crate::ID` is that of the calling program. 
- If our program A is used from someplace that isn't another program, the macro blows up because `crate::ID` isn't defined anywhere.

Both of these are the wrong thing to happen, but the fix is easy - just pass in `super::__ID` instead, which is what this PR does.