### PR TITLE
Fix clippy 1.78.0 lints

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-cli"
 version = "0.30.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
-rust-version = "1.60"
 edition = "2021"
 repository = "https://github.com/coral-xyz/anchor"
 description = "Anchor CLI"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -601,8 +601,8 @@ where
     deserializer.deserialize_any(StringOrCustomCluster(PhantomData))
 }
 
-impl ToString for Config {
-    fn to_string(&self) -> String {
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let programs = {
             let c = ser_programs(&self.programs);
             if c.is_empty() {
@@ -629,7 +629,8 @@ impl ToString for Config {
                 .then(|| self.workspace.clone()),
         };
 
-        toml::to_string(&cfg).expect("Must be well formed")
+        let cfg = toml::to_string(&cfg).expect("Must be well formed");
+        write!(f, "{}", cfg)
     }
 }
 
@@ -1395,9 +1396,9 @@ macro_rules! home_path {
             }
         }
 
-        impl ToString for $my_struct {
-            fn to_string(&self) -> String {
-                self.0.clone()
+        impl fmt::Display for $my_struct {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
             }
         }
     };

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -36,7 +36,7 @@ pub fn group_pointer_update<'info>(
         ctx.accounts.token_program_id.key,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
-        &[&ctx.accounts.authority.key],
+        &[ctx.accounts.authority.key],
         group_address,
     )?;
     anchor_lang::solana_program::program::invoke_signed(


### PR DESCRIPTION
### Problem

CI has [errors](https://github.com/coral-xyz/anchor/actions/runs/9101513719/job/25018878393) due to `clippy` lints.

### Summary of changes

- Remove unnecessary ref
- Change `ToString` impls to `std::fmt::Display`
- Remove `rust-version` field from CLI crate manifest