### PR TITLE
lang: Fix constant bytes declarations when using `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Use closures for `init` constraints to reduce the stack usage of `try_accounts` ([#2939](https://github.com/coral-xyz/anchor/pull/2939)).
 - lang: Allow the `cfg` attribute above the instructions ([#2339](https://github.com/coral-xyz/anchor/pull/2339)).
 - idl: Log output with `ANCHOR_LOG` on failure and improve build error message ([#3284](https://github.com/coral-xyz/anchor/pull/3284)).
+- lang: Fix constant bytes declarations when using `declare_program!` ([#3287](https://github.com/coral-xyz/anchor/pull/3287)).
 
 ### Breaking
 

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -229,5 +229,12 @@
         ]
       }
     }
+  ],
+  "constants": [
+    {
+      "name": "MASTER_SEED",
+      "type": "bytes",
+      "value": "[109, 97, 115, 116, 101, 114]"
+    }
   ]
 }

--- a/tests/declare-program/idls/external_legacy.json
+++ b/tests/declare-program/idls/external_legacy.json
@@ -1,26 +1,55 @@
 {
   "version": "0.1.0",
   "name": "external",
-  "metadata": {
-    "address": "Externa111111111111111111111111111111111111"
-  },
+  "constants": [
+    {
+      "name": "MASTER_SEED",
+      "type": "bytes",
+      "value": "[109, 97, 115, 116, 101, 114]"
+    }
+  ],
   "instructions": [
     {
       "name": "init",
       "accounts": [
-        { "name": "authority", "isMut": true, "isSigner": true },
-        { "name": "myAccount", "isMut": true, "isSigner": false },
-        { "name": "systemProgram", "isMut": false, "isSigner": false }
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "myAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
       ],
       "args": []
     },
     {
       "name": "update",
       "accounts": [
-        { "name": "authority", "isMut": false, "isSigner": true },
-        { "name": "myAccount", "isMut": true, "isSigner": false }
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "myAccount",
+          "isMut": true,
+          "isSigner": false
+        }
       ],
-      "args": [{ "name": "value", "type": "u32" }]
+      "args": [
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "updateComposite",
@@ -28,21 +57,53 @@
         {
           "name": "update",
           "accounts": [
-            { "name": "authority", "isMut": false, "isSigner": true },
-            { "name": "myAccount", "isMut": true, "isSigner": false }
+            {
+              "name": "authority",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "myAccount",
+              "isMut": true,
+              "isSigner": false
+            }
           ]
         }
       ],
-      "args": [{ "name": "value", "type": "u32" }]
+      "args": [
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "testCompilationDefinedTypeParam",
-      "accounts": [{ "name": "signer", "isMut": false, "isSigner": true }],
-      "args": [{ "name": "myAccount", "type": { "defined": "MyAccount" } }]
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "myAccount",
+          "type": {
+            "defined": "MyAccount"
+          }
+        }
+      ]
     },
     {
       "name": "testCompilationReturnType",
-      "accounts": [{ "name": "signer", "isMut": false, "isSigner": true }],
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
       "args": [],
       "returns": "bool"
     }
@@ -52,14 +113,28 @@
       "name": "MyAccount",
       "type": {
         "kind": "struct",
-        "fields": [{ "name": "field", "type": "u32" }]
+        "fields": [
+          {
+            "name": "field",
+            "type": "u32"
+          }
+        ]
       }
     }
   ],
   "events": [
     {
       "name": "MyEvent",
-      "fields": [{ "name": "value", "type": "u32", "index": false }]
+      "fields": [
+        {
+          "name": "value",
+          "type": "u32",
+          "index": false
+        }
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "address": "Externa111111111111111111111111111111111111"
+  }
 }

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -2,6 +2,9 @@ use anchor_lang::prelude::*;
 
 declare_id!("Externa111111111111111111111111111111111111");
 
+#[constant]
+pub const MASTER_SEED: &[u8] = b"master";
+
 #[program]
 pub mod external {
     use super::*;


### PR DESCRIPTION
### Problem

Declaring a bytes constant:

```rs
#[constant]
pub const MY_CONST: &[u8] = &[1, 2, 3, 4];
```

generates the following `constants` section in the IDL:

```json
"constants": [
    {
      "name": "MY_BYTES",
      "type": "bytes",
      "value": "[1, 2, 3, 4]"
    }
]
```

Using this IDL with `declare_program!` panics with:

```
error: proc macro panicked
 --> programs/my-program/src/lib.rs:9:1
  |
9 | declare_program!(some_program);
  | ^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: called `Result::unwrap()` on an `Err` value: Error("unexpected end of input, expected expression")
```

Initially reported in [the Anchor Discord server](https://discord.com/channels/889577356681945098/889584618372734977/1290078085601034312).

### Summary of changes

Fix constant bytes declarations when using `declare_program!` by handling constants that have the type `IdlType::Bytes` separately.