### PR TITLE
docs: Update `seeds` feature documentation

### DIFF
--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -39,15 +39,15 @@ url = "https://api.apr.dev"
 
 ## features
 
-#### seeds
+#### resolution
 
-This tells the IDL to include seed generation for PDA Accounts. The default is `false`
+This tells the IDL to support account resolution. The default is `true`.
 
 Example:
 
 ```
 [features]
-seeds = true
+resolution = true
 ```
 
 ## workspace


### PR DESCRIPTION
### Problem

`seeds` feature was renamed to `resolution` in https://github.com/coral-xyz/anchor/pull/2824, but docs site still mention `seeds`:

https://github.com/coral-xyz/anchor/blob/1c0b2132ec4713343f9c672479721f432ccbf904/docs/src/pages/docs/manifest.md#L42-L51

### Summary of changes

Update the `seeds` feature documentation:

- Rename it to `resolution`
- Change the default to `true`