### PR TITLE
cli: Avoid extra IDL generation during `verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix detecting false-positives from doc comments during module path conversion ([#3359](https://github.com/coral-xyz/anchor/pull/3359)).
 - cli: Remove passing the rent sysvar account to IDL instructions ([#3372](https://github.com/coral-xyz/anchor/pull/3372)).
 - lang: Fix `cpi` feature instructions not accounting for discriminator overrides ([#3376](https://github.com/coral-xyz/anchor/pull/3376)).
+- idl: Ignore compiler warnings during builds ([#3396](https://github.com/coral-xyz/anchor/pull/3396)).
+- cli: Avoid extra IDL generation during `verify` ([#3398](https://github.com/coral-xyz/anchor/pull/3398)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2067,7 +2067,7 @@ fn verify(
     if !skip_build {
         build(
             cfg_override,
-            false,
+            true,
             None,
             None,
             true,


### PR DESCRIPTION
### Problem

IDL is being generated twice inside the `verify` command:

1. During the regular `build` process, which also includes building the IDL:

    https://github.com/coral-xyz/anchor/blob/6fbfc40fe886ac1e943523e704a4991c325910a2/cli/src/lib.rs#L2068

2. Regular IDL generation: 

    https://github.com/coral-xyz/anchor/blob/6fbfc40fe886ac1e943523e704a4991c325910a2/cli/src/lib.rs#L2108

We can avoid the first build operation by setting the `no_idl` argument of `build` to `true`.

### Summary of changes

Avoid extra IDL generation inside the `verify` command.