### PR TITLE
cli: Migrate to `agave-install` when `solana_version` is `>= 1.18.19`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Disallow empty discriminators ([#3166](https://github.com/coral-xyz/anchor/pull/3166)).
 - cli: Add `--no-idl` option to the `test` command ([#3175](https://github.com/coral-xyz/anchor/pull/3175)).
 - spl: Add `burn_checked`, `mint_to_checked` and `approve_checked` instructions ([#3186]([https://github.com/coral-xyz/anchor/pull/3186)).
+- cli: Migrate to `agave-install` when `solana_version` is `>= 1.18.19` ([#3185](https://github.com/coral-xyz/anchor/pull/3185)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

`solana-install` is deprecated in `1.18.19` and logs a deprecation message when used:

```
⚠️  solana-install is deprecated and will be discontinued when v1.18 is no longer supported. Please switch to Agave: https://github.com/anza-xyz/agave/wiki/Agave-Transition
```

https://github.com/solana-labs/solana/commit/526b7faeb5d4523ad2430298a703951ad585e549

This makes versions `>= 1.18.19` unusable due to output parsing failure (see https://github.com/coral-xyz/anchor/issues/3147).

### Summary of changes

- Use `agave-install` if the `solana_version` field is `>= 1.18.19`
- Automatically install `agave-install` (or `solana-install`) if necessary