### PR TITLE
lang, ts: Remove "8 byte" requirement from discriminator error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Require `Discriminator` trait impl when using the `zero` constraint ([#3118](https://github.com/coral-xyz/anchor/pull/3118)).
 - ts: Remove `DISCRIMINATOR_SIZE` constant ([#3120](https://github.com/coral-xyz/anchor/pull/3120)).
 - lang: `#[account]` attribute arguments no longer parses identifiers as namespaces ([#3140](https://github.com/coral-xyz/anchor/pull/3140)).
-- spl: Rename metadata interface instruction fields from `token_program_id` to `program_id` ([3076](https://github.com/coral-xyz/anchor/pull/3076)).
+- spl: Rename metadata interface instruction fields from `token_program_id` to `program_id` ([#3076](https://github.com/coral-xyz/anchor/pull/3076)).
+- lang, ts: Remove "8 byte" requirement from discriminator error messages ([#3161](https://github.com/coral-xyz/anchor/pull/3161)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -21,8 +21,8 @@ pub const ERROR_CODE_OFFSET: u32 = 6000;
 #[error_code(offset = 0)]
 pub enum ErrorCode {
     // Instructions
-    /// 100 - 8 byte instruction identifier not provided
-    #[msg("8 byte instruction identifier not provided")]
+    /// 100 - Instruction discriminator not provided
+    #[msg("Instruction discriminator not provided")]
     InstructionMissing = 100,
     /// 101 - Fallback functions are not supported
     #[msg("Fallback functions are not supported")]
@@ -205,11 +205,11 @@ pub enum ErrorCode {
     /// 3000 - The account discriminator was already set on this account
     #[msg("The account discriminator was already set on this account")]
     AccountDiscriminatorAlreadySet = 3000,
-    /// 3001 - No 8 byte discriminator was found on the account
-    #[msg("No 8 byte discriminator was found on the account")]
+    /// 3001 - No discriminator was found on the account
+    #[msg("No discriminator was found on the account")]
     AccountDiscriminatorNotFound,
-    /// 3002 - 8 byte discriminator did not match what was expected
-    #[msg("8 byte discriminator did not match what was expected")]
+    /// 3002 - Account discriminator did not match what was expected
+    #[msg("Account discriminator did not match what was expected")]
     AccountDiscriminatorMismatch,
     /// 3003 - Failed to deserialize the account
     #[msg("Failed to deserialize the account")]

--- a/ts/packages/anchor/src/error.ts
+++ b/ts/packages/anchor/src/error.ts
@@ -435,10 +435,7 @@ export const LangErrorCode = {
 
 export const LangErrorMessage = new Map<number, string>([
   // Instructions.
-  [
-    LangErrorCode.InstructionMissing,
-    "8 byte instruction identifier not provided",
-  ],
+  [LangErrorCode.InstructionMissing, "Instruction discriminator not provided"],
   [
     LangErrorCode.InstructionFallbackNotFound,
     "Fallback functions are not supported",
@@ -614,11 +611,11 @@ export const LangErrorMessage = new Map<number, string>([
   ],
   [
     LangErrorCode.AccountDiscriminatorNotFound,
-    "No 8 byte discriminator was found on the account",
+    "No discriminator was found on the account",
   ],
   [
     LangErrorCode.AccountDiscriminatorMismatch,
-    "8 byte discriminator did not match what was expected",
+    "Account discriminator did not match what was expected",
   ],
   [LangErrorCode.AccountDidNotDeserialize, "Failed to deserialize the account"],
   [LangErrorCode.AccountDidNotSerialize, "Failed to serialize the account"],


### PR DESCRIPTION
### Problem

There are a few discriminator-related error messages that specifically include "8 byte" discriminators:

https://github.com/coral-xyz/anchor/blob/033b71f786347b91768f2251241e6fc9154de2e2/lang/src/error.rs#L24-L26

https://github.com/coral-xyz/anchor/blob/033b71f786347b91768f2251241e6fc9154de2e2/lang/src/error.rs#L208-L213

### Summary of changes

Update discriminator errors to remove the "8 byte" requirement.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.