### PR TITLE
Rename metadata interface ix fields from `token_program_id` to `program_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Require `Discriminator` trait impl when using the `zero` constraint ([#3118](https://github.com/coral-xyz/anchor/pull/3118)).
 - ts: Remove `DISCRIMINATOR_SIZE` constant ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
 - lang: `#[account]` attribute arguments no longer parses identifiers as namespaces ([#3140](https://github.com/coral-xyz/anchor/pull/3140)).
+- spl: Rename metadata interface instruction fields from `token_program_id` to `program_id` ([3076](https://github.com/coral-xyz/anchor/pull/3076)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/spl/src/token_2022_extensions/token_group.rs
+++ b/spl/src/token_2022_extensions/token_group.rs
@@ -9,7 +9,7 @@ pub fn token_group_initialize<'info>(
     max_size: u32,
 ) -> Result<()> {
     let ix = spl_token_group_interface::instruction::initialize_group(
-        ctx.accounts.token_program_id.key,
+        ctx.accounts.program_id.key,
         ctx.accounts.group.key,
         ctx.accounts.mint.key,
         ctx.accounts.mint_authority.key,
@@ -19,7 +19,7 @@ pub fn token_group_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
+            ctx.accounts.program_id,
             ctx.accounts.group,
             ctx.accounts.mint,
             ctx.accounts.mint_authority,
@@ -31,7 +31,7 @@ pub fn token_group_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenGroupInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
+    pub program_id: AccountInfo<'info>,
     pub group: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
@@ -41,7 +41,7 @@ pub fn token_member_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TokenMemberInitialize<'info>>,
 ) -> Result<()> {
     let ix = spl_token_group_interface::instruction::initialize_member(
-        ctx.accounts.token_program_id.key,
+        ctx.accounts.program_id.key,
         ctx.accounts.member.key,
         ctx.accounts.member_mint.key,
         ctx.accounts.member_mint_authority.key,
@@ -51,7 +51,7 @@ pub fn token_member_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
+            ctx.accounts.program_id,
             ctx.accounts.member,
             ctx.accounts.member_mint,
             ctx.accounts.member_mint_authority,
@@ -65,7 +65,7 @@ pub fn token_member_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMemberInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
+    pub program_id: AccountInfo<'info>,
     pub member: AccountInfo<'info>,
     pub member_mint: AccountInfo<'info>,
     pub member_mint_authority: AccountInfo<'info>,

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -13,7 +13,7 @@ pub fn token_metadata_initialize<'info>(
     uri: String,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        ctx.accounts.program_id.key,
         ctx.accounts.metadata.key,
         ctx.accounts.update_authority.key,
         ctx.accounts.mint.key,
@@ -25,7 +25,7 @@ pub fn token_metadata_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
+            ctx.accounts.program_id,
             ctx.accounts.metadata,
             ctx.accounts.update_authority,
             ctx.accounts.mint,
@@ -38,7 +38,7 @@ pub fn token_metadata_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
+    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
@@ -50,7 +50,7 @@ pub fn token_metadata_update_authority<'info>(
     new_authority: OptionalNonZeroPubkey,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::update_authority(
-        ctx.accounts.token_program_id.key,
+        ctx.accounts.program_id.key,
         ctx.accounts.metadata.key,
         ctx.accounts.current_authority.key,
         new_authority,
@@ -58,7 +58,7 @@ pub fn token_metadata_update_authority<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
+            ctx.accounts.program_id,
             ctx.accounts.metadata,
             ctx.accounts.current_authority,
         ],
@@ -69,7 +69,7 @@ pub fn token_metadata_update_authority<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataUpdateAuthority<'info> {
-    pub token_program_id: AccountInfo<'info>,
+    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub current_authority: AccountInfo<'info>,
     pub new_authority: AccountInfo<'info>,
@@ -81,7 +81,7 @@ pub fn token_metadata_update_field<'info>(
     value: String,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::update_field(
-        ctx.accounts.token_program_id.key,
+        ctx.accounts.program_id.key,
         ctx.accounts.metadata.key,
         ctx.accounts.update_authority.key,
         field,
@@ -90,7 +90,7 @@ pub fn token_metadata_update_field<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
+            ctx.accounts.program_id,
             ctx.accounts.metadata,
             ctx.accounts.update_authority,
         ],
@@ -101,7 +101,7 @@ pub fn token_metadata_update_field<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataUpdateField<'info> {
-    pub token_program_id: AccountInfo<'info>,
+    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -85,7 +85,7 @@ impl<'info> CreateMintAccount<'info> {
         uri: String,
     ) -> ProgramResult {
         let cpi_accounts = TokenMetadataInitialize {
-            token_program_id: self.token_program.to_account_info(),
+            program_id: self.token_program.to_account_info(),
             mint: self.mint.to_account_info(),
             metadata: self.mint.to_account_info(), // metadata account is the mint, since data is stored in mint
             mint_authority: self.authority.to_account_info(),


### PR DESCRIPTION
See #3073.

Rename fields to better reflect interface structure and match [spl_token_metadata_interface](https://docs.rs/spl-token-metadata-interface/latest/spl_token_metadata_interface/index.html) and [spl_token_group_interface](https://docs.rs/solarti-token-group-interface/latest/spl_token_group_interface/index.html) instructions.