### PR TITLE
feat: add alias to avm cli commands install and list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
 - lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
 - cli: Add support for fetching legacy IDLs ([#3324](https://github.com/coral-xyz/anchor/pull/3324)).
+- avm: Add short alias for `install` and `list` command ([#3326])(https://github.com/coral-xyz/anchor/pull/3326).
 
 ### Fixes
 

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -17,7 +17,7 @@ pub enum Commands {
         #[clap(value_parser = parse_version, required = false)]
         version: Option<Version>,
     },
-    #[clap(about = "Install a version of Anchor")]
+    #[clap(about = "Install a version of Anchor", alias = "i")]
     Install {
         /// Anchor version or commit
         #[clap(value_parser = parse_install_target)]
@@ -32,7 +32,7 @@ pub enum Commands {
         #[clap(value_parser = parse_version)]
         version: Version,
     },
-    #[clap(about = "List available versions of Anchor")]
+    #[clap(about = "List available versions of Anchor", alias = "ls")]
     List {},
     #[clap(about = "Update to the latest Anchor version")]
     Update {},


### PR DESCRIPTION
`anchor` cli already has aliases. added relevant aliases for `avm` cli as well.