### PR TITLE
lang: Fix `cpi` feature instructions not accounting for discriminator overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix `shell` command failing due to outdated program initialization ([#3351](https://github.com/coral-xyz/anchor/pull/3351)).
 - idl: Fix detecting false-positives from doc comments during module path conversion ([#3359](https://github.com/coral-xyz/anchor/pull/3359)).
 - cli: Remove passing the rent sysvar account to IDL instructions ([#3372](https://github.com/coral-xyz/anchor/pull/3372)).
+- lang: Fix `cpi` feature instructions not accounting for discriminator overrides ([#3376](https://github.com/coral-xyz/anchor/pull/3376)).
 
 ### Breaking
 

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -23,7 +23,7 @@ pub fn gen_discriminator(namespace: &str, name: impl ToString) -> proc_macro2::T
     format!("&{:?}", discriminator).parse().unwrap()
 }
 
-pub fn generate_ix_variant(name: String, args: &[IxArg]) -> proc_macro2::TokenStream {
+pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> proc_macro2::TokenStream {
     let ix_arg_names: Vec<&syn::Ident> = args.iter().map(|arg| &arg.name).collect();
     let ix_name_camel = generate_ix_variant_name(name);
 
@@ -40,7 +40,7 @@ pub fn generate_ix_variant(name: String, args: &[IxArg]) -> proc_macro2::TokenSt
     }
 }
 
-pub fn generate_ix_variant_name(name: String) -> proc_macro2::TokenStream {
+pub fn generate_ix_variant_name(name: &str) -> proc_macro2::TokenStream {
     let n = name.to_camel_case();
     n.parse().unwrap()
 }

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -25,10 +25,7 @@ pub fn gen_discriminator(namespace: &str, name: impl ToString) -> proc_macro2::T
 
 pub fn generate_ix_variant(name: String, args: &[IxArg]) -> proc_macro2::TokenStream {
     let ix_arg_names: Vec<&syn::Ident> = args.iter().map(|arg| &arg.name).collect();
-    let ix_name_camel: proc_macro2::TokenStream = {
-        let n = name.to_camel_case();
-        n.parse().unwrap()
-    };
+    let ix_name_camel = generate_ix_variant_name(name);
 
     if args.is_empty() {
         quote! {
@@ -41,4 +38,9 @@ pub fn generate_ix_variant(name: String, args: &[IxArg]) -> proc_macro2::TokenSt
             }
         }
     }
+}
+
+pub fn generate_ix_variant_name(name: String) -> proc_macro2::TokenStream {
+    let n = name.to_camel_case();
+    n.parse().unwrap()
 }

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -12,11 +12,12 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
             let cpi_method = {
                 let name = &ix.raw_method.sig.ident;
-                let ix_variant = generate_ix_variant(&name, &ix.args);
+                let name_str = name.to_string();
+                let ix_variant = generate_ix_variant(&name_str, &ix.args);
                 let method_name = &ix.ident;
                 let args: Vec<&syn::PatType> = ix.args.iter().map(|arg| &arg.raw_arg).collect();
                 let discriminator = {
-                    let name = generate_ix_variant_name(name.to_string());
+                    let name = generate_ix_variant_name(&name_str);
                     quote! { <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR }
                 };
                 let ret_type = &ix.returns.ty.to_token_stream();

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -1,6 +1,4 @@
-use crate::codegen::program::common::{
-    gen_discriminator, generate_ix_variant, SIGHASH_GLOBAL_NAMESPACE,
-};
+use crate::codegen::program::common::{generate_ix_variant, generate_ix_variant_name};
 use crate::Program;
 use heck::SnakeCase;
 use quote::{quote, ToTokens};
@@ -14,10 +12,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
             let cpi_method = {
                 let name = &ix.raw_method.sig.ident;
-                let ix_variant = generate_ix_variant(name.to_string(), &ix.args);
+                let ix_variant = generate_ix_variant(&name, &ix.args);
                 let method_name = &ix.ident;
                 let args: Vec<&syn::PatType> = ix.args.iter().map(|arg| &arg.raw_arg).collect();
-                let discriminator = gen_discriminator(SIGHASH_GLOBAL_NAMESPACE, name);
+                let discriminator = {
+                    let name = generate_ix_variant_name(name.to_string());
+                    quote! { <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR }
+                };
                 let ret_type = &ix.returns.ty.to_token_stream();
                 let ix_cfgs = &ix.cfgs;
                 let (method_ret, maybe_return) = match ret_type.to_string().as_str() {

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -97,11 +97,12 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .iter()
         .map(|ix| {
             let ix_arg_names: Vec<&syn::Ident> = ix.args.iter().map(|arg| &arg.name).collect();
-            let ix_name = generate_ix_variant_name(ix.raw_method.sig.ident.to_string());
             let ix_method_name = &ix.raw_method.sig.ident;
-            let anchor = &ix.anchor_ident;
-            let variant_arm = generate_ix_variant(ix.raw_method.sig.ident.to_string(), &ix.args);
+            let ix_method_name_str = ix_method_name.to_string();
+            let ix_name = generate_ix_variant_name(&ix_method_name_str);
+            let variant_arm = generate_ix_variant(&ix_method_name_str, &ix.args);
             let ix_name_log = format!("Instruction: {ix_name}");
+            let anchor = &ix.anchor_ident;
             let ret_type = &ix.returns.ty.to_token_stream();
             let cfgs = &ix.cfgs;
             let maybe_set_return_data = match ret_type.to_string().as_str() {

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -1,7 +1,6 @@
 use crate::codegen::program::common::*;
 use crate::program_codegen::idl::idl_accounts_and_functions;
 use crate::Program;
-use heck::CamelCase;
 use quote::{quote, ToTokens};
 
 // Generate non-inlined wrappers for each instruction handler, since Solana's
@@ -189,11 +188,6 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             #event_cpi_mod
         }
     }
-}
-
-fn generate_ix_variant_name(name: String) -> proc_macro2::TokenStream {
-    let n = name.to_camel_case();
-    n.parse().unwrap()
 }
 
 /// Generate the event module based on whether the `event-cpi` feature is enabled.


### PR DESCRIPTION
### Problem

CPI instruction discriminators do not take into account the potential discriminator overrides from the `#[interface]` attribute (https://github.com/coral-xyz/anchor/pull/2728) or the new [custom discriminator support](https://github.com/coral-xyz/anchor/issues/3097) via `#[instruction(discriminator = <VALUE>)]` (https://github.com/coral-xyz/anchor/pull/3137):

https://github.com/coral-xyz/anchor/blob/8ec7ec802a1a7d678b35501cccc7ea80fe24cc86/lang/syn/src/codegen/program/cpi.rs#L20

### Summary of changes

- Fix `cpi` feature instructions not accounting for discriminator overrides
- Perform a small refactor to reduce cloning and code duplication of related code