### PR TITLE
cli: Fix altering user-provided lib name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Ignore non semver solana/agave releases to avoid panic ([#3432](https://github.com/coral-xyz/anchor/pull/3432)).
 - ts: Fix loading programs with numbers in their names using `workspace` ([#3450](https://github.com/coral-xyz/anchor/pull/3450)).
 - lang: Remove a potential panic while getting the IDL in `declare_program!` ([#3458](https://github.com/coral-xyz/anchor/pull/3458)).
+- cli: Fix altering user-provided lib names ([#3467](https://github.com/coral-xyz/anchor/pull/3467)).
 
 ### Breaking
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -79,24 +79,15 @@ impl Manifest {
     }
 
     pub fn lib_name(&self) -> Result<String> {
-        if self.lib.is_some() && self.lib.as_ref().unwrap().name.is_some() {
-            Ok(self
-                .lib
-                .as_ref()
-                .unwrap()
-                .name
-                .as_ref()
-                .unwrap()
-                .to_string()
-                .to_snake_case())
-        } else {
-            Ok(self
+        match &self.lib {
+            Some(cargo_toml::Product {
+                name: Some(name), ..
+            }) => Ok(name.to_owned()),
+            _ => self
                 .package
                 .as_ref()
-                .ok_or_else(|| anyhow!("package section not provided"))?
-                .name
-                .to_string()
-                .to_snake_case())
+                .ok_or_else(|| anyhow!("package section not provided"))
+                .map(|pkg| pkg.name.to_snake_case()),
         }
     }
 


### PR DESCRIPTION
### Problem

Anchor converts user-provided lib name to snake case:

https://github.com/coral-xyz/anchor/blob/7b6c2b355e6068c20dd2c91f402e53d5f85ddd4a/cli/src/config.rs#L82-L91

This makes the output incompatible with `cargo` because `cargo` tooling does not alter user-provided lib names.

For example, if the user sets the lib name to include numbers (in some cases) or uses a non-standard, i.e. non-snake_case, name:

```toml
[lib]
name = "myProgram"
crate-type = ["cdylib", "lib"]
```

Running `anchor test` results in:

```
Unable to get latest blockhash. Test validator does not look started. Check ".anchor/test-ledger/test-ledger-log.txt" for errors. Consider increasing [test.startup_wait] in Anchor.toml.
```

And in `.anchor/test-ledger/test-ledger-log.txt`:

```
Error: program file does not exist: target/deploy/my_program.so
```

This is because the build tool (`cargo-build-sbf`) outputs the program binary as `myProgram.so`, but Anchor incorrectly tries to find `my_program.so`.

### Summary of changes

Fix altering user-provided lib name.

**Note:** Removing the [`to_snake_case`](https://github.com/coral-xyz/anchor/blob/7b6c2b355e6068c20dd2c91f402e53d5f85ddd4a/cli/src/config.rs#L91) call would have been enough to fix this issue, but the [`lib_name`](https://github.com/coral-xyz/anchor/blob/7b6c2b355e6068c20dd2c91f402e53d5f85ddd4a/cli/src/config.rs#L81-L101) method implementation was quite repetitive and unidiomatic, so I thought it would be great to rewrite it to make it more concise and idiomatic.