### PR TITLE
cli: Fix `shell` command failing due to outdated program initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Use OS-agnostic paths ([#3307](https://github.com/coral-xyz/anchor/pull/3307)).
 - avm: Use `rustc 1.79.0` when installing versions older than v0.31 ([#3315](https://github.com/coral-xyz/anchor/pull/3315)).
 - cli: Fix priority fee calculation causing panic on localnet ([#3318](https://github.com/coral-xyz/anchor/pull/3318)).
+- cli: Fix `shell` command failing due to outdated program initialization ([#3351](https://github.com/coral-xyz/anchor/pull/3351)).
 
 ### Breaking
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use heck::{ToPascalCase, ToSnakeCase};
+use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase};
 use solana_sdk::{
     pubkey::Pubkey,
     signature::{read_keypair_file, write_keypair_file, Keypair},
@@ -590,11 +590,10 @@ anchor.setProvider(provider);
         write!(
             &mut eval_string,
             r#"
-anchor.workspace.{} = new anchor.Program({}, new PublicKey("{}"), provider);
+anchor.workspace.{} = new anchor.Program({}, provider);
 "#,
-            program.name.to_pascal_case(),
+            program.name.to_lower_camel_case(),
             serde_json::to_string(&program.idl)?,
-            program.program_id
         )?;
     }
 


### PR DESCRIPTION
### Problem

`shell` command fails with:

```
TypeError: Cannot read properties of undefined (reading 'size')
```

This is due to the outdated program initialization (with the second argument being the program id):

https://github.com/coral-xyz/anchor/blob/eee03bc7c31ddc99bf3dbe1630283d9226aa7b9c/cli/src/rust_template.rs#L593

### Summary of changes

Fix `shell` command failing due to outdated program initialization.
