### PR TITLE
ci: Run the release workflow when the release workflow file changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
       - master
     paths:
       - VERSION
+      - ./github/workflows/release.yaml
 
 env:
   DIST: dist-${{ github.ref_name }}


### PR DESCRIPTION
### Problem

Making changes to the [release workflow](https://github.com/coral-xyz/anchor/blob/72c7e09538f38fa98de56caeee6e8c030c8b66b2/.github/workflows/release.yaml) doesn't run the tests in CI, meaning we won't know whether the CI release builds work until we make a version bump PR e.g. https://github.com/coral-xyz/anchor/pull/3259.

### Summary of changes

Run the release workflow when the release workflow file changes in PRs to the `master` branch.