### PR TITLE
client: Make `ThreadSafeSigner` trait public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Add option to pass in mock rpc client when using anchor_client ([#3053](https://github.com/coral-xyz/anchor/pull/3053)).
 - lang: Get discriminator length dynamically ([#3101](https://github.com/coral-xyz/anchor/pull/3101)).
 - lang: Add non-8-byte discriminator support in `declare_program!` ([#3103](https://github.com/coral-xyz/anchor/pull/3103)).
+- client: Make `ThreadSafeSigner` trait public ([#3107](https://github.com/coral-xyz/anchor/pull/3107)).
 
 ### Fixes
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -101,6 +101,8 @@ use tokio::{
 
 pub use anchor_lang;
 pub use cluster::Cluster;
+#[cfg(feature = "async")]
+pub use nonblocking::ThreadSafeSigner;
 pub use solana_client;
 pub use solana_sdk;
 


### PR DESCRIPTION
The `impl` blocks in `nonblocking.rs` and `blocking.rs` are public by default since the traits/structs they're defined on are defined in `lib.rs`. The exception is `ThreadSafeSigner`, which makes using `nonblocking.rs` tedious. This PR makes it public.