### PR TITLE
fix: Client is_signer usage in to_account_metas

### DIFF
--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -370,12 +370,14 @@ impl FromStr for IdlType {
                                 array_from_str(&nested_inner[1..])
                             }
                             None => {
-                                let (raw_type, raw_length) = inner
-                                    .rsplit_once(';')
-                                    .ok_or_else(|| anyhow!(
-                                        "Invalid array syntax: expected '[type; length]', found '[{}]'",
-                                        inner
-                                    ))?;
+                                let (raw_type, raw_length) =
+                                    inner.rsplit_once(';').ok_or_else(|| {
+                                        anyhow!(
+                                            "Invalid array syntax: expected '[type; length]', \
+                                             found '[{}]'",
+                                            inner
+                                        )
+                                    })?;
 
                                 let raw_type = raw_type.trim();
                                 if raw_type.is_empty() {

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -104,7 +104,7 @@ pub fn generate(
             AccountField::CompositeField(s) => {
                 let name = &s.ident;
                 quote! {
-                    account_metas.extend(self.#name.to_account_metas(None));
+                    account_metas.extend(self.#name.to_account_metas(is_signer));
                 }
             }
             AccountField::Field(f) => {
@@ -114,7 +114,7 @@ pub fn generate(
                 };
                 let is_signer = match is_signer {
                     false => quote! {false},
-                    true => quote! {true},
+                    true => quote! {is_signer.unwrap_or(true)},
                 };
                 let meta = match f.constraints.is_mutable() {
                     false => quote! { anchor_lang::solana_program::instruction::AccountMeta::new_readonly },

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -95,7 +95,7 @@ pub fn generate(
             AccountField::CompositeField(s) => {
                 let name = &s.ident;
                 quote! {
-                    account_metas.extend(self.#name.to_account_metas(None));
+                    account_metas.extend(self.#name.to_account_metas(is_signer));
                 }
             }
             AccountField::Field(f) => {
@@ -105,7 +105,7 @@ pub fn generate(
                 };
                 let is_signer = match is_signer {
                     false => quote! {false},
-                    true => quote! {true},
+                    true => quote! {is_signer.unwrap_or(true)},
                 };
                 let meta = match f.constraints.is_mutable() {
                     false => quote! { anchor_lang::solana_program::instruction::AccountMeta::new_readonly },

--- a/tests/declare-program/programs/declare-program/Cargo.toml
+++ b/tests/declare-program/programs/declare-program/Cargo.toml
@@ -14,9 +14,14 @@ no-idl = []
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]
+test-sbf = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
+
+[dev-dependencies]
+solana-sdk = "2"
+solana-program-test = "2"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -12,8 +12,12 @@ declare_program!(external_legacy);
 // https://github.com/raydium-io/raydium-idl/blob/6123104304ebcb42be175cc297a2c221ac96bb96/raydium_clmm/amm_v3.json
 declare_program!(amm_v3);
 
+pub const GLOBAL: &[u8] = b"global";
+
 #[program]
 pub mod declare_program {
+    use anchor_lang::solana_program::{instruction::Instruction, program::invoke_signed};
+
     use super::*;
 
     pub fn cpi(ctx: Context<Cpi>, value: u32) -> Result<()> {
@@ -89,6 +93,81 @@ pub mod declare_program {
 
         Ok(())
     }
+
+    pub fn account_utils(_ctx: Context<Utils>) -> Result<()> {
+        use external::utils::Account;
+
+        // Empty
+        if Account::try_from_bytes(&[]).is_ok() {
+            return Err(ProgramError::Custom(0).into());
+        }
+
+        const DISC: &[u8] = external::accounts::MyAccount::DISCRIMINATOR;
+
+        // Correct discriminator but invalid data
+        if Account::try_from_bytes(DISC).is_ok() {
+            return Err(ProgramError::Custom(1).into());
+        };
+
+        // Correct discriminator and valid data
+        match Account::try_from_bytes(&[DISC, &[1, 0, 0, 0]].concat()) {
+            Ok(Account::MyAccount(my_account)) => require_eq!(my_account.field, 1),
+            Err(e) => return Err(e.into()),
+        }
+
+        Ok(())
+    }
+
+    pub fn event_utils(_ctx: Context<Utils>) -> Result<()> {
+        use external::utils::Event;
+
+        // Empty
+        if Event::try_from_bytes(&[]).is_ok() {
+            return Err(ProgramError::Custom(0).into());
+        }
+
+        const DISC: &[u8] = external::events::MyEvent::DISCRIMINATOR;
+
+        // Correct discriminator but invalid data
+        if Event::try_from_bytes(DISC).is_ok() {
+            return Err(ProgramError::Custom(1).into());
+        };
+
+        // Correct discriminator and valid data
+        match Event::try_from_bytes(&[DISC, &[1, 0, 0, 0]].concat()) {
+            Ok(Event::MyEvent(my_event)) => require_eq!(my_event.value, 1),
+            Err(e) => return Err(e.into()),
+        }
+
+        Ok(())
+    }
+
+    pub fn proxy(ctx: Context<Proxy>, data: Vec<u8>) -> Result<()> {
+        let (authority, bump) = Pubkey::find_program_address(&[GLOBAL], &ID);
+
+        let accounts = ctx
+            .remaining_accounts
+            .iter()
+            .map(|ra| AccountMeta {
+                pubkey: ra.key(),
+                is_signer: ra.is_signer || &authority == ra.key,
+                is_writable: ra.is_writable,
+            })
+            .collect();
+
+        let signer_seeds: &[&[&[u8]]] = &[&[GLOBAL, &[bump]]];
+        invoke_signed(
+            &Instruction {
+                program_id: ctx.accounts.program.key(),
+                accounts,
+                data,
+            },
+            ctx.remaining_accounts,
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -102,4 +181,9 @@ pub struct Cpi<'info> {
 #[derive(Accounts)]
 pub struct Utils<'info> {
     pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct Proxy<'info> {
+    pub program: Program<'info, External>,
 }

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -16,9 +16,10 @@ pub const GLOBAL: &[u8] = b"global";
 
 #[program]
 pub mod declare_program {
-    use anchor_lang::solana_program::{instruction::Instruction, program::invoke_signed};
-
-    use super::*;
+    use {
+        super::*,
+        anchor_lang::solana_program::{instruction::Instruction, program::invoke_signed},
+    };
 
     pub fn cpi(ctx: Context<Cpi>, value: u32) -> Result<()> {
         let cpi_my_account = &mut ctx.accounts.cpi_my_account;
@@ -94,47 +95,50 @@ pub mod declare_program {
         Ok(())
     }
 
+    #[cfg(not(target_os = "solana"))]
     pub fn account_utils(_ctx: Context<Utils>) -> Result<()> {
-        use external::utils::Account;
+        use external::parsers::Account;
 
         // Empty
-        if Account::try_from_bytes(&[]).is_ok() {
+        if Account::parse(&[]).is_ok() {
             return Err(ProgramError::Custom(0).into());
         }
 
         const DISC: &[u8] = external::accounts::MyAccount::DISCRIMINATOR;
 
         // Correct discriminator but invalid data
-        if Account::try_from_bytes(DISC).is_ok() {
+        if Account::parse(DISC).is_ok() {
             return Err(ProgramError::Custom(1).into());
         };
 
         // Correct discriminator and valid data
-        match Account::try_from_bytes(&[DISC, &[1, 0, 0, 0]].concat()) {
+        match Account::parse(&[DISC, &[1, 0, 0, 0]].concat()) {
             Ok(Account::MyAccount(my_account)) => require_eq!(my_account.field, 1),
+            Ok(_) => return Err(ProgramError::Custom(2).into()),
             Err(e) => return Err(e.into()),
         }
 
         Ok(())
     }
 
+    #[cfg(not(target_os = "solana"))]
     pub fn event_utils(_ctx: Context<Utils>) -> Result<()> {
-        use external::utils::Event;
+        use external::parsers::Event;
 
         // Empty
-        if Event::try_from_bytes(&[]).is_ok() {
+        if Event::parse(&[]).is_ok() {
             return Err(ProgramError::Custom(0).into());
         }
 
         const DISC: &[u8] = external::events::MyEvent::DISCRIMINATOR;
 
         // Correct discriminator but invalid data
-        if Event::try_from_bytes(DISC).is_ok() {
+        if Event::parse(DISC).is_ok() {
             return Err(ProgramError::Custom(1).into());
         };
 
         // Correct discriminator and valid data
-        match Event::try_from_bytes(&[DISC, &[1, 0, 0, 0]].concat()) {
+        match Event::parse(&[DISC, &[1, 0, 0, 0]].concat()) {
             Ok(Event::MyEvent(my_event)) => require_eq!(my_event.value, 1),
             Err(e) => return Err(e.into()),
         }

--- a/tests/declare-program/programs/declare-program/tests/declare_program_test.rs
+++ b/tests/declare-program/programs/declare-program/tests/declare_program_test.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL, signature::Signer, system_instruction, transaction::Transaction,
+};
+use {
+    anchor_lang::{
+        prelude::Pubkey,
+        solana_program::{instruction::Instruction, system_program},
+        InstructionData, ToAccountMetas,
+    },
+    declare_program::external,
+    solana_program_test::{tokio, ProgramTest},
+};
+
+#[tokio::test]
+async fn proxy() {
+    let mut pt = ProgramTest::new("declare_program", declare_program::id(), None);
+    pt.add_program("external", external::ID, None);
+
+    let (banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let authority =
+        Pubkey::find_program_address(&[declare_program::GLOBAL], &declare_program::ID).0;
+    let mut accounts = declare_program::accounts::Proxy {
+        program: external::ID,
+    }
+    .to_account_metas(None);
+    accounts.extend(
+        external::client::accounts::Init {
+            authority,
+            my_account: Pubkey::find_program_address(&[authority.as_ref()], &external::ID).0,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(Some(false)), // Forward as remaining accounts but toggle authority not to be a signer
+    );
+
+    let data = declare_program::instruction::Proxy {
+        data: external::client::args::Init {}.data(),
+    }
+    .data();
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(&payer.pubkey(), &authority, LAMPORTS_PER_SOL),
+            Instruction {
+                program_id: declare_program::ID,
+                accounts,
+                data,
+            },
+        ],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    banks_client.process_transaction(transaction).await.unwrap();
+}

--- a/tests/declare-program/programs/declare-program/tests/declare_program_test.rs
+++ b/tests/declare-program/programs/declare-program/tests/declare_program_test.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_sdk::{
-    native_token::LAMPORTS_PER_SOL, signature::Signer, system_instruction, transaction::Transaction,
-};
 use {
     anchor_lang::{
         prelude::Pubkey,
@@ -11,6 +8,10 @@ use {
     },
     declare_program::external,
     solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        native_token::LAMPORTS_PER_SOL, signature::Signer, system_instruction,
+        transaction::Transaction,
+    },
 };
 
 #[tokio::test]

--- a/tests/declare-program/programs/declare-program/tests/parsers.rs
+++ b/tests/declare-program/programs/declare-program/tests/parsers.rs
@@ -64,8 +64,10 @@ pub fn test_event_parser() {
 
 #[test]
 pub fn test_instruction_parser() {
-    use anchor_lang::solana_program::instruction::Instruction as SolanaInstruction;
-    use external::parsers::Instruction;
+    use {
+        anchor_lang::solana_program::instruction::Instruction as SolanaInstruction,
+        external::parsers::Instruction,
+    };
 
     // Incorrect program
     assert!(Instruction::parse(&SolanaInstruction::new_with_bytes(


### PR DESCRIPTION
Problem: Not using `is_signer` prevents proper functioning of the client whenever a PDA is used, let's say when composing and instruction with the inner CPI using the inner client

That is not exactly for the general case but the sole purpose of this argument is for this objective so it seems reasonable to make it work.

From the trait
https://github.com/coral-xyz/anchor/blob/340e9c13f42191a1caa6092d811ed930a64c1f7b/lang/src/lib.rs#L154-L160