### PR TITLE
cli: Remove stripping workspace prefix from program id of the `upgrade` command

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3916,7 +3916,7 @@ fn upgrade(
             .arg("--keypair")
             .arg(cfg.provider.wallet.to_string())
             .arg("--program-id")
-            .arg(strip_workspace_prefix(program_id.to_string()))
+            .arg(program_id.to_string())
             .arg(strip_workspace_prefix(program_filepath))
             .args(&solana_args)
             .stdout(Stdio::inherit())


### PR DESCRIPTION
### Problem

Stripping the workspace prefix from the `program_id` argument is redundant because it's typed as `Pubkey`.

### Summary of changes

Remove unnecessarily stripping workspace prefix from the program id argument of the `upgrade` command.