### PR TITLE
ts: Extract Anchor error codes into their own package

### DIFF
--- a/.github/actions/setup-ts/action.yaml
+++ b/.github/actions/setup-ts/action.yaml
@@ -22,6 +22,8 @@ runs:
         key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/*.ts') }}
     - run: cd ts/packages/borsh && yarn --frozen-lockfile && yarn build && yarn link && cd ../../../
       shell: bash
+    - run: cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build && yarn link && cd ../../../
+      shell: bash
     - run: cd ts/packages/anchor && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../
       shell: bash
     - run: cd ts/packages/spl-associated-token-account && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -61,6 +61,7 @@ jobs:
       - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1
       # Init local borsh package
       - run: cd ts/packages/borsh && yarn --frozen-lockfile && yarn build
+      - run: cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl, ts: Add accounts resolution for associated token accounts ([#2927](https://github.com/coral-xyz/anchor/pull/2927)).
 - cli: Add `--no-install` option to the `init` command ([#2945](https://github.com/coral-xyz/anchor/pull/2945)).
 - lang: Implement `TryFromIntError` for `Error` to be able to propagate integer conversion errors ([#2950](https://github.com/coral-xyz/anchor/pull/2950)).
+- ts: Extract Anchor error codes into their own package ([#2983](https://github.com/coral-xyz/anchor/pull/2983)).
 
 ### Fixes
 

--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -7,6 +7,7 @@ fi
 
 git submodule update --init --recursive --depth 1
 cd ts/packages/borsh && yarn --frozen-lockfile && yarn build && yarn link --force && cd ../../../
+cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build && yarn link --force && cd ../../../
 cd ts/packages/anchor && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../
 cd ts/packages/spl-associated-token-account && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../
 cd ts/packages/spl-token && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../

--- a/ts/packages/anchor-errors/package.json
+++ b/ts/packages/anchor-errors/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@coral-xyz/anchor-errors",
+  "version": "0.30.0",
+  "description": "Anchor error codes",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "",
+    "clean": "rm -rf dist"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/ts/packages/anchor-errors/package.json
+++ b/ts/packages/anchor-errors/package.json
@@ -16,10 +16,17 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint:fix": "prettier src/** -w",
+    "lint": "prettier src/** --check",
+    "watch": "tsc --watch",
+    "prepublishOnly": "yarn build",
     "test": "",
     "clean": "rm -rf dist"
   },
   "files": [
     "dist"
-  ]
+  ],
+  "devDependencies": {
+    "prettier": "^2.1.2"
+  }
 }

--- a/ts/packages/anchor-errors/src/index.ts
+++ b/ts/packages/anchor-errors/src/index.ts
@@ -1,0 +1,275 @@
+// Instruction errors.
+
+/** 8 byte instruction identifier not provided. */
+export const ANCHOR_ERROR__INSTRUCTION_MISSING = 100 as const;
+/** Fallback functions are not supported. */
+export const ANCHOR_ERROR__INSTRUCTION_FALLBACK_NOT_FOUND = 101 as const;
+/** The program could not deserialize the given instruction. */
+export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_DESERIALIZE = 102 as const;
+/** The program could not serialize the given instruction. */
+export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_SERIALIZE = 103 as const;
+
+// IDL instruction errors.
+
+/** The program was compiled without idl instructions. */
+export const ANCHOR_ERROR__IDL_INSTRUCTION_STUB = 1000 as const;
+/** The transaction was given an invalid program for the IDL instruction. */
+export const ANCHOR_ERROR__IDL_INSTRUCTION_INVALID_PROGRAM = 1001 as const;
+/** IDL account must be empty in order to resize, try closing first. */
+export const ANCHOR_ERROR__IDL_ACCOUNT_NOT_EMPTY = 1002 as const;
+
+// Event instructions.
+
+/** The program was compiled without `event-cpi` feature. */
+export const ANCHOR_ERROR__EVENT_INSTRUCTION_STUB = 1500 as const;
+
+// Constraint errors.
+
+/** A mut constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MUT = 2000 as const;
+/** A has one constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_HAS_ONE = 2001 as const;
+/** A signer constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_SIGNER = 2002 as const;
+/** A raw constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_RAW = 2003 as const;
+/** An owner constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_OWNER = 2004 as const;
+/** A rent exemption constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_RENT_EXEMPT = 2005 as const;
+/** A seeds constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_SEEDS = 2006 as const;
+/** An executable constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_EXECUTABLE = 2007 as const;
+/** Deprecated Error, feel free to replace with something else. */
+export const ANCHOR_ERROR__CONSTRAINT_STATE = 2008 as const;
+/** An associated constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED = 2009 as const;
+/** An associated init constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_INIT = 2010 as const;
+/** A close constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_CLOSE = 2011 as const;
+/** An address constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_ADDRESS = 2012 as const;
+/** Expected zero account discriminant. */
+export const ANCHOR_ERROR__CONSTRAINT_ZERO = 2013 as const;
+/** A token mint constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_MINT = 2014 as const;
+/** A token owner constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_OWNER = 2015 as const;
+/** A mint mint authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_MINT_AUTHORITY = 2016 as const;
+/** A mint freeze authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_FREEZE_AUTHORITY = 2017 as const;
+/** A mint decimals constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_DECIMALS = 2018 as const;
+/** A space constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_SPACE = 2019 as const;
+/** A required account for the constraint is None. */
+export const ANCHOR_ERROR__CONSTRAINT_ACCOUNT_IS_NONE = 2020 as const;
+/** A token account token program constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_TOKEN_PROGRAM = 2021 as const;
+/** A mint token program constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TOKEN_PROGRAM = 2022 as const;
+/** An associated token account token program constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_TOKEN_TOKEN_PROGRAM =
+  2023 as const;
+/** A group pointer extension constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION =
+  2024 as const;
+/** A group pointer extension authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_AUTHORITY =
+  2025 as const;
+/** A group pointer extension group address constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_GROUP_ADDRESS =
+  2026 as const;
+/** A group member pointer extension constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION =
+  2027 as const;
+/** A group member pointer extension authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_AUTHORITY =
+  2028 as const;
+/** A group member pointer extension group address constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_MEMBER_ADDRESS =
+  2029 as const;
+/** A metadata pointer extension constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION =
+  2030 as const;
+/** A metadata pointer extension authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_AUTHORITY =
+  2031 as const;
+/** A metadata pointer extension metadata address constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_METADATA_ADDRESS =
+  2032 as const;
+/** A close authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION =
+  2033 as const;
+/** A close authority extension authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION_AUTHORITY =
+  2034 as const;
+/** A permanent delegate extension constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION =
+  2035 as const;
+/** A permanent delegate extension delegate constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION_DELEGATE =
+  2036 as const;
+/** A transfer hook extension constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION =
+  2037 as const;
+/** A transfer hook extension authority constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_AUTHORITY =
+  2038 as const;
+/** A transfer hook extension transfer hook program id constraint was violated. */
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_PROGRAM_ID =
+  2039 as const;
+
+// Require errors.
+
+/** A require expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_VIOLATED = 2500 as const;
+/** A require_eq expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_EQ_VIOLATED = 2501 as const;
+/** A require_keys_eq expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_KEYS_EQ_VIOLATED = 2502 as const;
+/** A require_neq expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_NEQ_VIOLATED = 2503 as const;
+/** A require_keys_neq expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_KEYS_NEQ_VIOLATED = 2504 as const;
+/** A require_gt expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_GT_VIOLATED = 2505 as const;
+/** A require_gte expression was violated. */
+export const ANCHOR_ERROR__REQUIRE_GTE_VIOLATED = 2506 as const;
+
+// Account errors.
+
+/** The account discriminator was already set on this account. */
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_ALREADY_SET = 3000 as const;
+/** No 8 byte discriminator was found on the account. */
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_NOT_FOUND = 3001 as const;
+/** 8 byte discriminator did not match what was expected. */
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_MISMATCH = 3002 as const;
+/** Failed to deserialize the account. */
+export const ANCHOR_ERROR__ACCOUNT_DID_NOT_DESERIALIZE = 3003 as const;
+/** Failed to serialize the account. */
+export const ANCHOR_ERROR__ACCOUNT_DID_NOT_SERIALIZE = 3004 as const;
+/** Not enough account keys given to the instruction. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_ENOUGH_KEYS = 3005 as const;
+/** The given account is not mutable. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_MUTABLE = 3006 as const;
+/** The given account is owned by a different program than expected. */
+export const ANCHOR_ERROR__ACCOUNT_OWNED_BY_WRONG_PROGRAM = 3007 as const;
+/** Program ID was not as expected. */
+export const ANCHOR_ERROR__INVALID_PROGRAM_ID = 3008 as const;
+/** Program account is not executable. */
+export const ANCHOR_ERROR__INVALID_PROGRAM_EXECUTABLE = 3009 as const;
+/** The given account did not sign. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_SIGNER = 3010 as const;
+/** The given account is not owned by the system program. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_SYSTEM_OWNED = 3011 as const;
+/** The program expected this account to be already initialized. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED = 3012 as const;
+/** The given account is not a program data account. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_PROGRAM_DATA = 3013 as const;
+/** The given account is not the associated token account. */
+export const ANCHOR_ERROR__ACCOUNT_NOT_ASSOCIATED_TOKEN_ACCOUNT = 3014 as const;
+/** The given public key does not match the required sysvar. */
+export const ANCHOR_ERROR__ACCOUNT_SYSVAR_MISMATCH = 3015 as const;
+/** The account reallocation exceeds the MAX_PERMITTED_DATA_INCREASE limit. */
+export const ANCHOR_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT = 3016 as const;
+/** The account was duplicated for more than one reallocation. */
+export const ANCHOR_ERROR__ACCOUNT_DUPLICATE_REALLOCS = 3017 as const;
+
+// Miscellaneous errors.
+
+/** The declared program id does not match the actual program id. */
+export const ANCHOR_ERROR__DECLARED_PROGRAM_ID_MISMATCH = 4100 as const;
+/** You cannot/should not initialize the payer account as a program account. */
+export const ANCHOR_ERROR__TRYING_TO_INIT_PAYER_AS_PROGRAM_ACCOUNT =
+  4101 as const;
+/** The program could not perform the numeric conversion, out of range integral type conversion attempted. */
+export const ANCHOR_ERROR__INVALID_NUMERIC_CONVERSION = 4102 as const;
+
+// Deprecated errors.
+
+/** The API being used is deprecated and should no longer be used. */
+export const ANCHOR_ERROR__DEPRECATED = 5000 as const;
+
+/** All valid Anchor error codes. */
+export type AnchorErrorCode =
+  | typeof ANCHOR_ERROR__INSTRUCTION_MISSING
+  | typeof ANCHOR_ERROR__INSTRUCTION_FALLBACK_NOT_FOUND
+  | typeof ANCHOR_ERROR__INSTRUCTION_DID_NOT_DESERIALIZE
+  | typeof ANCHOR_ERROR__INSTRUCTION_DID_NOT_SERIALIZE
+  | typeof ANCHOR_ERROR__IDL_INSTRUCTION_STUB
+  | typeof ANCHOR_ERROR__IDL_INSTRUCTION_INVALID_PROGRAM
+  | typeof ANCHOR_ERROR__IDL_ACCOUNT_NOT_EMPTY
+  | typeof ANCHOR_ERROR__EVENT_INSTRUCTION_STUB
+  | typeof ANCHOR_ERROR__CONSTRAINT_MUT
+  | typeof ANCHOR_ERROR__CONSTRAINT_HAS_ONE
+  | typeof ANCHOR_ERROR__CONSTRAINT_SIGNER
+  | typeof ANCHOR_ERROR__CONSTRAINT_RAW
+  | typeof ANCHOR_ERROR__CONSTRAINT_OWNER
+  | typeof ANCHOR_ERROR__CONSTRAINT_RENT_EXEMPT
+  | typeof ANCHOR_ERROR__CONSTRAINT_SEEDS
+  | typeof ANCHOR_ERROR__CONSTRAINT_EXECUTABLE
+  | typeof ANCHOR_ERROR__CONSTRAINT_STATE
+  | typeof ANCHOR_ERROR__CONSTRAINT_ASSOCIATED
+  | typeof ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_INIT
+  | typeof ANCHOR_ERROR__CONSTRAINT_CLOSE
+  | typeof ANCHOR_ERROR__CONSTRAINT_ADDRESS
+  | typeof ANCHOR_ERROR__CONSTRAINT_ZERO
+  | typeof ANCHOR_ERROR__CONSTRAINT_TOKEN_MINT
+  | typeof ANCHOR_ERROR__CONSTRAINT_TOKEN_OWNER
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_MINT_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_FREEZE_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_DECIMALS
+  | typeof ANCHOR_ERROR__CONSTRAINT_SPACE
+  | typeof ANCHOR_ERROR__CONSTRAINT_ACCOUNT_IS_NONE
+  | typeof ANCHOR_ERROR__CONSTRAINT_TOKEN_TOKEN_PROGRAM
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_TOKEN_PROGRAM
+  | typeof ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_TOKEN_TOKEN_PROGRAM
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_GROUP_ADDRESS
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_MEMBER_ADDRESS
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_METADATA_ADDRESS
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION_DELEGATE
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_AUTHORITY
+  | typeof ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_PROGRAM_ID
+  | typeof ANCHOR_ERROR__REQUIRE_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_EQ_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_KEYS_EQ_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_NEQ_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_KEYS_NEQ_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_GT_VIOLATED
+  | typeof ANCHOR_ERROR__REQUIRE_GTE_VIOLATED
+  | typeof ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_ALREADY_SET
+  | typeof ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_NOT_FOUND
+  | typeof ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_MISMATCH
+  | typeof ANCHOR_ERROR__ACCOUNT_DID_NOT_DESERIALIZE
+  | typeof ANCHOR_ERROR__ACCOUNT_DID_NOT_SERIALIZE
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_ENOUGH_KEYS
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_MUTABLE
+  | typeof ANCHOR_ERROR__ACCOUNT_OWNED_BY_WRONG_PROGRAM
+  | typeof ANCHOR_ERROR__INVALID_PROGRAM_ID
+  | typeof ANCHOR_ERROR__INVALID_PROGRAM_EXECUTABLE
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_SIGNER
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_SYSTEM_OWNED
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_PROGRAM_DATA
+  | typeof ANCHOR_ERROR__ACCOUNT_NOT_ASSOCIATED_TOKEN_ACCOUNT
+  | typeof ANCHOR_ERROR__ACCOUNT_SYSVAR_MISMATCH
+  | typeof ANCHOR_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT
+  | typeof ANCHOR_ERROR__ACCOUNT_DUPLICATE_REALLOCS
+  | typeof ANCHOR_ERROR__DECLARED_PROGRAM_ID_MISMATCH
+  | typeof ANCHOR_ERROR__TRYING_TO_INIT_PAYER_AS_PROGRAM_ACCOUNT
+  | typeof ANCHOR_ERROR__INVALID_NUMERIC_CONVERSION
+  | typeof ANCHOR_ERROR__DEPRECATED;

