### PR TITLE
idl: Fix instructions with tuple parameters not producing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Log output with `ANCHOR_LOG` on failure and improve build error message ([#3284](https://github.com/coral-xyz/anchor/pull/3284)).
 - lang: Fix constant bytes declarations when using `declare_program!` ([#3287](https://github.com/coral-xyz/anchor/pull/3287)).
 - lang: Fix using non-instruction composite accounts with `declare_program!` ([#3290](https://github.com/coral-xyz/anchor/pull/3290)).
+- idl: Fix instructions with tuple parameters not producing an error([#3294](https://github.com/coral-xyz/anchor/pull/3294)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

Tuples are not currently supported in the IDL, but using them in instruction parameters do not produce an error as described in https://github.com/coral-xyz/anchor/issues/3127.

### Summary of changes

Fix instructions with tuple parameters not producing an error during IDL generation.

Example error output:

```
error: Unsupported type
  --> programs/x/src/lib.rs:11:52
   |
11 |     pub fn test<'info>(ctx: Context<Test>, tuple: (u8, u64)) -> Result<()> {
   |                                                   ^^^^^^^^^
```

Resolves https://github.com/coral-xyz/anchor/issues/3127