### PR TITLE
feat: add options for package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
 - cli: Add support for fetching legacy IDLs ([#3324](https://github.com/coral-xyz/anchor/pull/3324)).
 - avm: Add short alias for `install` and `list` command ([#3326])(https://github.com/coral-xyz/anchor/pull/3326).
+- cli: Add optional `package-manager` flag in `init` command to set package manager field in Anchor.toml ([#3328]) (https://github.com/coral-xyz/anchor/pull/3328).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add `--program-id` option to `idl convert` command ([#3309](https://github.com/coral-xyz/anchor/pull/3309)).
 - lang: Generate documentation of constants in `declare_program!` ([#3311](https://github.com/coral-xyz/anchor/pull/3311)).
 - cli: Add support for fetching legacy IDLs ([#3324](https://github.com/coral-xyz/anchor/pull/3324)).
-- avm: Add short alias for `install` and `list` command ([#3326])(https://github.com/coral-xyz/anchor/pull/3326).
+- avm: Add short alias for `install` and `list` commands ([#3326](https://github.com/coral-xyz/anchor/pull/3326)).
 - avm: Add Windows support for renaming anchor binary ([#3325](https://github.com/coral-xyz/anchor/pull/3325)).
-- cli: Add optional `package-manager` flag in `init` command to set package manager field in Anchor.toml ([#3328]) (https://github.com/coral-xyz/anchor/pull/3328).
+- cli: Add optional `package-manager` flag in `init` command to set package manager field in Anchor.toml ([#3328](https://github.com/coral-xyz/anchor/pull/3328)).
 
 ### Fixes
 

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Result};
 use semver::{Version, VersionReq};
 
 use crate::{
-    config::{Config, Manifest, WithPath},
-    PackageManager, VERSION,
+    config::{Config, Manifest, PackageManager, WithPath},
+    VERSION,
 };
 
 /// Check whether `overflow-checks` codegen option is enabled.

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -31,7 +31,10 @@ pub fn check_overflow(cargo_toml_path: impl AsRef<Path>) -> Result<bool> {
 /// - `@coral-xyz/anchor` package version
 ///
 /// This function logs warnings in the case of a mismatch.
-pub fn check_anchor_version(cfg: &WithPath<Config>, package_manager: PackageManager) -> Result<()> {
+pub fn check_anchor_version(
+    cfg: &WithPath<Config>,
+    package_manager: &PackageManager,
+) -> Result<()> {
     let cli_version = Version::parse(VERSION)?;
 
     // Check lang crate

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -31,10 +31,7 @@ pub fn check_overflow(cargo_toml_path: impl AsRef<Path>) -> Result<bool> {
 /// - `@coral-xyz/anchor` package version
 ///
 /// This function logs warnings in the case of a mismatch.
-pub fn check_anchor_version(
-    cfg: &WithPath<Config>,
-    package_manager: &PackageManager,
-) -> Result<()> {
+pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
     let cli_version = Version::parse(VERSION)?;
 
     // Check lang crate
@@ -72,10 +69,13 @@ pub fn check_anchor_version(
         .and_then(|ver| VersionReq::parse(ver).ok())
         .filter(|ver| !ver.matches(&cli_version));
 
-    let update_cmd = match package_manager {
-        PackageManager::NPM => "npm update",
-        PackageManager::Yarn => "yarn upgrade",
-        PackageManager::PNPM => "pnpm update",
+    let update_cmd = match &cfg.toolchain.package_manager {
+        Some(pkg_manager) => match pkg_manager {
+            PackageManager::NPM => "npm update",
+            PackageManager::Yarn => "yarn upgrade",
+            PackageManager::PNPM => "pnpm update",
+        },
+        None => "npm update",
     };
 
     if let Some(ver) = mismatched_ts_version {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -380,7 +380,7 @@ pub struct Config {
 pub struct ToolchainConfig {
     pub anchor_version: Option<String>,
     pub solana_version: Option<String>,
-    pub package_manager: PackageManager,
+    pub package_manager: Option<PackageManager>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -387,9 +387,9 @@ pub struct ToolchainConfig {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize)]
 pub enum PackageManager {
     /// Use npm as the package manager.
-    #[default]
     NPM,
     /// Use yarn as the package manager.
+    #[default]
     Yarn,
     /// Use pnpm as the package manager.
     PNPM,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{get_keypair, is_hidden, keys_sync, PackageManager};
+use crate::{get_keypair, is_hidden, keys_sync};
 use anchor_client::Cluster;
 use anchor_lang_idl::types::Idl;
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -381,6 +381,30 @@ pub struct ToolchainConfig {
     pub anchor_version: Option<String>,
     pub solana_version: Option<String>,
     pub package_manager: Option<PackageManager>,
+}
+
+/// Package manager to use for the project.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize)]
+pub enum PackageManager {
+    /// Use npm as the package manager.
+    #[default]
+    NPM,
+    /// Use yarn as the package manager.
+    Yarn,
+    /// Use pnpm as the package manager.
+    PNPM,
+}
+
+impl std::fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let pkg_manager_str = match self {
+            PackageManager::NPM => "npm",
+            PackageManager::Yarn => "yarn",
+            PackageManager::PNPM => "pnpm",
+        };
+
+        write!(f, "{pkg_manager_str}")
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{get_keypair, is_hidden, keys_sync};
+use crate::{get_keypair, is_hidden, keys_sync, PackageManager};
 use anchor_client::Cluster;
 use anchor_lang_idl::types::Idl;
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -380,6 +380,7 @@ pub struct Config {
 pub struct ToolchainConfig {
     pub anchor_version: Option<String>,
     pub solana_version: Option<String>,
+    pub package_manager: PackageManager,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1036,10 +1036,10 @@ fn init(
 
     let mut cfg = Config::default();
 
-    let package_manager_cmd = package_manager.to_string();
     let test_script = test_template.get_test_script(javascript, &package_manager);
     cfg.scripts.insert("test".to_owned(), test_script);
 
+    let package_manager_cmd = package_manager.to_string();
     cfg.toolchain.package_manager = Some(package_manager);
 
     let mut localnet = BTreeMap::new();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1036,7 +1036,7 @@ fn init(
 
     let mut cfg = Config::default();
     let package_manager_cmd = package_manager.to_string();
-    cfg.toolchain.package_manager = package_manager;
+    cfg.toolchain.package_manager = Some(package_manager);
     let test_script = test_template.get_test_script(javascript, &package_manager_cmd);
     cfg.scripts.insert("test".to_owned(), test_script);
 
@@ -1403,7 +1403,7 @@ pub fn build(
     }
 
     // Check whether there is a mismatch between CLI and crate/package versions
-    check_anchor_version(&cfg, &cfg.toolchain.package_manager).ok();
+    check_anchor_version(&cfg).ok();
     check_deps(&cfg).ok();
 
     let idl_out = match idl {
@@ -4178,9 +4178,12 @@ fn migrate(cfg_override: &ConfigOverride) -> Result<()> {
                 rust_template::deploy_ts_script_host(&url, &module_path.display().to_string());
             fs::write(deploy_ts, deploy_script_host_str)?;
 
-            let package_manager_cmd = cfg.toolchain.package_manager.to_string();
+            let pkg_manager_cmd = match &cfg.toolchain.package_manager {
+                Some(pkg_manager) => pkg_manager.to_string(),
+                None => PackageManager::default().to_string(),
+            };
 
-            std::process::Command::new(package_manager_cmd)
+            std::process::Command::new(pkg_manager_cmd)
                 .args([
                     "run",
                     "ts-node",

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1073,18 +1073,16 @@ fn init(
     )?;
 
     if !no_install {
-        if package_manager_cmd != PackageManager::NPM.to_string() {
-            let package_manager_result = install_node_modules(&package_manager_cmd)?;
+        let package_manager_result = install_node_modules(&package_manager_cmd)?;
 
-            if !package_manager_result.status.success() {
-                println!(
-                    "Failed {} install will attempt to npm install",
-                    package_manager_cmd
-                );
-                install_node_modules("npm")?;
-            }
+        if !package_manager_result.status.success() && package_manager_cmd != "npm" {
+            println!(
+                "Failed {} install will attempt to npm install",
+                package_manager_cmd
+            );
+            install_node_modules("npm")?;
         } else {
-            install_node_modules(&package_manager_cmd)?;
+            eprintln!("Failed to install node modules");
         }
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1035,10 +1035,12 @@ fn init(
     fs::create_dir_all("app")?;
 
     let mut cfg = Config::default();
+
     let package_manager_cmd = package_manager.to_string();
-    cfg.toolchain.package_manager = Some(package_manager);
-    let test_script = test_template.get_test_script(javascript, &package_manager_cmd);
+    let test_script = test_template.get_test_script(javascript, &package_manager);
     cfg.scripts.insert("test".to_owned(), test_script);
+
+    cfg.toolchain.package_manager = Some(package_manager);
 
     let mut localnet = BTreeMap::new();
     let program_id = rust_template::get_or_create_program_id(&rust_name);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -84,7 +84,7 @@ pub enum Command {
         #[clap(long)]
         no_install: bool,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
         /// Don't initialize git
         #[clap(long)]
@@ -144,7 +144,7 @@ pub enum Command {
         #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     /// Expands macros (wrapper around cargo expand)
@@ -194,7 +194,7 @@ pub enum Command {
         #[clap(long, required = false)]
         skip_build: bool,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     #[clap(name = "test", alias = "t")]
@@ -240,7 +240,7 @@ pub enum Command {
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     /// Creates a new program.
@@ -282,7 +282,7 @@ pub enum Command {
     /// Runs the deploy migration script.
     Migrate {
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     /// Deploys, initializes an IDL, and migrates all in one command.
@@ -343,7 +343,7 @@ pub enum Command {
         #[clap(value_enum, long, default_value = "sbf")]
         arch: ProgramArch,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     /// Program keypair commands.
@@ -375,7 +375,7 @@ pub enum Command {
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
         /// Package Manager to use
-        #[clap(value_enum, long, short, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "npm")]
         package_manager: PackageManager,
     },
     /// Fetch and deserialize an account using the IDL provided.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -83,7 +83,7 @@ pub enum Command {
         #[clap(long)]
         no_install: bool,
         /// Package Manager to use
-        #[clap(value_enum, long, default_value = "npm")]
+        #[clap(value_enum, long, default_value = "yarn")]
         package_manager: PackageManager,
         /// Don't initialize git
         #[clap(long)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::config::{
     get_default_ledger_path, AnchorPackage, BootstrapMode, BuildConfig, Config, ConfigOverride,
-    Manifest, ProgramArch, ProgramDeployment, ProgramWorkspace, ScriptsConfig, TestValidator,
-    WithPath, SHUTDOWN_WAIT, STARTUP_WAIT,
+    Manifest, PackageManager, ProgramArch, ProgramDeployment, ProgramWorkspace, ScriptsConfig,
+    TestValidator, WithPath, SHUTDOWN_WAIT, STARTUP_WAIT,
 };
 use anchor_client::Cluster;
 use anchor_lang::idl::{IdlAccount, IdlInstruction, ERASED_AUTHORITY};
@@ -10,7 +10,7 @@ use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
 use anyhow::{anyhow, Context, Result};
 use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{CommandFactory, Parser};
 use dirs::home_dir;
 use flate2::read::GzDecoder;
 use flate2::read::ZlibDecoder;
@@ -22,7 +22,7 @@ use reqwest::blocking::multipart::{Form, Part};
 use reqwest::blocking::Client;
 use rust_template::{ProgramTemplate, TestTemplate};
 use semver::{Version, VersionReq};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{json, Map, Value as JsonValue};
 use solana_client::rpc_client::RpcClient;
 use solana_program::instruction::{AccountMeta, Instruction};
@@ -527,45 +527,6 @@ pub enum IdlCommand {
 pub enum ClusterCommand {
     /// Prints common cluster urls.
     List,
-}
-
-/// Package manager to use for the project.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize)]
-pub enum PackageManager {
-    /// Use npm as the package manager.
-    #[default]
-    NPM,
-    /// Use yarn as the package manager.
-    Yarn,
-    /// Use pnpm as the package manager.
-    PNPM,
-}
-
-impl FromStr for PackageManager {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<PackageManager> {
-        match s {
-            "npm" => Ok(PackageManager::NPM),
-            "yarn" => Ok(PackageManager::Yarn),
-            "pnpm" => Ok(PackageManager::PNPM),
-            _ => Err(anyhow!(
-                "Package manager should be one of [npm, yarn, pnpm]\n"
-            )),
-        }
-    }
-}
-
-impl std::fmt::Display for PackageManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let pkg_manager_str = match self {
-            PackageManager::NPM => "npm",
-            PackageManager::Yarn => "yarn",
-            PackageManager::PNPM => "pnpm",
-        };
-
-        write!(f, "{pkg_manager_str}")
-    }
 }
 
 fn get_keypair(path: &str) -> Result<Keypair> {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -401,7 +401,7 @@ pub fn ts_package_json(jest: bool, license: String) -> String {
     if jest {
         format!(
             r#"{{
-  "license": "{license}",              
+  "license": "{license}",
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
@@ -423,7 +423,7 @@ pub fn ts_package_json(jest: bool, license: String) -> String {
     } else {
         format!(
             r#"{{
-  "license": "{license}",  
+  "license": "{license}",
   "scripts": {{
     "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
     "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
@@ -607,30 +607,30 @@ pub enum TestTemplate {
     /// Generate template for Mocha unit-test
     #[default]
     Mocha,
-    /// Generate template for Jest unit-test    
+    /// Generate template for Jest unit-test
     Jest,
     /// Generate template for Rust unit-test
     Rust,
 }
 
 impl TestTemplate {
-    pub fn get_test_script(&self, js: bool) -> &str {
+    pub fn get_test_script(&self, js: bool, package_manager_cmd: &str) -> String {
         match &self {
             Self::Mocha => {
                 if js {
-                    "yarn run mocha -t 1000000 tests/"
+                    format!("{package_manager_cmd} run mocha -t 1000000 tests/")
                 } else {
-                    "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+                    format!("{package_manager_cmd} run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts")
                 }
             }
             Self::Jest => {
                 if js {
-                    "yarn run jest"
+                    format!("{package_manager_cmd} run jest")
                 } else {
-                    "yarn run jest --preset ts-jest"
+                    format!("{package_manager_cmd} run jest --preset ts-jest")
                 }
             }
-            Self::Rust => "cargo test",
+            Self::Rust => "cargo test".to_owned(),
         }
     }
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::ProgramWorkspace, create_files, override_or_create_files, solidity_template, Files,
-    VERSION,
+    PackageManager, VERSION,
 };
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
@@ -614,20 +614,26 @@ pub enum TestTemplate {
 }
 
 impl TestTemplate {
-    pub fn get_test_script(&self, js: bool, package_manager_cmd: &str) -> String {
+    pub fn get_test_script(&self, js: bool, pkg_manager: &PackageManager) -> String {
+        let pkg_manager_exec_cmd = match pkg_manager {
+            PackageManager::Yarn => "yarn run",
+            PackageManager::NPM => "npx",
+            PackageManager::PNPM => "pnpm exec",
+        };
+
         match &self {
             Self::Mocha => {
                 if js {
-                    format!("{package_manager_cmd} run mocha -t 1000000 tests/")
+                    format!("{pkg_manager_exec_cmd} mocha -t 1000000 tests/")
                 } else {
-                    format!("{package_manager_cmd} run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts")
+                    format!("{pkg_manager_exec_cmd} ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts")
                 }
             }
             Self::Jest => {
                 if js {
-                    format!("{package_manager_cmd} run jest")
+                    format!("{pkg_manager_exec_cmd} jest")
                 } else {
-                    format!("{package_manager_cmd} run jest --preset ts-jest")
+                    format!("{pkg_manager_exec_cmd} jest --preset ts-jest")
                 }
             }
             Self::Rust => "cargo test".to_owned(),


### PR DESCRIPTION
- Changes current behavior (require warn, try yarn, warn if yarn is missing, use npm) to using specified package manager (npm, yarn, pnpm) with npm as default fallback if not specified or if specified package manager is missing
- Use package manager option in test scripts too
- Update 'mismatched version' error message to also use specified package manager
~- Adds the `package_manager` flag in `init`, `build`, `test`, `verify`, and `publish` commands.~

This PR doesn't change yarn being used to build Anchor itself.

This PR is inspired by #2934, and builds up on it. 

Addresses #2881.