### PR TITLE
idl: Remove `anchor-syn` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add `idl type` command ([#3017](https://github.com/coral-xyz/anchor/pull/3017)).
 - lang: Add `anchor_lang::pubkey` macro for declaring `Pubkey` const values ([#3021](https://github.com/coral-xyz/anchor/pull/3021)).
 - cli: Sync program ids on the initial build ([#3023](https://github.com/coral-xyz/anchor/pull/3023)).
+- idl: Remove `anchor-syn` dependency ([#3030](https://github.com/coral-xyz/anchor/pull/3030)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
 name = "anchor-lang-idl"
 version = "0.1.0"
 dependencies = [
- "anchor-syn",
  "anyhow",
  "heck 0.3.3",
  "regex",

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -12,7 +12,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-build = ["anchor-syn", "regex"]
+build = ["regex"]
 convert = ["heck", "sha2"]
 
 [dependencies]
@@ -21,7 +21,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # `build` feature only
-anchor-syn = { path = "../lang/syn", version = "0.30.0", optional = true }
 regex = { version = "1", optional = true }
 
 # `convert` feature only


### PR DESCRIPTION
### Problem

The new IDL crate depends on `anchor-syn` (behind `build` feature flag), only to check the safety comments. Ideally, the IDL crate shouldn't depend on any of the other Anchor crates and be a stand-alone crate (as it's versioning is also different).

### Summary of changes

Handle the safety comment checks inside the `#[program]` macro's `idl-build` implementation. This should work fine since we pass the program path as an env variable (https://github.com/coral-xyz/anchor/pull/2946), and we can use that to run the logic with the `idl-build` feature. However, there is one downside: we lose the span information:

**Before:**

```
Error: 
        /program/src/lib.rs:87:8
        Struct field "new_account" is unsafe, but is not documented.
        Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
        See https://www.anchor-lang.com/docs/the-accounts-struct#safety-checks for more information.
```

**After:**

```
error: custom attribute panicked
  --> program/src/lib.rs:11:1
   |
11 | #[program]
   | ^^^^^^^^^^
   |
   = help: message: Safety checks failed: 
                   /program/src/lib.rs:0:0
                   Struct field "new_account" is unsafe, but is not documented.
                   Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
                   See https://www.anchor-lang.com/docs/the-accounts-struct#safety-checks for more information.
                               

error: could not compile `program` (lib test) due to 1 previous error
Error: Building IDL failed
```

The line and column info is set to `0` when we parse the crate inside a proc macro. Not exactly sure why this happens, but I don't think it's that big of a deal since the file name and the account name is still correct. Not planning to change the span info in this PR as it's harmless, and maybe we can make it work in the future?