### PR TITLE
ts: Upgrade `typescript` to 5.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - docker: Upgrade `node` to 20.16.0 LTS ([#3179](https://github.com/coral-xyz/anchor/pull/3179)).
 - ts: Change the `Program` constructor's `idl` parameter type to `any` ([#3181](https://github.com/coral-xyz/anchor/pull/3181)).
 - lang, spl: Remove `borsh 0.9` support ([#3199](https://github.com/coral-xyz/anchor/pull/3199)).
+- ts: Upgrade `typescript` to `5.5.4` and remove the generic parameters of `SimulateResponse` ([#3221](https://github.com/coral-xyz/anchor/pull/3221)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^9.0.0",
     "tslib": "^2.3.1",
     "typedoc": "^0.22.10",
-    "typescript": "^4.5.2"
+    "typescript": "^5.5.4"
   },
   "files": [
     "dist",

--- a/ts/packages/anchor/src/program/namespace/methods.ts
+++ b/ts/packages/anchor/src/program/namespace/methods.ts
@@ -332,9 +332,7 @@ export class MethodsBuilder<
     });
   }
 
-  public async simulate(
-    options?: ConfirmOptions
-  ): Promise<SimulateResponse<any, any>> {
+  public async simulate(options?: ConfirmOptions): Promise<SimulateResponse> {
     if (this._resolveAccounts) {
       await this._accountsResolver.resolve();
     }

--- a/ts/packages/anchor/src/program/namespace/simulate.ts
+++ b/ts/packages/anchor/src/program/namespace/simulate.ts
@@ -5,7 +5,7 @@ import { splitArgsAndCtx } from "../context.js";
 import { TransactionFn } from "./transaction.js";
 import { EventParser, Event } from "../event.js";
 import { Coder } from "../../coder/index.js";
-import { Idl, IdlEvent } from "../../idl.js";
+import { Idl, IdlEvent, IdlTypeDef } from "../../idl.js";
 import { translateError } from "../../error.js";
 import {
   AllEvents,
@@ -51,11 +51,11 @@ export default class SimulateFactory {
         throw new Error("Simulated logs not found");
       }
 
-      const events = [];
+      const events: Event[] = [];
       if (idl.events) {
         let parser = new EventParser(programId, coder);
         for (const event of parser.parseLogs(logs)) {
-          events.push(event as AllEvents<IDL>[number]);
+          events.push(event);
         }
       }
       return { events, raw: logs };
@@ -102,11 +102,7 @@ export default class SimulateFactory {
 export type SimulateNamespace<
   IDL extends Idl = Idl,
   I extends AllInstructions<IDL> = AllInstructions<IDL>
-> = MakeInstructionsNamespace<
-  IDL,
-  I,
-  Promise<SimulateResponse<AllEvents<IDL>[number], IdlTypes<IDL>>>
->;
+> = MakeInstructionsNamespace<IDL, I, Promise<SimulateResponse>>;
 
 /**
  * SimulateFn is a single method generated from an IDL. It simulates a method
@@ -117,13 +113,10 @@ export type SimulateNamespace<
 export type SimulateFn<
   IDL extends Idl = Idl,
   I extends AllInstructions<IDL> = AllInstructions<IDL>
-> = InstructionContextFn<
-  IDL,
-  I,
-  Promise<SimulateResponse<AllEvents<IDL>[number], IdlTypes<IDL>>>
->;
+> = InstructionContextFn<IDL, I, Promise<SimulateResponse>>;
 
-export type SimulateResponse<E extends IdlEvent, Defined> = {
-  events: readonly Event<E, Defined>[];
+// TODO: Infer event types
+export type SimulateResponse = {
+  events: readonly Event[];
   raw: readonly string[];
 };

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -4803,7 +4803,7 @@ typedoc@^0.22.10:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@*, typescript@^4.5.2:
+typescript@*:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
@@ -4812,6 +4812,11 @@ typescript@=4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Problem

TypeScript SDK is using an outdated `typescript` version (v4).

### Summary of changes

- Upgrade `typescript` to `5.5.4`
- Remove generic parameters of [`SimulateResponse`](https://github.com/coral-xyz/anchor/blob/fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae/ts/packages/anchor/src/program/namespace/simulate.ts#L129) to make build work (the event data was typed as `any` anyway)