### PR TITLE
lang: Remove a potential panic while getting the IDL in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix custom `provider.cluster` ([#3428](https://github.com/coral-xyz/anchor/pull/3428)).
 - cli: Ignore non semver solana/agave releases to avoid panic ([#3432](https://github.com/coral-xyz/anchor/pull/3432)).
 - ts: Fix loading programs with numbers in their names using `workspace` ([#3450](https://github.com/coral-xyz/anchor/pull/3450)).
+- lang: Remove a potential panic while getting the IDL in `declare_program!` ([#3458](https://github.com/coral-xyz/anchor/pull/3458)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

A part of the getting the IDL process can panic if getting the environment variable fails:

https://github.com/coral-xyz/anchor/blob/6ff6655526dab71c12a32450f1c3897ac970119f/lang/attribute/program/src/declare_program/mod.rs#L37

Although this is unlikely to panic given this is a `cargo` environment variable, it still makes sense to convert this to an `Err` variant rather than potentially panicking, especially considering the `get_idl` function already returning a `Result` type.

### Summary of changes

Remove a potential panic while getting the IDL in `declare_program!`.