### PR TITLE
cli: Skip IDL checks if `--no-idl` option is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Make `InitSpace` support unnamed & unit structs ([#3084](https://github.com/coral-xyz/anchor/pull/3084)).
 - lang: Fix using `owner` constraint with `Box`ed accounts ([#3087](https://github.com/coral-xyz/anchor/pull/3087)).
 - lang: Add a sanity check for unimplemented token extensions ([#3090](https://github.com/coral-xyz/anchor/pull/3090)).
+- cli: Skip IDL checks if `--no-idl` option is passed ([#3093](https://github.com/coral-xyz/anchor/pull/3093)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1819,8 +1819,6 @@ fn _build_rust_cwd(
     arch: &ProgramArch,
     cargo_args: Vec<String>,
 ) -> Result<()> {
-    check_idl_build_feature().ok();
-
     let exit = std::process::Command::new("cargo")
         .arg(arch.build_subcommand())
         .args(cargo_args.clone())
@@ -2734,6 +2732,8 @@ idl-build = ["anchor-lang/idl-build"{anchor_spl_idl_build}]
 in `{path}`."#
         ));
     }
+
+    check_idl_build_feature().ok();
 
     anchor_lang_idl::build::build_idl_with_cargo_args(
         std::env::current_dir()?,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2681,6 +2681,7 @@ fn idl_build(
                 .path
         }
     };
+    check_idl_build_feature().ok();
     let idl = anchor_lang_idl::build::build_idl_with_cargo_args(
         program_path,
         cfg.features.resolution,


### PR DESCRIPTION
### Problem

IDL checks are still done when the `--no-idl` option is passed.

### Summary of changes

- Move the checks inside the `generate_idl` function to make sure the checks are only being run when necessary
- Also add the IDL checks to the `idl build` command