### PR TITLE
cli: Add short alias for `idl build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Always convert IDLs ([#3265](https://github.com/coral-xyz/anchor/pull/3265)).
 - cli: Check whether the `idl-build` feature exists when using the `idl build` command ([#3273](https://github.com/coral-xyz/anchor/pull/3273)).
 - cli: Build IDL if there is only one program when using the `idl build` command ([#3275](https://github.com/coral-xyz/anchor/pull/3275)).
+- cli: Add short alias for the `idl build` command ([#3283](https://github.com/coral-xyz/anchor/pull/3283)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -470,6 +470,7 @@ pub enum IdlCommand {
         program_id: Pubkey,
     },
     /// Generates the IDL for the program using the compilation method.
+    #[clap(alias = "b")]
     Build {
         // Program name to build the IDL of(current dir's program if not specified)
         #[clap(short, long)]


### PR DESCRIPTION
### Problem

`anchor build` command supports short alias `anchor b`, but `anchor idl build` doesn't.

### Summary of changes

Add short alias (`b`) for the `idl build` command:

```sh
anchor idl b
```
