### PR TITLE
lang: Deprecate `#[interface]` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add `burn_checked`, `mint_to_checked` and `approve_checked` instructions ([#3186]([https://github.com/coral-xyz/anchor/pull/3186)).
 - cli: Migrate to `agave-install` when `solana_version` is `>= 1.18.19` ([#3185](https://github.com/coral-xyz/anchor/pull/3185)).
 - idl: Add `IdlBuilder` ([#3188](https://github.com/coral-xyz/anchor/pull/3188)).
+- cli: Make `clean` command also remove the `.anchor` directory ([#3192](https://github.com/coral-xyz/anchor/pull/3192)).
+- lang: Deprecate `#[interface]` attribute ([#3195](https://github.com/coral-xyz/anchor/pull/3195)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -91,6 +91,11 @@ pub fn declare_program(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// }
 /// ```
 #[cfg(feature = "interface-instructions")]
+#[deprecated(
+    since = "0.31.0",
+    note = "Use `#[instruction(discriminator = <EXPR>)]` instead.
+    See examples in https://github.com/coral-xyz/anchor/tree/v0.31.0/tests/spl/transfer-hook"
+)]
 #[proc_macro_attribute]
 pub fn interface(
     _args: proc_macro::TokenStream,

--- a/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
+++ b/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
@@ -18,6 +18,6 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = { path = "../../../../../lang", features = ["interface-instructions"] }
 anchor-spl = { path = "../../../../../spl" }
-spl-discriminator = "0.1.1"
-spl-tlv-account-resolution = "0.4.0"
-spl-transfer-hook-interface = "0.3.0"
+spl-discriminator = "0.2.5"
+spl-tlv-account-resolution = "0.6.5"
+spl-transfer-hook-interface = "0.6.5"

--- a/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
+++ b/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
@@ -18,5 +18,6 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = { path = "../../../../../lang", features = ["interface-instructions"] }
 anchor-spl = { path = "../../../../../spl" }
+spl-discriminator = "0.1.1"
 spl-tlv-account-resolution = "0.4.0"
 spl-transfer-hook-interface = "0.3.0"

--- a/tests/spl/transfer-hook/programs/transfer-hook/src/lib.rs
+++ b/tests/spl/transfer-hook/programs/transfer-hook/src/lib.rs
@@ -20,10 +20,13 @@ use {
         },
         token_interface::{Mint, TokenAccount},
     },
+    spl_discriminator::SplDiscriminate,
     spl_tlv_account_resolution::{account::ExtraAccountMeta, state::ExtraAccountMetaList},
     spl_transfer_hook_interface::{
         error::TransferHookError,
-        instruction::{ExecuteInstruction, TransferHookInstruction},
+        instruction::{
+            ExecuteInstruction, InitializeExtraAccountMetaListInstruction, TransferHookInstruction,
+        },
     },
 };
 
@@ -45,7 +48,7 @@ fn check_token_account_is_transferring(account_data: &[u8]) -> Result<()> {
 pub mod transfer_hook {
     use super::*;
 
-    #[interface(spl_transfer_hook_interface::initialize_extra_account_meta_list)]
+    #[instruction(discriminator = InitializeExtraAccountMetaListInstruction::SPL_DISCRIMINATOR_SLICE)]
     pub fn initialize(ctx: Context<Initialize>, metas: Vec<AnchorExtraAccountMeta>) -> Result<()> {
         let extra_metas_account = &ctx.accounts.extra_metas_account;
         let mint = &ctx.accounts.mint;
@@ -68,7 +71,7 @@ pub mod transfer_hook {
         Ok(())
     }
 
-    #[interface(spl_transfer_hook_interface::execute)]
+    #[instruction(discriminator = ExecuteInstruction::SPL_DISCRIMINATOR_SLICE)]
     pub fn execute(ctx: Context<Execute>, amount: u64) -> Result<()> {
         let source_account = &ctx.accounts.source_account;
         let destination_account = &ctx.accounts.destination_account;


### PR DESCRIPTION
### Problem

Adding support for custom discriminators made the `#[interface]` attribute redundant, since the only thing this attribute does is to override the instruction's discriminator. For example:

https://github.com/coral-xyz/anchor/blob/e6d7dafe12da661a36ad1b4f3b5970e8986e5321/tests/spl/transfer-hook/programs/transfer-hook/src/lib.rs#L71

can now be replaced with:

```rs
#[instruction(discriminator = ExecuteInstruction::SPL_DISCRIMINATOR_SLICE)]
```

Many ways to achieve the same thing often leads to confusion for users, and also [extra bloat](https://github.com/coral-xyz/anchor/blob/d732e756e112b134c9c2bd5894f9cff81849359f/lang/syn/src/parser/spl_interface.rs) in our codebase.

### Summary of changes

Deprecate the `#[interface]` attribute and add a deprecation note explaining how to migrate.

---

**Note:** This PR is part of a greater effort explained in https://github.com/coral-xyz/anchor/issues/3097.