### PR TITLE
Added WithdrawWithheldTokensFromAccounts IX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be incremented for features.
 
 ## [Unreleased]
-- spl: Implemented `withdrawWithheldTokensFromAccounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 
 ### Features
 
+- spl: Implemented `withdrawWithheldTokensFromAccounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 - ts: Add optional `commitment` parameter to `Program.addEventListener` ([#3052](https://github.com/coral-xyz/anchor/pull/3052)).
 - cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
 - cli: Add checks for incorrect usage of `idl-build` feature ([#3061](https://github.com/coral-xyz/anchor/pull/3061)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be incremented for features.
 
 ## [Unreleased]
+- spl: Implemented `withdrawWithheldTokensFromAccounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 
 ### Features
 

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -159,7 +159,6 @@ pub struct WithdrawWithheldTokensFromMint<'info> {
     pub authority: AccountInfo<'info>,
 }
 
-
 pub fn withdraw_withheld_tokens_from_accounts<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, WithdrawWithheldTokensFromAccounts<'info>>,
     sources: Vec<AccountInfo<'info>>,
@@ -173,7 +172,12 @@ pub fn withdraw_withheld_tokens_from_accounts<'info>(
         sources.iter().map(|a| a.key).collect::<Vec<_>>().as_slice(),
     )?;
 
-    let mut account_infos = vec![ctx.accounts.token_program_id, ctx.accounts.mint, ctx.accounts.destination, ctx.accounts.authority];
+    let mut account_infos = vec![
+        ctx.accounts.token_program_id,
+        ctx.accounts.mint,
+        ctx.accounts.destination,
+        ctx.accounts.authority,
+    ];
     account_infos.extend_from_slice(&sources);
 
     anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -158,3 +158,32 @@ pub struct WithdrawWithheldTokensFromMint<'info> {
     pub destination: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }
+
+
+pub fn withdraw_withheld_tokens_from_accounts<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, WithdrawWithheldTokensFromAccounts<'info>>,
+    sources: Vec<AccountInfo<'info>>,
+) -> Result<()> {
+    let ix = spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_accounts(
+        ctx.accounts.token_program_id.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.destination.key,
+        ctx.accounts.authority.key,
+        &[],
+        sources.iter().map(|a| a.key).collect::<Vec<_>>().as_slice(),
+    )?;
+
+    let mut account_infos = vec![ctx.accounts.token_program_id, ctx.accounts.mint, ctx.accounts.destination, ctx.accounts.authority];
+    account_infos.extend_from_slice(&sources);
+
+    anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
+        .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct WithdrawWithheldTokensFromAccounts<'info> {
+    pub token_program_id: AccountInfo<'info>,
+    pub mint: AccountInfo<'info>,
+    pub destination: AccountInfo<'info>,
+    pub authority: AccountInfo<'info>,
+}


### PR DESCRIPTION
It seems `WithdrawWithheldTokensFromAccounts` ix was missing from token22 transfer fee extensions, so I implemented it. 

You can check out the instruction [here](https://github.com/solana-labs/solana-program-library/blob/c4d51f20b8722d23b03e94c7075702fca52460dd/token/program-2022/src/extension/transfer_fee/instruction.rs#L346C1-L353C41)

It allows the fee withdraw authority to withdraw fees from t22 transfer fee extension accounts directly without having to first harvest to mint, then harvest from mint. Code is tested and working locally. 

This unlocks the ability for Anchor programs to delegate a PDA signer as the token withdraw authority, drastically improving security, as any signer can invoke an IX to claim tokens to a treasury without having to first claim to a mint account.