### PR TITLE
ci: Re-enable the `anchor init` test

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -358,9 +358,8 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      # TODO: Re-enable once https://github.com/solana-labs/solana/issues/33504 is resolved
-      # - run: cd "$(mktemp -d)" && anchor init hello-anchor && cd hello-anchor && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
-      # - uses: ./.github/actions/git-diff/
+      - run: cd "$(mktemp -d)" && anchor init hello-anchor && cd hello-anchor && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
+      - uses: ./.github/actions/git-diff/
 
   test-programs:
     needs: setup-anchor-cli


### PR DESCRIPTION
### Problem

The `anchor init` test in our CI was disabled in https://github.com/coral-xyz/anchor/pull/2756 due to an upstream breakage combined with an outdated Rust version coming from the Solana installation.

### Summary of changes

Re-enable the `anchor init` test.