### PR TITLE
ts: Improve error message of unsupported `view` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix installation with `--locked` argument using Rust v1.80 due to `time` crate issue ([#3143](https://github.com/coral-xyz/anchor/pull/3143)).
 - lang: Fix compilation warnings due to unused deprecated program id macros ([#3170](https://github.com/coral-xyz/anchor/pull/3170)).
 - ts: Remove `crypto-hash` dependency ([#3171](https://github.com/coral-xyz/anchor/pull/3171)).
+- ts: Improve error message of unsupported `view` method ([#3177](https://github.com/coral-xyz/anchor/pull/3177)).
 
 ### Breaking
 

--- a/ts/packages/anchor/src/program/namespace/methods.ts
+++ b/ts/packages/anchor/src/program/namespace/methods.ts
@@ -313,7 +313,12 @@ export class MethodsBuilder<
     }
 
     if (!this._viewFn) {
-      throw new Error("Method does not support views");
+      throw new Error(
+        [
+          "Method does not support views.",
+          "The instruction should return a value, and its accounts must be read-only",
+        ].join(" ")
+      );
     }
 
     // @ts-ignore


### PR DESCRIPTION
### Problem

`Error: Method does not support views` doesn't give any information why exactly the method is not compatible for viewing, as can bee seen from issues like https://github.com/coral-xyz/anchor/issues/3142, https://github.com/coral-xyz/anchor/issues/2648, https://github.com/coral-xyz/anchor/issues/2089.

### Summary of changes

Improve the error message of unsupported `view` method by mentioning the possible causes of the error.