### PR TITLE
lang: Remove unused code related to deprecated program id macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Skip IDL checks if `--no-idl` option is passed ([#3093](https://github.com/coral-xyz/anchor/pull/3093)).
 - lang: Remove unnecessary clone in account exit routine ([#3139](https://github.com/coral-xyz/anchor/pull/3139)).
 - cli: Fix installation with `--locked` argument using Rust v1.80 due to `time` crate issue ([#3143](https://github.com/coral-xyz/anchor/pull/3143)).
+- lang: Fix compilation warnings due to unused deprecated program id macros ([#3170](https://github.com/coral-xyz/anchor/pull/3170)).
 
 ### Breaking
 

--- a/lang/attribute/account/src/id.rs
+++ b/lang/attribute/account/src/id.rs
@@ -8,14 +8,11 @@
 
 extern crate proc_macro;
 
-use proc_macro2::{Delimiter, Span, TokenTree};
+use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{
-    bracketed,
     parse::{Parse, ParseStream, Result},
-    punctuated::Punctuated,
-    token::Bracket,
-    Expr, Ident, LitByte, LitStr, Path, Token,
+    Expr, LitByte, LitStr,
 };
 
 fn parse_id(
@@ -72,36 +69,6 @@ fn id_to_tokens(
     });
 }
 
-fn deprecated_id_to_tokens(
-    id: &proc_macro2::TokenStream,
-    pubkey_type: proc_macro2::TokenStream,
-    tokens: &mut proc_macro2::TokenStream,
-) {
-    tokens.extend(quote! {
-        /// The static program ID
-        pub static ID: #pubkey_type = #id;
-
-        /// Confirms that a given pubkey is equivalent to the program ID
-        #[deprecated()]
-        pub fn check_id(id: &#pubkey_type) -> bool {
-            id == &ID
-        }
-
-        /// Returns the program ID
-        #[deprecated()]
-        pub fn id() -> #pubkey_type {
-            ID
-        }
-
-        #[cfg(test)]
-        #[test]
-            fn test_id() {
-            #[allow(deprecated)]
-            assert!(check_id(&id()));
-        }
-    });
-}
-
 pub struct Pubkey(proc_macro2::TokenStream);
 
 impl Parse for Pubkey {
@@ -143,97 +110,6 @@ impl ToTokens for Id {
     }
 }
 
-struct IdDeprecated(proc_macro2::TokenStream);
-
-impl Parse for IdDeprecated {
-    fn parse(input: ParseStream) -> Result<Self> {
-        parse_id(
-            input,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-        )
-        .map(Self)
-    }
-}
-
-impl ToTokens for IdDeprecated {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        deprecated_id_to_tokens(
-            &self.0,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-            tokens,
-        )
-    }
-}
-
-struct ProgramSdkId(proc_macro2::TokenStream);
-impl Parse for ProgramSdkId {
-    fn parse(input: ParseStream) -> Result<Self> {
-        parse_id(
-            input,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-        )
-        .map(Self)
-    }
-}
-
-impl ToTokens for ProgramSdkId {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        id_to_tokens(
-            &self.0,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-            tokens,
-        )
-    }
-}
-
-struct ProgramSdkIdDeprecated(proc_macro2::TokenStream);
-impl Parse for ProgramSdkIdDeprecated {
-    fn parse(input: ParseStream) -> Result<Self> {
-        parse_id(
-            input,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-        )
-        .map(Self)
-    }
-}
-
-impl ToTokens for ProgramSdkIdDeprecated {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        deprecated_id_to_tokens(
-            &self.0,
-            quote! { anchor_lang::solana_program::pubkey::Pubkey },
-            tokens,
-        )
-    }
-}
-
-#[allow(dead_code)] // `respan` may be compiled out
-struct RespanInput {
-    to_respan: Path,
-    respan_using: Span,
-}
-
-impl Parse for RespanInput {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let to_respan: Path = input.parse()?;
-        let _comma: Token![,] = input.parse()?;
-        let respan_tree: TokenTree = input.parse()?;
-        match respan_tree {
-            TokenTree::Group(g) if g.delimiter() == Delimiter::None => {
-                let ident: Ident = syn::parse2(g.stream())?;
-                Ok(RespanInput {
-                    to_respan,
-                    respan_using: ident.span(),
-                })
-            }
-            val => Err(syn::Error::new_spanned(
-                val,
-                "expected None-delimited group",
-            )),
-        }
-    }
-}
-
 fn parse_pubkey(
     id_literal: &LitStr,
     pubkey_type: &proc_macro2::TokenStream,
@@ -253,70 +129,4 @@ fn parse_pubkey(
             [#(#bytes,)*]
         )
     })
-}
-
-struct Pubkeys {
-    method: Ident,
-    num: usize,
-    pubkeys: proc_macro2::TokenStream,
-}
-impl Parse for Pubkeys {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let pubkey_type = quote! {
-            anchor_lang::solana_program::pubkey::Pubkey
-        };
-
-        let method = input.parse()?;
-        let _comma: Token![,] = input.parse()?;
-        let (num, pubkeys) = if input.peek(syn::LitStr) {
-            let id_literal: LitStr = input.parse()?;
-            (1, parse_pubkey(&id_literal, &pubkey_type)?)
-        } else if input.peek(Bracket) {
-            let pubkey_strings;
-            bracketed!(pubkey_strings in input);
-            let punctuated: Punctuated<LitStr, Token![,]> =
-                Punctuated::parse_terminated(&pubkey_strings)?;
-            let mut pubkeys: Punctuated<proc_macro2::TokenStream, Token![,]> = Punctuated::new();
-            for string in punctuated.iter() {
-                pubkeys.push(parse_pubkey(string, &pubkey_type)?);
-            }
-            (pubkeys.len(), quote! {#pubkeys})
-        } else {
-            let stream: proc_macro2::TokenStream = input.parse()?;
-            return Err(syn::Error::new_spanned(stream, "unexpected token"));
-        };
-
-        Ok(Pubkeys {
-            method,
-            num,
-            pubkeys,
-        })
-    }
-}
-
-impl ToTokens for Pubkeys {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Pubkeys {
-            method,
-            num,
-            pubkeys,
-        } = self;
-
-        let pubkey_type = quote! {
-            anchor_lang::solana_program::pubkey::Pubkey
-        };
-        if *num == 1 {
-            tokens.extend(quote! {
-                pub fn #method() -> #pubkey_type {
-                    #pubkeys
-                }
-            });
-        } else {
-            tokens.extend(quote! {
-                pub fn #method() -> ::std::vec::Vec<#pubkey_type> {
-                    vec![#pubkeys]
-                }
-            });
-        }
-    }
 }


