### PR TITLE
docker: Upgrade Solana toolchain to 2.1.0

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ ANCHOR_CLI=v0.30.1
 #
 # Solana toolchain.
 #
-SOLANA_CLI=v2.0.8
+SOLANA_CLI=v2.1.0
 #
 # Build version should match the Anchor cli version.
 #


### PR DESCRIPTION
### Problem

CI currently runs Solana v2.1.0:

https://github.com/coral-xyz/anchor/blob/94ed4e0ff89b8259d609dcf5389c05ac9d1c7051/.github/workflows/tests.yaml#L17

But the Docker build still defaults to Solana v2.0.8:

https://github.com/coral-xyz/anchor/blob/94ed4e0ff89b8259d609dcf5389c05ac9d1c7051/docker/Makefile#L9

### Summary of changes

Upgrade default Solana toolchain of Docker to `2.1.0`