### PR TITLE
lang: Add `#[instruction]` attribute proc-macro

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -439,6 +439,8 @@ jobs:
             path: tests/safety-checks
           - cmd: cd tests/custom-coder && anchor test --skip-lint && npx tsc --noEmit
             path: tests/custom-coder
+          - cmd: cd tests/custom-discriminator && anchor test && npx tsc --noEmit
+            path: tests/custom-discriminator
           - cmd: cd tests/validator-clone && anchor test --skip-lint && npx tsc --noEmit
             path: tests/validator-clone
           - cmd: cd tests/cpi-returns && anchor test --skip-lint && npx tsc --noEmit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add `withdraw_withheld_tokens_from_accounts` instruction ([#3128]([https://github.com/coral-xyz/anchor/pull/3128)).
 - ts: Add optional `wallet` property to the `Provider` interface ([#3130](https://github.com/coral-xyz/anchor/pull/3130)).
 - cli: Warn if `anchor-spl/idl-build` is missing ([#3133](https://github.com/coral-xyz/anchor/pull/3133)).
+- lang: Add `#[instruction]` attribute proc-macro to override default instruction discriminators ([#3137](https://github.com/coral-xyz/anchor/pull/3137)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -103,3 +103,13 @@ pub fn interface(
     // discriminator.
     input
 }
+
+#[proc_macro_attribute]
+pub fn instruction(
+    _args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    // This macro itself is a no-op, but the `#[program]` macro will detect this attribute and use
+    // the arguments to transform the instruction.
+    input
+}

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -104,6 +104,46 @@ pub fn interface(
     input
 }
 
+/// This attribute is used to override the Anchor defaults of program instructions.
+///
+/// # Args
+///
+/// - `discriminator`: Override the default 8-byte discriminator
+///
+///     **Usage:** `discriminator = <CONST_EXPR>`
+///
+///     All constant expressions are supported.
+///
+///     **Examples:**
+///
+///     - `discriminator = 0` (shortcut for `[0]`)
+///     - `discriminator = [1, 2, 3, 4]`
+///     - `discriminator = b"hi"`
+///     - `discriminator = MY_DISC`
+///     - `discriminator = get_disc(...)`
+///
+/// # Example
+///
+/// ```ignore
+/// use anchor_lang::prelude::*;
+///
+/// declare_id!("CustomDiscriminator111111111111111111111111");
+///
+/// #[program]
+/// pub mod custom_discriminator {
+///     use super::*;
+///
+///     #[instruction(discriminator = [1, 2, 3, 4])]
+///     pub fn my_ix(_ctx: Context<MyIx>) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// #[derive(Accounts)]
+/// pub struct MyIx<'info> {
+///     pub signer: Signer<'info>,
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn instruction(
     _args: proc_macro::TokenStream,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -52,7 +52,7 @@ pub use anchor_attribute_account::{account, declare_id, pubkey, zero_copy};
 pub use anchor_attribute_constant::constant;
 pub use anchor_attribute_error::*;
 pub use anchor_attribute_event::{emit, event};
-pub use anchor_attribute_program::{declare_program, program};
+pub use anchor_attribute_program::{declare_program, instruction, program};
 pub use anchor_derive_accounts::Accounts;
 pub use anchor_derive_serde::{AnchorDeserialize, AnchorSerialize};
 pub use anchor_derive_space::InitSpace;
@@ -392,8 +392,8 @@ pub mod prelude {
         accounts::signer::Signer, accounts::system_account::SystemAccount,
         accounts::sysvar::Sysvar, accounts::unchecked_account::UncheckedAccount, constant,
         context::Context, context::CpiContext, declare_id, declare_program, emit, err, error,
-        event, program, pubkey, require, require_eq, require_gt, require_gte, require_keys_eq,
-        require_keys_neq, require_neq,
+        event, instruction, program, pubkey, require, require_eq, require_gt, require_gte,
+        require_keys_eq, require_keys_neq, require_neq,
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
         AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Discriminator, Id,

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -77,9 +77,9 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
 fn parse_ix_attr(attrs: &[syn::Attribute]) -> ParseResult<Option<IxAttr>> {
     attrs
         .iter()
-        .find_map(|attr| match attr.path.segments.last() {
-            Some(seg) if seg.ident == "instruction" => Some(attr),
-            _ => None,
+        .find(|attr| match attr.path.segments.last() {
+            Some(seg) => seg.ident == "instruction",
+            _ => false,
         })
         .map(|attr| attr.parse_args())
         .transpose()

--- a/tests/custom-discriminator/Anchor.toml
+++ b/tests/custom-discriminator/Anchor.toml
@@ -1,0 +1,9 @@
+[programs.localnet]
+custom_discriminator = "CustomDiscriminator111111111111111111111111"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/custom-discriminator/Cargo.toml
+++ b/tests/custom-discriminator/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tests/custom-discriminator/package.json
+++ b/tests/custom-discriminator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "custom-discriminator",
+  "version": "0.30.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  }
+}

--- a/tests/custom-discriminator/programs/custom-discriminator/Cargo.toml
+++ b/tests/custom-discriminator/programs/custom-discriminator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "custom-discriminator"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "custom_discriminator"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/custom-discriminator/programs/custom-discriminator/Xargo.toml
+++ b/tests/custom-discriminator/programs/custom-discriminator/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/custom-discriminator/programs/custom-discriminator/src/lib.rs
+++ b/tests/custom-discriminator/programs/custom-discriminator/src/lib.rs
@@ -1,0 +1,47 @@
+use anchor_lang::prelude::*;
+
+declare_id!("CustomDiscriminator111111111111111111111111");
+
+const CONST_DISC: &'static [u8] = &[55, 66, 77, 88];
+
+const fn get_disc(input: &str) -> &'static [u8] {
+    match input.as_bytes() {
+        b"wow" => &[4 + 5, 55 / 5],
+        _ => unimplemented!(),
+    }
+}
+
+#[program]
+pub mod custom_discriminator {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn int(_ctx: Context<DefaultIx>) -> Result<()> {
+        Ok(())
+    }
+
+    #[instruction(discriminator = [1, 2, 3, 4])]
+    pub fn array(_ctx: Context<DefaultIx>) -> Result<()> {
+        Ok(())
+    }
+
+    #[instruction(discriminator = b"hi")]
+    pub fn byte_str(_ctx: Context<DefaultIx>) -> Result<()> {
+        Ok(())
+    }
+
+    #[instruction(discriminator = CONST_DISC)]
+    pub fn constant(_ctx: Context<DefaultIx>) -> Result<()> {
+        Ok(())
+    }
+
+    #[instruction(discriminator = get_disc("wow"))]
+    pub fn const_fn(_ctx: Context<DefaultIx>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct DefaultIx<'info> {
+    pub signer: Signer<'info>,
+}

--- a/tests/custom-discriminator/tests/custom-discriminator.ts
+++ b/tests/custom-discriminator/tests/custom-discriminator.ts
@@ -1,0 +1,31 @@
+import * as anchor from "@coral-xyz/anchor";
+import assert from "assert";
+
+import type { CustomDiscriminator } from "../target/types/custom_discriminator";
+
+describe("custom-discriminator", () => {
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const program: anchor.Program<CustomDiscriminator> =
+    anchor.workspace.customDiscriminator;
+
+  describe("Can use custom instruction discriminators", () => {
+    const testCommon = async (ixName: keyof typeof program["methods"]) => {
+      const tx = await program.methods[ixName]().transaction();
+
+      // Verify discriminator
+      const ix = program.idl.instructions.find((ix) => ix.name === ixName)!;
+      assert(ix.discriminator.length < 8);
+      const data = tx.instructions[0].data;
+      assert(data.equals(Buffer.from(ix.discriminator)));
+
+      // Verify tx runs
+      await program.provider.sendAndConfirm!(tx);
+    };
+
+    it("Integer", () => testCommon("int"));
+    it("Array", () => testCommon("array"));
+    it("Byte string", () => testCommon("byteStr"));
+    it("Constant", () => testCommon("constant"));
+    it("Const Fn", () => testCommon("constFn"));
+  });
+});

--- a/tests/custom-discriminator/tsconfig.json
+++ b/tests/custom-discriminator/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/tests/custom-discriminator/tsconfig.json
+++ b/tests/custom-discriminator/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "target": "es6",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
     "chat",
     "composite",
     "custom-coder",
+    "custom-discriminator",
     "declare-id",
     "declare-program",
     "errors",


### PR DESCRIPTION
### Problem

There is no way to override the default 8-byte Anchor discriminators of program instructions.

### Summary of changes

Add `#[instruction]` attribute proc-macro that can be used to override Anchor defaults of program instructions.

This macro currently *only* allows overriding discriminators, but the functionality can be extended to override other defaults in the future.

### Example

```rs
#[instruction(discriminator = [0, 1, 2, 3])]
pub fn my_ix(_ctx: Context<MyIx>) -> Result<()> {
    Ok(())
}
```

More examples can be found in the [`custom-discriminator`](https://github.com/acheroncrypto/anchor/blob/lang-add-instruction-attribute-proc-macro/tests/custom-discriminator/programs/custom-discriminator/src/lib.rs) tests.

### Note

The initial design was to introduce a new `#[discriminator]` macro to share the implementation of instructions, accounts and events, as mentioned in https://github.com/coral-xyz/anchor/pull/2728#issuecomment-1858810416. However, given there is a demand from the users to override the other defaults of Anchor (e.g. serialization), it became clear that introducing a new macro for all of the overrides would not scale well.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.