### PR TITLE
lang: Fix using non-instruction composite accounts with `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Allow the `cfg` attribute above the instructions ([#2339](https://github.com/coral-xyz/anchor/pull/2339)).
 - idl: Log output with `ANCHOR_LOG` on failure and improve build error message ([#3284](https://github.com/coral-xyz/anchor/pull/3284)).
 - lang: Fix constant bytes declarations when using `declare_program!` ([#3287](https://github.com/coral-xyz/anchor/pull/3287)).
+- lang: Fix using non-instruction composite accounts with `declare_program!` ([#3290](https://github.com/coral-xyz/anchor/pull/3290)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -116,11 +116,10 @@ fn gen_internal_accounts_common(
         accs.iter()
             .flat_map(|acc| match acc {
                 IdlInstructionAccountItem::Composite(accs)
-                    if idl
+                    if !idl
                         .instructions
                         .iter()
-                        .find(|ix| ix.accounts == accs.accounts)
-                        .is_none() =>
+                        .any(|ix| ix.accounts == accs.accounts) =>
                 {
                     let mut non_ix_composite_accs =
                         get_non_instruction_composite_accounts(&accs.accounts, idl);

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -172,6 +172,52 @@
           "type": "u32"
         }
       ]
+    },
+    {
+      "name": "update_non_instruction_composite",
+      "discriminator": [
+        49,
+        218,
+        69,
+        196,
+        204,
+        66,
+        36,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "non_instruction_update",
+          "accounts": [
+            {
+              "name": "authority",
+              "signer": true
+            },
+            {
+              "name": "my_account",
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "authority"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "program",
+              "address": "Externa111111111111111111111111111111111111"
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
     }
   ],
   "accounts": [

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -23,6 +23,15 @@ pub mod external {
         Ok(())
     }
 
+    // Test the issue described in https://github.com/coral-xyz/anchor/issues/3274
+    pub fn update_non_instruction_composite(
+        ctx: Context<UpdateNonInstructionComposite>,
+        value: u32,
+    ) -> Result<()> {
+        ctx.accounts.non_instruction_update.my_account.field = value;
+        Ok(())
+    }
+
     // Compilation test for whether a defined type (an account in this case) can be used in `cpi` client.
     pub fn test_compilation_defined_type_param(
         _ctx: Context<TestCompilation>,
@@ -65,8 +74,21 @@ pub struct Update<'info> {
 }
 
 #[derive(Accounts)]
+pub struct NonInstructionUpdate<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut, seeds = [authority.key.as_ref()], bump)]
+    pub my_account: Account<'info, MyAccount>,
+    pub program: Program<'info, program::External>,
+}
+
+#[derive(Accounts)]
 pub struct UpdateComposite<'info> {
     pub update: Update<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateNonInstructionComposite<'info> {
+    pub non_instruction_update: NonInstructionUpdate<'info>,
 }
 
 #[account]


### PR DESCRIPTION
### Problem

Having non-instruction composite accounts in the IDL causes `declare_program!` to panic as described in https://github.com/coral-xyz/anchor/issues/3274.

### Summary of changes

Get all non-instruction composite accounts and combine it with actual instructions in order to fix using non-instruction composite accounts with `declare_program!`.

Resolves https://github.com/coral-xyz/anchor/issues/3274