### PR TITLE
lang: Fix using `owner` constraint with `Box`ed accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Make stack frames slimmer on ATA creation ([#3065](https://github.com/coral-xyz/anchor/pull/3065)).
 - lang: Remove `getrandom` dependency ([#3072](https://github.com/coral-xyz/anchor/pull/3072)).
 - lang: Make `InitSpace` support unnamed & unit structs ([#3084](https://github.com/coral-xyz/anchor/pull/3084)).
+- lang: Fix using `owner` constraint with `Box`ed accounts ([#3087](https://github.com/coral-xyz/anchor/pull/3087)).
 
 ### Breaking
 

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -1,4 +1,5 @@
 use crate::account::*;
+use crate::program::Misc;
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
@@ -802,4 +803,12 @@ pub struct InitManyAssociatedTokenAccounts<'info> {
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
     pub associated_token_program: Program<'info, AssociatedToken>,
+}
+
+#[derive(Accounts)]
+pub struct TestBoxedOwnerConstraint<'info> {
+    // Redundant check to test compilation
+    #[account(owner = program.key())]
+    pub my_account: Box<Account<'info, Data>>,
+    pub program: Program<'info, Misc>,
 }

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -386,10 +386,14 @@ pub mod misc {
         Ok(())
     }
 
-    #[allow(unused_variables)]
     pub fn test_init_many_associated_token_accounts(
         _ctx: Context<InitManyAssociatedTokenAccounts>,
     ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Compilation test for https://github.com/coral-xyz/anchor/issues/3074
+    pub fn test_boxed_owner_constraint(_ctx: Context<TestBoxedOwnerConstraint>) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
### Problem

There is a compilation error when using `owner` constraint with `Box`ed accounts as described in https://github.com/coral-xyz/anchor/issues/3074.

### Summary of changes

Fix the compilation error by dereferencing the `Box` type when necessary.

Resolves https://github.com/coral-xyz/anchor/issues/3074