### PR TITLE
bench: Use `agave-install` if Solana is v2

### DIFF
--- a/tests/bench/scripts/utils.ts
+++ b/tests/bench/scripts/utils.ts
@@ -498,7 +498,12 @@ export class VersionManager {
     const activeVersion = this.#getSolanaVersion();
     if (activeVersion === version) return;
 
-    spawn("solana-install", ["init", version], {
+    // `solana-install` is renamed to `agave-install` in Solana v2
+    // https://github.com/anza-xyz/agave/wiki/Agave-Transition
+    const cmdName = activeVersion.startsWith("2")
+      ? "agave-install"
+      : "solana-install";
+    spawn(cmdName, ["init", version], {
       logOutput: true,
       throwOnError: { msg: `Failed to set Solana version to ${version}` },
     });


### PR DESCRIPTION
### Problem

`solana-install` is no longer usable with Solana v2, which makes setting the Solana version during some of the benchmark commands fail:

https://github.com/coral-xyz/anchor/blob/6d6b24a8f2920e8780b3078c88ce7a090b8ba95f/tests/bench/scripts/utils.ts#L501

### Summary of changes

Use `agave-install` if Solana is v2.