### PR TITLE
cli: Install Solana from anza.xyz domain in Docker verifiable builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove `EventIndex` ([#3244](https://github.com/coral-xyz/anchor/pull/3244)).
 - spl: Remove `dex` feature ([#3257](https://github.com/coral-xyz/anchor/pull/3257)).
 - client, lang, spl: Upgrade Solana to v2 and SPL to the latest ([#3219](https://github.com/coral-xyz/anchor/pull/3219)).
+- cli: Install Solana from anza.xyz domain in Docker verifiable builds ([#3271](https://github.com/coral-xyz/anchor/pull/3271)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1728,7 +1728,7 @@ fn docker_prep(container_name: &str, build_config: &BuildConfig) -> Result<()> {
             &[
                 "curl",
                 "-sSfL",
-                &format!("https://release.solana.com/v{solana_version}/install",),
+                &format!("https://release.anza.xyz/v{solana_version}/install",),
                 "-o",
                 "solana_installer.sh",
             ],


### PR DESCRIPTION
### Problem

Solana v2 is not available from the solana.com domain. For more information, see [Agave Transition](https://github.com/anza-xyz/agave/wiki/Agave-Transition).

### Summary of changes

Install Solana from anza.xyz domain in Docker verifiable builds.

**Note:** This change only affects Docker verifiable builds, as the main migration process was handled in https://github.com/coral-xyz/anchor/pull/3185.