### PR TITLE
Tweak subheading in case people don't know what sealevel is.

### DIFF
--- a/docs/src/components/Hero.jsx
+++ b/docs/src/components/Hero.jsx
@@ -43,7 +43,7 @@ export function Hero() {
                 Anchor
               </p>
               <p className="mt-3 text-2xl tracking-tight text-slate-400">
-                Solana&apos;s Sealevel runtime framework
+                Solana's most popular smart contract framework.
               </p>
               <div className="mt-8 flex space-x-4 md:justify-center lg:justify-start">
                 <ButtonLink href="/">Get started</ButtonLink>


### PR DESCRIPTION
Following on from https://github.com/coral-xyz/anchor/pull/3160.

Note re: `&apos;` - I'm fairly sure we don't need to encode apostrophe in modern browsers in a UTF8 website.