### PR TITLE
avm: Use `#[cfg(unix)]` when running UNIX-only functionality

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -273,7 +273,7 @@ pub fn install_version(
         fs::write(&bin_path, res.bytes()?)?;
 
         // Set file to executable on UNIX
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(unix)]
         fs::set_permissions(
             bin_path,
             <fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o775),


### PR DESCRIPTION
### Problem

After downloading the binary for the specific target, we change file permissions in UNIX to make the file executable:

https://github.com/coral-xyz/anchor/blob/08110e9f1ac7a4f07d8c2babf55734d353258708/avm/src/lib.rs#L275-L280

While this technically works (because all non-Windows OS' we release binaries for are UNIX), it would still be better to use `#[cfg(unix)]` to make the intention clearer.

### Summary of changes

Use `#[cfg(unix)]` when running UNIX-only functionality instead of `#[cfg(not(target_os = "windows"))]`.