### PR TITLE
chore: clean unused anchor-spl

### DIFF
--- a/tests/idl/programs/external/Cargo.toml
+++ b/tests/idl/programs/external/Cargo.toml
@@ -18,4 +18,3 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
-anchor-spl = { path = "../../../../spl" }

--- a/tests/idl/programs/generics/Cargo.toml
+++ b/tests/idl/programs/generics/Cargo.toml
@@ -18,5 +18,4 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
-anchor-spl = { path = "../../../../spl" }
 external = { path = "../external", features = ["no-entrypoint"] }

--- a/tests/sysvars/programs/sysvars/Cargo.toml
+++ b/tests/sysvars/programs/sysvars/Cargo.toml
@@ -11,8 +11,7 @@ name = "sysvars"
 [features]
 no-entrypoint = []
 cpi = ["no-entrypoint"]
-idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
-anchor-spl = { path = "../../../../spl" }


### PR DESCRIPTION
under [tests](https://github.com/coral-xyz/anchor/tree/master/tests) folder, there are 3 programs including unused `anchor-spl` dependency.  which are:
idl/external
idl/generics
sysvars

I think they should be removed to avoid possible confusing. I tested this change both locally and in the Github Action in my forked project.
there is also an used `anchor-spl` in [test/tictactoe](https://github.com/coral-xyz/anchor/tree/master/tests/tictactoe), but i think this is an abandoned program. I am going to open an issue to ask about this program.