--- a/ts/packages/anchor-errors/src/index.ts
+++ b/ts/packages/anchor-errors/src/index.ts
@@ -1,198 +1,180 @@
 // Instruction errors.
 
 /** 8 byte instruction identifier not provided. */
-export const ANCHOR_ERROR__INSTRUCTION_MISSING = 100 as const;
+export const ANCHOR_ERROR__INSTRUCTION_MISSING = 100;
 /** Fallback functions are not supported. */
-export const ANCHOR_ERROR__INSTRUCTION_FALLBACK_NOT_FOUND = 101 as const;
+export const ANCHOR_ERROR__INSTRUCTION_FALLBACK_NOT_FOUND = 101;
 /** The program could not deserialize the given instruction. */
-export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_DESERIALIZE = 102 as const;
+export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_DESERIALIZE = 102;
 /** The program could not serialize the given instruction. */
-export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_SERIALIZE = 103 as const;
+export const ANCHOR_ERROR__INSTRUCTION_DID_NOT_SERIALIZE = 103;
 
 // IDL instruction errors.
 
 /** The program was compiled without idl instructions. */
-export const ANCHOR_ERROR__IDL_INSTRUCTION_STUB = 1000 as const;
+export const ANCHOR_ERROR__IDL_INSTRUCTION_STUB = 1000;
 /** The transaction was given an invalid program for the IDL instruction. */
