### PR TITLE
avm: Add Windows support for renaming anchor binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add short alias for the `idl build` command ([#3283](https://github.com/coral-xyz/anchor/pull/3283)).
 - cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
 - lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
+- avm: Add Windows support for renaming anchor binary ([#3325](https://github.com/coral-xyz/anchor/pull/3325)).
 
 ### Fixes
 

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -234,8 +234,9 @@ pub fn install_version(install_target: InstallTarget, force: bool) -> Result<()>
     }
 
     let bin_dir = get_bin_dir_path();
+    let bin_name = if cfg!(target_os = "windows") { "anchor.exe" } else { "anchor" };
     fs::rename(
-        bin_dir.join("anchor"),
+        bin_dir.join(bin_name),
         bin_dir.join(format!("anchor-{version}")),
     )?;
 


### PR DESCRIPTION

- Check the target OS to determine the correct binary name
- Use "anchor.exe" for Windows, "anchor" for other operating systems