### PR TITLE
cli: Fix template code shouldn't escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Improve error message of unsupported `view` method ([#3177](https://github.com/coral-xyz/anchor/pull/3177)).
 - idl: Fix panicking on tests ([#3197](https://github.com/coral-xyz/anchor/pull/3197)).
 - lang: Remove `arrayref` dependency ([#3201](https://github.com/coral-xyz/anchor/pull/3201)).
+- cli: Fix template code shouldn't escape ([#3210](https://github.com/coral-xyz/anchor/pull/3210)).
 
 ### Breaking
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -143,7 +143,7 @@ pub use initialize::*;
 pub struct Initialize {}
 
 pub fn handler(ctx: Context<Initialize>) -> Result<()> {
-    msg!("Greetings from: {{:?}}", ctx.program_id);
+    msg!("Greetings from: {:?}", ctx.program_id);
     Ok(())
 }
 "#


### PR DESCRIPTION
machine
rust version: 1.80.1
anchor version: 0.30.1
arch: macOS Sonoma arm64


process:

`anchor init program-name`
`anchor test`

then

```
error: argument never used
 --> programs/program-name/src/instructions/initialize.rs:7:36
  |
7 |     msg!("Greetings from: {{:?}}", ctx.program_id);
  |          ------------------------  ^^^^^^^^^^^^^^ argument never used
  |          |
  |          formatting specifier missing

warning: unused import: `state::*`
  --> programs/program-name/src/lib.rs:10:9
   |
10 | pub use state::*;
   |         ^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `program-name` (lib) generated 1 warning
error: could not compile `program-name` (lib) due to previous error; 1 warning emitted
```

connect conversation of the previous closed pr
https://github.com/coral-xyz/anchor/pull/3205/files/fd6c683ce5afd6e150a676a2fe992d0497ec3b90#r1736018760