### PR TITLE
avm: Move `tempfile` to `dev-dependencies`

### DIFF
--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -22,5 +22,7 @@ once_cell = "1.8.0"
 reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }
-tempfile = "3.3.0"
 chrono = "0.4"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -13,8 +13,9 @@ path = "src/anchor/main.rs"
 
 [dependencies]
 anyhow = "1.0.32"
-cfg-if = "1.0.0"
 cargo_toml = "0.19.2"
+cfg-if = "1.0.0"
+chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
@@ -22,7 +23,6 @@ once_cell = "1.8.0"
 reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }
-chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3.3.0"


### PR DESCRIPTION
### Problem

`tempfile` crate is only being used in tests, so it's unnecessary for it to be included in the `dependencies` section.

### Summary of changes

Move `tempfile` to `dev-dependencies` and reorder dependencies alphabetically.