-export const ANCHOR_ERROR__IDL_INSTRUCTION_INVALID_PROGRAM = 1001 as const;
+export const ANCHOR_ERROR__IDL_INSTRUCTION_INVALID_PROGRAM = 1001;
 /** IDL account must be empty in order to resize, try closing first. */
-export const ANCHOR_ERROR__IDL_ACCOUNT_NOT_EMPTY = 1002 as const;
+export const ANCHOR_ERROR__IDL_ACCOUNT_NOT_EMPTY = 1002;
 
 // Event instructions.
 
 /** The program was compiled without `event-cpi` feature. */
-export const ANCHOR_ERROR__EVENT_INSTRUCTION_STUB = 1500 as const;
+export const ANCHOR_ERROR__EVENT_INSTRUCTION_STUB = 1500;
 
 // Constraint errors.
 
 /** A mut constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MUT = 2000 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MUT = 2000;
 /** A has one constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_HAS_ONE = 2001 as const;
+export const ANCHOR_ERROR__CONSTRAINT_HAS_ONE = 2001;
 /** A signer constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_SIGNER = 2002 as const;
+export const ANCHOR_ERROR__CONSTRAINT_SIGNER = 2002;
 /** A raw constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_RAW = 2003 as const;
+export const ANCHOR_ERROR__CONSTRAINT_RAW = 2003;
 /** An owner constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_OWNER = 2004 as const;
+export const ANCHOR_ERROR__CONSTRAINT_OWNER = 2004;
 /** A rent exemption constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_RENT_EXEMPT = 2005 as const;
+export const ANCHOR_ERROR__CONSTRAINT_RENT_EXEMPT = 2005;
 /** A seeds constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_SEEDS = 2006 as const;
+export const ANCHOR_ERROR__CONSTRAINT_SEEDS = 2006;
 /** An executable constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_EXECUTABLE = 2007 as const;
+export const ANCHOR_ERROR__CONSTRAINT_EXECUTABLE = 2007;
 /** Deprecated Error, feel free to replace with something else. */
