### PR TITLE
cli: Warn if a manifest has `solana-program` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Include unresolved accounts in the resolution error message ([#3207](https://github.com/coral-xyz/anchor/pull/3207)).
 - lang: Add `LazyAccount` ([#3194](https://github.com/coral-xyz/anchor/pull/3194)).
 - avm: Ask whether to install if the version is not installed with the `use` command ([#3230](https://github.com/coral-xyz/anchor/pull/3230)).
+- cli: Warn if a manifest has `solana-program` dependency ([#3250](https://github.com/coral-xyz/anchor/pull/3250)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,7 +9,7 @@ use anchor_lang::{AccountDeserialize, AnchorDeserialize, AnchorSerialize, Discri
 use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
-use checks::{check_anchor_version, check_idl_build_feature, check_overflow};
+use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
 use clap::Parser;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
@@ -1328,6 +1328,7 @@ pub fn build(
 
     // Check whether there is a mismatch between CLI and crate/package versions
     check_anchor_version(&cfg).ok();
+    check_deps(&cfg).ok();
 
     let idl_out = match idl {
         Some(idl) => Some(PathBuf::from(idl)),


### PR DESCRIPTION
### Problem

Adding `solana-program` to the `dependencies` list in `Cargo.toml` should be avoided, as it's likely to increase the possibility of version conflicts between v1 and v2 (https://github.com/coral-xyz/anchor/pull/3219). Users should instead use the exported `anchor_lang::solana_program`.

### Summary of changes

Warn if a user's manifest has `solana-program` dependency:

```
WARNING: Adding `solana-program` as a separate dependency might cause conflicts.
To solve, remove the `solana-program` dependency and use the exported crate from `anchor-lang`.
`use solana_program` becomes `use anchor_lang::solana_program`.
Program name: `my-program`
```