### PR TITLE
idl: Add separate spec crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Sync program ids on the initial build ([#3023](https://github.com/coral-xyz/anchor/pull/3023)).
 - idl: Remove `anchor-syn` dependency ([#3030](https://github.com/coral-xyz/anchor/pull/3030)).
 - lang: Add `const` of program ID to `declare_id!` and `declare_program!` ([#3019](https://github.com/coral-xyz/anchor/pull/3019)).
+- idl: Add separate spec crate ([#3036](https://github.com/coral-xyz/anchor/pull/3036)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,12 +291,21 @@ dependencies = [
 name = "anchor-lang-idl"
 version = "0.1.0"
 dependencies = [
+ "anchor-lang-idl-spec",
  "anyhow",
  "heck 0.3.3",
  "regex",
  "serde",
  "serde_json",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "anchor-lang-idl-spec"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
 ]
 
 [[package]]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -8,6 +8,7 @@ use crate::config::{
 use anchor_client::Cluster;
 use anchor_lang::idl::{IdlAccount, IdlInstruction, ERASED_AUTHORITY};
 use anchor_lang::{AccountDeserialize, AnchorDeserialize, AnchorSerialize};
+use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
 use checks::{check_anchor_version, check_overflow};
@@ -2734,7 +2735,7 @@ fn idl_fetch(cfg_override: &ConfigOverride, address: Pubkey, out: Option<String>
 
 fn idl_convert(path: String, out: Option<String>) -> Result<()> {
     let idl = fs::read(path)?;
-    let idl = Idl::from_slice_with_conversion(&idl)?;
+    let idl = convert_idl(&idl)?;
     let out = match out {
         None => OutFile::Stdout,
         Some(out) => OutFile::File(PathBuf::from(out)),
@@ -2744,7 +2745,7 @@ fn idl_convert(path: String, out: Option<String>) -> Result<()> {
 
 fn idl_type(path: String, out: Option<String>) -> Result<()> {
     let idl = fs::read(path)?;
-    let idl = Idl::from_slice_with_conversion(&idl)?;
+    let idl = convert_idl(&idl)?;
     let types = idl_ts(&idl)?;
     match out {
         Some(out) => fs::write(out, types)?,

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -16,6 +16,7 @@ build = ["regex"]
 convert = ["heck", "sha2"]
 
 [dependencies]
+anchor-lang-idl-spec = { path = "./spec", version = "0.1.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/idl/spec/Cargo.toml
+++ b/idl/spec/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "anchor-lang-idl-spec"
+version = "0.1.0"
+authors = ["Anchor Maintainers <accounts@200ms.io>"]
+repository = "https://github.com/coral-xyz/anchor"
+edition = "2021"
+license = "Apache-2.0"
+description = "Anchor framework IDL spec"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -309,6 +309,7 @@ pub enum IdlType {
     Generic(String),
 }
 
+// TODO: Move to utils crate
 impl FromStr for IdlType {
     type Err = anyhow::Error;
 

--- a/idl/src/lib.rs
+++ b/idl/src/lib.rs
@@ -1,12 +1,12 @@
 //! Anchor IDL.
 
-pub mod types;
-
 #[cfg(feature = "build")]
 pub mod build;
 
 #[cfg(feature = "convert")]
 pub mod convert;
+
+pub use anchor_lang_idl_spec as types;
 
 #[cfg(feature = "build")]
 pub use serde_json;

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -1,7 +1,7 @@
 mod common;
 mod mods;
 
-use anchor_lang_idl::types::Idl;
+use anchor_lang_idl::{convert::convert_idl, types::Idl};
 use anyhow::anyhow;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
@@ -45,7 +45,7 @@ fn get_idl(name: &syn::Ident) -> anyhow::Result<Idl> {
         .map(|idl_dir| idl_dir.join(name.to_string()).with_extension("json"))
         .map(std::fs::read)?
         .map_err(|e| anyhow!("Failed to read IDL `{name}`: {e}"))
-        .map(|buf| Idl::from_slice_with_conversion(&buf))?
+        .map(|buf| convert_idl(&buf))?
 }
 
 fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {


### PR DESCRIPTION
### Problem

Making changes to the IDL crate, e.g. adding features such as the [`convert`](https://github.com/coral-xyz/anchor/pull/2986) feature, would require bumping the version even if the spec itself doesn't change. We essentially have two options to fix this:

- Remove the patch version from the `spec` field i.e. use `0.1` instead of `0.1.0` so that patch changes to the IDL crate version does not affect the `spec` field
- Add a new `spec` crate that only contains the IDL type specification so that the crate only gets a new version when there is an actual spec change

While both options seems viable, combined with the reasons explained in https://github.com/coral-xyz/anchor/pull/2901, the latter option seems to be more suitable.

### Summary of changes

Add a separate `anchor-lang-idl-spec` crate that only contains the IDL type specification, and re-export it from the main IDL crate to keep backwards compatibility.