### PR TITLE
docs: Add `idl build` command documentation

### DIFF
--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -125,6 +125,14 @@ It's recommended to use these commands to store an IDL on chain, at a determinis
 address, as a function of nothing but the program's ID. This
 allows us to generate clients for a program using nothing but the program ID.
 
+### Idl Build
+
+```shell
+anchor idl build
+```
+
+Generates the IDL for the program using the compilation method.
+
 ### Idl Init
 
 ```shell


### PR DESCRIPTION
### Problem

`idl build` command is not documented in the CLI section.

### Summary of changes

Add `idl build` command documentation.