### PR TITLE
cli: Remove allowing false positive `clippy::needless_borrows_for_generic_args`

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -864,8 +864,6 @@ pub struct _TestToml {
 }
 
 impl _TestToml {
-    // TODO: Remove if/when false positive gets fixed
-    #[allow(clippy::needless_borrows_for_generic_args)]
     fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let s = fs::read_to_string(&path)?;
         let parsed_toml: Self = toml::from_str(&s)?;


### PR DESCRIPTION
### Problem

Rust 1.80 had a false positive lint for [`needless_borrows_for_generic_args`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args):

```
warning: the borrowed expression implements the required traits
   --> cli/src/config.rs:892:69
    |
892 |                     *ledger_dir = canonicalize_filepath_from_origin(&ledger_dir, &path)?;
    |                                                                     ^^^^^^^^^^^ help: change this to: `ledger_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```

because applying the suggestion resulted in:

```
error[E0382]: use of moved value: `ledger_dir`
   --> cli/src/config.rs:892:21
    |
891 |                 if let Some(ledger_dir) = &mut validator.ledger {
    |                             ---------- move occurs because `ledger_dir` has type `&mut std::string::String`, which does not implement the `Copy` trait
892 |                     *ledger_dir = canonicalize_filepath_from_origin(ledger_dir, &path)?;
    |                     ^^^^^^^^^^^ value used here after move          ---------- value moved here
    |
```

so in https://github.com/coral-xyz/anchor/pull/3145, we disabled the lint for `clippy::needless_borrows_for_generic_args`:

https://github.com/coral-xyz/anchor/blob/6147beb47310e4008af663808f7f2298fa360782/cli/src/config.rs#L867-L868

We can now remove this check because the problem has been fixed in https://github.com/rust-lang/rust-clippy/pull/12892.

### Summary of changes

Remove `#[allow(clippy::needless_borrows_for_generic_args)]` since it's no longer necessary.