### PR TITLE
test templates: add mollusk

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -338,6 +338,9 @@ jobs:
     name: Test Anchor Init
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        template: [mocha, jest, rust, mollusk]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/
@@ -358,7 +361,7 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cd "$(mktemp -d)" && anchor init hello-anchor && cd hello-anchor && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
+      - run: cd "$(mktemp -d)" && anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }} && cd hello-anchor-${{ matrix.template }} && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
       - uses: ./.github/actions/git-diff/
 
   test-programs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Add short alias for `install` and `list` commands ([#3326](https://github.com/coral-xyz/anchor/pull/3326)).
 - avm: Add Windows support for renaming anchor binary ([#3325](https://github.com/coral-xyz/anchor/pull/3325)).
 - cli: Add optional `package-manager` flag in `init` command to set package manager field in Anchor.toml ([#3328](https://github.com/coral-xyz/anchor/pull/3328)).
+- cli: Add test template for [Mollusk](https://github.com/buffalojoec/mollusk) ([#3352](https://github.com/coral-xyz/anchor/pull/3352)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1036,7 +1036,11 @@ fn init(
     if solidity {
         solidity_template::create_program(&project_name)?;
     } else {
-        rust_template::create_program(&project_name, template)?;
+        rust_template::create_program(
+            &project_name,
+            template,
+            TestTemplate::Mollusk == test_template,
+        )?;
     }
 
     // Build the migrations directory.
@@ -1155,7 +1159,7 @@ fn new(
                 if solidity {
                     solidity_template::create_program(&name)?;
                 } else {
-                    rust_template::create_program(&name, template)?;
+                    rust_template::create_program(&name, template, false)?;
                 }
 
                 programs.insert(


### PR DESCRIPTION
This PR adds a test template for Mollusk!

Note: Unlike other test templates, this one actually puts the tests in the program crate, since it plays the best with `cargo test-sbf`. I think it's cleaner this way as well.