### PR TITLE
spl: Remove `spl-token-confidential-transfer-proof-generation` patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,8 +6723,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.1.0"
-source = "git+https://github.com/solana-labs/solana-program-library?rev=8e0ed0a#8e0ed0ab0d1caeb0b8125c0879ec6ae96a0685d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,3 @@ exclude = [
     "tests/cfo/deps/openbook-dex",
 ]
 resolver = "2"
-
-# TODO: Remove once there is a new compatible release on crates.io
-#
-# The latest version of this crate on crates.io depends on `curve25519-dalek ^3.2.1` which
-# conflicts with `solana-* ^2.1`.
-#
-# Details: https://github.com/solana-labs/solana-program-library/pull/7416#discussion_r1824643243
-[patch.crates-io]
-spl-token-confidential-transfer-proof-generation = { git = "https://github.com/solana-labs/solana-program-library", rev = "8e0ed0a" }


### PR DESCRIPTION
### Problem

`spl-token-confidential-transfer-proof-generation` patch was necessary during the Solana v2.1 upgrade (https://github.com/coral-xyz/anchor/pull/3339):

https://github.com/coral-xyz/anchor/blob/eee03bc7c31ddc99bf3dbe1630283d9226aa7b9c/Cargo.toml#L25-L32

However, it's no longer necessary after the new release of SPL crates that are compatible with Solana v2.1 (https://github.com/coral-xyz/anchor/pull/3346):

```
warning: Patch `spl-token-confidential-transfer-proof-generation v0.1.0 (https://github.com/solana-labs/solana-program-library?rev=8e0ed0a#8e0ed0ab)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
```

### Summary of changes

Remove the `spl-token-confidential-transfer-proof-generation` patch.