### PR TITLE
Fix clippy 1.80.0 lints

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -832,6 +832,8 @@ pub struct _TestToml {
 }
 
 impl _TestToml {
+    // TODO: Remove if/when false positive gets fixed
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let s = fs::read_to_string(&path)?;
         let parsed_toml: Self = toml::from_str(&s)?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(nightly, feature(proc_macro_span))]
-
 use crate::config::{
     AnchorPackage, BootstrapMode, BuildConfig, Config, ConfigOverride, Manifest, ProgramArch,
     ProgramDeployment, ProgramWorkspace, ScriptsConfig, TestValidator, WithPath,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3811,7 +3811,7 @@ fn upgrade(
             .arg("--url")
             .arg(url)
             .arg("--keypair")
-            .arg(&cfg.provider.wallet.to_string())
+            .arg(cfg.provider.wallet.to_string())
             .arg("--program-id")
             .arg(strip_workspace_prefix(program_id.to_string()))
             .arg(strip_workspace_prefix(program_filepath))

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -86,6 +86,7 @@ use std::ops::{Deref, DerefMut};
 /// those programs are not annotated with `#[account]` so you have to
 /// - create a wrapper type around the structs you want to wrap with Account
 /// - implement the functions required by Account yourself
+///
 /// instead of using `#[account]`. You only have to implement a fraction of the
 /// functions `#[account]` generates. See the example below for the code you have
 /// to write.

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -23,7 +23,7 @@ use std::ops::DerefMut;
 /// for example, the [`Account`](crate::accounts::account::Account). Namely,
 /// one must call
 /// - `load_init` after initializing an account (this will ignore the missing
-/// account discriminator that gets added only after the user's instruction code)
+///    account discriminator that gets added only after the user's instruction code)
 /// - `load` when the account is not mutable
 /// - `load_mut` when the account is mutable
 ///

--- a/lang/src/accounts/interface.rs
+++ b/lang/src/accounts/interface.rs
@@ -59,9 +59,9 @@ use std::ops::Deref;
 /// The required constraints are as follows:
 ///
 /// - `program` is the account of the program itself.
-/// Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
-/// Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
-/// will be `None` if it's not).
+///    Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
+///    Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
+///    will be `None` if it's not).
 /// - `program_data`'s constraint checks that its upgrade authority is the `authority` account.
 /// - Finally, `authority` needs to sign the transaction.
 ///

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -86,6 +86,7 @@ use std::ops::{Deref, DerefMut};
 /// those programs are not annotated with `#[account]` so you have to
 /// - create a wrapper type around the structs you want to wrap with InterfaceAccount
 /// - implement the functions required by InterfaceAccount yourself
+///
 /// instead of using `#[account]`. You only have to implement a fraction of the
 /// functions `#[account]` generates. See the example below for the code you have
 /// to write.

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -59,9 +59,9 @@ use std::ops::Deref;
 /// The required constraints are as follows:
 ///
 /// - `program` is the account of the program itself.
-/// Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
-/// Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
-/// will be `None` if it's not).
+///    Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
+///    Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
+///    will be `None` if it's not).
 /// - `program_data`'s constraint checks that its upgrade authority is the `authority` account.
 /// - Finally, `authority` needs to sign the transaction.
 ///

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -193,7 +193,7 @@ pub trait Lamports<'info>: AsRef<AccountInfo<'info>> {
     ///
     /// 1. The account must be marked `mut`.
     /// 2. The total lamports **before** the transaction must equal to total lamports **after**
-    /// the transaction.
+    ///    the transaction.
     /// 3. `lamports` field of the account info should not currently be borrowed.
     ///
     /// See [`Lamports::sub_lamports`] for subtracting lamports.
@@ -214,7 +214,7 @@ pub trait Lamports<'info>: AsRef<AccountInfo<'info>> {
     /// 1. The account must be owned by the executing program.
     /// 2. The account must be marked `mut`.
     /// 3. The total lamports **before** the transaction must equal to total lamports **after**
-    /// the transaction.
+    ///    the transaction.
     /// 4. `lamports` field of the account info should not currently be borrowed.
     ///
     /// See [`Lamports::add_lamports`] for adding lamports.


### PR DESCRIPTION
### Problem

CI [fails](https://github.com/coral-xyz/anchor/actions/runs/10217918704/job/28272813490) due to the new `clippy` lints introduced in the latest stable release.


### Summary of changes

- Fix `clippy::doc_lazy_continuation`, `unexpected_cfgs`, `clippy::needless_borrows_for_generic_args`
- Ignore false positive `clippy::needless_borrows_for_generic_args`