### PR TITLE
docs: Reverse the order of release notes

### DIFF
--- a/docs/src/pages/_app.jsx
+++ b/docs/src/pages/_app.jsx
@@ -27,9 +27,9 @@ const navigation = [
   {
     title: 'Release Notes',
     links: [
-      { title: '0.29.0', href: '/release-notes/0.29.0' },
-      { title: '0.30.0', href: '/release-notes/0.30.0' },
       { title: '0.30.1', href: '/release-notes/0.30.1' },
+      { title: '0.30.0', href: '/release-notes/0.30.0' },
+      { title: '0.29.0', href: '/release-notes/0.29.0' },
       { title: 'CHANGELOG', href: '/release-notes/changelog' },
     ],
   },


### PR DESCRIPTION
### Problem

Release notes in our docs show the latest release at the bottom:

![image](https://github.com/coral-xyz/anchor/assets/98934430/7f440ce4-3a34-4d07-b75b-388edf2a68dc)

### Summary of changes

Reverse the order of release notes and show the latest release at the top.