### PR TITLE
avm: Remove unused `VERSION` declaration

### DIFF
--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -3,8 +3,6 @@ use avm::InstallTarget;
 use clap::{CommandFactory, Parser, Subcommand};
 use semver::Version;
 
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #[derive(Parser)]
 #[clap(name = "avm", about = "Anchor version manager", version)]
 pub struct Cli {


### PR DESCRIPTION
### Problem

[The `VERSION` constant](https://github.com/coral-xyz/anchor/blob/143893f67e34c756db379c036f8f869975906855/avm/src/main.rs#L6) is not used anywhere.

### Summary of changes

Remove unused `VERSION` declaration.