### PR TITLE
lang: Remove `EventData` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - syn: Remove `bpf` target support in `hash` feature ([#3078](https://github.com/coral-xyz/anchor/pull/3078)).
 - client: Add `tokio` support to `RequestBuilder` with `async` feature ([#3057](https://github.com/coral-xyz/anchor/pull/3057])).
+- lang: Remove `EventData` trait ([#3083](https://github.com/coral-xyz/anchor/pull/3083])).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -300,14 +300,6 @@ pub trait Event: AnchorSerialize + AnchorDeserialize + Discriminator {
     fn data(&self) -> Vec<u8>;
 }
 
-// The serialized event data to be emitted via a Solana log.
-// TODO: remove this on the next major version upgrade.
-#[doc(hidden)]
-#[deprecated(since = "0.4.2", note = "Please use Event instead")]
-pub trait EventData: AnchorSerialize + Discriminator {
-    fn data(&self) -> Vec<u8>;
-}
-
 /// 8 byte unique identifier for a type.
 pub trait Discriminator {
     const DISCRIMINATOR: [u8; 8];


### PR DESCRIPTION
### Problem

The `EventData` trait has been deprecated slightly after the framework creation date:

https://github.com/coral-xyz/anchor/blob/f677742a978ffdf7bc321746b4119394f6654b7c/lang/src/lib.rs#L303-L309

### Summary of changes

Remove the `EventData` trait.