### PR TITLE
syn: Remove `bpf` target support in `hash` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+- syn: Remove `bpf` target support in `hash` feature ([#3078](https://github.com/coral-xyz/anchor/pull/3078)).
+
 ## [0.30.1] - 2024-06-20
 
 ### Features

--- a/lang/syn/src/hash.rs
+++ b/lang/syn/src/hash.rs
@@ -78,11 +78,6 @@ impl Hash {
         Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
     }
 
-    #[cfg(target_arch = "bpf")]
-    pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
-        Self(hash_array)
-    }
-
     pub fn to_bytes(self) -> [u8; HASH_BYTES] {
         self.0
     }
@@ -92,28 +87,9 @@ impl Hash {
 pub fn hashv(vals: &[&[u8]]) -> Hash {
     // Perform the calculation inline, calling this from within a program is
     // not supported
-    #[cfg(not(target_arch = "bpf"))]
-    {
-        let mut hasher = Hasher::default();
-        hasher.hashv(vals);
-        hasher.result()
-    }
-    // Call via a system call to perform the calculation
-    #[cfg(target_arch = "bpf")]
-    {
-        extern "C" {
-            fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64;
-        }
-        let mut hash_result = [0; HASH_BYTES];
-        unsafe {
-            sol_sha256(
-                vals as *const _ as *const u8,
-                vals.len() as u64,
-                &mut hash_result as *mut _ as *mut u8,
-            );
-        }
-        Hash::new_from_array(hash_result)
-    }
+    let mut hasher = Hasher::default();
+    hasher.hashv(vals);
+    hasher.result()
 }
 
 /// Return a Sha256 hash for the given data.


### PR DESCRIPTION
### Problem

`anchor-syn` is used for code parsing and generation, but we also have `hash` feature that has `bpf` target related code:

https://github.com/coral-xyz/anchor/blob/0a1d458c7b96b9a6369f7f212ffe1eb116f7566c/lang/syn/src/hash.rs#L101-L116

This whole module was copied from [`solana_program::hash`](https://github.com/anza-xyz/agave/blob/17e496d779ce5a10417e705fae3a40a8a5805119/sdk/program/src/hash.rs), which is likely why `bpf` related code wasn't removed. On-chain hashing should be done using `solana_program::hash`, which has the exact same functionality.

Also, `bpf` target arch has been deprecated as mentioned in https://github.com/coral-xyz/anchor/pull/3062#issuecomment-2220339659.

### Summary of changes

Remove `bpf` target arch related code.