### PR TITLE
ts: Change the `Program` constructor's `idl` parameter type to `any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang, ts: Remove "8 byte" requirement from discriminator error messages ([#3161](https://github.com/coral-xyz/anchor/pull/3161)).
 - lang: Remove `discriminator` method from `Discriminator` trait ([#3163](https://github.com/coral-xyz/anchor/pull/3163)).
 - docker: Upgrade `node` to 20.16.0 LTS ([#3179](https://github.com/coral-xyz/anchor/pull/3179)).
+- ts: Change the `Program` constructor's `idl` parameter type to `any` ([#3181](https://github.com/coral-xyz/anchor/pull/3181)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -279,7 +279,7 @@ export class Program<IDL extends Idl = Idl> {
    *                          public keys of missing accounts when building instructions
    */
   public constructor(
-    idl: IDL,
+    idl: any,
     provider: Provider = getProvider(),
     coder?: Coder,
     getCustomResolver?: (

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -286,20 +286,18 @@ export class Program<IDL extends Idl = Idl> {
       instruction: IdlInstruction
     ) => CustomAccountResolver<IDL> | undefined
   ) {
-    const camelCasedIdl = convertIdlToCamelCase(idl);
-
     // Fields.
-    this._idl = camelCasedIdl;
+    this._idl = convertIdlToCamelCase(idl);
     this._rawIdl = idl;
     this._provider = provider;
     this._programId = translateAddress(idl.address);
-    this._coder = coder ?? new BorshCoder(camelCasedIdl);
+    this._coder = coder ?? new BorshCoder(this._idl);
     this._events = new EventManager(this._programId, provider, this._coder);
 
     // Dynamic namespaces.
     const [rpc, instruction, transaction, account, simulate, methods, views] =
       NamespaceFactory.build(
-        camelCasedIdl,
+        this._idl,
         this._coder,
         this._programId,
         provider,


### PR DESCRIPTION
### Problem

TypeScript's automatic inference of JSON files messes with the ability to use `Program` constructor without additional casting:

```ts
import * as idl from "./idl/my_program.json";
import type { MyProgram } from "./types/my_program";

const program = new Program(idl as unknown as MyProgram, provider);
```

Casting to `unknown` or `any` is necessary when TypeScript automatically infers the type of the JSON file.

People rightfully ask how to handle this situation e.g. https://github.com/coral-xyz/anchor/issues/2914#issuecomment-2084711323.

### Summary of changes

Change the `Program` constructor's `idl` parameter type to `any`, so that we can simplify constructing programs:

```ts
const program = new Program<MyProgram>(idl, provider);
```

or

```ts
const program: Program<MyProgram> = new Program(idl, provider);
```
