### PR TITLE
docs: Fix deployment to Vercel

### DIFF
--- a/docs/src/components/Hero.jsx
+++ b/docs/src/components/Hero.jsx
@@ -43,7 +43,7 @@ export function Hero() {
                 Anchor
               </p>
               <p className="mt-3 text-2xl tracking-tight text-slate-400">
-                Solana's most popular smart contract framework.
+                Solana&apos;s most popular smart contract framework
               </p>
               <div className="mt-8 flex space-x-4 md:justify-center lg:justify-start">
                 <ButtonLink href="/">Get started</ButtonLink>


### PR DESCRIPTION
### Problem

https://github.com/coral-xyz/anchor/issues/3167 changed

https://github.com/coral-xyz/anchor/blob/9a528003ea9fd85795cf58691c42e9be52539a4f/docs/src/components/Hero.jsx#L46

to

https://github.com/coral-xyz/anchor/blob/b39be23bd9add8c887f64a12abe4405e218e6183/docs/src/components/Hero.jsx#L46

and [automatic deployment via GitHub actions stopped working](https://vercel.com/200ms/anchor-docs/Av5KvMaRMxeP6o34cQ1A67VLgegT) after that change.

I'm not able to see the logs, but the reason for the deployment failure is very likely to be the `&apos;` -> `'` change.

### Summary of changes

Revert the `&apos;` removal change while keeping the other changes.