### PR TITLE
docs: Open external navigation links in a new tab

### DIFF
--- a/docs/src/components/Navigation.jsx
+++ b/docs/src/components/Navigation.jsx
@@ -18,6 +18,9 @@ export function Navigation({ navigation, className }) {
                 <li key={link.href} className="relative">
                   <Link href={link.href}>
                     <a
+                      {...(link.href.startsWith('/')
+                        ? {}
+                        : { target: '_blank', rel: 'noopener noreferrer' })}
                       className={clsx(
                         'block w-full pl-3.5 before:pointer-events-none before:absolute before:-left-1 before:top-1/2 before:h-1.5 before:w-1.5 before:-translate-y-1/2 before:rounded-full',
                         {


### PR DESCRIPTION
### Problem

There are currently two external links, [Core Library](https://docs.rs/anchor-lang/latest/anchor_lang/) and [Rust Client Library](https://docs.rs/anchor-client/latest/anchor_client/), that can be opened from the navigation section. However, clicking these external links makes the user leave the docs site instead of opening them in a new tab.

### Summary of changes

Open external navigation links in a new tab.