### PR TITLE
cli: Add support for fetching legacy IDLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add short alias for the `idl build` command ([#3283](https://github.com/coral-xyz/anchor/pull/3283)).
 - cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
 - lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
+- cli: Add support for fetching legacy IDLs ([#3324](https://github.com/coral-xyz/anchor/pull/3324)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

`idl fetch` command is not compatible with legacy IDLs as mentioned in https://github.com/coral-xyz/anchor/issues/3302.

### Summary of changes

Add support for fetching legacy IDLs by removing the parsing of the account data to the `Idl` type.

This is the only place where the CLI doesn't convert the legacy IDLs to the new IDL spec (https://github.com/coral-xyz/anchor/pull/3265).

Resolves https://github.com/coral-xyz/anchor/issues/3302