### PR TITLE
lang: Reuse common override arguments

### DIFF
--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -22,9 +22,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 })
                 .collect();
             let impls = {
-                let discriminator = match ix.ix_attr.as_ref() {
-                    Some(ix_attr) if ix_attr.discriminator.is_some() => {
-                        ix_attr.discriminator.as_ref().unwrap().to_owned()
+                let discriminator = match ix.overrides.as_ref() {
+                    Some(overrides) if overrides.discriminator.is_some() => {
+                        overrides.discriminator.as_ref().unwrap().to_owned()
                     }
                     _ => {
                         // TODO: Remove `interface_discriminator`

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -69,23 +69,23 @@ pub struct Ix {
     // The ident for the struct deriving Accounts.
     pub anchor_ident: Ident,
     // The discriminator based on the `#[interface]` attribute.
-    // TODO: Remove and use `ix_attr`
+    // TODO: Remove and use `overrides`
     pub interface_discriminator: Option<[u8; 8]>,
-    /// `#[instruction]` attribute
-    pub ix_attr: Option<IxAttr>,
+    /// Overrides coming from the `#[instruction]` attribute
+    pub overrides: Option<Overrides>,
 }
 
-/// `#[instruction]` attribute proc-macro
+/// Common overrides for the `#[instruction]`, `#[account]` and `#[event]` attributes
 #[derive(Debug, Default)]
-pub struct IxAttr {
-    /// Discriminator override
+pub struct Overrides {
+    /// Override the default 8-byte discriminator
     pub discriminator: Option<TokenStream>,
 }
 
-impl Parse for IxAttr {
+impl Parse for Overrides {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         let mut attr = Self::default();
-        let args = input.parse_terminated::<_, Comma>(AttrArg::parse)?;
+        let args = input.parse_terminated::<_, Comma>(NamedArg::parse)?;
         for arg in args {
             match arg.name.to_string().as_str() {
                 "discriminator" => {
@@ -106,14 +106,14 @@ impl Parse for IxAttr {
     }
 }
 
-struct AttrArg {
+struct NamedArg {
     name: Ident,
     #[allow(dead_code)]
-    eq_token: Token!(=),
+    eq_token: Token![=],
     value: Expr,
 }
 
-impl Parse for AttrArg {
+impl Parse for NamedArg {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         Ok(Self {
             name: input.parse()?,


### PR DESCRIPTION
### Problem

The new `discriminator = <EXPR>` argument can be used with [`#[instruction]`](https://github.com/coral-xyz/anchor/pull/3137), [`#[account]`](https://github.com/coral-xyz/anchor/pull/3149), and [`#[event]`](https://github.com/coral-xyz/anchor/pull/3152) attributes, but they don't share code between each other, which results in unnecessary duplication.

### Summary of changes

Add a new `Overrides` struct that can be shared between all previously mentioned attributes above.

The implementation is slightly different for `#[account]` because it also has other arguments (zero copy and namespaces) that we'd like to keep backwards-compatible.

This change achieves the same functionality with less than half of the previous code.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.