### PR TITLE
cli: Make `clean` command also remove the `.anchor` directory

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -249,7 +249,7 @@ pub enum Command {
         #[clap(subcommand)]
         subcmd: IdlCommand,
     },
-    /// Remove all artifacts from the target directory except program keypairs.
+    /// Remove all artifacts from the generated directories except program keypairs.
     Clean,
     /// Deploys each program in the workspace.
     Deploy {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3733,8 +3733,14 @@ fn cluster_url(cfg: &Config, test_validator: &Option<TestValidator>) -> String {
 fn clean(cfg_override: &ConfigOverride) -> Result<()> {
     let cfg = Config::discover(cfg_override)?.expect("Not in workspace.");
     let cfg_parent = cfg.path().parent().expect("Invalid Anchor.toml");
+    let dot_anchor_dir = cfg_parent.join(".anchor");
     let target_dir = cfg_parent.join("target");
     let deploy_dir = target_dir.join("deploy");
+
+    if dot_anchor_dir.exists() {
+        fs::remove_dir_all(&dot_anchor_dir)
+            .map_err(|e| anyhow!("Could not remove directory {:?}: {}", dot_anchor_dir, e))?;
+    }
 
     if target_dir.exists() {
         for entry in fs::read_dir(target_dir)? {


### PR DESCRIPTION
### Problem

Running `anchor clean` does not remove the `.anchor` directory. The contents of `.anchor` is fully generated, and it can also get pretty big in terms of size.

### Summary of changes

Make `clean` command also remove the `.anchor` directory.