### PR TITLE
lang: Use `AccountDeserialize` rather than `AnchorDeserialize` when deserializing accounts with `Account` utils

### DIFF
--- a/lang/attribute/program/src/declare_program/mods/utils.rs
+++ b/lang/attribute/program/src/declare_program/mods/utils.rs
@@ -27,10 +27,9 @@ fn gen_account(idl: &Idl) -> proc_macro2::TokenStream {
     let if_statements = idl.accounts.iter().map(|acc| {
         let name = format_ident!("{}", acc.name);
         let disc = gen_discriminator(&acc.discriminator);
-        let disc_len = acc.discriminator.len();
         quote! {
             if value.starts_with(&#disc) {
-                return #name::try_from_slice(&value[#disc_len..])
+                return #name::try_deserialize_unchecked(&mut &value[..])
                     .map(Self::#name)
                     .map_err(Into::into)
             }


### PR DESCRIPTION
### Problem

`Account` (https://github.com/coral-xyz/anchor/pull/3091) currently only works with regular `borsh` serialized accounts.

### Summary of changes

Use `AccountDeserialize` rather than `AnchorDeserialize` when deserializing accounts with `Account` utils to make it also work with zero copy accounts.