-export const ANCHOR_ERROR__CONSTRAINT_STATE = 2008 as const;
+export const ANCHOR_ERROR__CONSTRAINT_STATE = 2008;
 /** An associated constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED = 2009 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED = 2009;
 /** An associated init constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_INIT = 2010 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_INIT = 2010;
 /** A close constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_CLOSE = 2011 as const;
+export const ANCHOR_ERROR__CONSTRAINT_CLOSE = 2011;
 /** An address constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_ADDRESS = 2012 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ADDRESS = 2012;
 /** Expected zero account discriminant. */
-export const ANCHOR_ERROR__CONSTRAINT_ZERO = 2013 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ZERO = 2013;
 /** A token mint constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_TOKEN_MINT = 2014 as const;
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_MINT = 2014;
 /** A token owner constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_TOKEN_OWNER = 2015 as const;
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_OWNER = 2015;
 /** A mint mint authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_MINT_AUTHORITY = 2016 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_MINT_AUTHORITY = 2016;
 /** A mint freeze authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_FREEZE_AUTHORITY = 2017 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_FREEZE_AUTHORITY = 2017;
 /** A mint decimals constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_DECIMALS = 2018 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_DECIMALS = 2018;
 /** A space constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_SPACE = 2019 as const;
+export const ANCHOR_ERROR__CONSTRAINT_SPACE = 2019;
 /** A required account for the constraint is None. */
-export const ANCHOR_ERROR__CONSTRAINT_ACCOUNT_IS_NONE = 2020 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ACCOUNT_IS_NONE = 2020;
 /** A token account token program constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_TOKEN_TOKEN_PROGRAM = 2021 as const;
+export const ANCHOR_ERROR__CONSTRAINT_TOKEN_TOKEN_PROGRAM = 2021;
 /** A mint token program constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_TOKEN_PROGRAM = 2022 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TOKEN_PROGRAM = 2022;
 /** An associated token account token program constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_TOKEN_TOKEN_PROGRAM =
-  2023 as const;
+export const ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_TOKEN_TOKEN_PROGRAM = 2023;
 /** A group pointer extension constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION =
-  2024 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION = 2024;
 /** A group pointer extension authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_AUTHORITY =
-  2025 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_AUTHORITY = 2025;
 /** A group pointer extension group address constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_GROUP_ADDRESS =
-  2026 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_GROUP_ADDRESS = 2026;
 /** A group member pointer extension constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION =
-  2027 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION = 2027;
 /** A group member pointer extension authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_AUTHORITY =
-  2028 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_AUTHORITY = 2028;
 /** A group member pointer extension group address constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_MEMBER_ADDRESS =
-  2029 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_MEMBER_ADDRESS = 2029;
 /** A metadata pointer extension constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION =
-  2030 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION = 2030;
 /** A metadata pointer extension authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_AUTHORITY =
-  2031 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_AUTHORITY = 2031;
 /** A metadata pointer extension metadata address constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_METADATA_ADDRESS =
-  2032 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_METADATA_ADDRESS = 2032;
 /** A close authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION =
-  2033 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION = 2033;
 /** A close authority extension authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION_AUTHORITY =
-  2034 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION_AUTHORITY = 2034;
 /** A permanent delegate extension constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION =
-  2035 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION = 2035;
 /** A permanent delegate extension delegate constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION_DELEGATE =
-  2036 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION_DELEGATE = 2036;
 /** A transfer hook extension constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION =
-  2037 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION = 2037;
 /** A transfer hook extension authority constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_AUTHORITY =
-  2038 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_AUTHORITY = 2038;
 /** A transfer hook extension transfer hook program id constraint was violated. */