### PR DESCRIPTION
### Problem

`rustc 1.82.0-nightly` prints some warnings related to unused code:

```
   Compiling anchor-attribute-account v0.30.1 (/home/x/anchor/lang/attribute/account)
warning: function `deprecated_id_to_tokens` is never used
  --> /home/x/anchor/lang/attribute/account/src/id.rs:75:4
   |
75 | fn deprecated_id_to_tokens(
   |    ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: struct `IdDeprecated` is never constructed
   --> /home/x/anchor/lang/attribute/account/src/id.rs:146:8
    |
146 | struct IdDeprecated(proc_macro2::TokenStream);
    |        ^^^^^^^^^^^^

warning: struct `ProgramSdkId` is never constructed
   --> /home/x/anchor/lang/attribute/account/src/id.rs:168:8
    |
168 | struct ProgramSdkId(proc_macro2::TokenStream);
    |        ^^^^^^^^^^^^

warning: struct `ProgramSdkIdDeprecated` is never constructed
   --> /home/x/anchor/lang/attribute/account/src/id.rs:189:8
    |
189 | struct ProgramSdkIdDeprecated(proc_macro2::TokenStream);
    |        ^^^^^^^^^^^^^^^^^^^^^^

warning: struct `Pubkeys` is never constructed
   --> /home/x/anchor/lang/attribute/account/src/id.rs:258:8
    |
258 | struct Pubkeys {
    |        ^^^^^^^

warning: `anchor-attribute-account` (lib) generated 5 warnings
```

### Summary of changes

Remove unused code related to the deprecated program id macros.

This is not a breaking change since all of the removed code was private.