### PR TITLE
lang: Remove `borsh 0.9` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `discriminator` method from `Discriminator` trait ([#3163](https://github.com/coral-xyz/anchor/pull/3163)).
 - docker: Upgrade `node` to 20.16.0 LTS ([#3179](https://github.com/coral-xyz/anchor/pull/3179)).
 - ts: Change the `Program` constructor's `idl` parameter type to `any` ([#3181](https://github.com/coral-xyz/anchor/pull/3181)).
+- lang, spl: Remove `borsh 0.9` support ([#3199](https://github.com/coral-xyz/anchor/pull/3199)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -54,7 +54,7 @@ anchor-lang-idl = { path = "../idl", version = "0.1.1", optional = true }
 arrayref = "0.3"
 base64 = "0.21"
 bincode = "1"
-borsh = ">=0.9, <0.11"
+borsh = "0.10.3"
 bytemuck = "1"
 solana-program = "1.17.3"
 thiserror = "1"

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -15,7 +15,7 @@ idl-build = ["anchor-syn/idl-build"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.30.1" }
-borsh-derive-internal = ">=0.9, <0.11"
+borsh-derive-internal = "0.10.3"
 proc-macro2 = "1"
 syn = { version = "1", features = ["full"] }
 quote = "1"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -27,7 +27,7 @@ token_2022_extensions = ["spl-token-2022", "spl-token-group-interface", "spl-tok
 
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.30.1", features = ["derive"] }
-borsh = { version = ">=0.9, <0.11", optional = true }
+borsh = { version = "0.10.3", optional = true }
 mpl-token-metadata = { version = "4", optional = true }
 serum_dex = { git = "https://github.com/openbook-dex/program/", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"], optional = true }
 spl-associated-token-account = { version = "3", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
### Problem

`borsh 0.9` support has been removed (https://github.com/anza-xyz/agave/pull/1440) from Solana v2. We've been supporting it for over a year, and now that we'll soon upgrade to Solana v2, it's time to remove it.

### Summary of changes

Remove the `borsh 0.9` support.