### PR TITLE
docs: Improve Javascript Anchor Types reference

### DIFF
--- a/docs/src/pages/docs/javascript-anchor-types.md
+++ b/docs/src/pages/docs/javascript-anchor-types.md
@@ -8,48 +8,85 @@ This reference shows you how Anchor maps Rust types to JavaScript/TypeScript typ
 ---
 
 {% table %}
-* Rust Type
-* JavaScript Type
+* Type
+* Rust
+* TypeScript
 * Example
-* Note
 ---
+* ## Boolean
 * `bool`
 * `boolean`
-* ```javascript
-  await program
-    .methods
-    .init(true)
-    .rpc();
+* ```typescript
+  true
   ```
 ---
-* `u64/u128/i64/i128`
-* `anchor.BN`
-* ```javascript
-  await program
-    .methods
-    .init(new anchor.BN(99))
-    .rpc();
-    ```
-* [https://github.com/indutny/bn.js](https://github.com/indutny/bn.js )
----
+* ## Integer
 * `u8/u16/u32/i8/i16/i32`
 * `number`
-* ```javascript
-  await program
-    .methods
-    .init(99)
-    .rpc();
-    ```
+* ```typescript
+  99
+  ```
 ---
+* ## Big integer
+* `u64/u128/i64/i128`
+* `anchor.BN`
+* ```typescript
+  new anchor.BN(99)
+  ```
+---
+* ## Float
 * `f32/f64`
 * `number`
-* ```javascript
-  await program
-    .methods
-    .init(1.0)
-    .rpc();
-    ```
+* ```typescript
+  1.0
+  ```
 ---
+* ## String
+* `String`
+* `string`
+* ```typescript
+  "hello"
+  ```
+---
+* ## Array
+* `[T; N]`
+* `Array<T>`
+* ```typescript
+  [1, 2, 3]
+  ```
+---
+* ## Vector
+* `Vec<T>`
+* `Array<T>`
+* ```typescript
+  [1, 2, 3]
+  ```
+---
+* ## Option
+* `Option<T>`
+* `T | null | undefined`
+* `None`:
+  ```typescript
+  null
+  ```
+  `Some(val)`:
+  ```typescript
+  42
+  ```
+---
+* ## Struct
+* `Struct`
+* `object`
+* ```rust
+  struct MyStruct {
+    val: u16,
+  }
+  ```
+  ```typescript
+  { val: 99 }
+  ```
+---
+* ## Enum
 * `Enum`
 * `object`
 * ```rust
@@ -57,83 +94,18 @@ This reference shows you how Anchor maps Rust types to JavaScript/TypeScript typ
       One,
       Two { val: u32 },
       Three(u8, i16),
-  };
-  ```
-  ```javascript
-  // Unit variant
-  await program
-    .methods
-    .init({ one: {} })
-    .rpc();
-
-  // Named variant
-  await program
-    .methods
-    .init({ two: { val: 99 } })
-    .rpc();
-
-  // Unnamed (tuple) variant
-  await program
-    .methods
-    .init({ three: [12, -34] })
-    .rpc();
-  ```
----
-* `Struct`
-* `{ val: {} }`
-* ```rust
-  struct MyStruct {
-    val: u16,
   }
   ```
-  ```javascript
-  await program
-    .methods
-    .init({ val: 99 })
-    .rpc();
+  Unit variant:
+  ```typescript
+  { one : {} }
   ```
----
-* `[T; N]`
-* `Array<T>`
-* ```javascript
-  await program
-    .methods
-    .init([1, 2, 3])
-    .rpc();
+  Named variant:
+  ```typescript
+  { two: { val: 99 } }
   ```
----
-* `String`
-* `string`
-* ```javascript
-  await program
-    .methods
-    .init("hello")
-    .rpc();
-  ```
----
-* `Vec<T>`
-* `Array<T>`
-* ```javascript
-  await program
-    .methods
-    .init([1, 2, 3])
-    .rpc();
-  ```
-
----
-* `Option<T>`
-* `T | null | undefined`
-* ```javascript
-  // `null` for `None`
-  await program
-    .methods
-    .init(null)
-    .rpc();
-
-  // Non-nullish value for `Option<T>`
-  await program
-    .methods
-    .init(42)
-    .rpc();
+  Unnamed (tuple) variant:
+  ```typescript
+  { three: [12, -34] }
   ```
 {% /table %}


### PR DESCRIPTION
### Problem

[JavaScript Anchor Types](https://www.anchor-lang.com/docs/javascript-anchor-types) has the following problems:

- It's not possible to link an individual type e.g. if someone specifically asks for how to pass `enum`s from TS, we should be able to link that section specifically https://www.anchor-lang.com/docs/javascript-anchor-types#enum
- All examples include the same boilerplate `await program.methods.init(<VAL>).rpc();` when we only care about the `<VAL>`
- In "Javascript Type" column, there are TS types such as `Array<T>`, meaning table column can be renamed from "JavaScript Type" to "TypeScript Type"
- "Note" column doesn't include any notes other than linking https://github.com/indutny/bn.js, which is not very useful and takes up a large space

### Summary of changes

- Make indiviual types from the page linkable
- Remove the boilerplate from the examples and only include the example value(s)
- Add "Type" column
- Rename "Rust Type" to "Rust"
- Rename "Javascript Type" to "TypeScript"
- Remove "Note" column