### PR TITLE
idl: Fix using full path types with `Program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `arrayref` dependency ([#3201](https://github.com/coral-xyz/anchor/pull/3201)).
 - cli: Fix template code shouldn't escape ([#3210](https://github.com/coral-xyz/anchor/pull/3210)).
 - idl: Fix using `address` constraint with non-const expressions ([#3216](https://github.com/coral-xyz/anchor/pull/3216)).
+- idl: Fix using full path types with `Program` ([#3228](https://github.com/coral-xyz/anchor/pull/3228)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -144,14 +144,10 @@ pub fn gen_idl_build_impl_accounts_struct(accounts: &AccountsStruct) -> TokenStr
 
 fn get_address(acc: &Field) -> TokenStream {
     match &acc.ty {
-        Ty::Program(ty) => ty
-            .account_type_path
-            .path
-            .segments
-            .last()
-            .map(|seg| &seg.ident)
-            .map(|ident| quote! { Some(#ident::id().to_string()) })
-            .unwrap_or_else(|| quote! { None }),
+        Ty::Program(_) => {
+            let ty = acc.account_ty();
+            quote! { Some(<#ty as anchor_lang::Id>::id().to_string()) }
+        }
         Ty::Sysvar(_) => {
             let ty = acc.account_ty();
             let sysvar_id_trait = quote!(anchor_lang::solana_program::sysvar::SysvarId);

--- a/tests/idl/programs/new-idl/src/lib.rs
+++ b/tests/idl/programs/new-idl/src/lib.rs
@@ -291,6 +291,7 @@ pub struct AccountAndEventFieldAccount {
 pub struct FullPath<'info> {
     #[account(zero)]
     pub account: Account<'info, FullPathAccount>,
+    pub external_program: Program<'info, external::program::External>,
 }
 
 #[account]


### PR DESCRIPTION
### Problem

```rs
#[derive(Accounts)]
pub struct FullPath<'info> {
    pub external_program: Program<'info, external::program::External>,
}
```

This fails to compile:

```
error[E0599]: no function or associated item named `id` found for struct `External` in the current scope
   --> programs/new-idl/src/lib.rs:290:10
    |
290 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `External<'_>`
...
377 | pub struct External<'info> {
    | -------------------------- function or associated item `id` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `id`, perhaps you need to implement one of them:
            candidate #1: `SysvarId`
            candidate #2: `anchor_lang::Id`
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0599`.
error: could not compile `new-idl` (lib test) due to 1 previous error
Error: Building IDL failed
```

### Summary of changes

Fix using full path types in `Program` by using the full path of the given account type and the `anchor_lang::Id` trait.