### PR TITLE
idl: Check ambiguous discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Use associated discriminator constants instead of hardcoding in `#[account]` ([#3144](https://github.com/coral-xyz/anchor/pull/3144)).
 - lang: Add `discriminator` argument to `#[account]` attribute ([#3149](https://github.com/coral-xyz/anchor/pull/3149)).
 - lang: Add `discriminator` argument to `#[event]` attribute ([#3152](https://github.com/coral-xyz/anchor/pull/3152)).
+- idl: Check ambiguous discriminators ([#3157](https://github.com/coral-xyz/anchor/pull/3157)).
 
 ### Fixes
 

--- a/tests/custom-discriminator/Anchor.toml
+++ b/tests/custom-discriminator/Anchor.toml
@@ -1,8 +1,19 @@
+[workspace]
+exclude = ["programs/ambiguous-discriminator"]
+
+[features]
+resolution = true
+skip-lint = false
+
 [programs.localnet]
+ambiguous-discriminator = "AmbiguousDiscriminator111111111111111111111"
 custom_discriminator = "CustomDiscriminator111111111111111111111111"
 
+[registry]
+url = "https://api.apr.dev"
+
 [provider]
-cluster = "localnet"
+cluster = "Localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/tests/custom-discriminator/programs/ambiguous-discriminator/Cargo.toml
+++ b/tests/custom-discriminator/programs/ambiguous-discriminator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ambiguous-discriminator"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "ambiguous_discriminator"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/custom-discriminator/programs/ambiguous-discriminator/Xargo.toml
+++ b/tests/custom-discriminator/programs/ambiguous-discriminator/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/custom-discriminator/programs/ambiguous-discriminator/src/lib.rs
+++ b/tests/custom-discriminator/programs/ambiguous-discriminator/src/lib.rs
@@ -1,0 +1,31 @@
+use anchor_lang::prelude::*;
+
+declare_id!("AmbiguousDiscriminator111111111111111111111");
+
+#[program]
+pub mod ambiguous_discriminator {
+    use super::*;
+
+    /// Compilation should error due to ambiguous discriminators.
+    pub fn check_accounts(_ctx: Context<CheckAccounts>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct CheckAccounts<'info> {
+    pub some_account: Account<'info, SomeAccount>,
+    pub another_account: Account<'info, AnotherAccount>,
+}
+
+#[account(discriminator = 1)]
+pub struct SomeAccount {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+#[account(discriminator = [1, 2, 3, 4])]
+pub struct AnotherAccount {
+    pub a: u32,
+}

--- a/tests/custom-discriminator/tests/ambiguous-discriminator.ts
+++ b/tests/custom-discriminator/tests/ambiguous-discriminator.ts
@@ -1,0 +1,22 @@
+import { spawnSync } from "child_process";
+
+describe("ambiguous-discriminator", () => {
+  it("Returns ambiguous discriminator error on builds", () => {
+    const result = spawnSync("anchor", [
+      "idl",
+      "build",
+      "-p",
+      "ambiguous-discriminator",
+    ]);
+    if (result.status === 0) {
+      throw new Error("Ambiguous errors did not make building the IDL fail");
+    }
+
+    const output = result.output.toString();
+    if (!output.includes("Error: Program ambiguous-discriminator not found")) {
+      throw new Error(
+        `Ambiguous discriminators did not return the expected error: "${output}"`
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Problem

The ability to set custom discriminators means the user can also set discriminators that are ambiguous. For example:

```rs
#[account(discriminator = 1)]
pub struct SomeAccount {
    pub a: u8,
    pub b: u16,
    pub c: u32,
}

#[account(discriminator = [1, 2, 3, 4])]
pub struct AnotherAccount {
    pub a: u32,
}
```

In this example, there is no way to reliably decide the expected account type from a given account info's data. For this reason, Anchor should not allow compilation of this program.

However, this results in another problem — definitions of accounts, events, and instructions don't have access to other definitions' discriminators, as proc-macros are stateless. To solve this, ambiguous discriminators should be checked during the IDL generation process, since we have access to all discriminator values (and introducing another `idl-build`-like feature just to check discriminators would increase the already long build times even more).

### Summary of changes

Check potential discriminator collisisons during the IDL generation step.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.