### PR TITLE
idl: Fix `unexpected_cfgs` build warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix using optional accounts with `declare_program!` ([#2967](https://github.com/coral-xyz/anchor/pull/2967)).
 - lang: Fix instruction return type generation with `declare_program!` ([#2977](https://github.com/coral-xyz/anchor/pull/2977)).
 - cli: Fix IDL write getting corrupted from retries ([#2964](https://github.com/coral-xyz/anchor/pull/2964)).
+- idl: Fix `unexpected_cfgs` build warning ([#2992](https://github.com/coral-xyz/anchor/pull/2992)).
 
 ### Breaking
 

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -35,3 +35,7 @@ thiserror = "1"
 
 # `idl-build` feature only
 cargo_toml = { version = "0.19", optional = true }
+
+# https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ["cfg(procmacro2_semver_exempt)"] }


### PR DESCRIPTION
### Problem

There is a new `#[cfg]` related lint  with Rust 1.80 (nightly-2024-05-05):

```
warning: unexpected `cfg` condition name: `procmacro2_semver_exempt`
   --> ~/anchor/lang/syn/src/idl/defined.rs:493:19
    |
493 |             #[cfg(procmacro2_semver_exempt)]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: consider using a Cargo feature instead or adding `println!("cargo::rustc-check-cfg=cfg(procmacro2_semver_exempt)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
```

See https://blog.rust-lang.org/2024/05/06/check-cfg.html

### Summary of changes

Allow `#[cfg(procmacro2_semver_exempt)]` in `Cargo.toml`'s [`[lints.rust.unexpected_cfgs]` section](https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs). This `#[cfg]` is necessary for resolving external types with the help of `proc-macro2` crate.