### PR TITLE
avm: Ask whether to install if the version is not installed with the `use` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Deprecate `#[interface]` attribute ([#3195](https://github.com/coral-xyz/anchor/pull/3195)).
 - ts: Include unresolved accounts in the resolution error message ([#3207](https://github.com/coral-xyz/anchor/pull/3207)).
 - lang: Add `LazyAccount` ([#3194](https://github.com/coral-xyz/anchor/pull/3194)).
+- avm: Ask whether to install if the version is not installed with the `use` command ([#3230](https://github.com/coral-xyz/anchor/pull/3230)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

Using `avm use <VERSION>` results in an error if the version is not already installed:

```
Version 0.30.0 is not installed, staying on version 0.30.1.
Error: You need to run 'avm install 0.30.0' to install it before using it.
```

### Summary of changes

Ask the user whether to install the given version if the version is not already installed:

```
Version 0.30.0 is not installed. Would you like to install? [y/n]
```

Resolves https://github.com/coral-xyz/anchor/issues/3229