### PR TITLE
cli: Fix custom `provider.cluster`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Avoid extra IDL generation during `verify` ([#3398](https://github.com/coral-xyz/anchor/pull/3398)).
 - lang: Require `zero` accounts to be unique ([#3409](https://github.com/coral-xyz/anchor/pull/3409)).
 - lang: Deduplicate `zero` accounts against `init` accounts ([#3422](https://github.com/coral-xyz/anchor/pull/3422)).
+- cli: Fix custom `provider.cluster` ([#3428](https://github.com/coral-xyz/anchor/pull/3428)).
 
 ### Breaking
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -7,7 +7,8 @@ use dirs::home_dir;
 use heck::ToSnakeCase;
 use reqwest::Url;
 use serde::de::{self, MapAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use solana_cli_config::{Config as SolanaConfig, CONFIG_FILE};
 use solana_sdk::clock::Slot;
 use solana_sdk::pubkey::Pubkey;
@@ -590,9 +591,27 @@ struct _Config {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Provider {
-    #[serde(deserialize_with = "des_cluster")]
+    #[serde(serialize_with = "ser_cluster", deserialize_with = "des_cluster")]
     cluster: Cluster,
     wallet: String,
+}
+
+fn ser_cluster<S: Serializer>(cluster: &Cluster, s: S) -> Result<S::Ok, S::Error> {
+    match cluster {
+        Cluster::Custom(http, ws) => {
+            match (Url::parse(http), Url::parse(ws)) {
+                // If `ws` was derived from `http`, serialize `http` as string
+                (Ok(h), Ok(w)) if h.domain() == w.domain() => s.serialize_str(http),
+                _ => {
+                    let mut map = s.serialize_map(Some(2))?;
+                    map.serialize_entry("http", http)?;
+                    map.serialize_entry("ws", ws)?;
+                    map.end()
+                }
+            }
+        }
+        _ => s.serialize_str(&cluster.to_string()),
+    }
 }
 
 fn des_cluster<'de, D>(deserializer: D) -> Result<Cluster, D::Error>

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1484,15 +1484,34 @@ mod tests {
         wallet = \"id.json\"
     ";
 
-    const CUSTOM_CONFIG: &str = "
+    #[test]
+    fn parse_custom_cluster_str() {
+        let config = Config::from_str(
+            "
+        [provider]
+        cluster = \"http://my-url.com\"
+        wallet = \"id.json\"
+    ",
+        )
+        .unwrap();
+        assert!(!config.features.skip_lint);
+
+        // Make sure the layout of `provider.cluster` stays the same after serialization
+        assert!(config
+            .to_string()
+            .contains(r#"cluster = "http://my-url.com""#));
+    }
+
+    #[test]
+    fn parse_custom_cluster_map() {
+        let config = Config::from_str(
+            "
         [provider]
         cluster = { http = \"http://my-url.com\", ws = \"ws://my-url.com\" }
         wallet = \"id.json\"
-    ";
-
-    #[test]
-    fn parse_custom_cluster() {
-        let config = Config::from_str(CUSTOM_CONFIG).unwrap();
+    ",
+        )
+        .unwrap();
         assert!(!config.features.skip_lint);
     }
 


### PR DESCRIPTION
### Problem

`provider.cluster` serialization is not compatible with its deserialization.

This is because in https://github.com/coral-xyz/anchor/pull/2271, a custom deserialization function was implemented to support custom endpoints (as mentioned in https://github.com/coral-xyz/anchor/issues/673#issuecomment-912757160):

https://github.com/coral-xyz/anchor/blob/2ae3774639e299e4eb64d27176989699056f4364/cli/src/config.rs#L593-L594

but there was no custom serialization implementation that was compatible with the new deserialization. Thus, setting `provider.cluster` to a custom value:

```toml
[provider]
cluster = "https://anchor.solana/path"
```

results in:

```
Workspace configuration error: Unable to deserialize config: TOML parse error at line 15, column 11
   |
15 | cluster = ["https://anchor.solana/path", "wss://anchor.solana/path"]
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
invalid type: sequence, expected string or map
```

when a command, e.g. `anchor keys sync`, serializes `Anchor.toml`, as also mentioned in issues such as https://github.com/coral-xyz/anchor/issues/3388 and https://github.com/coral-xyz/anchor/issues/3222.

### Summary of changes

Fix using a custom endpoint in `provider.cluster` by:

- Implementing a custom serialization function for `Cluster`.
- Overriding the default serialization of `provider.cluster` with the new function.

Fixes https://github.com/coral-xyz/anchor/issues/3222