### PR TITLE
ts: Update `engines.node` to `>= 17`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix constant bytes declarations when using `declare_program!` ([#3287](https://github.com/coral-xyz/anchor/pull/3287)).
 - lang: Fix using non-instruction composite accounts with `declare_program!` ([#3290](https://github.com/coral-xyz/anchor/pull/3290)).
 - idl: Fix instructions with tuple parameters not producing an error([#3294](https://github.com/coral-xyz/anchor/pull/3294)).
+- ts: Update `engines.node` to `>= 17` ([#3301](https://github.com/coral-xyz/anchor/pull/3301)).
 
 ### Breaking
 

--- a/examples/tutorial/basic-0/package.json
+++ b/examples/tutorial/basic-0/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/examples/tutorial/basic-1/package.json
+++ b/examples/tutorial/basic-1/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/examples/tutorial/basic-2/package.json
+++ b/examples/tutorial/basic-2/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/examples/tutorial/basic-3/package.json
+++ b/examples/tutorial/basic-3/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/examples/tutorial/basic-4/package.json
+++ b/examples/tutorial/basic-4/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/examples/tutorial/basic-5/package.json
+++ b/examples/tutorial/basic-5/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint && anchor clean"

--- a/tests/anchor-cli-account/package.json
+++ b/tests/anchor-cli-account/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/anchor-cli-idl/package.json
+++ b/tests/anchor-cli-idl/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "./test.sh"

--- a/tests/bpf-upgradeable-state/package.json
+++ b/tests/bpf-upgradeable-state/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "bpf-upgradeable-state",
-    "version": "0.24.0",
-    "license": "(MIT OR Apache-2.0)",
-    "homepage": "https://github.com/coral-xyz/anchor#readme",
-    "bugs": {
-        "url": "https://github.com/coral-xyz/anchor/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/coral-xyz/anchor.git"
-    },
-    "engines": {
-        "node": ">=11"
-    }
+  "name": "bpf-upgradeable-state",
+  "version": "0.24.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  }
 }

--- a/tests/cashiers-check/package.json
+++ b/tests/cashiers-check/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/cfo/package.json
+++ b/tests/cfo/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor run test-with-build"

--- a/tests/chat/package.json
+++ b/tests/chat/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/composite/package.json
+++ b/tests/composite/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/cpi-returns/package.json
+++ b/tests/cpi-returns/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor run test-with-build"

--- a/tests/custom-coder/package.json
+++ b/tests/custom-coder/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test --skip-lint"

--- a/tests/declare-id/package.json
+++ b/tests/declare-id/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/docs/package.json
+++ b/tests/docs/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/errors/package.json
+++ b/tests/errors/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/escrow/package.json
+++ b/tests/escrow/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/events/package.json
+++ b/tests/events/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/floats/package.json
+++ b/tests/floats/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "floats",
-    "version": "0.30.1",
-    "license": "(MIT OR Apache-2.0)",
-    "homepage": "https://github.com/coral-xyz/anchor#readme",
-    "bugs": {
-      "url": "https://github.com/coral-xyz/anchor/issues"
-    },
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/coral-xyz/anchor.git"
-    },
-    "engines": {
-      "node": ">=11"
-    },
-    "scripts": {
-      "test": "anchor test"
-    }
+  "name": "floats",
+  "version": "0.30.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  },
+  "scripts": {
+    "test": "anchor test"
   }
+}

--- a/tests/ido-pool/package.json
+++ b/tests/ido-pool/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/lockup/package.json
+++ b/tests/lockup/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/misc/package.json
+++ b/tests/misc/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/multiple-suites-run-single/package.json
+++ b/tests/multiple-suites-run-single/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "multiple-suites-run-single",
-    "version": "0.24.2",
-    "license": "(MIT OR Apache-2.0)",
-    "homepage": "https://github.com/coral-xyz/anchor#readme",
-    "bugs": {
-      "url": "https://github.com/coral-xyz/anchor/issues"
-    },
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/coral-xyz/anchor.git"
-    },
-    "engines": {
-      "node": ">=11"
-    },
-    "scripts": {
-      "test": "anchor test"
-    }
+  "name": "multiple-suites-run-single",
+  "version": "0.24.2",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  },
+  "scripts": {
+    "test": "anchor test"
   }
+}

--- a/tests/multiple-suites/package.json
+++ b/tests/multiple-suites/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "multiple-suites",
-    "version": "0.30.1",
-    "license": "(MIT OR Apache-2.0)",
-    "homepage": "https://github.com/coral-xyz/anchor#readme",
-    "bugs": {
-      "url": "https://github.com/coral-xyz/anchor/issues"
-    },
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/coral-xyz/anchor.git"
-    },
-    "engines": {
-      "node": ">=11"
-    },
-    "scripts": {
-      "test": "anchor test"
-    }
+  "name": "multiple-suites",
+  "version": "0.30.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  },
+  "scripts": {
+    "test": "anchor test"
   }
+}

--- a/tests/multisig/package.json
+++ b/tests/multisig/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/optional/package.json
+++ b/tests/optional/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/pda-derivation/package.json
+++ b/tests/pda-derivation/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/pyth/package.json
+++ b/tests/pyth/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/realloc/package.json
+++ b/tests/realloc/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/relations-derivation/package.json
+++ b/tests/relations-derivation/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/solang/package.json
+++ b/tests/solang/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor run test-with-build"

--- a/tests/spl/token-extensions/package.json
+++ b/tests/spl/token-extensions/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/token-proxy/package.json
+++ b/tests/spl/token-proxy/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/token-wrapper/package.json
+++ b/tests/spl/token-wrapper/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/transfer-hook/package.json
+++ b/tests/spl/transfer-hook/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/swap/package.json
+++ b/tests/swap/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/system-accounts/package.json
+++ b/tests/system-accounts/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/sysvars/package.json
+++ b/tests/sysvars/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/tictactoe/package.json
+++ b/tests/tictactoe/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/typescript/package.json
+++ b/tests/typescript/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/validator-clone/package.json
+++ b/tests/validator-clone/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/zero-copy/package.json
+++ b/tests/zero-copy/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "test": "anchor test"

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=17"
   },
   "scripts": {
     "build": "rimraf dist/ && yarn build:node && yarn build:browser",


### PR DESCRIPTION
### Problem

`@coral-xyz/anchor` library's `node` version requirement is not specific enough:

https://github.com/coral-xyz/anchor/blob/6eb4cc7539636983e768561ea9c528d59486799d/ts/packages/anchor/package.json#L22

This is because of using [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) internally, which requires `node >= 17` (see [compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone#browser_compatibility)).

Users may run into this problem if they use an outdated `node` version, e.g. https://github.com/coral-xyz/anchor/issues/2969.

### Summary of changes

Update `engines.node` field of `package.json` to `>= 17`.