### PR TITLE
docs: Add `keys` command to the CLI documentation

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -326,7 +326,7 @@ pub enum Command {
         #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
     },
-    /// Keypair commands.
+    /// Program keypair commands.
     Keys {
         #[clap(subcommand)]
         subcmd: KeysCommand,
@@ -376,7 +376,7 @@ pub enum Command {
 pub enum KeysCommand {
     /// List all of the program keys.
     List,
-    /// Sync the program's `declare_id!` pubkey with the program's actual pubkey.
+    /// Sync program `declare_id!` pubkeys with the program's actual pubkey.
     Sync {
         /// Only sync the given program instead of all programs
         #[clap(short, long)]
@@ -4512,7 +4512,7 @@ fn keys_list(cfg_override: &ConfigOverride) -> Result<()> {
     })
 }
 
-/// Sync the program's `declare_id!` pubkey with the pubkey from `target/deploy/<KEYPAIR>.json`.
+/// Sync program `declare_id!` pubkeys with the pubkey from `target/deploy/<KEYPAIR>.json`.
 fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Result<()> {
     with_workspace(cfg_override, |cfg| {
         let declare_id_regex = RegexBuilder::new(r#"^(([\w]+::)*)declare_id!\("(\w*)"\)"#)

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -28,6 +28,7 @@ SUBCOMMANDS:
     help       Prints this message or the help of the given subcommand(s)
     idl        Commands for interacting with interface definitions
     init       Initializes a workspace
+    keys       Program keypair commands
     migrate    Runs the deploy migration script
     new        Creates a new program
     shell      Starts a node shell with an Anchor client setup according to the local config
@@ -195,6 +196,26 @@ Initializes a project workspace with the following structure.
 - `app/`: Directory for your application frontend.
 - `tests/`: Directory for JavaScript integration tests.
 - `migrations/deploy.js`: Deploy script.
+
+## Keys
+
+Program keypair commands.
+
+### Keys List
+
+```shell
+anchor keys list
+```
+
+List all of the program keys.
+
+### Keys Sync
+
+```shell
+anchor keys sync
+```
+
+Sync program `declare_id!` pubkeys with the program's actual pubkey.
 
 ## Migrate
 


### PR DESCRIPTION
### Problem

`anchor keys` command is not mentioned in [the CLI documentation](https://www.anchor-lang.com/docs/cli).

### Summary of changes

Add `keys` command to the CLI documentation.