### PR TITLE
lang: Fix compilation error when an `#[account]` struct has generics

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -100,7 +100,11 @@ pub fn account(
         );
         format!("{discriminator:?}").parse().unwrap()
     };
-    let disc = quote! { #account_name::DISCRIMINATOR };
+    let disc = if account_strct.generics.lt_token.is_some() {
+        quote! { #account_name::#type_gen::DISCRIMINATOR }
+    } else {
+        quote! { #account_name::DISCRIMINATOR }
+    };
 
     let owner_impl = {
         if namespace.is_empty() {


### PR DESCRIPTION
### Problem

The change in https://github.com/coral-xyz/anchor/pull/3144 introduced [a compilation error](https://github.com/coral-xyz/anchor/actions/runs/10225567464/job/28294759633) when the `#[account]` struct has generics, but it wasn't caught due to [the latest `clippy` lints](https://github.com/coral-xyz/anchor/actions/runs/10217918704/job/28272813490).

Example problematic definition:

https://github.com/coral-xyz/anchor/blob/dc6ac2d631fd759339c67a25996c9570bb1e71df/lang/tests/generics_test.rs#L30-L33

### Summary of changes

Conditionally add the generics to the `DISCRIMINATOR` constant accessors based on whether the account struct definition has generics.

This change is only aimed at fixing [the CI errors](https://github.com/coral-xyz/anchor/actions/runs/10225567464/job/28294759633) because the IDL spec (intentionally) does not support having generics in the account struct definitions. This might change in the future, but the fix in this PR is simple enough that we don't need to deal with removing the generic implementation.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.