### PR TITLE
lang: Support legacy IDLs with `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Extract Anchor error codes into their own package ([#2983](https://github.com/coral-xyz/anchor/pull/2983)).
 - cli: Add additional solana arguments to the `upgrade` command ([#2998](https://github.com/coral-xyz/anchor/pull/2998)).
 - spl: Export `spl-associated-token-account` crate ([#2999](https://github.com/coral-xyz/anchor/pull/2999)).
+- lang: Support legacy IDLs with `declare_program!` ([#2997](https://github.com/coral-xyz/anchor/pull/2997)).
 
 ### Fixes
 

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -17,7 +17,7 @@ idl-build = ["anchor-syn/idl-build"]
 interface-instructions = ["anchor-syn/interface-instructions"]
 
 [dependencies]
-anchor-lang-idl = { path = "../../../idl", version = "0.1.0" }
+anchor-lang-idl = { path = "../../../idl", version = "0.1.0", features = ["convert"] }
 anchor-syn = { path = "../../syn", version = "0.30.0" }
 anyhow = "1"
 bs58 = "0.5"

--- a/tests/declare-program/idls/external_legacy.json
+++ b/tests/declare-program/idls/external_legacy.json
@@ -1,0 +1,65 @@
+{
+  "version": "0.1.0",
+  "name": "external",
+  "metadata": {
+    "address": "Externa111111111111111111111111111111111111"
+  },
+  "instructions": [
+    {
+      "name": "init",
+      "accounts": [
+        { "name": "authority", "isMut": true, "isSigner": true },
+        { "name": "myAccount", "isMut": true, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "update",
+      "accounts": [
+        { "name": "authority", "isMut": false, "isSigner": true },
+        { "name": "myAccount", "isMut": true, "isSigner": false }
+      ],
+      "args": [{ "name": "value", "type": "u32" }]
+    },
+    {
+      "name": "updateComposite",
+      "accounts": [
+        {
+          "name": "update",
+          "accounts": [
+            { "name": "authority", "isMut": false, "isSigner": true },
+            { "name": "myAccount", "isMut": true, "isSigner": false }
+          ]
+        }
+      ],
+      "args": [{ "name": "value", "type": "u32" }]
+    },
+    {
+      "name": "testCompilationDefinedTypeParam",
+      "accounts": [{ "name": "signer", "isMut": false, "isSigner": true }],
+      "args": [{ "name": "myAccount", "type": { "defined": "MyAccount" } }]
+    },
+    {
+      "name": "testCompilationReturnType",
+      "accounts": [{ "name": "signer", "isMut": false, "isSigner": true }],
+      "args": [],
+      "returns": "bool"
+    }
+  ],
+  "accounts": [
+    {
+      "name": "MyAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [{ "name": "field", "type": "u32" }]
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "MyEvent",
+      "fields": [{ "name": "value", "type": "u32", "index": false }]
+    }
+  ]
+}

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -5,6 +5,9 @@ declare_id!("Dec1areProgram11111111111111111111111111111");
 declare_program!(external);
 use external::program::External;
 
+// Compilation check for legacy IDL (pre Anchor `0.30`)
+declare_program!(external_legacy);
+
 #[program]
 pub mod declare_program {
     use super::*;


### PR DESCRIPTION
### Problem

It's not possible to use legacy IDLs (pre-Anchor `0.30`) with the [`declare_program!`](https://github.com/coral-xyz/anchor/pull/2857) macro as described in https://github.com/coral-xyz/anchor/issues/2972.

### Summary of changes

Add support for legacy IDLs by automatically converting them to the new IDL spec (https://github.com/coral-xyz/anchor/pull/2986).

Resolves https://github.com/coral-xyz/anchor/issues/2972