### PR TITLE
cli: Use OS-agnostic paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix using non-instruction composite accounts with `declare_program!` ([#3290](https://github.com/coral-xyz/anchor/pull/3290)).
 - idl: Fix instructions with tuple parameters not producing an error([#3294](https://github.com/coral-xyz/anchor/pull/3294)).
 - ts: Update `engines.node` to `>= 17` ([#3301](https://github.com/coral-xyz/anchor/pull/3301)).
+- cli: Use OS-agnostic paths ([#3307](https://github.com/coral-xyz/anchor/pull/3307)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1613,7 +1613,7 @@ fn build_cwd_verifiable(
                 .join("target")
                 .join("types")
                 .join(&idl.metadata.name)
-                .with_extension("json");
+                .with_extension("ts");
             fs::write(&ts_file, idl_ts(&idl)?)?;
 
             // Copy out the TypeScript type.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3584,10 +3584,7 @@ fn stream_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<std::proc
         let idl = convert_idl(&idl)?;
 
         let log_file = File::create(
-            program_logs_dir
-                .join(&idl.address)
-                .join(&program.lib_name)
-                .with_extension("log"),
+            program_logs_dir.join(format!("{}.{}.log", idl.address, program.lib_name)),
         )?;
         let stdio = std::process::Stdio::from(log_file);
         let child = std::process::Command::new("solana")

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3583,7 +3583,12 @@ fn stream_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<std::proc
         let idl = fs::read(idl_path)?;
         let idl = convert_idl(&idl)?;
 
-        let log_file = File::create(program_logs_dir.join(&idl.address).join(&program.lib_name))?;
+        let log_file = File::create(
+            program_logs_dir
+                .join(&idl.address)
+                .join(&program.lib_name)
+                .with_extension("log"),
+        )?;
         let stdio = std::process::Stdio::from(log_file);
         let child = std::process::Command::new("solana")
             .arg("logs")
@@ -3597,7 +3602,8 @@ fn stream_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<std::proc
     if let Some(test) = config.test_validator.as_ref() {
         if let Some(genesis) = &test.genesis {
             for entry in genesis {
-                let log_file = File::create(program_logs_dir.join(&entry.address))?;
+                let log_file =
+                    File::create(program_logs_dir.join(&entry.address).with_extension("log"))?;
                 let stdio = std::process::Stdio::from(log_file);
                 let child = std::process::Command::new("solana")
                     .arg("logs")


### PR DESCRIPTION
### Problem

The CLI assumes the path separator to be `/` but Windows uses `\` instead.

### Summary of changes

Use OS-agnostic paths.

---

This change should be enough to (mostly) resolve https://github.com/coral-xyz/anchor/issues/2453 from our side, but the main issue of Solana tools not working properly on Windows still remains.