### PR TITLE
Add internal rpc func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add `withdraw_withheld_tokens_from_accounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 - ts: Add optional `wallet` property to the `Provider` interface ([#3130](https://github.com/coral-xyz/anchor/pull/3130)).
 - cli: Warn if `anchor-spl/idl-build` is missing ([#3133](https://github.com/coral-xyz/anchor/pull/3133)).
+- client: Add `internal_rpc` method for `mock` feature ([#3135](https://github.com/coral-xyz/anchor/pull/3135)).
 
 ### Fixes
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -240,6 +240,11 @@ impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
         self.program_id
     }
 
+    #[cfg(feature = "mock")]
+    pub fn internal_rpc(&self) -> &AsyncRpcClient {
+        &self.internal_rpc_client
+    }
+
     async fn account_internal<T: AccountDeserialize>(
         &self,
         address: Pubkey,


### PR DESCRIPTION
Using the mock feature is a bit annoying, as usually we just have one rpc client lying around and if we pass it to the program client we lose ownership of it and cannot use it anywhere else. This PR adds a method to allow us to borrow it.