### PR TITLE
lang: Remove the fallback function shortcut in `try_entry` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add non-8-byte discriminator support in `declare_program!` ([#3103](https://github.com/coral-xyz/anchor/pull/3103)).
 - client: Make `ThreadSafeSigner` trait public ([#3107](https://github.com/coral-xyz/anchor/pull/3107)).
 - lang: Update `dispatch` function to support dynamic discriminators ([#3104](https://github.com/coral-xyz/anchor/pull/3104)).
+- lang: Remove the fallback function shortcut in `try_entry` function ([#3109](https://github.com/coral-xyz/anchor/pull/3109)).
 
 ### Fixes
 

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -29,8 +29,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .as_ref()
         .map(|fallback_fn| {
             let program_name = &program.name;
-            let method = &fallback_fn.raw_method;
-            let fn_name = &method.sig.ident;
+            let fn_name = &fallback_fn.raw_method.sig.ident;
             quote! {
                 #program_name::#fn_name(program_id, accounts, data)
             }

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -34,8 +34,10 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 #program_name::#fn_name(program_id, accounts, data)
             }
         })
-        .unwrap_or(quote! {
-            Err(anchor_lang::error::ErrorCode::InstructionFallbackNotFound.into())
+        .unwrap_or_else(|| {
+            quote! {
+                Err(anchor_lang::error::ErrorCode::InstructionFallbackNotFound.into())
+            }
         });
 
     let event_cpi_handler = generate_event_cpi_handler();

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -1,13 +1,9 @@
-use crate::program_codegen::dispatch;
 use crate::Program;
 use heck::CamelCase;
 use quote::quote;
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let name: proc_macro2::TokenStream = program.name.to_string().to_camel_case().parse().unwrap();
-    let fallback_maybe = dispatch::gen_fallback(program).unwrap_or(quote! {
-        Err(anchor_lang::error::ErrorCode::InstructionMissing.into())
-    });
     quote! {
         #[cfg(not(feature = "no-entrypoint"))]
         anchor_lang::solana_program::entrypoint!(entry);
@@ -61,9 +57,6 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             }
             if *program_id != ID {
                 return Err(anchor_lang::error::ErrorCode::DeclaredProgramIdMismatch.into());
-            }
-            if data.len() < 8 {
-                return #fallback_maybe;
             }
 
             dispatch(program_id, accounts, data)


### PR DESCRIPTION
### Problem

[`try_entry`](https://github.com/coral-xyz/anchor/blob/ccac42dfcf8d42cb156f05689906e9b48394d58a/lang/syn/src/codegen/program/entry.rs#L57) function returns early if the instruction data is less than 8 bytes:

https://github.com/coral-xyz/anchor/blob/ccac42dfcf8d42cb156f05689906e9b48394d58a/lang/syn/src/codegen/program/entry.rs#L65-L67

### Summary of changes

- Remove the fallback function shortcut in [`try_entry`](https://github.com/coral-xyz/anchor/blob/ccac42dfcf8d42cb156f05689906e9b48394d58a/lang/syn/src/codegen/program/entry.rs#L57) function
- Remove [`gen_fallback`](https://github.com/coral-xyz/anchor/blob/ccac42dfcf8d42cb156f05689906e9b48394d58a/lang/syn/src/codegen/program/dispatch.rs#L81) function and inline where the fallback is being used (since this is the only place it's being used)
- Remove [`generate_event_cpi_handler`](https://github.com/coral-xyz/anchor/blob/ccac42dfcf8d42cb156f05689906e9b48394d58a/lang/syn/src/codegen/program/dispatch.rs#L93) function and inline it to make it consistent with the above change

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.