### PR TITLE
lang: Deduplicate `zero` accounts against `init` accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Ignore compiler warnings during builds ([#3396](https://github.com/coral-xyz/anchor/pull/3396)).
 - cli: Avoid extra IDL generation during `verify` ([#3398](https://github.com/coral-xyz/anchor/pull/3398)).
 - lang: Require `zero` accounts to be unique ([#3409](https://github.com/coral-xyz/anchor/pull/3409)).
+- lang: Deduplicate `zero` accounts against `init` accounts ([#3422](https://github.com/coral-xyz/anchor/pull/3422)).
 
 ### Breaking
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -212,8 +212,8 @@ pub fn generate_constraint_zeroed(
 
     // Require `zero` constraint accounts to be unique by:
     //
-    // 1. Getting the names of all accounts that have the `zero` constraint and are declared before
-    //    the current field (in order to avoid checking the same field).
+    // 1. Getting the names of all accounts that have the `zero` or the `init` constraints and are
+    //    declared before the current field (in order to avoid checking the same field).
     // 2. Comparing the key of the current field with all the previous fields' keys.
     // 3. Returning an error if a match is found.
     let unique_account_checks = accs
@@ -224,7 +224,7 @@ pub fn generate_constraint_zeroed(
             _ => None,
         })
         .take_while(|field| field.ident != f.ident)
-        .filter(|field| field.constraints.is_zeroed())
+        .filter(|field| field.constraints.is_zeroed() || field.constraints.init.is_some())
         .map(|other_field| {
             let other = &other_field.ident;
             let err = quote! {

--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -752,3 +752,14 @@ pub struct TestMultipleZeroConstraint<'info> {
     #[account(zero)]
     pub two: Option<Account<'info, Data>>,
 }
+
+#[derive(Accounts)]
+pub struct TestInitAndZero<'info> {
+    #[account(init, payer = payer, space = Data::DISCRIMINATOR.len() + Data::LEN)]
+    pub init: Option<Account<'info, Data>>,
+    #[account(zero)]
+    pub zero: Option<Account<'info, Data>>,
+    #[account(mut)]
+    pub payer: Option<Signer<'info>>,
+    pub system_program: Option<Program<'info, System>>,
+}

--- a/tests/misc/programs/misc-optional/src/lib.rs
+++ b/tests/misc/programs/misc-optional/src/lib.rs
@@ -406,4 +406,8 @@ pub mod misc_optional {
     pub fn test_multiple_zero_constraint(_ctx: Context<TestMultipleZeroConstraint>) -> Result<()> {
         Ok(())
     }
+
+    pub fn test_init_and_zero(_ctx: Context<TestInitAndZero>) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -824,3 +824,14 @@ pub struct TestMultipleZeroConstraint<'info> {
     #[account(zero)]
     pub two: Account<'info, Data>,
 }
+
+#[derive(Accounts)]
+pub struct TestInitAndZero<'info> {
+    #[account(init, payer = payer, space = Data::DISCRIMINATOR.len() + Data::LEN)]
+    pub init: Account<'info, Data>,
+    #[account(zero)]
+    pub zero: Account<'info, Data>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -405,4 +405,8 @@ pub mod misc {
     pub fn test_multiple_zero_constraint(_ctx: Context<TestMultipleZeroConstraint>) -> Result<()> {
         Ok(())
     }
+
+    pub fn test_init_and_zero(_ctx: Context<TestInitAndZero>) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -3241,7 +3241,7 @@ const miscTest = (
       });
     });
 
-    describe.only("`zero` constraint unique account checks", () => {
+    describe("`zero` constraint unique account checks", () => {
       it("Works with different accounts (multiple `zero`)", async () => {
         const oneKp = anchor.web3.Keypair.generate();
         const twoKp = anchor.web3.Keypair.generate();


### PR DESCRIPTION
### Problem

Same as https://github.com/coral-xyz/anchor/pull/3409 with the difference being the `init` constraint combined with `zero` (rather than all `zero`):

```rs
#[derive(Accounts)]
pub struct TestInitAndZero<'info> {
    #[account(init, ...)]
    pub init: Account<'info, Data>,
    #[account(zero)]
    pub zero: Account<'info, Data>,
    #[account(mut)]
    pub payer: Signer<'info>,
    pub system_program: Program<'info, System>,
}
```

### Summary of changes

Deduplicate accounts with the `zero` constraint against accounts with the `init` constraint. Note that this only applies to `init` accounts that are declared before `zero` accounts, as initialization fails on its own if the order is reversed.

Additionally, this change only concerns the `zero` constraint, as passing the same account for multiple `init`s fails without needing additional checks due to the account already being created after the initial `init`.