### PR TITLE
cli: Remove `solana-program` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ dependencies = [
  "solana-cli-config",
  "solana-client",
  "solana-faucet",
- "solana-program",
  "solana-sdk",
  "solang-parser",
  "syn 1.0.109",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,6 @@ shellexpand = "2.1.0"
 solana-client = "2"
 solana-cli-config = "2"
 solana-faucet = "2"
-solana-program = "2"
 solana-sdk = "2"
 # Pin solang-parser because it may break in a backwards incompatible way in minor versions
 solang-parser = "=0.3.3"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,13 +25,13 @@ use semver::{Version, VersionReq};
 use serde::Deserialize;
 use serde_json::{json, Map, Value as JsonValue};
 use solana_client::rpc_client::RpcClient;
-use solana_program::instruction::{AccountMeta, Instruction};
 use solana_sdk::account_utils::StateMut;
 use solana_sdk::bpf_loader;
 use solana_sdk::bpf_loader_deprecated;
 use solana_sdk::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
+use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signature::Signer;
@@ -3994,7 +3994,7 @@ fn create_idl_account(
             AccountMeta::new_readonly(keypair.pubkey(), true),
             AccountMeta::new(idl_address, false),
             AccountMeta::new_readonly(program_signer, false),
-            AccountMeta::new_readonly(solana_program::system_program::ID, false),
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
             AccountMeta::new_readonly(*program_id, false),
         ];
         instructions.push(Instruction {
@@ -4010,7 +4010,7 @@ fn create_idl_account(
                 accounts: vec![
                     AccountMeta::new(idl_address, false),
                     AccountMeta::new_readonly(keypair.pubkey(), true),
-                    AccountMeta::new_readonly(solana_program::system_program::ID, false),
+                    AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
                 ],
                 data,
             });


### PR DESCRIPTION
### Problem

Anchor CLI has direct dependency to both `solana-program` and `solana-sdk`:

https://github.com/coral-xyz/anchor/blob/8eec2e3b0dd245435565bab4518cd24e284382ad/cli/Cargo.toml#L42-L43

This is harmless, but it's also unnecessary since `solana-sdk` can be considered as a superset of `solana-program`.

### Summary of changes

Replace `solana-program` usage with `solana-sdk` and remove `solana-program` dependency from CLI.