### PR TITLE
avm: Make installation download binaries by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Add test template for [Mollusk](https://github.com/buffalojoec/mollusk) ([#3352](https://github.com/coral-xyz/anchor/pull/3352)).
 - idl: Disallow account discriminators that can conflict with the `zero` constraint ([#3365](https://github.com/coral-xyz/anchor/pull/3365)).
 - cli: Include recommended solana args by default and add new `--max-retries` option to the `deploy` command ([#3354](https://github.com/coral-xyz/anchor/pull/3354)).
+- avm: Make installation download binaries by default ([#3445](https://github.com/coral-xyz/anchor/pull/3445)).
 
 ### Fixes
 

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -26,6 +26,9 @@ pub enum Commands {
         /// Flag to force installation even if the version
         /// is already installed
         force: bool,
+        #[clap(long)]
+        /// Build from source code rather than downloading prebuilt binaries
+        from_source: bool,
     },
     #[clap(about = "Uninstall a version of Anchor")]
     Uninstall {
@@ -77,7 +80,8 @@ pub fn entry(opts: Cli) -> Result<()> {
         Commands::Install {
             version_or_commit,
             force,
-        } => avm::install_version(version_or_commit, force),
+            from_source,
+        } => avm::install_version(version_or_commit, force, from_source),
         Commands::Uninstall { version } => avm::uninstall_version(&version),
         Commands::List {} => avm::list_versions(),
         Commands::Update {} => avm::update(),


### PR DESCRIPTION
### Problem

Installing `anchor-cli` using `avm` takes quite a bit of time because it's trying to build the binary from source.

Now that releases starting from v0.31.0 (https://github.com/coral-xyz/anchor/pull/3259) will have binaries (https://github.com/coral-xyz/anchor/pull/3439), it makes sense to support installing `anchor-cli` by downloading prebuilt binaries.

### Summary of changes

- Download binaries in `avm install` by default
- Add `--from-source` flag to build from source code if that's preferred (or required due to problems such as unsupported platform)

Resolves https://github.com/coral-xyz/anchor/issues/1411