### PR TITLE
ci: Fix client example test

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -216,7 +216,7 @@ jobs:
         with:
           name: optional.so
           path: tests/optional/target/deploy/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: events.so
           path: tests/events/target/deploy/


### PR DESCRIPTION
### Problem

Client example test CI [fails](https://github.com/coral-xyz/anchor/actions/runs/10836049845/job/30070064790#step:1:36) due to `actions/download-artifact` being outdated.

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

### Summary of changes

Upgrade `actions/download-artifact` to v3.