### PR TITLE
lang: Generate documentation of constants in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Build IDL if there is only one program when using the `idl build` command ([#3275](https://github.com/coral-xyz/anchor/pull/3275)).
 - cli: Add short alias for the `idl build` command ([#3283](https://github.com/coral-xyz/anchor/pull/3283)).
 - cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
+- lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/declare_program/mods/constants.rs
+++ b/lang/attribute/program/src/declare_program/mods/constants.rs
@@ -1,11 +1,12 @@
 use anchor_lang_idl::types::{Idl, IdlType};
 use quote::{format_ident, quote, ToTokens};
 
-use super::common::convert_idl_type_to_syn_type;
+use super::common::{convert_idl_type_to_syn_type, gen_docs};
 
 pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let constants = idl.constants.iter().map(|c| {
         let name = format_ident!("{}", c.name);
+        let docs = gen_docs(&c.docs);
         let val = syn::parse_str::<syn::Expr>(&c.value)
             .unwrap()
             .to_token_stream();
@@ -15,8 +16,10 @@ pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
             _ => (convert_idl_type_to_syn_type(&c.ty).to_token_stream(), val),
         };
 
-        // TODO: Docs
-        quote! { pub const #name: #ty = #val; }
+        quote! {
+            #docs
+            pub const #name: #ty = #val;
+        }
     });
 
     quote! {

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -279,6 +279,9 @@
   "constants": [
     {
       "name": "MASTER_SEED",
+      "docs": [
+        "Master seed slice"
+      ],
       "type": "bytes",
       "value": "[109, 97, 115, 116, 101, 114]"
     }

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("Externa111111111111111111111111111111111111");
 
+/// Master seed slice
 #[constant]
 pub const MASTER_SEED: &[u8] = b"master";
 


### PR DESCRIPTION
### Problem

Constant definitions generated by `declare_program!` don't currently have the documentation comments included in their definition. This was because I originally implemented `declare_program!` with the legacy IDL spec, which did not store the documentation of constants.

### Summary of changes

Generate documentation of constants in `declare_program!`.