### PR TITLE
docs: Add `workspace.exclude` documentation

### DIFF
--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -82,6 +82,19 @@ members = [
 ]
 ```
 
+#### exclude
+
+Opposite of `workspace.members`.
+
+Example:
+
+```toml
+[workspace]
+exclude = [
+    "programs/my_program"
+]
+```
+
 ## programs
 
 Example:


### PR DESCRIPTION
### Problem

`workspace.exclude` feature is not documented in Anchor docs site.

### Summary of changes

Add `workspace.exclude` documentation.