### PR TITLE
lang: Use associated discriminator constants instead of hardcoding in `#[account]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Warn if `anchor-spl/idl-build` is missing ([#3133](https://github.com/coral-xyz/anchor/pull/3133)).
 - client: Add `internal_rpc` method for `mock` feature ([#3135](https://github.com/coral-xyz/anchor/pull/3135)).
 - lang: Add `#[instruction]` attribute proc-macro to override default instruction discriminators ([#3137](https://github.com/coral-xyz/anchor/pull/3137)).
+- lang: Use associated discriminator constants instead of hardcoding in `#[account]` ([#3144](https://github.com/coral-xyz/anchor/pull/3144)).
 
 ### Fixes
 

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -100,6 +100,7 @@ pub fn account(
         );
         format!("{discriminator:?}").parse().unwrap()
     };
+    let disc = quote! { #account_name::DISCRIMINATOR };
 
     let owner_impl = {
         if namespace.is_empty() {
@@ -162,18 +163,18 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::AccountDeserialize for #account_name #type_gen #where_clause {
                     fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                        if buf.len() < #discriminator.len() {
+                        if buf.len() < #disc.len() {
                             return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
                         }
-                        let given_disc = &buf[..#discriminator.len()];
-                        if &#discriminator != given_disc {
+                        let given_disc = &buf[..#disc.len()];
+                        if #disc != given_disc {
                             return Err(anchor_lang::error!(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch).with_account_name(#account_name_str));
                         }
                         Self::try_deserialize_unchecked(buf)
                     }
 
                     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                        let data: &[u8] = &buf[#discriminator.len()..];
+                        let data: &[u8] = &buf[#disc.len()..];
                         // Re-interpret raw bytes into the POD data structure.
                         let account = anchor_lang::__private::bytemuck::from_bytes(data);
                         // Copy out the bytes into a new, owned data structure.
@@ -191,7 +192,7 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::AccountSerialize for #account_name #type_gen #where_clause {
                     fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> anchor_lang::Result<()> {
-                        if writer.write_all(&#discriminator).is_err() {
+                        if writer.write_all(#disc).is_err() {
                             return Err(anchor_lang::error::ErrorCode::AccountDidNotSerialize.into());
                         }
 
@@ -205,18 +206,18 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::AccountDeserialize for #account_name #type_gen #where_clause {
                     fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                        if buf.len() < #discriminator.len() {
+                        if buf.len() < #disc.len() {
                             return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
                         }
-                        let given_disc = &buf[..#discriminator.len()];
-                        if &#discriminator != given_disc {
+                        let given_disc = &buf[..#disc.len()];
+                        if #disc != given_disc {
                             return Err(anchor_lang::error!(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch).with_account_name(#account_name_str));
                         }
                         Self::try_deserialize_unchecked(buf)
                     }
 
                     fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-                        let mut data: &[u8] = &buf[#discriminator.len()..];
+                        let mut data: &[u8] = &buf[#disc.len()..];
                         AnchorDeserialize::deserialize(&mut data)
                             .map_err(|_| anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into())
                     }


### PR DESCRIPTION
### Problem

The `#[account]` attribute generates uses hardcoded values for discriminators multiple times:

https://github.com/coral-xyz/anchor/blob/56af130b740b4a50b8ea27efeb6b79c3844296c9/lang/attribute/account/src/lib.rs#L165-L169

This expands to:

```rs
if buf.len() < [200, 118, 9, 135, 8, 198, 62, 135].len() {
    return Err(
        anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into(),
    );
}
let given_disc = &buf[..[200, 118, 9, 135, 8, 198, 62, 135].len()];
if &[200, 118, 9, 135, 8, 198, 62, 135] != given_disc {
```

The discriminators were being hardcoded before, but getting the length dynamically (rather than hardcoding as 8) in https://github.com/coral-xyz/anchor/pull/3101 made the problem more obvious.

Additionally, this makes overriding discriminators via argument e.g. `discriminator = DISC` or `discriminator = &[1]` unreliable because appending `.len()` to these expressions sometimes result in `&usize` type which causes compile errors.

### Summary of changes

Use the associated discriminator constant instead of hardcoding the value. This is functionally idential as the same code now expands to:

```rs
if buf.len() < MyAccount::DISCRIMINATOR.len() {
    return Err(
        anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into(),
    );
}
let given_disc = &buf[..MyAccount::DISCRIMINATOR.len()];
if MyAccount::DISCRIMINATOR != given_disc {
```

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.