### PR TITLE
docs: Remove redundant `avm use latest` after installation

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -41,11 +41,10 @@ On Linux systems you may need to install additional dependencies if cargo instal
 sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 ```
 
-Install the latest version of the CLI using `avm`, and then set it to be the version to use.
+Install the latest version of the CLI using `avm`:
 
 ```shell
 avm install latest
-avm use latest
 ```
 
 Verify the installation.


### PR DESCRIPTION
### Problem

`avm install` command [switches to the installed version automatically](https://github.com/coral-xyz/anchor/blob/9df0684f1bbd7687273ccbfaca882e9fe9c6ae1b/avm/src/lib.rs#L248), which makes running `avm use` command afterwards redundant:

https://github.com/coral-xyz/anchor/blob/9df0684f1bbd7687273ccbfaca882e9fe9c6ae1b/docs/src/pages/docs/installation.md#L47-L48

### Summary of changes

Remove the redundant `avm use latest` after installation.