### PR TITLE
fix: correct unsafe bytemuck trait path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Fix using IDLs that have defined types as generic arguments ([#3016](https://github.com/coral-xyz/anchor/pull/3016)).
 - idl: Fix generation with unsupported expressions ([#3033](https://github.com/coral-xyz/anchor/pull/3033)).
 - idl: Fix using `address` constraint with field expressions ([#3034](https://github.com/coral-xyz/anchor/pull/3034)).
+- lang: Fix using `bytemuckunsafe` account serialization with `declare_program!` ([#3037](https://github.com/coral-xyz/anchor/pull/3037)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -62,8 +62,8 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
                         matches!(ty_def.serialization, IdlSerialization::BytemuckUnsafe)
                             .then(|| {
                                 quote! {
-                                    unsafe impl anchor_lang::__private::Pod for #name {}
-                                    unsafe impl anchor_lang::__private::Zeroable for #name {}
+                                    unsafe impl anchor_lang::__private::bytemuck::Pod for #name {}
+                                    unsafe impl anchor_lang::__private::bytemuck::Zeroable for #name {}
                                 }
                             })
                             .unwrap_or_default();


### PR DESCRIPTION
Problem: Implementation for "bytemuckunsafe" serialization uses incorrect import trait path, causing declare_program! to fail for IDLs using "serialization": "bytemuckunsafe".

This PR uses the correct path