### PR TITLE
lang: Export `Discriminator` trait from `prelude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Add optional `commitment` parameter to `Program.addEventListener` ([#3052](https://github.com/coral-xyz/anchor/pull/3052)).
 - cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
 - cli: Add checks for incorrect usage of `idl-build` feature ([#3061](https://github.com/coral-xyz/anchor/pull/3061)).
+- lang: Export `Discriminator` trait from `prelude` ([#3075](https://github.com/coral-xyz/anchor/pull/3075)).
 
 ### Fixes
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -404,8 +404,9 @@ pub mod prelude {
         require_keys_neq, require_neq,
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
-        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Id, InitSpace, Key,
-        Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Discriminator, Id,
+        InitSpace, Key, Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos,
+        ToAccountMetas,
     };
     pub use anchor_attribute_error::*;
     pub use borsh;

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -65,8 +65,6 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 sighash
             };
 
-
-            use anchor_lang::Discriminator;
             match sighash {
                 #(#global_dispatch_arms)*
                 anchor_lang::idl::IDL_IX_TAG_LE => {

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -127,7 +127,7 @@ pub fn gen_idl_build_impl_accounts_struct(accounts: &AccountsStruct) -> TokenStr
                     if let Some(ty) = <#defined>::create_type() {
                         let account = #idl::IdlAccount {
                             name: ty.name.clone(),
-                            discriminator: <#defined as anchor_lang::Discriminator>::DISCRIMINATOR.into(),
+                            discriminator: #defined::DISCRIMINATOR.into(),
                         };
                         accounts.insert(account.name.clone(), account);
                         types.insert(ty.name.clone(), ty);

--- a/lang/syn/src/idl/event.rs
+++ b/lang/syn/src/idl/event.rs
@@ -61,7 +61,7 @@ fn impl_idl_build_event(event_struct: &syn::ItemStruct) -> TokenStream {
             let ty = #ts;
             let event = #idl::IdlEvent {
                 name: ty.name.clone(),
-                discriminator: <Self as anchor_lang::Discriminator>::DISCRIMINATOR.into(),
+                discriminator: Self::DISCRIMINATOR.into(),
             };
             types.insert(ty.name.clone(), ty);
             Some(event)

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -32,9 +32,6 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
             let name = ix.ident.to_string();
             let name_pascal = format_ident!("{}", name.to_camel_case());
             let ctx_ident = &ix.anchor_ident;
-            let discriminator = quote! {
-                <crate::instruction::#name_pascal as anchor_lang::Discriminator>::DISCRIMINATOR
-            };
 
             let docs = match &ix.docs {
                 Some(docs) if !no_docs => quote! { vec![#(#docs.into()),*] },
@@ -80,7 +77,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                     #idl::IdlInstruction {
                         name: #name.into(),
                         docs: #docs,
-                        discriminator: #discriminator.into(),
+                        discriminator: crate::instruction::#name_pascal::DISCRIMINATOR.into(),
                         accounts: #ctx_ident::__anchor_private_gen_idl_accounts(
                             &mut accounts,
                             &mut types,


### PR DESCRIPTION
### Problem

[`Discriminator`](https://github.com/coral-xyz/anchor/blob/59ee310cfa18524e7449db73604db21b0e04780c/lang/src/lib.rs#L312) trait is required to be in scope to get access to the data type's discriminator, but it requires manually importing the trait because it's not exported from `prelude`.

### Summary of changes

- Export `Discriminator` trait from `prelude`
- Remove redundant `Discriminator` trait import in codegen
- Remove full paths for the `Discriminator` trait from IDL's `discriminator` field generation