### PR TITLE
cli: Accept integers for `warp_slot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang, spl: Remove `borsh 0.9` support ([#3199](https://github.com/coral-xyz/anchor/pull/3199)).
 - ts: Upgrade `typescript` to `5.5.4` and remove the generic parameters of `SimulateResponse` ([#3221](https://github.com/coral-xyz/anchor/pull/3221)).
 - ts: Remove `StateCoder`([#3224](https://github.com/coral-xyz/anchor/pull/3224)).
+- cli: Accept integers for `warp_slot` ([#3235](https://github.com/coral-xyz/anchor/pull/3235)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -9,6 +9,7 @@ use reqwest::Url;
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use solana_cli_config::{Config as SolanaConfig, CONFIG_FILE};
+use solana_sdk::clock::Slot;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
 use solang_parser::pt::{ContractTy, SourceUnitPart};
@@ -1069,7 +1070,7 @@ pub struct _Validator {
     pub ticks_per_slot: Option<u16>,
     // Warp the ledger to WARP_SLOT after starting the validator.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub warp_slot: Option<String>,
+    pub warp_slot: Option<Slot>,
     // Deactivate one or more features.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivate_feature: Option<Vec<String>>,
@@ -1107,7 +1108,7 @@ pub struct Validator {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ticks_per_slot: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub warp_slot: Option<String>,
+    pub warp_slot: Option<Slot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivate_feature: Option<Vec<String>>,
 }

--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -145,7 +145,7 @@ These options are passed into the options with the same name in the `solana-test
 ```toml
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"     # This is the url of the cluster that accounts are cloned from (See `test.validator.clone`).
-warp_slot = "1337"                              # Warp the ledger to `warp_slot` after starting the validator.
+warp_slot = 1337                                # Warp the ledger to `warp_slot` after starting the validator.
 slots_per_epoch = 5                             # Override the number of slots in an epoch.
 rpc_port = 1337                                 # Set JSON RPC on this port, and the next port for the RPC websocket.
 limit_ledger_size = 1337                        # Keep this amount of shreds in root slots.


### PR DESCRIPTION
### Problem

[`solana-test-validator`'s `warp_slot` option is of type `Option<Slot>`](https://github.com/anza-xyz/agave/blob/e5d5a08d33e01347dab2f3ab682f2c5679dd209d/test-validator/src/lib.rs#L120), and [`Slot` is defined as `u64`](https://github.com/anza-xyz/agave/blob/e5d5a08d33e01347dab2f3ab682f2c5679dd209d/sdk/clock/src/lib.rs#L145). However, this is incompatible with our definition:

https://github.com/coral-xyz/anchor/blob/ec74adbcbbfac4324d519a01b3524949553512db/cli/src/config.rs#L1072

### Summary of changes

Change the `warp_slot` type to `Option<u64>` to be compatible with `solana-test-validator`'s definition.