### PR TITLE
client: Support non-8-byte discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Update `dispatch` function to support dynamic discriminators ([#3104](https://github.com/coral-xyz/anchor/pull/3104)).
 - lang: Remove the fallback function shortcut in `try_entry` function ([#3109](https://github.com/coral-xyz/anchor/pull/3109)).
 - ts: Get discriminator lengths dynamically ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
+- client: Support non-8-byte discriminators ([#3125](https://github.com/coral-xyz/anchor/pull/3125)).
 
 ### Fixes
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -373,8 +373,8 @@ pub fn handle_program_log<T: anchor_lang::Event + anchor_lang::AnchorDeserialize
         .strip_prefix(PROGRAM_LOG)
         .or_else(|| l.strip_prefix(PROGRAM_DATA))
     {
-        let borsh_bytes = match STANDARD.decode(log) {
-            Ok(borsh_bytes) => borsh_bytes,
+        let log_bytes = match STANDARD.decode(log) {
+            Ok(log_bytes) => log_bytes,
             _ => {
                 #[cfg(feature = "debug")]
                 println!("Could not base64 decode log: {}", log);
@@ -382,19 +382,14 @@ pub fn handle_program_log<T: anchor_lang::Event + anchor_lang::AnchorDeserialize
             }
         };
 
-        let mut slice: &[u8] = &borsh_bytes[..];
-        let disc: [u8; 8] = {
-            let mut disc = [0; 8];
-            disc.copy_from_slice(&borsh_bytes[..8]);
-            slice = &slice[8..];
-            disc
-        };
-        let mut event = None;
-        if disc == T::discriminator() {
-            let e: T = anchor_lang::AnchorDeserialize::deserialize(&mut slice)
-                .map_err(|e| ClientError::LogParseError(e.to_string()))?;
-            event = Some(e);
-        }
+        let event = log_bytes
+            .starts_with(T::DISCRIMINATOR)
+            .then(|| {
+                let mut data = &log_bytes[T::DISCRIMINATOR.len()..];
+                T::deserialize(&mut data).map_err(|e| ClientError::LogParseError(e.to_string()))
+            })
+            .transpose()?;
+
         Ok((event, None, false))
     }
     // System log.


### PR DESCRIPTION
### Problem

`anchor-client` assumes discriminator length to always equal 8:

https://github.com/coral-xyz/anchor/blob/9fce3dfc9c534116238326e7f628d6827dc03988/client/src/lib.rs#L385-L391

### Summary of changes

Get the discriminator length dynamically rather than hardcoding as 8.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.