### PR TITLE
feat: Export `create_associated_token_account` and `create_associated_token_account_idempotent` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Implement `TryFromIntError` for `Error` to be able to propagate integer conversion errors ([#2950](https://github.com/coral-xyz/anchor/pull/2950)).
 - idl: Add ability to convert legacy IDLs ([#2986](https://github.com/coral-xyz/anchor/pull/2986)).
 - ts: Extract Anchor error codes into their own package ([#2983](https://github.com/coral-xyz/anchor/pull/2983)).
-- lang: Export `create_associated_token_account` and `create_associated_token_account_idempotent` instructions ([#2999](https://github.com/coral-xyz/anchor/pull/2999)).
+- spl: Export `spl-associated-token-account` crate ([#2999](https://github.com/coral-xyz/anchor/pull/2999)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Implement `TryFromIntError` for `Error` to be able to propagate integer conversion errors ([#2950](https://github.com/coral-xyz/anchor/pull/2950)).
 - idl: Add ability to convert legacy IDLs ([#2986](https://github.com/coral-xyz/anchor/pull/2986)).
 - ts: Extract Anchor error codes into their own package ([#2983](https://github.com/coral-xyz/anchor/pull/2983)).
+- lang: Export `create_associated_token_account` and `create_associated_token_account_idempotent` instructions ([#2999](https://github.com/coral-xyz/anchor/pull/2999)).
 
 ### Fixes
 

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -4,6 +4,7 @@ use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
 
 pub use spl_associated_token_account;
+pub use spl_associated_token_account::ID;
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {
     let ix = spl_associated_token_account::instruction::create_associated_token_account(

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -3,11 +3,7 @@ use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
 
-pub use spl_associated_token_account::{
-    get_associated_token_address, get_associated_token_address_with_program_id,
-    instruction::{create_associated_token_account, create_associated_token_account_idempotent},
-    ID,
-};
+pub use spl_associated_token_account;
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {
     let ix = spl_associated_token_account::instruction::create_associated_token_account(

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -4,7 +4,9 @@ use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
 
 pub use spl_associated_token_account::{
-    get_associated_token_address, get_associated_token_address_with_program_id, ID,
+    get_associated_token_address, get_associated_token_address_with_program_id,
+    instruction::{create_associated_token_account, create_associated_token_account_idempotent},
+    ID,
 };
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -4,7 +4,9 @@ use anchor_lang::Result;
 use anchor_lang::{context::CpiContext, Accounts};
 
 pub use spl_associated_token_account;
-pub use spl_associated_token_account::ID;
+pub use spl_associated_token_account::{
+    get_associated_token_address, get_associated_token_address_with_program_id, ID,
+};
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {
     let ix = spl_associated_token_account::instruction::create_associated_token_account(


### PR DESCRIPTION
Currently when working with tokens in anchor client, most of the basic operations can be done because `anchor_spl` exposes them e.g. we can create a token, mint it, transfer it, etc. The only thing in a "basic" token workflow that cannot be done is create associated token accounts. 

I don't know why this is, but I'd imagine it's because at the time that `anchor_spl` was first written ATAs weren't the default yet and normal token accounts could be created with it on the client side. Nowadays this has changed though, so I believe updating the exports to expose ATA creation is appropriate.