### PR TITLE
cli: Fix the default JS update command being incorrect

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -69,16 +69,13 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
         .and_then(|ver| VersionReq::parse(ver).ok())
         .filter(|ver| !ver.matches(&cli_version));
 
-    let update_cmd = match &cfg.toolchain.package_manager {
-        Some(pkg_manager) => match pkg_manager {
+    if let Some(ver) = mismatched_ts_version {
+        let update_cmd = match cfg.toolchain.package_manager.clone().unwrap_or_default() {
             PackageManager::NPM => "npm update",
             PackageManager::Yarn => "yarn upgrade",
             PackageManager::PNPM => "pnpm update",
-        },
-        None => "npm update",
-    };
+        };
 
-    if let Some(ver) = mismatched_ts_version {
         eprintln!(
             "WARNING: `@coral-xyz/anchor` version({ver}) and the current CLI version\
                 ({cli_version}) don't match.\n\n\t\


### PR DESCRIPTION
### Problem

The JS update command currently defaults to `npm` because https://github.com/coral-xyz/anchor/pull/3328 initially made `npm` the default package manager. We've later decided to not change the default package manager and keep `yarn` the default until v0.32 in https://github.com/coral-xyz/anchor/pull/3328#discussion_r1816557402. However, the JS update command hasn't been updated to reflect this change.

### Summary of changes

Fix the default JS update command being incorrect.