### PR TITLE
avm: Always install commit hash inputs from source

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -180,8 +180,9 @@ pub fn install_version(
         return Ok(());
     }
 
+    let is_commit = matches!(install_target, InstallTarget::Commit(_));
     let is_older_than_v0_31_0 = version < Version::parse("0.31.0")?;
-    if from_source || is_older_than_v0_31_0 {
+    if from_source || is_commit || is_older_than_v0_31_0 {
         // Build from source using `cargo install --git`
         let mut args: Vec<String> = vec![
             "install".into(),


### PR DESCRIPTION
### Problem

Trying to install using a commit hash (`avm install <COMMIT>`) will start to fail when v0.31.0 is out because of the recent change of making the binary download the default starting with v0.31.0 (https://github.com/coral-xyz/anchor/pull/3445).

You'd need to add the `--from-source` flag to make it work, which seems unnecessary, given trying to download binaries from releases that don't exist will always fail.

### Summary of changes

Always install versions with commit hash inputs by building from source.