### PR TITLE
lang: Include `pubkey!` macro in `prelude`

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -400,7 +400,7 @@ pub mod prelude {
         accounts::signer::Signer, accounts::system_account::SystemAccount,
         accounts::sysvar::Sysvar, accounts::unchecked_account::UncheckedAccount, constant,
         context::Context, context::CpiContext, declare_id, declare_program, emit, err, error,
-        event, program, require, require_eq, require_gt, require_gte, require_keys_eq,
+        event, program, pubkey, require, require_eq, require_gt, require_gte, require_keys_eq,
         require_keys_neq, require_neq,
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,

--- a/tests/idl/programs/idl/src/lib.rs
+++ b/tests/idl/programs/idl/src/lib.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_spl::{token, token_interface};
-use std::str::FromStr;
 
 declare_id!("id11111111111111111111111111111111111111111");
 
@@ -221,7 +220,7 @@ impl Default for State {
             i128_field: i128::MIN / 2 - 10,
             bytes_field: vec![1, 2, 255, 254],
             string_field: String::from("hello"),
-            pubkey_field: Pubkey::from_str("EPZP2wrcRtMxrAPJCXVEQaYD9eH7fH7h12YqKDcd4aS7").unwrap(),
+            pubkey_field: pubkey!("EPZP2wrcRtMxrAPJCXVEQaYD9eH7fH7h12YqKDcd4aS7"),
             vec_field: vec![1, 2, 100, 1000, u64::MAX],
             vec_struct_field: vec![FooStruct::default()],
             option_field: None,


### PR DESCRIPTION
### Problem

`pubkey!` macro added in https://github.com/coral-xyz/anchor/pull/3021 is not included in the `anchor_lang::prelude`.

### Summary of changes

- Add `pubkey!` macro in `anchor_lang::prelude`
- Replace `Pubkey::from_str` to `pubkey!` macro in tests