### PR TITLE
lang: Require `Discriminator` trait impl when using the `zero` constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `EventData` trait ([#3083](https://github.com/coral-xyz/anchor/pull/3083)).
 - client: Remove `async_rpc` method ([#3053](https://github.com/coral-xyz/anchor/pull/3053)).
 - lang: Make discriminator type unsized ([#3098](https://github.com/coral-xyz/anchor/pull/3098)).
+- lang: Require `Discriminator` trait impl when using the `zero` constraint ([#3118](https://github.com/coral-xyz/anchor/pull/3118)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -198,12 +198,7 @@ pub fn generate_constraint_init(
 }
 
 pub fn generate_constraint_zeroed(f: &Field, _c: &ConstraintZeroed) -> proc_macro2::TokenStream {
-    // Require known account type that implements the `Discriminator` trait in order to decide
-    // the discriminator length to check
-    let account_ty = match &f.ty {
-        Ty::Account(_) | Ty::AccountLoader(_) => f.account_ty(),
-        _ => panic!("`zero` constraint requires the type to implement the `Discriminator` trait"),
-    };
+    let account_ty = f.account_ty();
     let discriminator = quote! { #account_ty::DISCRIMINATOR };
 
     let field = &f.ident;

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -1174,6 +1174,15 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         if self.init.is_some() {
             return Err(ParseError::new(c.span(), "init already provided"));
         }
+
+        // Require a known account type that implements the `Discriminator` trait so that we can
+        // get the discriminator length dynamically
+        if !matches!(&self.f_ty, Some(Ty::Account(_) | Ty::AccountLoader(_))) {
+            return Err(ParseError::new(
+                c.span(),
+                "`zero` constraint requires the type to implement the `Discriminator` trait",
+            ));
+        }
         self.zeroed.replace(c);
         Ok(())
     }


### PR DESCRIPTION
### Problem

`zero` constraint assumes the discriminator length is always 8:

https://github.com/coral-xyz/anchor/blob/c06ec446e26ce1939734a8ec58b677a1927f3ede/lang/syn/src/codegen/accounts/constraints.rs#L207-L213

### Summary of changes

- Get the discriminator length in `zero` constraint from the account's `Discriminator` trait implementation
- Require using `Account` or `AccountLoader` when using the `zero` constraint to give a more friendly error message rather than `rustc` generated compile error

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.