### PR TITLE
tests: Move constant seed derivation test to `pda-derivation`

### DIFF
--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -12,6 +12,7 @@ use anchor_spl::{
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub const MY_SEED: [u8; 2] = *b"hi";
+pub const MY_SEED_BYTES: &[u8] = b"hi";
 pub const MY_SEED_STR: &str = "hi";
 pub const MY_SEED_U8: u8 = 1;
 pub const MY_SEED_U32: u32 = 2;
@@ -36,6 +37,10 @@ pub mod pda_derivation {
 
     pub fn init_my_account(ctx: Context<InitMyAccount>, _seed_a: u8) -> Result<()> {
         ctx.accounts.account.data = 1337;
+        Ok(())
+    }
+
+    pub fn test_seed_constant(_ctx: Context<TestSeedConstant>) -> Result<()> {
         Ok(())
     }
 
@@ -125,6 +130,21 @@ pub struct Nested<'info> {
     )]
     /// CHECK: Not needed
     account_nested: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct TestSeedConstant<'info> {
+    #[account(mut)]
+    my_account: Signer<'info>,
+    #[account(
+      init,
+      payer = my_account,
+      seeds = [MY_SEED_BYTES],
+      space = 100,
+      bump,
+    )]
+    account: Account<'info, MyAccount>,
+    system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -104,6 +104,10 @@ describe("typescript", () => {
     expect(called).is.true;
   });
 
+  it("Can use constant seed ref", async () => {
+    await program.methods.testSeedConstant().rpc();
+  });
+
   it("Can resolve associated token accounts", async () => {
     const mintKp = anchor.web3.Keypair.generate();
     await program.methods

--- a/tests/relations-derivation/programs/relations-derivation/src/lib.rs
+++ b/tests/relations-derivation/programs/relations-derivation/src/lib.rs
@@ -5,8 +5,6 @@ use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
-pub const SEED: &[u8] = b"contant-seed";
-
 #[program]
 pub mod relations_derivation {
     use super::*;
@@ -18,10 +16,6 @@ pub mod relations_derivation {
     }
 
     pub fn test_relation(_ctx: Context<TestRelation>) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn test_seed_constant(_ctx: Context<TestSeedConstant>) -> Result<()> {
         Ok(())
     }
 
@@ -69,21 +63,6 @@ pub struct TestRelation<'info> {
     )]
     account: Account<'info, MyAccount>,
     nested: Nested<'info>,
-}
-
-#[derive(Accounts)]
-pub struct TestSeedConstant<'info> {
-    #[account(mut)]
-    my_account: Signer<'info>,
-    #[account(
-      init,
-      payer = my_account,
-      seeds = [SEED],
-      space = 100,
-      bump,
-    )]
-    account: Account<'info, MyAccount>,
-    system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -41,10 +41,6 @@ describe("typescript", () => {
     await tx.rpc();
   });
 
-  it("Can use relations derivation with seed constant", async () => {
-    await program.methods.testSeedConstant().accounts({}).rpc();
-  });
-
   it("Can use relations derivation with `address` constraint", () => {
     // Only compile test for now since the IDL spec doesn't currently support field access
     // expressions for the `address` constraint


### PR DESCRIPTION
### Problem

[This](https://github.com/coral-xyz/anchor/blob/f7916d415997a2c5409ec2bb1638059a01359541/tests/relations-derivation/programs/relations-derivation/src/lib.rs#L74-L87) test incorrectly lives in [`relations-derivation`](https://github.com/coral-xyz/anchor/tree/f7916d415997a2c5409ec2bb1638059a01359541/tests/relations-derivation) tests.

### Summary of changes

Move the test inside [`pda-derivation`](https://github.com/coral-xyz/anchor/tree/f7916d415997a2c5409ec2bb1638059a01359541/tests/pda-derivation) where it belongs.