### PR TITLE
idl: Make safety comment checks fail silently when program path env is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- idl: Make safety comment checks fail silently when program path env is not set ([#3045](https://github.com/coral-xyz/anchor/pull/3045])).
+
 ### Breaking
 
 ## [0.30.1] - 2024-06-20

--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -22,6 +22,11 @@ pub fn get_no_docs() -> bool {
         .unwrap_or_default()
 }
 
+pub fn get_program_path() -> Result<String> {
+    std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH")
+        .map_err(|_| anyhow!("Failed to get program path"))
+}
+
 pub fn get_idl_module_path() -> TokenStream {
     quote!(anchor_lang::idl::types)
 }

--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -22,8 +22,9 @@ pub fn get_no_docs() -> bool {
         .unwrap_or_default()
 }
 
-pub fn get_program_path() -> Result<String> {
+pub fn get_program_path() -> Result<PathBuf> {
     std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH")
+        .map(PathBuf::from)
         .map_err(|_| anyhow!("Failed to get program path"))
 }
 

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use cargo_toml::Manifest;
 use quote::ToTokens;
 
-use super::common::find_path;
+use super::common::{find_path, get_program_path};
 use crate::parser::context::CrateContext;
 
 pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<syn::Type>> {
@@ -17,8 +17,7 @@ pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<sy
         .ok_or_else(|| anyhow!("`{name}` not found in use statements"))?;
 
     // Get crate name and version from lock file
-    let program_path =
-        std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH").expect("Failed to get program path");
+    let program_path = get_program_path()?;
     let lock_path = find_path("Cargo.lock", program_path)?;
     let lock_file = parse_lock_file(lock_path)?;
     let registry_path = get_registry_path()?;

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -6,7 +6,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::{
-    common::{gen_print_section, get_idl_module_path, get_no_docs},
+    common::{gen_print_section, get_idl_module_path, get_no_docs, get_program_path},
     defined::gen_idl_type,
 };
 use crate::{
@@ -156,10 +156,27 @@ fn check_safety_comments() -> Result<()> {
         return Ok(());
     }
 
-    std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH")
+    let program_path = get_program_path();
+    if program_path.is_err() {
+        // Getting the program path can fail in the following scenarios:
+        //
+        // - Anchor CLI version is incompatible with the current version
+        // - The error is coming from Rust Analyzer when the user has `idl-build` feature enabled,
+        // likely due to enabling all features (https://github.com/coral-xyz/anchor/issues/3042)
+        //
+        // For the first case, we have a warning when the user is using different versions of the
+        // lang and CLI crate. For the second case, users would either have to disable the
+        // `idl-build` feature, or define the program path environment variable in Rust Analyzer
+        // settings.
+        //
+        // Given this feature is not a critical one, and it works by default with `anchor build`,
+        // we can fail silently in the case of an error rather than panicking.
+        return Ok(());
+    }
+
+    program_path
         .map(PathBuf::from)
         .map(|path| path.join("src").join("lib.rs"))
-        .map_err(|_| anyhow!("Failed to get program path"))
         .map(CrateContext::parse)?
         .map_err(|e| anyhow!("Failed to parse crate: {e}"))?
         .safety_checks()

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::{anyhow, Result};
 use heck::CamelCase;
 use proc_macro2::TokenStream;
@@ -175,7 +173,6 @@ fn check_safety_comments() -> Result<()> {
     }
 
     program_path
-        .map(PathBuf::from)
         .map(|path| path.join("src").join("lib.rs"))
         .map(CrateContext::parse)?
         .map_err(|e| anyhow!("Failed to parse crate: {e}"))?


### PR DESCRIPTION
### Problem

IDL generation expects `ANCHOR_IDL_BUILD_PROGRAM_PATH` environment variable to be set, but if the user is using Rust Analyzer with all features enabled, they will run into a panic due the environment variable not being set as described in https://github.com/coral-xyz/anchor/issues/3042.

### Summary of changes

Make safety comment checks fail silently when the `ANCHOR_IDL_BUILD_PROGRAM_PATH` environment variable is not set.

Note that the checks still work as expected, this is only to improve an LSP related issue.

Resolves https://github.com/coral-xyz/anchor/issues/3042