### PR TITLE
ts: Add optional `wallet` property to the `Provider` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- spl: Implemented `withdrawWithheldTokensFromAccounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 - ts: Add optional `commitment` parameter to `Program.addEventListener` ([#3052](https://github.com/coral-xyz/anchor/pull/3052)).
 - cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).
 - cli: Add checks for incorrect usage of `idl-build` feature ([#3061](https://github.com/coral-xyz/anchor/pull/3061)).
@@ -26,6 +25,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove the fallback function shortcut in `try_entry` function ([#3109](https://github.com/coral-xyz/anchor/pull/3109)).
 - ts: Get discriminator lengths dynamically ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
 - client: Support non-8-byte discriminators ([#3125](https://github.com/coral-xyz/anchor/pull/3125)).
+- spl: Add `withdraw_withheld_tokens_from_accounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
+- ts: Add optional `wallet` property to the `Provider` interface ([#3130](https://github.com/coral-xyz/anchor/pull/3130)).
 
 ### Fixes
 

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -243,13 +243,11 @@ export class AccountsResolver<IDL extends Idl> {
         if ((account.signer || account.address) && !this.get([...path, name])) {
           // Default signers to the provider
           if (account.signer) {
-            // @ts-expect-error
             if (!this._provider.wallet) {
               throw new Error(
                 "This function requires the `Provider` interface implementor to have a `wallet` field."
               );
             }
-            // @ts-expect-error
             this.set([...path, name], this._provider.wallet.publicKey);
           }
 

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -11,6 +11,7 @@ import {
   SendOptions,
   VersionedTransaction,
   RpcResponseAndContext,
+  Keypair,
 } from "@solana/web3.js";
 import { bs58 } from "./utils/bytes/index.js";
 import { isBrowser, isVersionedTransaction } from "./utils/common.js";
@@ -22,6 +23,7 @@ import {
 export default interface Provider {
   readonly connection: Connection;
   readonly publicKey?: PublicKey;
+  readonly wallet?: Wallet;
 
   send?(
     tx: Transaction | VersionedTransaction,
@@ -360,6 +362,8 @@ export interface Wallet {
     txs: T[]
   ): Promise<T[]>;
   publicKey: PublicKey;
+  /** Keypair of the configured payer (Node only) */
+  payer?: Keypair;
 }
 
 // Copy of Connection.sendAndConfirmRawTransaction that throws


### PR DESCRIPTION
ts: Add optional `wallet` property to the `Provider` interface

### Problem

The definition of the `Provider` interface doesn't include the `wallet` property as mentioned in https://github.com/coral-xyz/anchor/issues/3122

https://github.com/coral-xyz/anchor/blob/c5337c5e8eca134f8f5c23fcae4a91e8cf5f0c34/ts/packages/anchor/src/provider.ts#L22-L49

### Summary of changes

- Add optional `wallet` property to the `Provider` interface
- Add optional `payer` property to the `Wallet` interface

Resolves https://github.com/coral-xyz/anchor/issues/3122