### PR TITLE
lang: Fix instruction return type generation with `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix using `Vec<u8>` type with `declare_program!` ([#2966](https://github.com/coral-xyz/anchor/pull/2966)).
 - lang: Fix `ProgramError::ArithmeticOverflow` not found error ([#2975](https://github.com/coral-xyz/anchor/pull/2975)).
 - lang: Fix using optional accounts with `declare_program!` ([#2967](https://github.com/coral-xyz/anchor/pull/2967)).
+- lang: Fix instruction return type generation with `declare_program!` ([#2977](https://github.com/coral-xyz/anchor/pull/2977)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -50,7 +50,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
                 let ty = convert_idl_type_to_syn_type(ty);
                 (
                     quote! { anchor_lang::Result<Return::<#ty>> },
-                    quote! { Ok(Return::<#ty> { phantom:: std::marker::PhantomData }) },
+                    quote! { Ok(Return::<#ty> { phantom: std::marker::PhantomData }) },
                 )
             },
             None => (

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -45,6 +45,56 @@
       "args": []
     },
     {
+      "name": "test_compilation_defined_type_param",
+      "discriminator": [
+        61,
+        118,
+        87,
+        242,
+        137,
+        97,
+        90,
+        223
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "_my_account",
+          "type": {
+            "defined": {
+              "name": "MyAccount"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "test_compilation_return_type",
+      "discriminator": [
+        174,
+        51,
+        51,
+        121,
+        52,
+        61,
+        38,
+        28
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "returns": "bool"
+    },
+    {
       "name": "update",
       "discriminator": [
         219,
@@ -78,47 +128,6 @@
         {
           "name": "value",
           "type": "u32"
-        }
-      ]
-    },
-    {
-      "name": "update_all",
-      "discriminator": [
-        205,
-        139,
-        239,
-        66,
-        134,
-        131,
-        110,
-        182
-      ],
-      "accounts": [
-        {
-          "name": "authority",
-          "signer": true
-        },
-        {
-          "name": "my_account",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "account",
-                "path": "authority"
-              }
-            ]
-          }
-        }
-      ],
-      "args": [
-        {
-          "name": "my_account",
-          "type": {
-            "defined": {
-              "name": "MyAccount"
-            }
-          }
         }
       ]
     },

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -21,10 +21,22 @@ pub mod external {
     }
 
     // Compilation test for whether a defined type (an account in this case) can be used in `cpi` client.
-    pub fn update_all(ctx: Context<Update>, my_account: MyAccount) -> Result<()> {
-        *ctx.accounts.my_account = my_account;
+    pub fn test_compilation_defined_type_param(
+        _ctx: Context<TestCompilation>,
+        _my_account: MyAccount,
+    ) -> Result<()> {
         Ok(())
     }
+
+    // Compilation test for whether a custom return type can be specified in `cpi` client
+    pub fn test_compilation_return_type(_ctx: Context<TestCompilation>) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[derive(Accounts)]
+pub struct TestCompilation<'info> {
+    pub signer: Signer<'info>,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
### Problem

CPI client generation has typo with extra column (`:`) which causes compilation error when instruction return type is not `()`.

### Summary of changes

- Remove the extra `:`
- Add a compilation test case with instruction return type