### PR TITLE
lang: Remove `discriminator` method from `Discriminator` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: `#[account]` attribute arguments no longer parses identifiers as namespaces ([#3140](https://github.com/coral-xyz/anchor/pull/3140)).
 - spl: Rename metadata interface instruction fields from `token_program_id` to `program_id` ([#3076](https://github.com/coral-xyz/anchor/pull/3076)).
 - lang, ts: Remove "8 byte" requirement from discriminator error messages ([#3161](https://github.com/coral-xyz/anchor/pull/3161)).
+- lang: Remove `discriminator` method from `Discriminator` trait ([#3163](https://github.com/coral-xyz/anchor/pull/3163)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -303,9 +303,6 @@ pub trait Event: AnchorSerialize + AnchorDeserialize + Discriminator {
 /// 8 byte unique identifier for a type.
 pub trait Discriminator {
     const DISCRIMINATOR: &'static [u8];
-    fn discriminator() -> &'static [u8] {
-        Self::DISCRIMINATOR
-    }
 }
 
 /// Defines the space of an account for initialization.

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -22,7 +22,7 @@ async fn update_foo() {
     let foo_pubkey = Pubkey::new_unique();
     let foo_account = {
         let mut foo_data = Vec::new();
-        foo_data.extend_from_slice(&zero_copy::Foo::discriminator());
+        foo_data.extend_from_slice(zero_copy::Foo::DISCRIMINATOR);
         foo_data.extend_from_slice(bytemuck::bytes_of(&zero_copy::Foo {
             authority: authority.pubkey(),
             ..zero_copy::Foo::default()


### PR DESCRIPTION
### Problem

There is no reason to have both an associated constant and a method that returns the exact same thing, as in the case with the `Discriminator` trait:

https://github.com/coral-xyz/anchor/blob/bb809fd1df295fb9b7c1cc7596c5c6ccece4c2cf/lang/src/lib.rs#L304-L309

The reason why both exist is likely because of backwards compatibility reasons (`DISCRIMINATOR` constant was added after the `discriminator` method).

This is no longer necessary, and it's fitting to remove it now that the return type has also changed.

### Summary of changes

Remove the `discriminator` method of the `Discriminator` trait.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.