### PR TITLE
avm: Remove `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,6 @@ dependencies = [
  "clap 4.5.17",
  "clap_complete",
  "dirs",
- "once_cell",
  "reqwest",
  "semver",
  "serde",

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -19,7 +19,6 @@ chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
-once_cell = "1.8.0"
 reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Error, Result};
 use cargo_toml::Manifest;
 use chrono::{TimeZone, Utc};
-use once_cell::sync::Lazy;
 use reqwest::header::USER_AGENT;
 use reqwest::StatusCode;
 use semver::{Prerelease, Version};
@@ -10,9 +9,10 @@ use std::fs;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::LazyLock;
 
 /// Storage directory for AVM, customizable by setting the $AVM_HOME, defaults to ~/.avm
-pub static AVM_HOME: Lazy<PathBuf> = Lazy::new(|| {
+pub static AVM_HOME: LazyLock<PathBuf> = LazyLock::new(|| {
     cfg_if::cfg_if! {
         if #[cfg(test)] {
             let dir = tempfile::tempdir().expect("Could not create temporary directory");


### PR DESCRIPTION
### Problem

Rust's standard library supports the functionality of [`once_cell::sync::Lazy`](https://docs.rs/once_cell/1.20.2/once_cell/sync/struct.Lazy.html) with [`std::sync::LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) since Rust v1.80 (stable).

We can switch to using the `std` implementation to remove the `once_cell` dependency from `avm`:

https://github.com/coral-xyz/anchor/blob/4b12678ca39973789da9de28b60d80a947019a62/avm/src/lib.rs#L15

https://github.com/coral-xyz/anchor/blob/4b12678ca39973789da9de28b60d80a947019a62/avm/Cargo.toml#L22

### Summary of changes

Remove the `once_cell` dependency from `avm`.