### PR TITLE
cli: Add `idl convert` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add additional solana arguments to the `upgrade` command ([#2998](https://github.com/coral-xyz/anchor/pull/2998)).
 - spl: Export `spl-associated-token-account` crate ([#2999](https://github.com/coral-xyz/anchor/pull/2999)).
 - lang: Support legacy IDLs with `declare_program!` ([#2997](https://github.com/coral-xyz/anchor/pull/2997)).
+- cli: Add `idl convert` command ([#3009](https://github.com/coral-xyz/anchor/pull/3009)).
 
 ### Fixes
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ dev = []
 
 [dependencies]
 anchor-client = { path = "../client", version = "0.30.0" }
-anchor-lang-idl = { path = "../idl", features = ["build"], version = "0.1.0" }
+anchor-lang-idl = { path = "../idl", version = "0.1.0", features = ["build", "convert"] }
 anchor-lang = { path = "../lang", version = "0.30.0" }
 anyhow = "1.0.32"
 base64 = "0.21"


### PR DESCRIPTION
### Problem

It's not possible to convert legacy IDLs to the new IDL spec from the CLI.

### Summary of changes

Add `anchor idl convert` command to convert legacy IDLs to the new IDL spec.

### Note

This conversion is aimed at making this transition period smoother when there are both legacy and new IDLs.

The conversion will not/cannot be perfect as the legacy IDLs does not store enough information that can reliably be converted to the new IDL spec. Therefore, it is preferred for old projects that don't want to upgrade Anchor to `0.30` to generate their IDLs using the newest Anchor version, so that everyone else can compose with their programs much easier.