### PR TITLE
lang: Add `Account` utility type to get accounts from bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
 - cli: Add checks for incorrect usage of `idl-build` feature ([#3061](https://github.com/coral-xyz/anchor/pull/3061)).
 - lang: Export `Discriminator` trait from `prelude` ([#3075](https://github.com/coral-xyz/anchor/pull/3075)).
+- lang: Add `Account` utility type to get accounts from bytes ([#3091](https://github.com/coral-xyz/anchor/pull/3091)).
 
 ### Fixes
 

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -52,6 +52,30 @@ pub mod declare_program {
         Ok(())
     }
 
+    pub fn account_utils(_ctx: Context<Utils>) -> Result<()> {
+        use external::utils::Account;
+
+        // Empty
+        if Account::try_from_bytes(&[]).is_ok() {
+            return Err(ProgramError::Custom(0).into());
+        }
+
+        const DISC: &[u8] = &external::accounts::MyAccount::DISCRIMINATOR;
+
+        // Correct discriminator but invalid data
+        if Account::try_from_bytes(DISC).is_ok() {
+            return Err(ProgramError::Custom(1).into());
+        };
+
+        // Correct discriminator and valid data
+        match Account::try_from_bytes(&[DISC, &[1, 0, 0, 0]].concat()) {
+            Ok(Account::MyAccount(my_account)) => require_eq!(my_account.field, 1),
+            Err(e) => return Err(e.into()),
+        }
+
+        Ok(())
+    }
+
     pub fn event_utils(_ctx: Context<Utils>) -> Result<()> {
         use external::utils::Event;
 

--- a/tests/declare-program/tests/declare-program.ts
+++ b/tests/declare-program/tests/declare-program.ts
@@ -47,6 +47,10 @@ describe("declare-program", () => {
     assert.strictEqual(myAccount.field, value);
   });
 
+  it("Can use account utils", async () => {
+    await program.methods.accountUtils().rpc();
+  });
+
   it("Can use event utils", async () => {
     await program.methods.eventUtils().rpc();
   });


### PR DESCRIPTION
### Problem

Similar to https://github.com/coral-xyz/anchor/issues/2885, there isn't a convenient method to get deserialized program account from bytes.

### Summary of changes

Add `Account` enum similar to `Event` enum added in https://github.com/coral-xyz/anchor/pull/2897:

```rs
/// An enum that includes all accounts of the declared program as a tuple variant.
///
/// See [`Self::try_from_bytes`] to create an instance from bytes.
pub enum Account {
    SomeAccount(SomeAccount),
    OtherAccount(OtherAccount),
}

impl Account {
    /// Try to create an account based on the given bytes.
    ///
    /// This method returns an error if the discriminator of the given bytes don't match
    /// with any of the existing accounts, or if the deserialization fails.
    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
        // ...
    }
}
```

This is accesible from `program_name::utils::Account` where `program_name` is declared as `declare_program!(program_name)`.