### PR TITLE
Remove `rust-version` from crate manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix IDL write getting corrupted from retries ([#2964](https://github.com/coral-xyz/anchor/pull/2964)).
 - idl: Fix `unexpected_cfgs` build warning ([#2992](https://github.com/coral-xyz/anchor/pull/2992)).
 - lang: Make tuple struct fields public in `declare_program!` ([#2994](https://github.com/coral-xyz/anchor/pull/2994)).
+- Remove `rust-version` from crate manifests ([#3000](https://github.com/coral-xyz/anchor/pull/3000)).
 
 ### Breaking
 

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "avm"
 version = "0.30.0"
-rust-version = "1.60"
 edition = "2021"
 
 [[bin]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-client"
 version = "0.30.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
-rust-version = "1.60"
 edition = "2021"
 license = "Apache-2.0"
 description = "An RPC client to interact with Anchor programs"

--- a/client/example/Cargo.toml
+++ b/client/example/Cargo.toml
@@ -2,7 +2,6 @@
 name = "example"
 version = "0.1.0"
 authors = ["Armani Ferrante <armaniferrante@gmail.com>"]
-rust-version = "1.60"
 edition = "2021"
 
 [workspace]

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -3,20 +3,15 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use url::Url;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Cluster {
     Testnet,
     Mainnet,
     Devnet,
+    #[default]
     Localnet,
     Debug,
     Custom(String, String),
-}
-
-impl Default for Cluster {
-    fn default() -> Self {
-        Cluster::Localnet
-    }
 }
 
 impl FromStr for Cluster {

--- a/examples/tutorial/basic-0/programs/basic-0/Cargo.toml
+++ b/examples/tutorial/basic-0/programs/basic-0/Cargo.toml
@@ -2,7 +2,6 @@
 name = "basic-0"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-1/programs/basic-1/Cargo.toml
+++ b/examples/tutorial/basic-1/programs/basic-1/Cargo.toml
@@ -2,7 +2,6 @@
 name = "basic-1"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-2/programs/basic-2/Cargo.toml
+++ b/examples/tutorial/basic-2/programs/basic-2/Cargo.toml
@@ -2,7 +2,6 @@
 name = "basic-2"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-3/programs/puppet-master/Cargo.toml
+++ b/examples/tutorial/basic-3/programs/puppet-master/Cargo.toml
@@ -2,7 +2,6 @@
 name = "puppet-master"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-3/programs/puppet/Cargo.toml
+++ b/examples/tutorial/basic-3/programs/puppet/Cargo.toml
@@ -2,7 +2,6 @@
 name = "puppet"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-4/programs/basic-4/Cargo.toml
+++ b/examples/tutorial/basic-4/programs/basic-4/Cargo.toml
@@ -2,7 +2,6 @@
 name = "basic-4"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/examples/tutorial/basic-5/programs/basic-5/Cargo.toml
+++ b/examples/tutorial/basic-5/programs/basic-5/Cargo.toml
@@ -2,7 +2,6 @@
 name = "basic-5"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -3,7 +3,6 @@ name = "anchor-lang-idl"
 version = "0.1.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
-rust-version = "1.60"
 edition = "2021"
 license = "Apache-2.0"
 description = "Anchor framework IDL"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -3,7 +3,6 @@ name = "anchor-lang"
 version = "0.30.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
-rust-version = "1.60"
 edition = "2021"
 license = "Apache-2.0"
 description = "Solana Sealevel eDSL"

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for instruction access control"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining an account"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating constant types"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating error types"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining a program"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro for accounts"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro for serialization and deserialization"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro to automatically calculate the size of a structure or an enum"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"
 description = "Anchor syntax parsing and code generation tools"
-rust-version = "1.60"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-spl"
 version = "0.30.0"
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
-rust-version = "1.60"
 edition = "2021"
 license = "Apache-2.0"
 description = "CPI clients for SPL programs"

--- a/tests/bpf-upgradeable-state/programs/bpf-upgradeable-state/Cargo.toml
+++ b/tests/bpf-upgradeable-state/programs/bpf-upgradeable-state/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bpf-upgradeable-state"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/cashiers-check/programs/cashiers-check/Cargo.toml
+++ b/tests/cashiers-check/programs/cashiers-check/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cashiers-check"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/cfo/programs/cfo/Cargo.toml
+++ b/tests/cfo/programs/cfo/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cfo"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/chat/programs/chat/Cargo.toml
+++ b/tests/chat/programs/chat/Cargo.toml
@@ -2,7 +2,6 @@
 name = "chat"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/composite/programs/composite/Cargo.toml
+++ b/tests/composite/programs/composite/Cargo.toml
@@ -2,7 +2,6 @@
 name = "composite"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/custom-coder/programs/native-system/Cargo.toml
+++ b/tests/custom-coder/programs/native-system/Cargo.toml
@@ -2,7 +2,6 @@
 name = "native-system"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/custom-coder/programs/spl-token/Cargo.toml
+++ b/tests/custom-coder/programs/spl-token/Cargo.toml
@@ -2,7 +2,6 @@
 name = "spl-token"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/declare-program/programs/declare-program/Cargo.toml
+++ b/tests/declare-program/programs/declare-program/Cargo.toml
@@ -2,7 +2,6 @@
 name = "declare-program"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/declare-program/programs/external/Cargo.toml
+++ b/tests/declare-program/programs/external/Cargo.toml
@@ -2,7 +2,6 @@
 name = "external"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/errors/programs/errors/Cargo.toml
+++ b/tests/errors/programs/errors/Cargo.toml
@@ -2,7 +2,6 @@
 name = "errors"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/escrow/programs/escrow/Cargo.toml
+++ b/tests/escrow/programs/escrow/Cargo.toml
@@ -2,7 +2,6 @@
 name = "escrow"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/events/programs/events/Cargo.toml
+++ b/tests/events/programs/events/Cargo.toml
@@ -2,7 +2,6 @@
 name = "events"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/idl/programs/docs/Cargo.toml
+++ b/tests/idl/programs/docs/Cargo.toml
@@ -2,7 +2,6 @@
 name = "docs"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/idl/programs/new-idl/Cargo.toml
+++ b/tests/idl/programs/new-idl/Cargo.toml
@@ -2,7 +2,6 @@
 name = "new-idl"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/idl/programs/relations-derivation/Cargo.toml
+++ b/tests/idl/programs/relations-derivation/Cargo.toml
@@ -2,7 +2,6 @@
 name = "relations-derivation"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/ido-pool/programs/ido-pool/Cargo.toml
+++ b/tests/ido-pool/programs/ido-pool/Cargo.toml
@@ -2,7 +2,6 @@
 name = "ido-pool"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/lockup/programs/lockup/Cargo.toml
+++ b/tests/lockup/programs/lockup/Cargo.toml
@@ -2,7 +2,6 @@
 name = "lockup"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/lockup/programs/registry/Cargo.toml
+++ b/tests/lockup/programs/registry/Cargo.toml
@@ -2,7 +2,6 @@
 name = "registry"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/misc/programs/misc-optional/Cargo.toml
+++ b/tests/misc/programs/misc-optional/Cargo.toml
@@ -2,7 +2,6 @@
 name = "misc-optional"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.56"
 edition = "2021"
 
 [lib]

--- a/tests/misc/programs/misc/Cargo.toml
+++ b/tests/misc/programs/misc/Cargo.toml
@@ -2,7 +2,6 @@
 name = "misc"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/misc/programs/remaining-accounts/Cargo.toml
+++ b/tests/misc/programs/remaining-accounts/Cargo.toml
@@ -2,7 +2,6 @@
 name = "remaining-accounts"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/misc/programs/shared/Cargo.toml
+++ b/tests/misc/programs/shared/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared"
 version = "0.1.0"
-rust-version = "1.60"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/multisig/programs/multisig/Cargo.toml
+++ b/tests/multisig/programs/multisig/Cargo.toml
@@ -2,7 +2,6 @@
 name = "multisig"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/pda-derivation/programs/pda-derivation/Cargo.toml
+++ b/tests/pda-derivation/programs/pda-derivation/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pda-derivation"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/pyth/programs/pyth/Cargo.toml
+++ b/tests/pyth/programs/pyth/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pyth"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/relations-derivation/programs/relations-derivation/Cargo.toml
+++ b/tests/relations-derivation/programs/relations-derivation/Cargo.toml
@@ -2,7 +2,6 @@
 name = "relations-derivation"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/spl/metadata/programs/metadata/Cargo.toml
+++ b/tests/spl/metadata/programs/metadata/Cargo.toml
@@ -2,7 +2,6 @@
 name = "metadata"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/spl/token-extensions/programs/token-extensions/Cargo.toml
+++ b/tests/spl/token-extensions/programs/token-extensions/Cargo.toml
@@ -2,7 +2,6 @@
 name = "token-extensions"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
+++ b/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
@@ -2,7 +2,6 @@
 name = "token-proxy"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
+++ b/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
@@ -2,7 +2,6 @@
 name = "token-wrapper"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
+++ b/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
@@ -2,7 +2,6 @@
 name = "transfer-hook"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/swap/programs/swap/Cargo.toml
+++ b/tests/swap/programs/swap/Cargo.toml
@@ -2,7 +2,6 @@
 name = "swap"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/system-accounts/programs/system-accounts/Cargo.toml
+++ b/tests/system-accounts/programs/system-accounts/Cargo.toml
@@ -2,7 +2,6 @@
 name = "system-accounts"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/sysvars/programs/sysvars/Cargo.toml
+++ b/tests/sysvars/programs/sysvars/Cargo.toml
@@ -2,7 +2,6 @@
 name = "sysvars"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/tictactoe/programs/tictactoe/Cargo.toml
+++ b/tests/tictactoe/programs/tictactoe/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tictactoe"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/typescript/programs/shared/Cargo.toml
+++ b/tests/typescript/programs/shared/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared"
 version = "0.1.0"
-rust-version = "1.60"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/typescript/programs/typescript/Cargo.toml
+++ b/tests/typescript/programs/typescript/Cargo.toml
@@ -2,7 +2,6 @@
 name = "typescript"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/zero-copy/programs/shared/Cargo.toml
+++ b/tests/zero-copy/programs/shared/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared"
 version = "0.1.0"
-rust-version = "1.60"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -2,7 +2,6 @@
 name = "zero-copy"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]

--- a/tests/zero-copy/programs/zero-cpi/Cargo.toml
+++ b/tests/zero-copy/programs/zero-cpi/Cargo.toml
@@ -2,7 +2,6 @@
 name = "zero-cpi"
 version = "0.1.0"
 description = "Created with Anchor"
-rust-version = "1.60"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
### Problem

Our [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) heavily depends on what `solana-program` crate uses, and it's mostly redundant when the toolchain is controlled by the Solana installation.

I've originally run into an MSRV related issue in https://github.com/coral-xyz/anchor/pull/2997, and I think it's better to get rid of this specification rather than bumping it.

### Summary of changes

Remove all `rust-version` fields from crate manifests.