### PR TITLE
idl: Disallow empty discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Check ambiguous discriminators ([#3157](https://github.com/coral-xyz/anchor/pull/3157)).
 - idl: Disallow all zero account discriminators ([#3159](https://github.com/coral-xyz/anchor/pull/3159)).
 - cli: Support non-8-byte discriminators ([#3165](https://github.com/coral-xyz/anchor/pull/3165)).
+- idl: Disallow empty discriminators ([#3166](https://github.com/coral-xyz/anchor/pull/3166)).
 
 ### Fixes
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -293,6 +293,22 @@ fn verify(idl: &Idl) -> Result<()> {
         ));
     }
 
+    // Check empty discriminators
+    macro_rules! check_empty_discriminators {
+        ($field:ident) => {
+            if let Some(item) = idl.$field.iter().find(|it| it.discriminator.is_empty()) {
+                return Err(anyhow!(
+                    "Empty discriminators are not allowed for {}: `{}`",
+                    stringify!($field),
+                    item.name
+                ));
+            }
+        };
+    }
+    check_empty_discriminators!(accounts);
+    check_empty_discriminators!(events);
+    check_empty_discriminators!(instructions);
+
     // Check potential discriminator collisions
     macro_rules! check_discriminator_collision {
         ($field:ident) => {
@@ -312,7 +328,6 @@ fn verify(idl: &Idl) -> Result<()> {
             }
         };
     }
-
     check_discriminator_collision!(accounts);
     check_discriminator_collision!(events);
     check_discriminator_collision!(instructions);


### PR DESCRIPTION
### Problem

It's possible to set the discriminators to an empty array. For example:

```rs
#[account(discriminator = [])]
pub struct MyAccount {}
```

This shouldn't be allowed due to security and convenience reasons.

### Summary of changes

Disallow empty discriminators during IDL generation.

The reason for handling this during IDL build process is because we can't reliably get the discriminator from parsing the input (e.g. `discriminator = EMPTY` is also valid).

And the reason for not implementing our own custom discriminator type e.g.

```rs
pub struct NonZeroDiscriminator(&'static [u8]);
```

is because it would not allow using programs that don't have discriminators (e.g. some of the SPL programs).


---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.