### PR TITLE
cli: Add checks for incorrect usage of `idl-build` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 - ts: Add optional `commitment` parameter to `Program.addEventListener` ([#3052](https://github.com/coral-xyz/anchor/pull/3052)).
-- cli: Pass "cargo args" to idl generation when building program or idl ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
+- cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
+- cli: Add checks for incorrect usage of `idl-build` feature ([#3061](https://github.com/coral-xyz/anchor/pull/3061)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -80,3 +80,25 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
 
     Ok(())
 }
+
+/// Check whether the `idl-build` feature is being used correctly.
+///
+/// **Note:** The check expects the current directory to be a program directory.
+pub fn check_idl_build_feature() -> Result<()> {
+    Manifest::from_path("Cargo.toml")?
+        .dependencies
+        .iter()
+        .filter(|(_, dep)| dep.req_features().contains(&"idl-build".into()))
+        .for_each(|(name, _)| {
+            eprintln!(
+                "WARNING: `idl-build` feature of crate `{name}` is enabled by default. \
+                    This is not the intended usage.\n\n\t\
+                    To solve, do not enable the `idl-build` feature and include crates that have \
+                    `idl-build` feature in the `idl-build` feature list:\n\n\t\
+                    [features]\n\t\
+                    idl-build = [\"{name}/idl-build\", ...]\n"
+            )
+        });
+
+    Ok(())
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,7 +11,7 @@ use anchor_lang::{AccountDeserialize, AnchorDeserialize, AnchorSerialize};
 use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
-use checks::{check_anchor_version, check_overflow};
+use checks::{check_anchor_version, check_idl_build_feature, check_overflow};
 use clap::Parser;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
@@ -1819,9 +1819,10 @@ fn _build_rust_cwd(
     arch: &ProgramArch,
     cargo_args: Vec<String>,
 ) -> Result<()> {
-    let subcommand = arch.build_subcommand();
+    check_idl_build_feature().ok();
+
     let exit = std::process::Command::new("cargo")
-        .arg(subcommand)
+        .arg(arch.build_subcommand())
         .args(cargo_args.clone())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -1830,6 +1831,7 @@ fn _build_rust_cwd(
     if !exit.status.success() {
         std::process::exit(exit.status.code().unwrap_or(1));
     }
+
     // Generate IDL
     if !no_idl {
         let idl = generate_idl(cfg, skip_lint, no_docs, &cargo_args)?;


### PR DESCRIPTION
### Problem

People sometimes incorrectly enable `idl-build` feature by default e.g.

```toml
[dependencies]
anchor-lang = { version = "0.30.1", features = ["idl-build"] }
```

This is not the intended usage, as it results in unnecessary compilation and unrelated stack errors.

### Summary of changes

Add a warning in CLI that specifically checks for the above case, and show how to fix it:

```
WARNING: `idl-build` feature of crate `anchor-lang` is enabled by default. This is not the intended usage.

        To solve, do not enable the `idl-build` feature and include crates that have `idl-build` feature in the `idl-build` feature list:

        [features]
        idl-build = ["anchor-lang/idl-build", ...]
```