### PR TITLE
cli: Add `--program-id` option to `idl convert` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Check whether the `idl-build` feature exists when using the `idl build` command ([#3273](https://github.com/coral-xyz/anchor/pull/3273)).
 - cli: Build IDL if there is only one program when using the `idl build` command ([#3275](https://github.com/coral-xyz/anchor/pull/3275)).
 - cli: Add short alias for the `idl build` command ([#3283](https://github.com/coral-xyz/anchor/pull/3283)).
+- cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

IDL conversion requires legacy IDLs to have `metadata.address` field, but some of the existing legacy IDLs don't have the field specified (because the legacy IDL spec did not require it). This usually results in users having to manually edit the IDL file to include the mentioned field, which can be annoying as also mentioned in https://github.com/coral-xyz/anchor/issues/3303.

### Summary of changes

Add `--program-id` option to the `idl convert` command:

```
anchor idl convert <PATH> --program-id <PROGRAM_ID>
```

Resolves https://github.com/coral-xyz/anchor/issues/3303