### PR TITLE
idl: Fix panicking on tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix compilation warnings due to unused deprecated program id macros ([#3170](https://github.com/coral-xyz/anchor/pull/3170)).
 - ts: Remove `crypto-hash` dependency ([#3171](https://github.com/coral-xyz/anchor/pull/3171)).
 - ts: Improve error message of unsupported `view` method ([#3177](https://github.com/coral-xyz/anchor/pull/3177)).
+- idl: Fix panicking on tests ([#3197](https://github.com/coral-xyz/anchor/pull/3197)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -497,9 +497,7 @@ pub fn gen_idl_type(
                 use quote::ToTokens;
 
                 let source_path = proc_macro2::Span::call_site().source_file().path();
-                let lib_path = find_path("lib.rs", &source_path).expect("lib.rs should exist");
-
-                if let Ok(ctx) = CrateContext::parse(lib_path) {
+                if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
                     let name = path.path.segments.last().unwrap().ident.to_string();
                     let alias = ctx.type_aliases().find(|ty| ty.ident == name);
                     if let Some(alias) = alias {


### PR DESCRIPTION
### Problem

The IDL generation has an optional type alias resolution feature that parses the crate code starting from the crate's root (`lib.rs`). The current code simply uses `.expect` because it's expected that all Solana programs have this file, but if there is a `tests` folder inside the program directory, this code panics:

https://github.com/coral-xyz/anchor/blob/679c1306f39f529bebf72b4f4d2bfa4a54b633c4/lang/syn/src/idl/defined.rs#L500

### Summary of changes

Fix panicking when `lib.rs` file doesn't exist.