### PR TITLE
spl: Update `mpl-token-metadata` version requirement to `5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "5.0.0-beta.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89cc55341b83e3331244447b3fa6d8711a386457799e9529c3423f9a9981a37"
+checksum = "989e6a3000e761d3b2d685662a3a9ee99826f9369fb033bd1bc7011b1cf02ed9"
 dependencies = [
  "borsh 0.10.3",
  "num-derive 0.3.3",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -27,7 +27,7 @@ token_2022_extensions = ["spl-token-2022", "spl-token-group-interface", "spl-tok
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.30.1", features = ["derive"] }
 borsh = { version = "0.10.3", optional = true }
-mpl-token-metadata = { version = "5.0.0-beta.0", optional = true }
+mpl-token-metadata = { version = "5", optional = true }
 spl-associated-token-account = { version = "6", features = ["no-entrypoint"], optional = true }
 spl-memo = { version = "6", features = ["no-entrypoint"], optional = true }
 spl-token = { version = "7", features = ["no-entrypoint"], optional = true }


### PR DESCRIPTION
### Problem

`anchor-spl` specifies a pre-release version of `mpl-token-metadata`:

https://github.com/coral-xyz/anchor/blob/354271cb196f1462ed06139b3e0a02ef9492216d/spl/Cargo.toml#L30

This was done to resolve conflicts during the Solana v2 upgrade (https://github.com/coral-xyz/anchor/pull/3219#issuecomment-2325131139). However, this is no longer necessary now that there is a stable v5 release.

### Summary of changes

Change the dependency version requirement of `mpl-token-metadata` to `5`.