### PR TITLE
lang: Parse `#[account]` attribute arguments with `syn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Make discriminator type unsized ([#3098](https://github.com/coral-xyz/anchor/pull/3098)).
 - lang: Require `Discriminator` trait impl when using the `zero` constraint ([#3118](https://github.com/coral-xyz/anchor/pull/3118)).
 - ts: Remove `DISCRIMINATOR_SIZE` constant ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
+- lang: `#[account]` attribute arguments no longer parses identifiers as namespaces ([#3140](https://github.com/coral-xyz/anchor/pull/3140)).
 
 ## [0.30.1] - 2024-06-20
 


### PR DESCRIPTION
### Problem

`#[account]` macro arguments are parsed by converting the tokens to string and interpreting:

https://github.com/coral-xyz/anchor/blob/f6a8042c40fe15ab98f4fdc0a984bad42d9a5594/lang/attribute/account/src/lib.rs#L70-L94

This makes adding named arguments e.g. `discriminator = <EXPR>` challenging.

Furthermore, any argument other than `zero_copy` and `zero_copy(unsafe)` is interpreted as custom namespace, even when the argument is not a string.

### Summary of changes

- Parse the arguments using `syn`
- Unknown non-string arguments (e.g. `#[account(my_namespace)]`) are no longer interpreted as custom namespaces, and they return an error instead

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.