### PR TITLE
idl: Log output with `ANCHOR_LOG` on failure and improve build error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix using full path types with `Program` ([#3228](https://github.com/coral-xyz/anchor/pull/3228)).
 - lang: Use closures for `init` constraints to reduce the stack usage of `try_accounts` ([#2939](https://github.com/coral-xyz/anchor/pull/2939)).
 - lang: Allow the `cfg` attribute above the instructions ([#2339](https://github.com/coral-xyz/anchor/pull/2339)).
+- idl: Log output with `ANCHOR_LOG` on failure and improve build error message ([#3284](https://github.com/coral-xyz/anchor/pull/3284)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

There is an undocumented feature (setting the `ANCHOR_LOG` environment variable) that allows you to log the output of the underlying `cargo test` command we run to generate the IDL. However, this doesn't show the output when the `cargo test` command fails because [the IDL builder returns early](https://github.com/coral-xyz/anchor/blob/cf81636805088441e0d676ecbfc61e840947628f/idl/src/build.rs#L174-L176), which is [before the logging code runs](https://github.com/coral-xyz/anchor/blob/cf81636805088441e0d676ecbfc61e840947628f/idl/src/build.rs#L194-L197) as mentioned in https://github.com/coral-xyz/anchor/issues/3042#issuecomment-2377712770:

```sh
$ ANCHOR_LOG=true anchor idl build
Error: Building IDL failed
```

### Summary of changes

Log output when the `ANCHOR_LOG` is set on failure and improve the build error message.

**Before:**

```sh
$ anchor idl build
Error: Building IDL failed
```

**After:**

```sh
$ anchor idl build
Error: Building IDL failed. Run `ANCHOR_LOG=true anchor idl build` to see the logs.
```

**With `ANCHOR_LOG`:**

```sh
$ ANCHOR_LOG=true anchor idl build
running 2 tests
. 1/2
__anchor_private_print_idl_program --- FAILED

successes:

---- __anchor_private_print_idl_address stdout ----
--- IDL begin address ---
"\"Abc1111111111111111111111111111111111111111\""
--- IDL end address ---


successes:
    __anchor_private_print_idl_address

failures:

---- __anchor_private_print_idl_program stdout ----
--- IDL begin program ---
thread '__anchor_private_print_idl_program' panicked at programs/my-program/src/lib.rs:53:9:
Oops, something went wrong!
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    __anchor_private_print_idl_program

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


Error: Building IDL failed. Run `ANCHOR_LOG=true anchor idl build` to see the logs.
```