### PR TITLE
docs: Fix the `warp_slot` example

### DIFF
--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -145,7 +145,7 @@ These options are passed into the options with the same name in the `solana-test
 ```toml
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"     # This is the url of the cluster that accounts are cloned from (See `test.validator.clone`).
-warp_slot = 1337                                # Warp the ledger to `warp_slot` after starting the validator.
+warp_slot = "1337"                              # Warp the ledger to `warp_slot` after starting the validator.
 slots_per_epoch = 5                             # Override the number of slots in an epoch.
 rpc_port = 1337                                 # Set JSON RPC on this port, and the next port for the RPC websocket.
 limit_ledger_size = 1337                        # Keep this amount of shreds in root slots.


### PR DESCRIPTION
### Problem

`warp_slot` of `[test.validator]` section [expects an optional string](https://github.com/coral-xyz/anchor/blob/ec74adbcbbfac4324d519a01b3524949553512db/cli/src/config.rs#L1072), but we have an integer:

https://github.com/coral-xyz/anchor/blob/ec74adbcbbfac4324d519a01b3524949553512db/docs/src/pages/docs/manifest.md#L148

Using this example results in:

```
Error: Unable to deserialize config: TOML parse error at line 21, column 13
   |
21 | warp_slot = 1337
   |             ^^^^
invalid type: integer `1337`, expected a string
```

### Summary of changes

Fix `warp_slot` example by converting it to a string.