-export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_PROGRAM_ID =
-  2039 as const;
+export const ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_PROGRAM_ID = 2039;
 
 // Require errors.
 
 /** A require expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_VIOLATED = 2500 as const;
+export const ANCHOR_ERROR__REQUIRE_VIOLATED = 2500;
 /** A require_eq expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_EQ_VIOLATED = 2501 as const;
+export const ANCHOR_ERROR__REQUIRE_EQ_VIOLATED = 2501;
 /** A require_keys_eq expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_KEYS_EQ_VIOLATED = 2502 as const;
+export const ANCHOR_ERROR__REQUIRE_KEYS_EQ_VIOLATED = 2502;
 /** A require_neq expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_NEQ_VIOLATED = 2503 as const;
+export const ANCHOR_ERROR__REQUIRE_NEQ_VIOLATED = 2503;
 /** A require_keys_neq expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_KEYS_NEQ_VIOLATED = 2504 as const;
+export const ANCHOR_ERROR__REQUIRE_KEYS_NEQ_VIOLATED = 2504;
 /** A require_gt expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_GT_VIOLATED = 2505 as const;
+export const ANCHOR_ERROR__REQUIRE_GT_VIOLATED = 2505;
 /** A require_gte expression was violated. */
-export const ANCHOR_ERROR__REQUIRE_GTE_VIOLATED = 2506 as const;
+export const ANCHOR_ERROR__REQUIRE_GTE_VIOLATED = 2506;
 
 // Account errors.
 
 /** The account discriminator was already set on this account. */
-export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_ALREADY_SET = 3000 as const;
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_ALREADY_SET = 3000;
 /** No 8 byte discriminator was found on the account. */
-export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_NOT_FOUND = 3001 as const;
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_NOT_FOUND = 3001;
 /** 8 byte discriminator did not match what was expected. */
-export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_MISMATCH = 3002 as const;
+export const ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_MISMATCH = 3002;
 /** Failed to deserialize the account. */
-export const ANCHOR_ERROR__ACCOUNT_DID_NOT_DESERIALIZE = 3003 as const;
+export const ANCHOR_ERROR__ACCOUNT_DID_NOT_DESERIALIZE = 3003;
 /** Failed to serialize the account. */
-export const ANCHOR_ERROR__ACCOUNT_DID_NOT_SERIALIZE = 3004 as const;
+export const ANCHOR_ERROR__ACCOUNT_DID_NOT_SERIALIZE = 3004;
 /** Not enough account keys given to the instruction. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_ENOUGH_KEYS = 3005 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_ENOUGH_KEYS = 3005;
 /** The given account is not mutable. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_MUTABLE = 3006 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_MUTABLE = 3006;
 /** The given account is owned by a different program than expected. */
-export const ANCHOR_ERROR__ACCOUNT_OWNED_BY_WRONG_PROGRAM = 3007 as const;
+export const ANCHOR_ERROR__ACCOUNT_OWNED_BY_WRONG_PROGRAM = 3007;
 /** Program ID was not as expected. */
-export const ANCHOR_ERROR__INVALID_PROGRAM_ID = 3008 as const;
+export const ANCHOR_ERROR__INVALID_PROGRAM_ID = 3008;
 /** Program account is not executable. */
-export const ANCHOR_ERROR__INVALID_PROGRAM_EXECUTABLE = 3009 as const;
+export const ANCHOR_ERROR__INVALID_PROGRAM_EXECUTABLE = 3009;
 /** The given account did not sign. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_SIGNER = 3010 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_SIGNER = 3010;
 /** The given account is not owned by the system program. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_SYSTEM_OWNED = 3011 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_SYSTEM_OWNED = 3011;
 /** The program expected this account to be already initialized. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED = 3012 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED = 3012;
 /** The given account is not a program data account. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_PROGRAM_DATA = 3013 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_PROGRAM_DATA = 3013;
 /** The given account is not the associated token account. */
-export const ANCHOR_ERROR__ACCOUNT_NOT_ASSOCIATED_TOKEN_ACCOUNT = 3014 as const;
+export const ANCHOR_ERROR__ACCOUNT_NOT_ASSOCIATED_TOKEN_ACCOUNT = 3014;
 /** The given public key does not match the required sysvar. */
-export const ANCHOR_ERROR__ACCOUNT_SYSVAR_MISMATCH = 3015 as const;
+export const ANCHOR_ERROR__ACCOUNT_SYSVAR_MISMATCH = 3015;
 /** The account reallocation exceeds the MAX_PERMITTED_DATA_INCREASE limit. */
-export const ANCHOR_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT = 3016 as const;
+export const ANCHOR_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT = 3016;
 /** The account was duplicated for more than one reallocation. */
-export const ANCHOR_ERROR__ACCOUNT_DUPLICATE_REALLOCS = 3017 as const;
+export const ANCHOR_ERROR__ACCOUNT_DUPLICATE_REALLOCS = 3017;
 
 // Miscellaneous errors.
 
 /** The declared program id does not match the actual program id. */
-export const ANCHOR_ERROR__DECLARED_PROGRAM_ID_MISMATCH = 4100 as const;
+export const ANCHOR_ERROR__DECLARED_PROGRAM_ID_MISMATCH = 4100;
 /** You cannot/should not initialize the payer account as a program account. */
