### PR TITLE
cli: Build IDL if there is only one program when using the `idl build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add completions command to generate shell completions via the clap_complete crate ([#3251](https://github.com/coral-xyz/anchor/pull/3251)).
 - cli: Always convert IDLs ([#3265](https://github.com/coral-xyz/anchor/pull/3265)).
 - cli: Check whether the `idl-build` feature exists when using the `idl build` command ([#3273](https://github.com/coral-xyz/anchor/pull/3273)).
+- cli: Build IDL if there is only one program when using the `idl build` command ([#3275](https://github.com/coral-xyz/anchor/pull/3275)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2728,11 +2728,16 @@ fn idl_build(
         Some(name) => cfg.get_program(&name)?.path,
         None => {
             let current_dir = std::env::current_dir()?;
-            cfg.read_all_programs()?
-                .into_iter()
-                .find(|program| program.path == current_dir)
-                .ok_or_else(|| anyhow!("Not in a program directory"))?
-                .path
+            let programs = cfg.read_all_programs()?;
+            if programs.len() == 1 {
+                programs.into_iter().next().unwrap().path
+            } else {
+                programs
+                    .into_iter()
+                    .find(|program| program.path == current_dir)
+                    .ok_or_else(|| anyhow!("Not in a program directory"))?
+                    .path
+            }
         }
     };
     std::env::set_current_dir(program_path)?;


### PR DESCRIPTION
### Problem

Running the `idl build` command when there is only one program inside the workspace root results in an error:

```sh
$ anchor idl build
Error: Not in a program directory
```

You need to specify which program's IDL to build if the current directory is not a program directory:

```sh
anchor idl build -p <PROGRAM_NAME>
```

This is unnecessary when there is only one program in the workspace.

### Summary of changes

Build IDL if there is only one program inside the workspace when using the `idl build` command outside of a program directory.