### PR TITLE
idl: Disallow account discriminators that can conflict with the `zero` constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - avm: Add Windows support for renaming anchor binary ([#3325](https://github.com/coral-xyz/anchor/pull/3325)).
 - cli: Add optional `package-manager` flag in `init` command to set package manager field in Anchor.toml ([#3328](https://github.com/coral-xyz/anchor/pull/3328)).
 - cli: Add test template for [Mollusk](https://github.com/buffalojoec/mollusk) ([#3352](https://github.com/coral-xyz/anchor/pull/3352)).
+- idl: Disallow account discriminators that can conflict with the `zero` constraint ([#3365](https://github.com/coral-xyz/anchor/pull/3365)).
 
 ### Fixes
 


### PR DESCRIPTION
### Problem

In the following scenario:

1. Account 1's discriminator starts with 0
2. Account 2's discriminator is a 1-byte custom discriminator
3. Account 2 gets initialized using the `zero` constraint:

    ```rs
    #[account(zero)]
    pub account2: AccountLoader<'info, Account2>
    ```

It's possible to pass an already initialized Account 1 to a place that expects non-initialized Account 2, because the first byte of Account 1 is also 0, which is what the `zero` constraint checks.

### Summary of changes

Disallow account discriminators that can conflict with the `zero` constraint.