### PR TITLE
idl: Disallow all zero account discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `discriminator` argument to `#[account]` attribute ([#3149](https://github.com/coral-xyz/anchor/pull/3149)).
 - lang: Add `discriminator` argument to `#[event]` attribute ([#3152](https://github.com/coral-xyz/anchor/pull/3152)).
 - idl: Check ambiguous discriminators ([#3157](https://github.com/coral-xyz/anchor/pull/3157)).
+- idl: Disallow all zero account discriminators ([#3159](https://github.com/coral-xyz/anchor/pull/3159)).
 
 ### Fixes
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -317,5 +317,17 @@ fn verify(idl: &Idl) -> Result<()> {
     check_discriminator_collision!(events);
     check_discriminator_collision!(instructions);
 
+    // Disallow all zero account discriminators
+    if let Some(account) = idl
+        .accounts
+        .iter()
+        .find(|acc| acc.discriminator.iter().all(|b| *b == 0))
+    {
+        return Err(anyhow!(
+            "All zero account discriminators are not allowed (account: `{}`)",
+            account.name
+        ));
+    }
+
     Ok(())
 }

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -42,7 +42,7 @@ mod id;
 ///
 ///     **Examples:**
 ///
-///     - `discriminator = 0` (shortcut for `[0]`)
+///     - `discriminator = 1` (shortcut for `[1]`)
 ///     - `discriminator = [1, 2, 3, 4]`
 ///     - `discriminator = b"hi"`
 ///     - `discriminator = MY_DISC`

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -21,7 +21,7 @@ use syn::parse_macro_input;
 ///
 ///     **Examples:**
 ///
-///     - `discriminator = 0` (shortcut for `[0]`)
+///     - `discriminator = 1` (shortcut for `[1]`)
 ///     - `discriminator = [1, 2, 3, 4]`
 ///     - `discriminator = b"hi"`
 ///     - `discriminator = MY_DISC`

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -116,7 +116,7 @@ pub fn interface(
 ///
 ///     **Examples:**
 ///
-///     - `discriminator = 0` (shortcut for `[0]`)
+///     - `discriminator = 1` (shortcut for `[1]`)
 ///     - `discriminator = [1, 2, 3, 4]`
 ///     - `discriminator = b"hi"`
 ///     - `discriminator = MY_DISC`


### PR DESCRIPTION
### Problem

Setting account discriminators to all zeros conflicts with the `zero` account constraint (which checks the discriminator bytes to be all zeros). For example:

```rs
#[account(discriminator = 0)]
pub struct MyAccount {}

#[derive(Accounts)]
pub struct MyIx<'info> {
    #[account(zero)]
    pub my_account: Account<'info, MyAccount>,
}
```

### Summary of changes

Return an error during IDL generation if an account has all zero discriminator.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.