### PR TITLE
lang: Add a sanity check for unimplemented token extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `getrandom` dependency ([#3072](https://github.com/coral-xyz/anchor/pull/3072)).
 - lang: Make `InitSpace` support unnamed & unit structs ([#3084](https://github.com/coral-xyz/anchor/pull/3084)).
 - lang: Fix using `owner` constraint with `Box`ed accounts ([#3087](https://github.com/coral-xyz/anchor/pull/3087)).
+- lang: Add a sanity check for unimplemented token extensions ([#3090](https://github.com/coral-xyz/anchor/pull/3090)).
 
 ### Breaking
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -937,7 +937,9 @@ fn generate_constraint_init_group(
                                             mint: #field.to_account_info(),
                                         }), #permanent_delegate.unwrap())?;
                                     },
-                                    _ => {} // do nothing
+                                    // All extensions specified by the user should be implemented.
+                                    // If this line runs, it means there is a bug in the codegen.
+                                    _ => unimplemented!("{e:?}"),
                                 }
                             };
                         }


### PR DESCRIPTION
### Problem

Codegen currently skips unimplemented token extensions:

https://github.com/coral-xyz/anchor/blob/79d1cec79e86c0601a23a3c1ae79b8abf2ec15ae/lang/syn/src/codegen/accounts/constraints.rs#L940

This is not ideal since extensions are defined internally by us (from the user's constraints). If a token extension constraint is specified, and we've included the extension in the internal `extensions` variable, then not doing anything with it later on should be considered an internal bug. Therefore, it's better to panic in this case rather than doing nothing.

### Summary of changes

Panic via `unimplemented!` macro if an extension has a missing implementation.