### PR TITLE
Bump minimum Solana crate versions to `1.17.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix using defined types in instruction parameters with `declare_program!` ([#2959](https://github.com/coral-xyz/anchor/pull/2959)).
 - lang: Fix using const generics with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2965)).
 - lang: Fix using `Vec<u8>` type with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
+- lang: Fix `ProgramError::ArithmeticOverflow` not found error ([#2975](https://github.com/coral-xyz/anchor/pull/2975)).
 
 ### Breaking
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,11 +35,11 @@ semver = "1.0.4"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "2.1.0"
-solana-client = "1.16"
-solana-cli-config = "1.16"
-solana-faucet = "1.16"
-solana-program = "1.16"
-solana-sdk = "1.16"
+solana-client = "1.17.3"
+solana-cli-config = "1.17.3"
+solana-faucet = "1.17.3"
+solana-program = "1.17.3"
+solana-sdk = "1.17.3"
 # Pin solang-parser because it may break in a backwards incompatible way in minor versions
 solang-parser = "=0.3.3"
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,9 +21,9 @@ anyhow = "1"
 futures = "0.3"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-solana-account-decoder = "1.16"
-solana-client = "1.16"
-solana-sdk = "1.16"
+solana-account-decoder = "1.17.3"
+solana-client = "1.17.3"
+solana-sdk = "1.17.3"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 url = "2"

--- a/client/example/Cargo.toml
+++ b/client/example/Cargo.toml
@@ -20,5 +20,5 @@ events = { path = "../../tests/events/programs/events", features = ["no-entrypoi
 anyhow = "1.0.32"
 clap = { version = "4.2.4", features = ["derive"] }
 shellexpand = "2.1.0"
-solana-sdk = "1.16"
+solana-sdk = "1.17.3"
 tokio = { version = "1", features = ["full"] }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -57,7 +57,7 @@ base64 = "0.21"
 bincode = "1"
 borsh = ">=0.9, <0.11"
 bytemuck = "1"
-solana-program = "1.16"
+solana-program = "1.17.3"
 thiserror = "1"
 # TODO: Remove. This crate has been added to fix a build error with the 1.16.0 release.
 getrandom = { version = "0.2", features = ["custom"] }

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -23,4 +23,4 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 
 [dev-dependencies]
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
-solana-program-test = "1.16"
+solana-program-test = "1.17.3"


### PR DESCRIPTION
### Problem

The latest version (`0.30.0`) is using `ProgramError::ArithmeticOverflow` which was added in https://github.com/solana-labs/solana/pull/33767 and does not exist before `solana-program 1.17.3`. However, we still support `1.16` in our version requirements: 

https://github.com/coral-xyz/anchor/blob/518b73f21959efc86407ab1da03f538ae6c53121/lang/Cargo.toml#L60

We could potentially fix this by introducing a new error variant ourselves or using an existing error variant, but given we're going to need to bump our Solana version anyway, and the fact that [`1.17.3`](https://crates.io/crates/solana-program/1.17.3) release was published ~8 months ago, it's better to just bump the versions.

### Summary of changes

Bump the minimum version of all Solana crates to `1.17.3`.

Closes https://github.com/coral-xyz/anchor/issues/2949