### PR TITLE
cli: Fix priority fee calculation causing panic on localnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Update `engines.node` to `>= 17` ([#3301](https://github.com/coral-xyz/anchor/pull/3301)).
 - cli: Use OS-agnostic paths ([#3307](https://github.com/coral-xyz/anchor/pull/3307)).
 - avm: Use `rustc 1.79.0` when installing versions older than v0.31 ([#3315](https://github.com/coral-xyz/anchor/pull/3315)).
+- cli: Fix priority fee calculation causing panic on localnet ([#3318](https://github.com/coral-xyz/anchor/pull/3318)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4726,6 +4726,10 @@ fn get_recommended_micro_lamport_fee(client: &RpcClient, priority_fee: Option<u6
     }
 
     let mut fees = client.get_recent_prioritization_fees(&[])?;
+    if fees.is_empty() {
+        // Fees may be empty, e.g. on localnet
+        return Ok(0);
+    }
 
     // Get the median fee from the most recent recent 150 slots' prioritization fee
     fees.sort_unstable_by_key(|fee| fee.prioritization_fee);


### PR DESCRIPTION
### Problem

https://github.com/coral-xyz/anchor/blob/880a1e98a31f48362d2402f0a3649309c84f3909/cli/src/lib.rs#L4735

Fails with:

```
thread 'main' panicked at cli/src/lib.rs:4735:15:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

When there is no recent prioritization fees, e.g. on localnet.

### Summary of changes

Fix priority fee calculation causing panic on localnet.