### PR TITLE
ts: Get discriminator lengths dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Make `ThreadSafeSigner` trait public ([#3107](https://github.com/coral-xyz/anchor/pull/3107)).
 - lang: Update `dispatch` function to support dynamic discriminators ([#3104](https://github.com/coral-xyz/anchor/pull/3104)).
 - lang: Remove the fallback function shortcut in `try_entry` function ([#3109](https://github.com/coral-xyz/anchor/pull/3109)).
+- ts: Get discriminator lengths dynamically ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
 
 ### Fixes
 
@@ -44,6 +45,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Remove `async_rpc` method ([#3053](https://github.com/coral-xyz/anchor/pull/3053)).
 - lang: Make discriminator type unsized ([#3098](https://github.com/coral-xyz/anchor/pull/3098)).
 - lang: Require `Discriminator` trait impl when using the `zero` constraint ([#3118](https://github.com/coral-xyz/anchor/pull/3118)).
+- ts: Remove `DISCRIMINATOR_SIZE` constant ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/ts/packages/anchor/src/coder/borsh/discriminator.ts
+++ b/ts/packages/anchor/src/coder/borsh/discriminator.ts
@@ -1,4 +1,0 @@
-/**
- * Number of bytes in anchor discriminators
- */
-export const DISCRIMINATOR_SIZE = 8;

--- a/ts/packages/anchor/src/coder/borsh/event.ts
+++ b/ts/packages/anchor/src/coder/borsh/event.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "buffer";
 import { Layout } from "buffer-layout";
 import * as base64 from "../../utils/bytes/base64.js";
-import { Idl } from "../../idl.js";
+import { Idl, IdlDiscriminator } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import { EventCoder } from "../index.js";
 
@@ -9,12 +9,10 @@ export class BorshEventCoder implements EventCoder {
   /**
    * Maps account type identifier to a layout.
    */
-  private layouts: Map<string, Layout>;
-
-  /**
-   * Maps base64 encoded event discriminator to event name.
-   */
-  private discriminators: Map<string, string>;
+  private layouts: Map<
+    string,
+    { discriminator: IdlDiscriminator; layout: Layout }
+  >;
 
   public constructor(idl: Idl) {
     if (!idl.events) {
@@ -27,21 +25,20 @@ export class BorshEventCoder implements EventCoder {
       throw new Error("Events require `idl.types`");
     }
 
-    const layouts: [string, Layout<any>][] = idl.events.map((ev) => {
+    const layouts = idl.events.map((ev) => {
       const typeDef = types.find((ty) => ty.name === ev.name);
       if (!typeDef) {
         throw new Error(`Event not found: ${ev.name}`);
       }
-      return [ev.name, IdlCoder.typeDefLayout({ typeDef, types })];
+      return [
+        ev.name,
+        {
+          discriminator: ev.discriminator,
+          layout: IdlCoder.typeDefLayout({ typeDef, types }),
+        },
+      ] as const;
     });
     this.layouts = new Map(layouts);
-
-    this.discriminators = new Map<string, string>(
-      (idl.events ?? []).map((ev) => [
-        base64.encode(Buffer.from(ev.discriminator)),
-        ev.name,
-      ])
-    );
   }
 
   public decode(log: string): {
@@ -55,19 +52,18 @@ export class BorshEventCoder implements EventCoder {
     } catch (e) {
       return null;
     }
-    const disc = base64.encode(logArr.slice(0, 8));
 
-    // Only deserialize if the discriminator implies a proper event.
-    const eventName = this.discriminators.get(disc);
-    if (!eventName) {
-      return null;
+    for (const [name, layout] of this.layouts) {
+      const givenDisc = logArr.subarray(0, layout.discriminator.length);
+      const matches = givenDisc.equals(Buffer.from(layout.discriminator));
+      if (matches) {
+        return {
+          name,
+          data: layout.layout.decode(logArr.subarray(givenDisc.length)),
+        };
+      }
     }
 
-    const layout = this.layouts.get(eventName);
-    if (!layout) {
-      throw new Error(`Unknown event: ${eventName}`);
-    }
-    const data = layout.decode(logArr.slice(8));
-    return { data, name: eventName };
+    return null;
   }
 }

--- a/ts/packages/anchor/src/coder/borsh/index.ts
+++ b/ts/packages/anchor/src/coder/borsh/index.ts
@@ -7,7 +7,6 @@ import { Coder } from "../index.js";
 
 export { BorshInstructionCoder } from "./instruction.js";
 export { BorshAccountsCoder } from "./accounts.js";
-export { DISCRIMINATOR_SIZE } from "./discriminator.js";
 export { BorshEventCoder } from "./event.js";
 
 /**

--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -16,7 +16,7 @@ import {
   IdlDiscriminator,
 } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
-import { DISCRIMINATOR_SIZE, InstructionCoder } from "../index.js";
+import { InstructionCoder } from "../index.js";
 
 /**
  * Encodes and decodes program instructions.
@@ -28,9 +28,6 @@ export class BorshInstructionCoder implements InstructionCoder {
     { discriminator: IdlDiscriminator; layout: Layout }
   >;
 
-  // Base58 encoded sighash to instruction layout.
-  private sighashLayouts: Map<string, { name: string; layout: Layout }>;
-
   public constructor(private idl: Idl) {
     const ixLayouts = idl.instructions.map((ix) => {
       const name = ix.name;
@@ -41,13 +38,6 @@ export class BorshInstructionCoder implements InstructionCoder {
       return [name, { discriminator: ix.discriminator, layout }] as const;
     });
     this.ixLayouts = new Map(ixLayouts);
-
-    const sighashLayouts = ixLayouts.map(
-      ([name, { discriminator, layout }]) => {
-        return [bs58.encode(discriminator), { name, layout }] as const;
-      }
-    );
-    this.sighashLayouts = new Map(sighashLayouts);
   }
 
   /**
@@ -77,17 +67,18 @@ export class BorshInstructionCoder implements InstructionCoder {
       ix = encoding === "hex" ? Buffer.from(ix, "hex") : bs58.decode(ix);
     }
 
-    const disc = ix.slice(0, DISCRIMINATOR_SIZE);
-    const data = ix.slice(DISCRIMINATOR_SIZE);
-    const decoder = this.sighashLayouts.get(bs58.encode(disc));
-    if (!decoder) {
-      return null;
+    for (const [name, layout] of this.ixLayouts) {
+      const givenDisc = ix.subarray(0, layout.discriminator.length);
+      const matches = givenDisc.equals(Buffer.from(layout.discriminator));
+      if (matches) {
+        return {
+          name,
+          data: layout.layout.decode(ix.subarray(givenDisc.length)),
+        };
+      }
     }
 
-    return {
-      name: decoder.name,
-      data: decoder.layout.decode(data),
-    };
+    return null;
   }
 
   /**

--- a/ts/packages/anchor/tests/coder-accounts.spec.ts
+++ b/ts/packages/anchor/tests/coder-accounts.spec.ts
@@ -1,7 +1,5 @@
 import * as assert from "assert";
 import { BorshCoder, Idl } from "../src";
-import { DISCRIMINATOR_SIZE } from "../src/coder/borsh/discriminator";
-import { sha256 } from "@noble/hashes/sha256";
 
 describe("coder.accounts", () => {
   test("Can encode and decode user-defined accounts, including those with consecutive capital letters", () => {


### PR DESCRIPTION
### Problem

TypeScript library uses a hardcoded value for the discriminator length in many places:

https://github.com/coral-xyz/anchor/blob/293ee9142bcbcf253e4507b83a941e7d580699aa/ts/packages/anchor/src/coder/borsh/discriminator.ts#L1-L4

### Summary of changes

- Remove the `DISCRIMINATOR_SIZE` constant
- Get discriminator lengths of instructions, accounts and events dynamically

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.