### PR TITLE
lang: Remove `arrayref` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Remove `crypto-hash` dependency ([#3171](https://github.com/coral-xyz/anchor/pull/3171)).
 - ts: Improve error message of unsupported `view` method ([#3177](https://github.com/coral-xyz/anchor/pull/3177)).
 - idl: Fix panicking on tests ([#3197](https://github.com/coral-xyz/anchor/pull/3197)).
+- lang: Remove `arrayref` dependency ([#3201](https://github.com/coral-xyz/anchor/pull/3201)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,6 @@ dependencies = [
  "anchor-derive-serde",
  "anchor-derive-space",
  "anchor-lang-idl",
- "arrayref",
  "base64 0.21.7",
  "bincode",
  "borsh 0.10.3",

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -51,7 +51,6 @@ anchor-derive-space = { path = "./derive/space", version = "0.30.1" }
 # `anchor-lang-idl` should only be included with `idl-build` feature
 anchor-lang-idl = { path = "../idl", version = "0.1.1", optional = true }
 
-arrayref = "0.3"
 base64 = "0.21"
 bincode = "1"
 borsh = "0.10.3"


### PR DESCRIPTION
### Problem

[`arrayref`](https://github.com/droundy/arrayref) is no longer used after the custom discriminator support (https://github.com/coral-xyz/anchor/issues/3097).

### Summary of changes

Remove the `arrayref` dependency.