### PR TITLE
ts: Remove `crypto-hash` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove unnecessary clone in account exit routine ([#3139](https://github.com/coral-xyz/anchor/pull/3139)).
 - cli: Fix installation with `--locked` argument using Rust v1.80 due to `time` crate issue ([#3143](https://github.com/coral-xyz/anchor/pull/3143)).
 - lang: Fix compilation warnings due to unused deprecated program id macros ([#3170](https://github.com/coral-xyz/anchor/pull/3170)).
+- ts: Remove `crypto-hash` dependency ([#3171](https://github.com/coral-xyz/anchor/pull/3171)).
 
 ### Breaking
 

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -42,7 +42,6 @@
     "buffer-layout": "^1.2.2",
     "camelcase": "^6.3.0",
     "cross-fetch": "^3.1.5",
-    "crypto-hash": "^1.3.0",
     "eventemitter3": "^4.0.7",
     "pako": "^2.0.3",
     "snake-case": "^3.0.4",

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1923,11 +1923,6 @@ crypto-hash@*:
   resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-2.0.1.tgz#46c3732e65a078ea06b8b4ae686db41216f81213"
   integrity sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ==
 
-crypto-hash@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-1.3.0.tgz#b402cb08f4529e9f4f09346c3e275942f845e247"
-  integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
-
 cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"


### PR DESCRIPTION
### Problem

[`crypto-hash`](https://www.npmjs.com/package/crypto-hash) package is not used in `@coral-xyz/anchor`, but we depend on it:

https://github.com/coral-xyz/anchor/blob/d6b6ac7a4d4920e418a613815bf9c8057d44a609/ts/packages/anchor/package.json#L45

### Summary of changes

Remove the `crypto-hash` dependency.