### PR TITLE
cli: Sync program ids on the initial build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Support legacy IDLs with `declare_program!` ([#2997](https://github.com/coral-xyz/anchor/pull/2997)).
 - cli: Add `idl convert` command ([#3009](https://github.com/coral-xyz/anchor/pull/3009)).
 - cli: Add `idl type` command ([#3017](https://github.com/coral-xyz/anchor/pull/3017)).
+- cli: Sync program ids on the initial build ([#3023](https://github.com/coral-xyz/anchor/pull/3023)).
 
 ### Fixes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{get_keypair, is_hidden};
+use crate::{get_keypair, is_hidden, keys_sync};
 use anchor_client::Cluster;
 use anchor_lang_idl::types::Idl;
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -512,6 +512,13 @@ impl Config {
                     .path();
                 if let Some(filename) = p.file_name() {
                     if filename.to_str() == Some("Anchor.toml") {
+                        // Make sure the program id is correct (only on the initial build)
+                        let deploy_dir = p.parent().unwrap().join("target").join("deploy");
+                        if !deploy_dir.exists() {
+                            println!("Updating program ids...");
+                            keys_sync(&ConfigOverride::default(), None)?;
+                        }
+
                         let cfg = Config::from_path(&p)?;
                         return Ok(Some(WithPath::new(cfg, p)));
                     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -517,6 +517,7 @@ impl Config {
                         let deploy_dir = p.parent().unwrap().join("target").join("deploy");
                         if !deploy_dir.exists() && !cfg.programs.contains_key(&Cluster::Localnet) {
                             println!("Updating program ids...");
+                            fs::create_dir_all(deploy_dir)?;
                             keys_sync(&ConfigOverride::default(), None)?;
                             cfg = Config::from_path(&p)?;
                         }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -513,13 +513,14 @@ impl Config {
                 if let Some(filename) = p.file_name() {
                     if filename.to_str() == Some("Anchor.toml") {
                         // Make sure the program id is correct (only on the initial build)
+                        let mut cfg = Config::from_path(&p)?;
                         let deploy_dir = p.parent().unwrap().join("target").join("deploy");
-                        if !deploy_dir.exists() {
+                        if !deploy_dir.exists() && !cfg.programs.contains_key(&Cluster::Localnet) {
                             println!("Updating program ids...");
                             keys_sync(&ConfigOverride::default(), None)?;
+                            cfg = Config::from_path(&p)?;
                         }
 
-                        let cfg = Config::from_path(&p)?;
                         return Ok(Some(WithPath::new(cfg, p)));
                     }
                 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1825,7 +1825,9 @@ fn _build_rust_cwd(
         .join("deploy");
     if !deploy_dir.exists() {
         println!("Updating program ids...");
+        let cwd = std::env::current_dir()?;
         keys_sync(&ConfigOverride::default(), None)?;
+        std::env::set_current_dir(cwd)?;
     }
 
     let subcommand = arch.build_subcommand();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1816,20 +1816,6 @@ fn _build_rust_cwd(
     arch: &ProgramArch,
     cargo_args: Vec<String>,
 ) -> Result<()> {
-    // Make sure the program id is correct (only on the initial build)
-    let deploy_dir = cfg
-        .path()
-        .parent()
-        .ok_or_else(|| anyhow!("Config parent should exist"))?
-        .join("target")
-        .join("deploy");
-    if !deploy_dir.exists() {
-        println!("Updating program ids...");
-        let cwd = std::env::current_dir()?;
-        keys_sync(&ConfigOverride::default(), None)?;
-        std::env::set_current_dir(cwd)?;
-    }
-
     let subcommand = arch.build_subcommand();
     let exit = std::process::Command::new("cargo")
         .arg(subcommand)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1816,6 +1816,18 @@ fn _build_rust_cwd(
     arch: &ProgramArch,
     cargo_args: Vec<String>,
 ) -> Result<()> {
+    // Make sure the program id is correct (only on the initial build)
+    let deploy_dir = cfg
+        .path()
+        .parent()
+        .ok_or_else(|| anyhow!("Config parent should exist"))?
+        .join("target")
+        .join("deploy");
+    if !deploy_dir.exists() {
+        println!("Updating program ids...");
+        keys_sync(&ConfigOverride::default(), None)?;
+    }
+
     let subcommand = arch.build_subcommand();
     let exit = std::process::Command::new("cargo")
         .arg(subcommand)


### PR DESCRIPTION
### Problem

Latest versions of Anchor handles program id declarations automatically if the program is created using `anchor init` or `anchor new`. However, if the user downloads the program from GitHub, they would have to run `anchor keys sync` to update their program id to the correct id, and this causes confusion for new devs as mentioned in https://github.com/coral-xyz/anchor/issues/3022.

### Summary of changes

Sync the program ids automatically on the first ever build (depending on `target/deploy` exists).

Resolves https://github.com/coral-xyz/anchor/issues/3022