-export const ANCHOR_ERROR__TRYING_TO_INIT_PAYER_AS_PROGRAM_ACCOUNT =
-  4101 as const;
+export const ANCHOR_ERROR__TRYING_TO_INIT_PAYER_AS_PROGRAM_ACCOUNT = 4101;
 /** The program could not perform the numeric conversion, out of range integral type conversion attempted. */
-export const ANCHOR_ERROR__INVALID_NUMERIC_CONVERSION = 4102 as const;
+export const ANCHOR_ERROR__INVALID_NUMERIC_CONVERSION = 4102;
 
 // Deprecated errors.
 
 /** The API being used is deprecated and should no longer be used. */
-export const ANCHOR_ERROR__DEPRECATED = 5000 as const;
+export const ANCHOR_ERROR__DEPRECATED = 5000;
 
 /** All valid Anchor error codes. */
 export type AnchorErrorCode =

--- a/ts/packages/anchor-errors/tsconfig.json
+++ b/ts/packages/anchor-errors/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -33,6 +33,7 @@
     "test": "jest tests --detectOpenHandles"
   },
   "dependencies": {
+    "@coral-xyz/anchor-errors": "^0.30.0",
     "@coral-xyz/borsh": "^0.30.0",
     "@noble/hashes": "^1.3.1",
     "@solana/web3.js": "^1.68.0",

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "rimraf dist/ && yarn build:node && yarn build:browser",
-    "build:node": "cd ../borsh && yarn build && cd ../anchor && tsc && tsc -p tsconfig.cjs.json",
+    "build:node": "cd ../borsh && yarn build && cd ../anchor-errors && yarn build && cd ../anchor && tsc && tsc -p tsconfig.cjs.json",
     "build:browser": "rollup --config",
     "lint:fix": "prettier src/** tests/** -w",
     "lint": "prettier src/** tests/** --check",

--- a/ts/packages/anchor/src/error.ts
+++ b/ts/packages/anchor/src/error.ts
@@ -1,4 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
+import * as errors from "@coral-xyz/anchor-errors";
 import * as features from "./utils/features.js";
 
 export class IdlError extends Error {
@@ -307,100 +308,132 @@ export function translateError(err: any, idlErrors: Map<number, string>) {
 
 export const LangErrorCode = {
   // Instructions.
-  InstructionMissing: 100,
-  InstructionFallbackNotFound: 101,
-  InstructionDidNotDeserialize: 102,
-  InstructionDidNotSerialize: 103,
+  InstructionMissing: errors.ANCHOR_ERROR__INSTRUCTION_MISSING,
+  InstructionFallbackNotFound:
+    errors.ANCHOR_ERROR__INSTRUCTION_FALLBACK_NOT_FOUND,
+  InstructionDidNotDeserialize:
+    errors.ANCHOR_ERROR__INSTRUCTION_DID_NOT_DESERIALIZE,
+  InstructionDidNotSerialize:
+    errors.ANCHOR_ERROR__INSTRUCTION_DID_NOT_SERIALIZE,
 
   // IDL instructions.
-  IdlInstructionStub: 1000,
-  IdlInstructionInvalidProgram: 1001,
-  IdlAccountNotEmpty: 1002,
+  IdlInstructionStub: errors.ANCHOR_ERROR__IDL_INSTRUCTION_STUB,
+  IdlInstructionInvalidProgram:
+    errors.ANCHOR_ERROR__IDL_INSTRUCTION_INVALID_PROGRAM,
+  IdlAccountNotEmpty: errors.ANCHOR_ERROR__IDL_ACCOUNT_NOT_EMPTY,
 
   // Event instructions.
-  EventInstructionStub: 1500,
+  EventInstructionStub: errors.ANCHOR_ERROR__EVENT_INSTRUCTION_STUB,
 
   // Constraints.
-  ConstraintMut: 2000,
-  ConstraintHasOne: 2001,
-  ConstraintSigner: 2002,
-  ConstraintRaw: 2003,
-  ConstraintOwner: 2004,
-  ConstraintRentExempt: 2005,
-  ConstraintSeeds: 2006,
-  ConstraintExecutable: 2007,
-  ConstraintState: 2008,
-  ConstraintAssociated: 2009,
-  ConstraintAssociatedInit: 2010,
-  ConstraintClose: 2011,
-  ConstraintAddress: 2012,
-  ConstraintZero: 2013,
-  ConstraintTokenMint: 2014,
-  ConstraintTokenOwner: 2015,
-  ConstraintMintMintAuthority: 2016,
-  ConstraintMintFreezeAuthority: 2017,
-  ConstraintMintDecimals: 2018,
-  ConstraintSpace: 2019,
-  ConstraintAccountIsNone: 2020,
-  ConstraintTokenTokenProgram: 2021,
-  ConstraintMintTokenProgram: 2022,
-  ConstraintAssociatedTokenTokenProgram: 2023,
-  ConstraintMintGroupPointerExtension: 2024,
-  ConstraintMintGroupPointerExtensionAuthority: 2025,
-  ConstraintMintGroupPointerExtensionGroupAddress: 2026,
-  ConstraintMintGroupMemberPointerExtension: 2027,
-  ConstraintMintGroupMemberPointerExtensionAuthority: 2028,
-  ConstraintMintGroupMemberPointerExtensionMemberAddress: 2029,
-  ConstraintMintMetadataPointerExtension: 2030,
-  ConstraintMintMetadataPointerExtensionAuthority: 2031,
-  ConstraintMintMetadataPointerExtensionMetadataAddress: 2032,
-  ConstraintMintCloseAuthorityExtension: 2033,
-  ConstraintMintCloseAuthorityExtensionAuthority: 2034,
-  ConstraintMintPermanentDelegateExtension: 2035,
-  ConstraintMintPermanentDelegateExtensionDelegate: 2036,
-  ConstraintMintTransferHookExtension: 2037,
-  ConstraintMintTransferHookExtensionAuthority: 2038,
-  ConstraintMintTransferHookExtensionProgramId: 2039,
+  ConstraintMut: errors.ANCHOR_ERROR__CONSTRAINT_MUT,
+  ConstraintHasOne: errors.ANCHOR_ERROR__CONSTRAINT_HAS_ONE,
+  ConstraintSigner: errors.ANCHOR_ERROR__CONSTRAINT_SIGNER,
+  ConstraintRaw: errors.ANCHOR_ERROR__CONSTRAINT_RAW,
+  ConstraintOwner: errors.ANCHOR_ERROR__CONSTRAINT_OWNER,
+  ConstraintRentExempt: errors.ANCHOR_ERROR__CONSTRAINT_RENT_EXEMPT,
+  ConstraintSeeds: errors.ANCHOR_ERROR__CONSTRAINT_SEEDS,
+  ConstraintExecutable: errors.ANCHOR_ERROR__CONSTRAINT_EXECUTABLE,
+  ConstraintState: errors.ANCHOR_ERROR__CONSTRAINT_STATE,
+  ConstraintAssociated: errors.ANCHOR_ERROR__CONSTRAINT_ASSOCIATED,
+  ConstraintAssociatedInit: errors.ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_INIT,
+  ConstraintClose: errors.ANCHOR_ERROR__CONSTRAINT_CLOSE,
+  ConstraintAddress: errors.ANCHOR_ERROR__CONSTRAINT_ADDRESS,
+  ConstraintZero: errors.ANCHOR_ERROR__CONSTRAINT_ZERO,
+  ConstraintTokenMint: errors.ANCHOR_ERROR__CONSTRAINT_TOKEN_MINT,
+  ConstraintTokenOwner: errors.ANCHOR_ERROR__CONSTRAINT_TOKEN_OWNER,
+  ConstraintMintMintAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_MINT_AUTHORITY,
+  ConstraintMintFreezeAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_FREEZE_AUTHORITY,
+  ConstraintMintDecimals: errors.ANCHOR_ERROR__CONSTRAINT_MINT_DECIMALS,
+  ConstraintSpace: errors.ANCHOR_ERROR__CONSTRAINT_SPACE,
+  ConstraintAccountIsNone: errors.ANCHOR_ERROR__CONSTRAINT_ACCOUNT_IS_NONE,
+  ConstraintTokenTokenProgram:
+    errors.ANCHOR_ERROR__CONSTRAINT_TOKEN_TOKEN_PROGRAM,
+  ConstraintMintTokenProgram:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_TOKEN_PROGRAM,
+  ConstraintAssociatedTokenTokenProgram:
+    errors.ANCHOR_ERROR__CONSTRAINT_ASSOCIATED_TOKEN_TOKEN_PROGRAM,
+  ConstraintMintGroupPointerExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION,
+  ConstraintMintGroupPointerExtensionAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_AUTHORITY,
+  ConstraintMintGroupPointerExtensionGroupAddress:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_POINTER_EXTENSION_GROUP_ADDRESS,
+  ConstraintMintGroupMemberPointerExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION,
+  ConstraintMintGroupMemberPointerExtensionAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_AUTHORITY,
+  ConstraintMintGroupMemberPointerExtensionMemberAddress:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_GROUP_MEMBER_POINTER_EXTENSION_MEMBER_ADDRESS,
+  ConstraintMintMetadataPointerExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION,
+  ConstraintMintMetadataPointerExtensionAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_AUTHORITY,
+  ConstraintMintMetadataPointerExtensionMetadataAddress:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_METADATA_POINTER_EXTENSION_METADATA_ADDRESS,
+  ConstraintMintCloseAuthorityExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION,
+  ConstraintMintCloseAuthorityExtensionAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_CLOSE_AUTHORITY_EXTENSION_AUTHORITY,
+  ConstraintMintPermanentDelegateExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION,
+  ConstraintMintPermanentDelegateExtensionDelegate:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_PERMANENT_DELEGATE_EXTENSION_DELEGATE,
+  ConstraintMintTransferHookExtension:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION,
+  ConstraintMintTransferHookExtensionAuthority:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_AUTHORITY,
+  ConstraintMintTransferHookExtensionProgramId:
+    errors.ANCHOR_ERROR__CONSTRAINT_MINT_TRANSFER_HOOK_EXTENSION_PROGRAM_ID,
 
   // Require.
-  RequireViolated: 2500,
-  RequireEqViolated: 2501,
-  RequireKeysEqViolated: 2502,
-  RequireNeqViolated: 2503,
-  RequireKeysNeqViolated: 2504,
-  RequireGtViolated: 2505,
-  RequireGteViolated: 2506,
+  RequireViolated: errors.ANCHOR_ERROR__REQUIRE_VIOLATED,
+  RequireEqViolated: errors.ANCHOR_ERROR__REQUIRE_EQ_VIOLATED,
+  RequireKeysEqViolated: errors.ANCHOR_ERROR__REQUIRE_KEYS_EQ_VIOLATED,
+  RequireNeqViolated: errors.ANCHOR_ERROR__REQUIRE_NEQ_VIOLATED,
+  RequireKeysNeqViolated: errors.ANCHOR_ERROR__REQUIRE_KEYS_NEQ_VIOLATED,
+  RequireGtViolated: errors.ANCHOR_ERROR__REQUIRE_GT_VIOLATED,
+  RequireGteViolated: errors.ANCHOR_ERROR__REQUIRE_GTE_VIOLATED,
 
   // Accounts.
-  AccountDiscriminatorAlreadySet: 3000,
-  AccountDiscriminatorNotFound: 3001,
-  AccountDiscriminatorMismatch: 3002,
-  AccountDidNotDeserialize: 3003,
-  AccountDidNotSerialize: 3004,
-  AccountNotEnoughKeys: 3005,
-  AccountNotMutable: 3006,
-  AccountOwnedByWrongProgram: 3007,
-  InvalidProgramId: 3008,
-  InvalidProgramExecutable: 3009,
-  AccountNotSigner: 3010,
-  AccountNotSystemOwned: 3011,
-  AccountNotInitialized: 3012,
-  AccountNotProgramData: 3013,
-  AccountNotAssociatedTokenAccount: 3014,
-  AccountSysvarMismatch: 3015,
-  AccountReallocExceedsLimit: 3016,
-  AccountDuplicateReallocs: 3017,
+  AccountDiscriminatorAlreadySet:
+    errors.ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_ALREADY_SET,
+  AccountDiscriminatorNotFound:
+    errors.ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_NOT_FOUND,
+  AccountDiscriminatorMismatch:
+    errors.ANCHOR_ERROR__ACCOUNT_DISCRIMINATOR_MISMATCH,
+  AccountDidNotDeserialize: errors.ANCHOR_ERROR__ACCOUNT_DID_NOT_DESERIALIZE,
+  AccountDidNotSerialize: errors.ANCHOR_ERROR__ACCOUNT_DID_NOT_SERIALIZE,
+  AccountNotEnoughKeys: errors.ANCHOR_ERROR__ACCOUNT_NOT_ENOUGH_KEYS,
+  AccountNotMutable: errors.ANCHOR_ERROR__ACCOUNT_NOT_MUTABLE,
+  AccountOwnedByWrongProgram:
+    errors.ANCHOR_ERROR__ACCOUNT_OWNED_BY_WRONG_PROGRAM,
+  InvalidProgramId: errors.ANCHOR_ERROR__INVALID_PROGRAM_ID,
+  InvalidProgramExecutable: errors.ANCHOR_ERROR__INVALID_PROGRAM_EXECUTABLE,
+  AccountNotSigner: errors.ANCHOR_ERROR__ACCOUNT_NOT_SIGNER,
+  AccountNotSystemOwned: errors.ANCHOR_ERROR__ACCOUNT_NOT_SYSTEM_OWNED,
+  AccountNotInitialized: errors.ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED,
+  AccountNotProgramData: errors.ANCHOR_ERROR__ACCOUNT_NOT_PROGRAM_DATA,
+  AccountNotAssociatedTokenAccount:
+    errors.ANCHOR_ERROR__ACCOUNT_NOT_ASSOCIATED_TOKEN_ACCOUNT,
+  AccountSysvarMismatch: errors.ANCHOR_ERROR__ACCOUNT_SYSVAR_MISMATCH,
+  AccountReallocExceedsLimit:
+    errors.ANCHOR_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT,
+  AccountDuplicateReallocs: errors.ANCHOR_ERROR__ACCOUNT_DUPLICATE_REALLOCS,
 
   // Miscellaneous
-  DeclaredProgramIdMismatch: 4100,
-  TryingToInitPayerAsProgramAccount: 4101,
-  InvalidNumericConversion: 4102,
+  DeclaredProgramIdMismatch: errors.ANCHOR_ERROR__DECLARED_PROGRAM_ID_MISMATCH,
+  TryingToInitPayerAsProgramAccount:
+    errors.ANCHOR_ERROR__TRYING_TO_INIT_PAYER_AS_PROGRAM_ACCOUNT,
+  InvalidNumericConversion: errors.ANCHOR_ERROR__INVALID_NUMERIC_CONVERSION,
 
   // Used for APIs that shouldn't be used anymore.
-  Deprecated: 5000,
+  Deprecated: errors.ANCHOR_ERROR__DEPRECATED,
 };
 
-export const LangErrorMessage = new Map([
+export const LangErrorMessage = new Map<number, string>([
   // Instructions.
   [
     LangErrorCode.InstructionMissing,


### PR DESCRIPTION
This PR extract all Anchor error codes as plain constants into a new granular package named `@coral-xyz/anchor-errors`.

This enables anyone to access these constants without having to depend on Anchor's dependencies such as **web3.js v1**.

For instance, it enables **web3.js v2** users to assert that a custom program error is an Anchor error using the following code snippet.

```ts
import { isProgramError } from "@solana/web3.js"; // v2
import { ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED } from "@coral-xyz/anchor-errors";

isProgramError(
  error,
  transactionMessage,
  MY_PROGRAM_ADDRESS,
  ANCHOR_ERROR__ACCOUNT_NOT_INITIALIZED
);
```

Note that I went for multiple constants instead of an enum for [reasons explained here](https://github.com/solana-labs/solana-web3.js/blob/71cba9915ce30b1bac11e4cac1afa0150e96536a/packages/errors/src/codes.ts#L299-L313).

Also note that I did not remove the existing `LangErrorCode` object to avoid introducing a breaking change. However, this may be safely dissolved on the next breaking change version.