### PR TITLE
Fix clippy 1.81.0 lints

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1271,7 +1271,7 @@ fn expand_program(
     let exit = std::process::Command::new("cargo")
         .arg("expand")
         .arg(target_dir_arg)
-        .arg(&format!("--package={package_name}"))
+        .arg(format!("--package={package_name}"))
         .args(cargo_args)
         .stderr(Stdio::inherit())
         .output()


### PR DESCRIPTION
### Problem

New lints introduced in the latest `clippy` makes [CI](https://github.com/coral-xyz/anchor/actions/runs/10781924599/job/29900903295) fail.

### Summary of changes

Fix `clippy::needless_borrows_for_generic_args`.