### PR TITLE
cli: Check whether the `idl-build` feature exists when using the `idl build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Warn if a manifest has `solana-program` dependency ([#3250](https://github.com/coral-xyz/anchor/pull/3250)).
 - cli: Add completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
 - cli: Always convert IDLs ([#3265](https://github.com/coral-xyz/anchor/pull/3265)).
+- cli: Check whether the `idl-build` feature exists when using the `idl build` command ([#3273](https://github.com/coral-xyz/anchor/pull/3273)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -115,7 +115,31 @@ pub fn check_deps(cfg: &WithPath<Config>) -> Result<()> {
 ///
 /// **Note:** The check expects the current directory to be a program directory.
 pub fn check_idl_build_feature() -> Result<()> {
-    let manifest = Manifest::from_path("Cargo.toml")?;
+    let manifest = Manifest::discover()?.ok_or_else(|| anyhow!("Cargo.toml not found"))?;
+
+    // Check whether the manifest has `idl-build` feature
+    let has_idl_build_feature = manifest
+        .features
+        .iter()
+        .any(|(feature, _)| feature == "idl-build");
+    if !has_idl_build_feature {
+        let path = manifest.path().display();
+        let anchor_spl_idl_build = manifest
+            .dependencies
+            .iter()
+            .any(|dep| dep.0 == "anchor-spl")
+            .then_some(r#", "anchor-spl/idl-build""#)
+            .unwrap_or_default();
+
+        return Err(anyhow!(
+            r#"`idl-build` feature is missing. To solve, add
+
+[features]
+idl-build = ["anchor-lang/idl-build"{anchor_spl_idl_build}]
+
+in `{path}`."#
+        ));
+    }
 
     // Check if `idl-build` is enabled by default
     manifest

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -115,7 +115,8 @@ pub fn check_deps(cfg: &WithPath<Config>) -> Result<()> {
 ///
 /// **Note:** The check expects the current directory to be a program directory.
 pub fn check_idl_build_feature() -> Result<()> {
-    let manifest = Manifest::discover()?.ok_or_else(|| anyhow!("Cargo.toml not found"))?;
+    let manifest_path = Path::new("Cargo.toml").canonicalize()?;
+    let manifest = Manifest::from_path(&manifest_path)?;
 
     // Check whether the manifest has `idl-build` feature
     let has_idl_build_feature = manifest
@@ -123,7 +124,6 @@ pub fn check_idl_build_feature() -> Result<()> {
         .iter()
         .any(|(feature, _)| feature == "idl-build");
     if !has_idl_build_feature {
-        let path = manifest.path().display();
         let anchor_spl_idl_build = manifest
             .dependencies
             .iter()
@@ -137,7 +137,7 @@ pub fn check_idl_build_feature() -> Result<()> {
 [features]
 idl-build = ["anchor-lang/idl-build"{anchor_spl_idl_build}]
 
-in `{path}`."#
+in `{manifest_path:?}`."#
         ));
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2724,8 +2724,6 @@ fn idl_build(
     cargo_args: Vec<String>,
 ) -> Result<()> {
     let cfg = Config::discover(cfg_override)?.expect("Not in workspace");
-    check_idl_build_feature()?;
-
     let program_path = match program_name {
         Some(name) => cfg.get_program(&name)?.path,
         None => {
@@ -2737,8 +2735,10 @@ fn idl_build(
                 .path
         }
     };
+    std::env::set_current_dir(program_path)?;
+
+    check_idl_build_feature()?;
     let idl = anchor_lang_idl::build::IdlBuilder::new()
-        .program_path(program_path)
         .resolution(cfg.features.resolution)
         .skip_lint(cfg.features.skip_lint || skip_lint)
         .no_docs(no_docs)


### PR DESCRIPTION
### Problem

`idl-build` feature is required to be listed in the `[features]` section of `Cargo.toml` for IDL generation process to work, but it's only checked when using the regular `build command`, and not when using the `idl build` command.

### Summary of changes

Check whether the `idl-build` feature exists when using the `idl build` command.