### PR TITLE
idl: Fix using `address` constraint with non-const expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix panicking on tests ([#3197](https://github.com/coral-xyz/anchor/pull/3197)).
 - lang: Remove `arrayref` dependency ([#3201](https://github.com/coral-xyz/anchor/pull/3201)).
 - cli: Fix template code shouldn't escape ([#3210](https://github.com/coral-xyz/anchor/pull/3210)).
+- idl: Fix using `address` constraint with non-const expressions ([#3216](https://github.com/coral-xyz/anchor/pull/3216)).
 
 ### Breaking
 

--- a/tests/relations-derivation/programs/relations-derivation/src/lib.rs
+++ b/tests/relations-derivation/programs/relations-derivation/src/lib.rs
@@ -67,8 +67,19 @@ pub struct TestRelation<'info> {
 
 #[derive(Accounts)]
 pub struct TestAddressRelation<'info> {
+    // Included wit the `address` field in IDL
+    // It's actually `static` but it doesn't matter for our purposes
+    #[account(address = crate::ID)]
+    constant: UncheckedAccount<'info>,
+    #[account(address = crate::id())]
+    const_fn: UncheckedAccount<'info>,
+
+    // Not included with the `address` field in IDL
     #[account(address = my_account.my_account)]
-    account: UncheckedAccount<'info>,
+    field: UncheckedAccount<'info>,
+    #[account(address = my_account.my_account())]
+    method: UncheckedAccount<'info>,
+
     #[account(seeds = [b"seed"], bump = my_account.bump)]
     my_account: Account<'info, MyAccount>,
 }
@@ -77,4 +88,10 @@ pub struct TestAddressRelation<'info> {
 pub struct MyAccount {
     pub my_account: Pubkey,
     pub bump: u8,
+}
+
+impl MyAccount {
+    pub fn my_account(&self) -> Pubkey {
+        self.my_account
+    }
 }

--- a/tests/relations-derivation/programs/relations-derivation/src/lib.rs
+++ b/tests/relations-derivation/programs/relations-derivation/src/lib.rs
@@ -19,7 +19,7 @@ pub mod relations_derivation {
         Ok(())
     }
 
-    pub fn test_address_relation(_ctx: Context<TestAddressRelation>) -> Result<()> {
+    pub fn test_address(_ctx: Context<TestAddress>) -> Result<()> {
         Ok(())
     }
 }
@@ -66,7 +66,7 @@ pub struct TestRelation<'info> {
 }
 
 #[derive(Accounts)]
-pub struct TestAddressRelation<'info> {
+pub struct TestAddress<'info> {
     // Included wit the `address` field in IDL
     // It's actually `static` but it doesn't matter for our purposes
     #[account(address = crate::ID)]

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -41,8 +41,13 @@ describe("typescript", () => {
     await tx.rpc();
   });
 
-  it("Can use relations derivation with `address` constraint", () => {
-    // Only compile test for now since the IDL spec doesn't currently support
-    // non-const expressions with the `address` constraint
+  it("Can use `address` constraint", () => {
+    const ix = program.idl.instructions.find(
+      (ix) => ix.name === "testAddress"
+    )!;
+    expect(ix.accounts.find((acc) => acc.name === "constant")!.address).to.not
+      .be.undefined;
+    expect(ix.accounts.find((acc) => acc.name === "constFn")!.address).to.not.be
+      .undefined;
   });
 });

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -42,7 +42,7 @@ describe("typescript", () => {
   });
 
   it("Can use relations derivation with `address` constraint", () => {
-    // Only compile test for now since the IDL spec doesn't currently support field access
-    // expressions for the `address` constraint
+    // Only compile test for now since the IDL spec doesn't currently support
+    // non-const expressions with the `address` constraint
   });
 });


### PR DESCRIPTION
### Problem

IDL generation fails if you use non-const expressions with the `address` constraint:

```rs
#[derive(Accounts)]
pub struct MyIx {
    #[account(address = my_account.authority()])
    pub authority: Signer<'info>,
    pub my_account: Account<'info, MyAccount>,
}

#[account]
pub struct MyAccount {
    pub authority: Pubkey,
}

impl MyAccount {
    pub fn authority(&self) -> Pubkey {
        self.authority
    }
}
```

We had a similar problem in https://github.com/coral-xyz/anchor/issues/2912, but that was only specific to field expressions and was fixed in https://github.com/coral-xyz/anchor/pull/3034.

### Summary of changes

Rather than assuming all expressions (other than field expressions) are valid for the `address` field (in the IDL), only assume the following expressions are valid:

- If the last segment of the path is all uppercase (`const`) e.g. `my_program::ID`
- Function call with no arguments (`const fn`) e.g. `my_program::id()`

For everything else, skip the `address` field resolution.