### PR TITLE
idl: Fix detecting false-positives from doc comments during module path conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Use `rustc 1.79.0` when installing versions older than v0.31 ([#3315](https://github.com/coral-xyz/anchor/pull/3315)).
 - cli: Fix priority fee calculation causing panic on localnet ([#3318](https://github.com/coral-xyz/anchor/pull/3318)).
 - cli: Fix `shell` command failing due to outdated program initialization ([#3351](https://github.com/coral-xyz/anchor/pull/3351)).
+- idl: Fix detecting false-positives from doc comments during module path conversion ([#3359](https://github.com/coral-xyz/anchor/pull/3359)).
 
 ### Breaking
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -303,18 +303,20 @@ fn install_toolchain_if_needed(toolchain: &str) -> Result<()> {
 /// Convert paths to name if there are no conflicts.
 fn convert_module_paths(idl: Idl) -> Idl {
     let idl = serde_json::to_string(&idl).unwrap();
-    let idl = Regex::new(r#""((\w+::)+)(\w+)""#)
+    let idl = Regex::new(r#""(\w+::)+(\w+)""#)
         .unwrap()
         .captures_iter(&idl.clone())
         .fold(idl, |acc, cur| {
             let path = cur.get(0).unwrap().as_str();
-            let name = cur.get(3).unwrap().as_str();
+            let name = cur.get(2).unwrap().as_str();
 
             // Replace path with name
             let replaced_idl = acc.replace(path, &format!(r#""{name}""#));
 
             // Check whether there is a conflict
-            let has_conflict = replaced_idl.contains(&format!(r#"::{name}""#));
+            let has_conflict = Regex::new(&format!(r#""(\w+::)+{name}""#))
+                .unwrap()
+                .is_match(&replaced_idl);
             if has_conflict {
                 acc
             } else {

--- a/tests/idl/programs/new-idl/src/lib.rs
+++ b/tests/idl/programs/new-idl/src/lib.rs
@@ -144,6 +144,15 @@ pub mod new_idl {
     }
 }
 
+/// IDL test for the issue explained in https://github.com/coral-xyz/anchor/issues/3358
+///
+/// For example, using [`SimpleAccount`] and adding the full path at the end of a doc comment
+/// used to result in a false-positive when detecting conflicts.
+///
+/// [`SimpleAccount`]: crate::SimpleAccount
+#[constant]
+pub const TEST_CONVERT_MODULE_PATHS: &[u8] = b"convert_module_paths";
+
 #[account]
 #[derive(InitSpace)]
 pub struct SimpleAccount {


### PR DESCRIPTION
### Problem

It's possible for doc comments to trigger false-positives during converting module paths step as explained in https://github.com/coral-xyz/anchor/issues/3358.

### Summary of changes

Fix detecting false-positives from doc comments during module path conversion.

Resolves https://github.com/coral-xyz/anchor/issues/3358