### PR TITLE
avm: Use `rustc 1.79.0` when installing versions older than v0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix instructions with tuple parameters not producing an error([#3294](https://github.com/coral-xyz/anchor/pull/3294)).
 - ts: Update `engines.node` to `>= 17` ([#3301](https://github.com/coral-xyz/anchor/pull/3301)).
 - cli: Use OS-agnostic paths ([#3307](https://github.com/coral-xyz/anchor/pull/3307)).
+- avm: Use `rustc 1.79.0` when installing versions older than v0.31 ([#3315](https://github.com/coral-xyz/anchor/pull/3315)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

Installing Anchor from `avm` using `rustc >1.79` fails due to the problem mentioned in https://github.com/coral-xyz/anchor/pull/3143.

This was going to get solved after v0.31.0 release, however, external factors blocked the release (https://github.com/coral-xyz/anchor/pull/3259) much longer than expected.

### Summary of changes

Automatically switch to using `rustc 1.79.0` when installing Anchor versions older than `0.31.0`.