### PR TITLE
idl: Fix using `address` constraint with field expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix upgradeable program clones ([#3010](https://github.com/coral-xyz/anchor/pull/3010)).
 - ts: Fix using IDLs that have defined types as generic arguments ([#3016](https://github.com/coral-xyz/anchor/pull/3016)).
 - idl: Fix generation with unsupported expressions ([#3033](https://github.com/coral-xyz/anchor/pull/3033)).
+- idl: Fix using `address` constraint with field expressions ([#3034](https://github.com/coral-xyz/anchor/pull/3034)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -161,6 +161,7 @@ fn get_address(acc: &Field) -> TokenStream {
             .address
             .as_ref()
             .map(|constraint| &constraint.address)
+            .filter(|address| !matches!(address, syn::Expr::Field(_)))
             .map(|address| quote! { Some(#address.to_string()) })
             .unwrap_or_else(|| quote! { None }),
     }

--- a/tests/relations-derivation/programs/relations-derivation/src/lib.rs
+++ b/tests/relations-derivation/programs/relations-derivation/src/lib.rs
@@ -16,10 +16,16 @@ pub mod relations_derivation {
         ctx.accounts.account.bump = ctx.bumps.account;
         Ok(())
     }
+
     pub fn test_relation(_ctx: Context<TestRelation>) -> Result<()> {
         Ok(())
     }
+
     pub fn test_seed_constant(_ctx: Context<TestSeedConstant>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn test_address_relation(_ctx: Context<TestAddressRelation>) -> Result<()> {
         Ok(())
     }
 }
@@ -78,6 +84,14 @@ pub struct TestSeedConstant<'info> {
     )]
     account: Account<'info, MyAccount>,
     system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct TestAddressRelation<'info> {
+    #[account(address = my_account.my_account)]
+    account: UncheckedAccount<'info>,
+    #[account(seeds = [b"seed"], bump = my_account.bump)]
+    my_account: Account<'info, MyAccount>,
 }
 
 #[account]

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -44,4 +44,9 @@ describe("typescript", () => {
   it("Can use relations derivation with seed constant", async () => {
     await program.methods.testSeedConstant().accounts({}).rpc();
   });
+
+  it("Can use relations derivation with `address` constraint", () => {
+    // Only compile test for now since the IDL spec doesn't currently support field access
+    // expressions for the `address` constraint
+  });
 });


### PR DESCRIPTION
### Problem

Using `address = <ACCOUNT>.<FIELD>` does not compile with the current IDL generation as explained in https://github.com/coral-xyz/anchor/issues/2912.

### Summary of changes

Skip including `address` field in the IDL if field access expression is being used with the `address constraint`.

Note that using `has_one` should be preferred (like I mentioned in https://github.com/coral-xyz/anchor/issues/2912#issuecomment-2061172476) as it also supports automatic resolution.

Resolves https://github.com/coral-xyz/anchor/issues/2912