### PR TITLE
idl: Fix generation with unsupported expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - Remove `rust-version` from crate manifests ([#3000](https://github.com/coral-xyz/anchor/pull/3000)).
 - cli: Fix upgradeable program clones ([#3010](https://github.com/coral-xyz/anchor/pull/3010)).
 - ts: Fix using IDLs that have defined types as generic arguments ([#3016](https://github.com/coral-xyz/anchor/pull/3016)).
+- idl: Fix generation with unsupported expressions ([#3033](https://github.com/coral-xyz/anchor/pull/3033)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -390,7 +390,9 @@ impl SeedPath {
         let seed_str = seed.to_token_stream().to_string();
 
         // Check unsupported cases e.g. `&(account.field + 1).to_le_bytes()`
-        if seed_str.contains(|c: char| matches!(c, '+' | '-' | '*' | '/' | '%' | '^')) {
+        if !seed_str.contains('"')
+            && seed_str.contains(|c: char| matches!(c, '+' | '-' | '*' | '/' | '%' | '^'))
+        {
             return Err(anyhow!("Seed expression not supported: {seed:#?}"));
         }
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -390,7 +390,7 @@ impl SeedPath {
         let seed_str = seed.to_token_stream().to_string();
 
         // Check unsupported cases e.g. `&(account.field + 1).to_le_bytes()`
-        if seed_str.contains(|c: char| !c.is_ascii_alphanumeric()) {
+        if seed_str.contains(|c: char| matches!(c, '+' | '-' | '*' | '/' | '%' | '^')) {
             return Err(anyhow!("Seed expression not supported: {seed:#?}"));
         }
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -389,6 +389,11 @@ impl SeedPath {
         // Convert the seed into the raw string representation.
         let seed_str = seed.to_token_stream().to_string();
 
+        // Check unsupported cases e.g. `&(account.field + 1).to_le_bytes()`
+        if seed_str.contains(|c: char| !c.is_ascii_alphanumeric()) {
+            return Err(anyhow!("Seed expression not supported: {seed:#?}"));
+        }
+
         // Break up the seed into each subfield component.
         let mut components = seed_str.split('.').collect::<Vec<_>>();
         if components.len() <= 1 {

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -42,6 +42,10 @@ pub mod pda_derivation {
     pub fn associated_token_resolution(_ctx: Context<AssociatedTokenResolution>) -> Result<()> {
         Ok(())
     }
+
+    pub fn seed_math_expr(_ctx: Context<SeedMathExpr>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -144,6 +148,14 @@ pub struct AssociatedTokenResolution<'info> {
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
     pub associated_token_program: Program<'info, AssociatedToken>,
+}
+
+#[derive(Accounts)]
+pub struct SeedMathExpr<'info> {
+    #[account(seeds = [b"const"], bump)]
+    pub my_account: Account<'info, MyAccount>,
+    #[account(seeds = [&(my_account.data + 1).to_le_bytes()], bump)]
+    pub math_expr_account: UncheckedAccount<'info>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -112,4 +112,9 @@ describe("typescript", () => {
       .signers([mintKp])
       .rpc();
   });
+
+  // TODO: Support more expressions in the IDL e.g. math operations?
+  it("Can use non-supported expressions", () => {
+    // Compilation test to fix issues like https://github.com/coral-xyz/anchor/issues/2933
+  });
 });

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -61,7 +61,7 @@ describe("typescript", () => {
       program.programId
     )[0];
 
-    const tx = program.methods.initMyAccount(seedA).accounts({
+    const tx = program.methods.initMyAccount(seedA).accountsPartial({
       base: base.publicKey,
       base2: base.publicKey,
       anotherBase: another.publicKey,
@@ -94,7 +94,7 @@ describe("typescript", () => {
     );
     await customProgram.methods
       .initMyAccount(seedA)
-      .accounts({
+      .accountsPartial({
         base: base.publicKey,
         base2: base.publicKey,
         anotherBase: another.publicKey,
@@ -114,7 +114,7 @@ describe("typescript", () => {
   });
 
   // TODO: Support more expressions in the IDL e.g. math operations?
-  it("Can use non-supported expressions", () => {
+  it("Can use unsupported expressions", () => {
     // Compilation test to fix issues like https://github.com/coral-xyz/anchor/issues/2933
   });
 });


### PR DESCRIPTION
### Problem

Some expressions, e.g. math expressions, are not parseable in the IDL, and they cause compile errors during the generation process.

### Summary of changes

Do not parse the seeds that contain non-ASCII-alphanumeric characters.

Resolves https://github.com/coral-xyz/anchor/issues/2933