### PR TITLE
lang: Add non-8-byte discriminator support in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `Account` utility type to get accounts from bytes ([#3091](https://github.com/coral-xyz/anchor/pull/3091)).
 - client: Add option to pass in mock rpc client when using anchor_client ([#3053](https://github.com/coral-xyz/anchor/pull/3053)).
 - lang: Get discriminator length dynamically ([#3101](https://github.com/coral-xyz/anchor/pull/3101)).
+- lang: Add non-8-byte discriminator support in `declare_program!` ([#3103](https://github.com/coral-xyz/anchor/pull/3103)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -21,7 +21,7 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
                         return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
                     }
 
-                    let given_disc = &buf[..8];
+                    let given_disc = &buf[..#discriminator.len()];
                     if &#discriminator != given_disc {
                         return Err(
                             anchor_lang::error!(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch)
@@ -51,7 +51,7 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
                         #try_deserialize
 
                         fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                            let mut data: &[u8] = &buf[8..];
+                            let mut data: &[u8] = &buf[#discriminator.len()..];
                             AnchorDeserialize::deserialize(&mut data)
                                 .map_err(|_| anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into())
                         }
@@ -75,7 +75,7 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
                             #try_deserialize
 
                             fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                                let data: &[u8] = &buf[8..];
+                                let data: &[u8] = &buf[#discriminator.len()..];
                                 let account = anchor_lang::__private::bytemuck::from_bytes(data);
                                 Ok(*account)
                             }

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -46,15 +46,11 @@ fn gen_internal_args_mod(idl: &Idl) -> proc_macro2::TokenStream {
             }
         };
 
-        let impl_discriminator = if ix.discriminator.len() == 8 {
-            let discriminator = gen_discriminator(&ix.discriminator);
-            quote! {
-                impl anchor_lang::Discriminator for #ix_struct_name {
-                    const DISCRIMINATOR: &'static [u8] = &#discriminator;
-                }
+        let discriminator = gen_discriminator(&ix.discriminator);
+        let impl_discriminator = quote! {
+            impl anchor_lang::Discriminator for #ix_struct_name {
+                const DISCRIMINATOR: &'static [u8] = &#discriminator;
             }
-        } else {
-            quote! {}
         };
 
         let impl_ix_data = quote! {


### PR DESCRIPTION
### Problem

[`declare_program!`](https://github.com/coral-xyz/anchor/pull/2857) only supports 8 bytes long discriminators.

### Summary of changes

Don't make assumptions about discriminator size in `declare_program!`.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.