### PR TITLE
Add avm to system path

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -41,6 +41,20 @@ On Linux systems you may need to install additional dependencies if cargo instal
 sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 ```
 
+If you're using bash, add `avm` to Linux PATH for bash, then reload the shell:
+
+```shell
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+If you're using zsh, add `avm` to Linux or Unix PATH for zsh, then reload the shell:
+
+```shell
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
 Install the latest version of the CLI using `avm`, and then set it to be the version to use.
 
 ```shell

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -41,14 +41,21 @@ On Linux systems you may need to install additional dependencies if cargo instal
 sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 ```
 
-If you're using bash, add `avm` to Linux PATH for bash, then reload the shell:
+If you're using `bash`, add `avm` to PATH for `bash`, then reload the shell:
 
 ```shell
 echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-If you're using zsh, add `avm` to Linux or Unix PATH for zsh, then reload the shell:
+If you're using `fish`, add `avm` to PATH for `fish`, then reload the shell:
+
+```shell
+echo "set -gx PATH \$PATH \$HOME/.cargo/bin" >> ~/.config/fish/config.fish
+source ~/.config/fish/config.fish
+```
+
+If you're using `zsh`, add `avm` to PATH for `zsh`, then reload the shell:
 
 ```shell
 echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc


### PR DESCRIPTION
Problem:

While following the documentation to install `avm`, my system was unable to locate the `avm` command. This was due to the absence of the Cargo binary directory ($HOME/.cargo/bin) in my system PATH. While this issue may stem from my own Rust installation, it might benefit users to have a reminder in the documentation about the necessity of including the Cargo binary directory in the system PATH for the successful execution of `avm install latest`.

Proposed Solution:

I suggest updating the documentation to include instructions for adding the entire Cargo binary directory to the system PATH. This will help users avoid similar issues and streamline their installation process.

Additional Concern:

`avm install latest` fails on my system, as does `avm install 0.29.0` (both with the same error):

![Screenshot From 2024-09-24 05-13-41](https://github.com/user-attachments/assets/95f107ce-5405-4611-b0fb-1153d64b1bdf)

Thank you for considering this PR!
