### PR TITLE
fix: Make fields in tuple structs public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix instruction return type generation with `declare_program!` ([#2977](https://github.com/coral-xyz/anchor/pull/2977)).
 - cli: Fix IDL write getting corrupted from retries ([#2964](https://github.com/coral-xyz/anchor/pull/2964)).
 - idl: Fix `unexpected_cfgs` build warning ([#2992](https://github.com/coral-xyz/anchor/pull/2992)).
+- lang: Fix using tuple structs with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2994)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix instruction return type generation with `declare_program!` ([#2977](https://github.com/coral-xyz/anchor/pull/2977)).
 - cli: Fix IDL write getting corrupted from retries ([#2964](https://github.com/coral-xyz/anchor/pull/2964)).
 - idl: Fix `unexpected_cfgs` build warning ([#2992](https://github.com/coral-xyz/anchor/pull/2992)).
-- lang: Fix using tuple structs with `declare_program!` ([#2965](https://github.com/coral-xyz/anchor/pull/2994)).
+- lang: Make tuple struct fields public in `declare_program!` ([#2994](https://github.com/coral-xyz/anchor/pull/2994)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -211,7 +211,11 @@ pub fn convert_idl_type_def_to_ts(
                     }
                 },
                 |tys| {
-                    let tys = tys.iter().map(convert_idl_type_to_syn_type);
+                    let tys = tys
+                        .iter()
+                        .map(convert_idl_type_to_syn_type)
+                        .map(|ty| quote! { pub #ty });
+
                     quote! {
                         #declare_struct (#(#tys,)*);
                     }


### PR DESCRIPTION
Currently when defining a tuple struct in an external program such as `struct T(pub u32)`, `declare_program!` will transform this into `struct T(u32)`. This effectively means initializing `T` in the program importing it isn't possible. This also differs from how normal structs work where each field is automatically made public. This PR changes this for tuple structs and makes each field of the tuple public too.