### PR TITLE
Make `solana_account_decoder` dep public in anchor client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- client: Make `solana_account_decoder` dep public in anchor client ([#3455](https://github.com/coral-xyz/anchor/pull/3455)).
 - ts: Add optional `options.blockhash` to `Provider.sendAndConfirm` ([#3070](https://github.com/coral-xyz/anchor/pull/3070)).
 - ts: Add optional `commitment` parameter to `Program.addEventListener` ([#3052](https://github.com/coral-xyz/anchor/pull/3052)).
 - cli, idl: Pass `cargo` args to IDL generation when building program or IDL ([#3059](https://github.com/coral-xyz/anchor/pull/3059)).

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -112,6 +112,7 @@ pub use anchor_lang;
 pub use cluster::Cluster;
 #[cfg(feature = "async")]
 pub use nonblocking::ThreadSafeSigner;
+pub use solana_account_decoder;
 pub use solana_client;
 pub use solana_sdk;
 


### PR DESCRIPTION
Currently, anchor-client already exports `solana_client` and `solana_sdk` to make it easier for the user to not have to manually keep the version between these and anchor client in sync. Unfortunately it does not export `solana_account_decoder`, even though this one is used internally and is needed to instantiate certain (commonly-used) structs in `solana_sdk` such as [RpcAccountInfoConfig](https://docs.rs/solana-rpc-client-api/2.1.7/solana_rpc_client_api/config/struct.RpcAccountInfoConfig.html). This means the user has to manually configure its version which is annoying. This can be fixed easily by exporting it too, so this PR adds that.