### PR TITLE
cli: Warn if `anchor-spl/idl-build` is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Support non-8-byte discriminators ([#3125](https://github.com/coral-xyz/anchor/pull/3125)).
 - spl: Add `withdraw_withheld_tokens_from_accounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 - ts: Add optional `wallet` property to the `Provider` interface ([#3130](https://github.com/coral-xyz/anchor/pull/3130)).
+- cli: Warn if `anchor-spl/idl-build` is missing ([#3133](https://github.com/coral-xyz/anchor/pull/3133)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -85,7 +85,10 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
 ///
 /// **Note:** The check expects the current directory to be a program directory.
 pub fn check_idl_build_feature() -> Result<()> {
-    Manifest::from_path("Cargo.toml")?
+    let manifest = Manifest::from_path("Cargo.toml")?;
+
+    // Check if `idl-build` is enabled by default
+    manifest
         .dependencies
         .iter()
         .filter(|(_, dep)| dep.req_features().contains(&"idl-build".into()))
@@ -97,6 +100,23 @@ pub fn check_idl_build_feature() -> Result<()> {
                     `idl-build` feature in the `idl-build` feature list:\n\n\t\
                     [features]\n\t\
                     idl-build = [\"{name}/idl-build\", ...]\n"
+            )
+        });
+
+    // Check `anchor-spl`'s `idl-build` feature
+    manifest
+        .dependencies
+        .get("anchor-spl")
+        .and_then(|_| manifest.features.get("idl-build"))
+        .map(|feature_list| !feature_list.contains(&"anchor-spl/idl-build".into()))
+        .unwrap_or_default()
+        .then(|| {
+            eprintln!(
+                "WARNING: `idl-build` feature of `anchor-spl` is not enabled. \
+                This is likely to result in cryptic compile errors.\n\n\t\
+                To solve, add `anchor-spl/idl-build` to the `idl-build` feature list:\n\n\t\
+                [features]\n\t\
+                idl-build = [\"anchor-spl/idl-build\", ...]\n"
             )
         });
 


### PR DESCRIPTION
### Problem

Not enabling `anchor-spl`'s `idl-build` feature can result in cryptic compilation errors during IDL build process:

```
error[E0599]: no function or associated item named `create_type` found for struct `anchor_spl::token::TokenAccount` in the current scope
   --> programs/debug/src/lib.rs:263:10
    |
263 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `TokenAccount`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no associated item named `DISCRIMINATOR` found for struct `anchor_spl::token::TokenAccount` in the current scope
   --> programs/debug/src/lib.rs:263:10
    |
263 | #[derive(Accounts)]
    |          ^^^^^^^^ associated item not found in `TokenAccount`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no function or associated item named `insert_types` found for struct `anchor_spl::token::TokenAccount` in the current scope
   --> programs/debug/src/lib.rs:263:10
    |
263 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `TokenAccount`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)
```

### Summary of changes

Log a warning if `anchor-spl/idl-build` is missing:

```
WARNING: `idl-build` feature of `anchor-spl` is not enabled. This is likely to result in cryptic compile errors.

        To solve, add `anchor-spl/idl-build` to the `idl-build` feature list:

        [features]
        idl-build = ["anchor-spl/idl-build", ...]
```
