### PR TITLE
lang: Remove `getrandom` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Avoid interference from rust tests during IDL generation ([#3058](https://github.com/coral-xyz/anchor/pull/3058)).
 - lang: Fix `align` repr support in `declare-program!` ([#3056](https://github.com/coral-xyz/anchor/pull/3056)).
 - lang: Make stack frames slimmer on ATA creation ([#3065](https://github.com/coral-xyz/anchor/pull/3065)).
+- lang: Remove `getrandom` dependency ([#3072](https://github.com/coral-xyz/anchor/pull/3072)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,6 @@ dependencies = [
  "bincode",
  "borsh 0.10.3",
  "bytemuck",
- "getrandom 0.2.10",
  "solana-program",
  "thiserror",
 ]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -58,5 +58,3 @@ borsh = ">=0.9, <0.11"
 bytemuck = "1"
 solana-program = "1.17.3"
 thiserror = "1"
-# TODO: Remove. This crate has been added to fix a build error with the 1.16.0 release.
-getrandom = { version = "0.2", features = ["custom"] }


### PR DESCRIPTION
### Problem

[`getrandom`](https://github.com/rust-random/getrandom) dependency was added in https://github.com/coral-xyz/anchor/pull/2512 to fix a problem related to Solana v1.16 release. The issue has been fixed upstream, and we don't support Solana v1.16 anymore.

### Summary of changes

Remove the `getrandom` dependency.