### PR TITLE
cli: Always convert IDLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Ask whether to install if the version is not installed with the `use` command ([#3230](https://github.com/coral-xyz/anchor/pull/3230)).
 - cli: Warn if a manifest has `solana-program` dependency ([#3250](https://github.com/coral-xyz/anchor/pull/3250)).
 - cli: Add completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
+- cli: Always convert IDLs ([#3265](https://github.com/coral-xyz/anchor/pull/3265)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

Interpreting the bytes as the `Idl` type fails if the IDL is a legacy IDL (pre v0.30). This can be fixed by always automatically converting the IDL using the [`convert_idl`](https://github.com/coral-xyz/anchor/blob/967127146c6222c17e503a8bb329b55c45a59841/idl/src/convert.rs#L13) function in various commands, so that the user doesn't have to run `anchor idl convert` first.

### Summary of changes

Always convert IDLs when reading them from the file system.