### PR TITLE
feat: cli completions + clap version bump to v4.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `LazyAccount` ([#3194](https://github.com/coral-xyz/anchor/pull/3194)).
 - avm: Ask whether to install if the version is not installed with the `use` command ([#3230](https://github.com/coral-xyz/anchor/pull/3230)).
 - cli: Warn if a manifest has `solana-program` dependency ([#3250](https://github.com/coral-xyz/anchor/pull/3250)).
-- cli: Added completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
+- cli: Add completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `LazyAccount` ([#3194](https://github.com/coral-xyz/anchor/pull/3194)).
 - avm: Ask whether to install if the version is not installed with the `use` command ([#3230](https://github.com/coral-xyz/anchor/pull/3230)).
 - cli: Warn if a manifest has `solana-program` dependency ([#3250](https://github.com/coral-xyz/anchor/pull/3250)).
+- cli: Added completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap 4.5.17",
+ "clap_complete",
  "dirs",
  "once_cell",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,8 @@ dependencies = [
  "bincode",
  "cargo_toml",
  "chrono",
- "clap 4.4.6",
+ "clap 4.5.17",
+ "clap_complete",
  "dirs",
  "flate2",
  "heck 0.4.1",
@@ -366,23 +367,24 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -677,7 +679,7 @@ dependencies = [
  "cargo_toml",
  "cfg-if",
  "chrono",
- "clap 4.4.6",
+ "clap 4.5.17",
  "dirs",
  "once_cell",
  "reqwest",
@@ -1109,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1119,23 +1121,32 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.5.1",
- "strsim 0.10.0",
+ "clap_lex 0.7.2",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
+dependencies = [
+ "clap 4.5.17",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.55",
@@ -1152,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
@@ -2016,6 +2027,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2274,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -5128,6 +5151,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -15,7 +15,8 @@ path = "src/anchor/main.rs"
 anyhow = "1.0.32"
 cfg-if = "1.0.0"
 cargo_toml = "0.19.2"
-clap = { version = "4.2.4", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive"] }
+clap_complete = "4.5.26"
 dirs = "4.0.0"
 once_cell = "1.8.0"
 reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Error, Result};
 use avm::InstallTarget;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::generate;
 use semver::Version;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -38,6 +39,11 @@ pub enum Commands {
     List {},
     #[clap(about = "Update to the latest Anchor version")]
     Update {},
+    #[clap(about = "Generate shell completions for AVM")]
+    Completions {
+        #[clap(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 // If `latest` is passed use the latest available version.
@@ -78,6 +84,10 @@ pub fn entry(opts: Cli) -> Result<()> {
         Commands::Uninstall { version } => avm::uninstall_version(&version),
         Commands::List {} => avm::list_versions(),
         Commands::Update {} => avm::update(),
+        Commands::Completions { shell } => {
+            generate(shell, &mut Cli::command(), "avm", &mut std::io::stdout());
+            Ok(())
+        }
     }
 }
 

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Error, Result};
 use avm::InstallTarget;
 use clap::{CommandFactory, Parser, Subcommand};
-use clap_complete::generate;
 use semver::Version;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -85,7 +84,7 @@ pub fn entry(opts: Cli) -> Result<()> {
         Commands::List {} => avm::list_versions(),
         Commands::Update {} => avm::update(),
         Commands::Completions { shell } => {
-            generate(shell, &mut Cli::command(), "avm", &mut std::io::stdout());
+            clap_complete::generate(shell, &mut Cli::command(), "avm", &mut std::io::stdout());
             Ok(())
         }
     }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,8 @@ base64 = "0.21"
 bincode = "1.3.3"
 cargo_toml = "0.19.2"
 chrono = "0.4.19"
-clap = { version = "4.2.4", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive"] }
+clap_complete = "4.5.26"
 dirs = "4.0"
 flate2 = "1.0.19"
 heck = "0.4.0"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -10,7 +10,8 @@ use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
 use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
 use flate2::read::ZlibDecoder;
@@ -364,6 +365,11 @@ pub enum Command {
         /// IDL to use (defaults to workspace IDL)
         #[clap(long)]
         idl: Option<String>,
+    },
+    /// Generates shell completions.
+    Completions {
+        #[clap(value_enum)]
+        shell: clap_complete::Shell,
     },
 }
 
@@ -924,6 +930,15 @@ fn process_command(opts: Opts) -> Result<()> {
             address,
             idl,
         } => account(&opts.cfg_override, account_type, address, idl),
+        Command::Completions { shell } => {
+            generate(
+                shell,
+                &mut Opts::command(),
+                "anchor",
+                &mut std::io::stdout(),
+            );
+            Ok(())
+        }
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,7 +11,6 @@ use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTyp
 use anyhow::{anyhow, Context, Result};
 use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
 use clap::{CommandFactory, Parser};
-use clap_complete::generate;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
 use flate2::read::ZlibDecoder;
@@ -931,7 +930,7 @@ fn process_command(opts: Opts) -> Result<()> {
             idl,
         } => account(&opts.cfg_override, account_type, address, idl),
         Command::Completions { shell } => {
-            generate(
+            clap_complete::generate(
                 shell,
                 &mut Opts::command(),
                 "anchor",

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -87,6 +87,7 @@ Shell completions can be generated for `bash`, `elvish`, `fish`, `powershell`, a
 ```bash
 mkdir -p $HOME/.local/share/bash-completion/completions
 anchor completions bash > $HOME/.local/share/bash-completion/completions/anchor
+avm completions bash > $HOME/.local/share/bash-completion/completions/avm
 exec bash
 ```
 
@@ -95,6 +96,7 @@ exec bash
 ```bash
 mkdir -p $HOME/.config/fish/completions
 anchor completions fish > $HOME/.config/fish/completions/anchor.fish
+avm completions fish > $HOME/.config/fish/completions/avm.fish
 source $HOME/.config/fish/config.fish
 ```
 
@@ -111,5 +113,6 @@ Next run:
 
 ```bash
 anchor completions zsh | sudo tee /usr/local/share/zsh/site-functions/_anchor
+avm completions zsh | sudo tee /usr/local/share/zsh/site-functions/_avm
 exec zsh
 ```

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -77,3 +77,39 @@ Now verify the CLI is installed properly.
 ```shell
 anchor --version
 ```
+
+## Generating Shell Completions
+
+Shell completions can be generated for `bash`, `elvish`, `fish`, `powershell`, and `zsh`.
+
+### Bash
+
+```bash
+mkdir -p $HOME/.local/share/bash-completion/completions
+anchor completions bash > $HOME/.local/share/bash-completion/completions/anchor
+exec bash
+```
+
+### Fish
+
+```bash
+mkdir -p $HOME/.config/fish/completions
+anchor completions fish > $HOME/.config/fish/completions/anchor.fish
+source $HOME/.config/fish/config.fish
+```
+
+### Zsh
+
+First ensure the following is in your `.zshrc` file. If using `oh-my-zsh` this step can be skipped.
+
+```bash
+autoload -U compinit
+compinit -i
+```
+
+Next run:
+
+```bash
+anchor completions zsh | sudo tee /usr/local/share/zsh/site-functions/_anchor
+exec zsh
+```


### PR DESCRIPTION
Small QoL improvement by introducing CLI completions for Anchor.

Instead of repeatedly using `anchor --help`, we can now use `anchor ` + tab to generate completions.

This adds the `clap_completions` dependency to Anchor.
clap_completions uses clap v4.5.17, so the clap version used in Anchor has also been bumped.

There are no breaking changes between the currently used v4.2.4 and v4.5.17 - mainly just performance + bug fixes (https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/bebe80de-7ac0-4474-a5ca-3e4d7891b8d1">
<img width="532" alt="image" src="https://github.com/user-attachments/assets/66985c4a-bcc7-423c-9b2c-65d9f57fbb5c">


Update:

Also added completions for avm.

<img width="606" alt="image" src="https://github.com/user-attachments/assets/f7feec3f-3d25-43a7-a394-a4ebc627e3f7">
