### PR TITLE
ts: Include unresolved accounts in the resolution error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Add `IdlBuilder` ([#3188](https://github.com/coral-xyz/anchor/pull/3188)).
 - cli: Make `clean` command also remove the `.anchor` directory ([#3192](https://github.com/coral-xyz/anchor/pull/3192)).
 - lang: Deprecate `#[interface]` attribute ([#3195](https://github.com/coral-xyz/anchor/pull/3195)).
+- ts: Include unresolved accounts in the resolution error message ([#3207](https://github.com/coral-xyz/anchor/pull/3207)).
 
 ### Fixes
 

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -51,6 +51,10 @@ pub mod pda_derivation {
     pub fn seed_math_expr(_ctx: Context<SeedMathExpr>) -> Result<()> {
         Ok(())
     }
+
+    pub fn resolution_error(_ctx: Context<ResolutionError>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -176,6 +180,15 @@ pub struct SeedMathExpr<'info> {
     pub my_account: Account<'info, MyAccount>,
     #[account(seeds = [&(my_account.data + 1).to_le_bytes()], bump)]
     pub math_expr_account: UncheckedAccount<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ResolutionError<'info> {
+    pub unknown: UncheckedAccount<'info>,
+    #[account(seeds = [unknown.key.as_ref()], bump)]
+    pub pda: UncheckedAccount<'info>,
+    #[account(seeds = [pda.key.as_ref()], bump)]
+    pub another_pda: UncheckedAccount<'info>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -121,4 +121,17 @@ describe("typescript", () => {
   it("Can use unsupported expressions", () => {
     // Compilation test to fix issues like https://github.com/coral-xyz/anchor/issues/2933
   });
+
+  it("Includes the unresolved accounts if resolution fails", async () => {
+    try {
+      // `unknown` account is required for account resolution to work, but it's
+      // intentionally not provided to test the error message
+      await program.methods.resolutionError().rpc();
+      throw new Error("Should throw due to account resolution failure!");
+    } catch (e) {
+      expect(e.message).to.equal(
+        "Reached maximum depth for account resolution. Unresolved accounts: `pda`, `anotherPda`"
+      );
+    }
+  });
 });


### PR DESCRIPTION
### Problem

If account resolution fails to resolve all accounts, it throws:

```
Error: Reached maximum depth for account resolution
```

This is a pretty generic error and doesn't tell which accounts weren't able to get resolved, as also mentioned in https://github.com/coral-xyz/anchor/issues/3111#issuecomment-2248850086.

### Summary of changes

- Include the unresolved accounts in the resolution error message:

    ```
    Reached maximum depth for account resolution. Unresolved accounts: `pda`, `anotherPda`
    ```
- Add a test case

Resolves https://github.com/coral-xyz/anchor/issues/3111