### PR TITLE
lang: Remove `EventIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Upgrade `typescript` to `5.5.4` and remove the generic parameters of `SimulateResponse` ([#3221](https://github.com/coral-xyz/anchor/pull/3221)).
 - ts: Remove `StateCoder`([#3224](https://github.com/coral-xyz/anchor/pull/3224)).
 - cli: Accept integers for `warp_slot` ([#3235](https://github.com/coral-xyz/anchor/pull/3235)).
+- lang: Remove `EventIndex` ([#3244](https://github.com/coral-xyz/anchor/pull/3244)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -42,7 +42,7 @@ pub fn event(
         .unwrap_or_else(|| gen_discriminator("event", event_name));
 
     let ret = quote! {
-        #[derive(anchor_lang::__private::EventIndex, AnchorSerialize, AnchorDeserialize)]
+        #[derive(AnchorSerialize, AnchorDeserialize)]
         #event_strct
 
         impl anchor_lang::Event for #event_name {
@@ -70,14 +70,6 @@ pub fn event(
 
     #[allow(unreachable_code)]
     proc_macro::TokenStream::from(ret)
-}
-
-// EventIndex is a marker macro. It functionally does nothing other than
-// allow one to mark fields with the `#[index]` inert attribute, which is
-// used to add metadata to IDLs.
-#[proc_macro_derive(EventIndex, attributes(index))]
-pub fn derive_event(_item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    proc_macro::TokenStream::from(quote! {})
 }
 
 /// Logs an event that can be subscribed to by clients.

--- a/lang/attribute/program/src/declare_program/mods/events.rs
+++ b/lang/attribute/program/src/declare_program/mods/events.rs
@@ -16,7 +16,6 @@ pub fn gen_events_mod(idl: &Idl) -> proc_macro2::TokenStream {
             .expect("Type must exist");
 
         quote! {
-            #[derive(anchor_lang::__private::EventIndex)]
             #ty_def
 
             impl anchor_lang::Event for #name {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -452,7 +452,6 @@ pub mod prelude {
 #[doc(hidden)]
 pub mod __private {
     pub use anchor_attribute_account::ZeroCopyAccessor;
-    pub use anchor_attribute_event::EventIndex;
     pub use base64;
     pub use bytemuck;
 

--- a/tests/events/programs/events/src/lib.rs
+++ b/tests/events/programs/events/src/lib.rs
@@ -46,13 +46,11 @@ pub struct TestEventCpi {}
 #[event]
 pub struct MyEvent {
     pub data: u64,
-    #[index]
     pub label: String,
 }
 
 #[event]
 pub struct MyOtherEvent {
     pub data: u64,
-    #[index]
     pub label: String,
 }


### PR DESCRIPTION
### Problem

The new IDL spec did not support marking the event index because nobody used it. We might support it in the future if there are people who'd want to use it, but for now, `EventIndex` is redundant.

### Summary of changes

Remove `EventIndex` and its derive macro implementation (including the `#[index]` attribute).