### PR TITLE
fix: avoid interference from rust tests during IDL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- idl: Make safety comment checks fail silently when program path env is not set ([#3045](https://github.com/coral-xyz/anchor/pull/3045])).
+- idl: Make safety comment checks fail silently when program path env is not set ([#3045](https://github.com/coral-xyz/anchor/pull/3045)).
+- idl: Avoid interference from rust tests during IDL generation ([#3058](https://github.com/coral-xyz/anchor/pull/3058)).
 
 ### Breaking
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -130,7 +130,9 @@ fn build(program_path: &Path, resolution: bool, skip_lint: bool, no_docs: bool) 
                 "--- IDL begin errors ---" => state = State::Errors(vec![]),
                 "--- IDL begin program ---" => state = State::Program(vec![]),
                 _ => {
-                    if line.starts_with("test result: ok") {
+                    if line.starts_with("test result: ok")
+                        && !line.starts_with("test result: ok. 0 passed; 0 failed; 0")
+                    {
                         if let Some(idl) = idl.as_mut() {
                             idl.address = mem::take(&mut address);
                             idl.constants = mem::take(&mut constants);


### PR DESCRIPTION
### Problem

The test result/summary line from `cargo test` is used as delimiter to assign the content of the different IDL sections to the final idl variable.
However that delimiter check is currently too loose and leads to some of the IDL sections being wiped when rust tests are present in the program crate.

### Solution

This PR tightens the delimiter check to exclude other test results from wiping those sections.
