### PR TITLE
Fix false positives when using `version-bump.sh` script

### DIFF
--- a/idl/src/convert.rs
+++ b/idl/src/convert.rs
@@ -6,7 +6,7 @@ use crate::types::Idl;
 /// `idl.metadata.spec` field.
 ///
 /// If `spec` field is not specified, the conversion will fallback to the legacy IDL spec
-/// (pre Anchor v0.30.1).
+/// (pre Anchor v0.30).
 ///
 /// **Note:** For legacy IDLs, `idl.metadata.address` field is required to be populated with
 /// program's address otherwise an error will be returned.
@@ -27,7 +27,7 @@ pub fn convert_idl(idl: &[u8]) -> Result<Idl> {
     }
 }
 
-/// Legacy IDL spec (pre Anchor v0.30.1)
+/// Legacy IDL spec (pre Anchor v0.30)
 mod legacy {
     use crate::types as t;
     use anyhow::{anyhow, Result};

--- a/version-bump.sh
+++ b/version-bump.sh
@@ -18,25 +18,23 @@ case "$(uname)" in
   Darwin*) sedi=(-i "")
 esac
 
-# Don't replace version with the following globs
-skip_globs=":!**/yarn.lock :!Cargo.lock :!package.json :!tests/bench/bench.json :!bench/*.md"
-
-git grep -l $(cat VERSION) -- $skip_globs |
+# Only replace version with the following globs
+allow_globs=":**/Cargo.toml **/Makefile docs/src/pages/docs/*.md client/src/lib.rs"
+git grep -l $(cat VERSION) -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$(cat VERSION)/$version/g"
 
-# Potential for collisions in package.json files, handle those separately
+# Potential for collisions in `package.json` files, handle those separately
 # Replace only matching "version": "x.xx.x" and "@coral-xyz/anchor": "x.xx.x"
-git grep -l $(cat VERSION) -- '**/package.json' | \
+git grep -l $(cat VERSION) -- "**/package.json" | \
     xargs sed "${sedi[@]}" \
     -e "s/@coral-xyz\/anchor\": \"$(cat VERSION)\"/@coral-xyz\/anchor\": \"$version\"/g" \
     -e "s/\"version\": \"$(cat VERSION)\"/\"version\": \"$version\"/g"
 
-# Potential for collisions in Cargo.lock, use cargo update to update it
-cargo update --workspace
-
-# Insert version number into CHANGELOG.md
-sed "${sedi[@]}" -e "s/## \[Unreleased\]/## [Unreleased]\n\n## [$version] - $(date '+%Y-%m-%d')/g" CHANGELOG.md
+# Insert version number into CHANGELOG
+sed "${sedi[@]}" -e \
+    "s/## \[Unreleased\]/## [Unreleased]\n\n### Features\n\n### Fixes\n\n### Breaking\n\n## [$version] - $(date '+%Y-%m-%d')/g" \
+    CHANGELOG.md
 
 pushd ts && yarn && popd
 pushd tests && yarn && popd


### PR DESCRIPTION
### Problem

Running [`version-bump.sh`](https://github.com/coral-xyz/anchor/blob/e68b96f45480d7fa9dec1ac1137687e92d297775/version-bump.sh) makes a lot of incorrect updates in various files.

### Summary of changes

- Change the lookup glob to explicitly allow only the required paths rather than using a skip logic
- Add "Features", "Fixes" and "Breaking" section to the `Unreleased` version in CHANGELOG
- Revert a false positive update from the last version bump (https://github.com/coral-xyz/anchor/pull/3040)