### PR TITLE
bench: Sync to update Solana version

### DIFF
--- a/bench/BINARY_SIZE.md
+++ b/bench/BINARY_SIZE.md
@@ -14,11 +14,11 @@ The programs and their tests are located in [/tests/bench](https://github.com/co
 
 ## [Unreleased]
 
-Solana version: 1.18.17
+Solana version: 2.0.8
 
 | Program | Binary Size | -                        |
 | ------- | ----------- | ------------------------ |
-| bench   | 1,096,096   | 🔴 **+305,088 (38.57%)** |
+| bench   | 1,097,424   | 🔴 **+306,416 (38.74%)** |
 
 ### Notable changes
 

--- a/bench/COMPUTE_UNITS.md
+++ b/bench/COMPUTE_UNITS.md
@@ -14,7 +14,7 @@ The programs and their tests are located in [/tests/bench](https://github.com/co
 
 ## [Unreleased]
 
-Solana version: 1.18.17
+Solana version: 2.0.8
 
 | Instruction                 | Compute Units | -                     |
 | --------------------------- | ------------- | --------------------- |

--- a/bench/STACK_MEMORY.md
+++ b/bench/STACK_MEMORY.md
@@ -14,7 +14,7 @@ The programs and their tests are located in [/tests/bench](https://github.com/co
 
 ## [Unreleased]
 
-Solana version: 1.18.17
+Solana version: 2.0.8
 
 | Instruction                    | Stack Memory | -   |
 | ------------------------------ | ------------ | --- |

--- a/tests/bench/bench.json
+++ b/tests/bench/bench.json
@@ -930,10 +930,10 @@
     }
   },
   "unreleased": {
-    "solanaVersion": "1.18.17",
+    "solanaVersion": "2.0.8",
     "result": {
       "binarySize": {
-        "bench": 1096096
+        "bench": 1097424
       },
       "computeUnits": {
         "accountInfo1": 573,


### PR DESCRIPTION
### Problem

Benchmark results are outdated and still show Solana version as `1.18.17`:

https://github.com/coral-xyz/anchor/blob/020a3046582944030f17b6524006eeaf26951cb8/bench/BINARY_SIZE.md#L17

CI didn't catch it during the Solana v2 upgrade (https://github.com/coral-xyz/anchor/pull/3219) because there is no meaningful difference in our benchmarks due to Solana v1.18 and v2.0 using the same Rust version (`rustc 1.75.0`).

### Summary of changes

Sync benchmark files to update Solana version.