### PR TITLE
idl: Ignore compiler warnings during builds

### DIFF
--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -167,7 +167,7 @@ fn build(
             if skip_lint { "TRUE" } else { "FALSE" },
         )
         .env("ANCHOR_IDL_BUILD_PROGRAM_PATH", program_path)
-        .env("RUSTFLAGS", "--cfg procmacro2_semver_exempt")
+        .env("RUSTFLAGS", "--cfg procmacro2_semver_exempt -A warnings")
         .current_dir(program_path)
         .stderr(Stdio::inherit())
         .output()?;


### PR DESCRIPTION
### Problem

The current IDL build process uses the `nightly` compiler to generate the IDL. The recent `cargo 1.85.0-nightly (4c39aaff6 2024-11-25)` introduced a new set of warnings, for example:

```
warning: unexpected `cfg` condition value: `custom-heap`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `feature` are: `cpi`, `default`, `idl-build`, `no-entrypoint`, `no-idl`, and `no-log-ix-name`
  = help: consider adding `custom-heap` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default
  = note: this warning originates in the macro `$crate::custom_heap_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `solana`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, and `vita` and 6 more
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the macro `$crate::custom_heap_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `custom-panic`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `feature` are: `cpi`, `default`, `idl-build`, `no-entrypoint`, `no-idl`, and `no-log-ix-name`
  = help: consider adding `custom-panic` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the macro `$crate::custom_panic_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `solana`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, and `vita` and 6 more
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the macro `$crate::custom_panic_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `anchor-debug`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `feature` are: `cpi`, `default`, `idl-build`, `no-entrypoint`, `no-idl`, and `no-log-ix-name`
  = help: consider adding `anchor-debug` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `anchor-debug`
 --> programs/warnings/src/lib.rs:5:1
  |
5 | #[program]
  | ^^^^^^^^^^
  |
  = note: expected values for `feature` are: `cpi`, `default`, `idl-build`, `no-entrypoint`, `no-idl`, and `no-log-ix-name`
  = help: consider adding `anchor-debug` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Some of these warnings come from Anchor and some from Solana. Furthermore, all of the above warnings come from macro code, so there isn't much the user can do to fix them (other than allowing/ignoring them).

Another related problem is that most of the times, the warnings produced by the Solana build toolchain is the same as the `nightly` compiler, meaning we show the same warnings unnecessarily.

### Summary of changes

Ignore all compiler warnings during IDL builds.

Resolves https://github.com/coral-xyz/anchor/issues/3386