### PR TITLE
idl: Fix missing `program::seed` resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Fix loading programs with numbers in their names using `workspace` ([#3450](https://github.com/coral-xyz/anchor/pull/3450)).
 - lang: Remove a potential panic while getting the IDL in `declare_program!` ([#3458](https://github.com/coral-xyz/anchor/pull/3458)).
 - cli: Fix altering user-provided lib names ([#3467](https://github.com/coral-xyz/anchor/pull/3467)).
+- idl: Fix missing `program::seed` resolution ([#3474](https://github.com/coral-xyz/anchor/pull/3474)).
 
 ### Breaking
 

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -55,6 +55,10 @@ pub mod pda_derivation {
     pub fn resolution_error(_ctx: Context<ResolutionError>) -> Result<()> {
         Ok(())
     }
+
+    pub fn unsupported_program_seed(_ctx: Context<UnsupportedProgramSeed>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -189,6 +193,21 @@ pub struct ResolutionError<'info> {
     pub pda: UncheckedAccount<'info>,
     #[account(seeds = [pda.key.as_ref()], bump)]
     pub another_pda: UncheckedAccount<'info>,
+}
+
+#[derive(Accounts)]
+
+pub struct UnsupportedProgramSeed<'info> {
+    #[account(
+        seeds = [],
+        seeds::program = external_function_with_an_argument(&pda.key),
+        bump
+    )]
+    pub pda: UncheckedAccount<'info>,
+}
+
+fn external_function_with_an_argument(pk: &Pubkey) -> Pubkey {
+    *pk
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -134,4 +134,12 @@ describe("typescript", () => {
       );
     }
   });
+
+  it("Skips resolution if `program::seeds` expression is not supported", async () => {
+    const acc = program.idl.instructions
+      .find((ix) => ix.name === "unsupportedProgramSeed")!
+      .accounts.find((acc) => acc.name === "pda")!;
+    // @ts-expect-error
+    expect(acc.pda).to.be.undefined;
+  });
 });


### PR DESCRIPTION
### Problem

If `seeds` gets parsed successfully but `program::seed` fails to get parsed, the generated account in the IDL has `seeds` field, but it does not have the program information. I noticed this while answering another related problem in https://github.com/coral-xyz/anchor/issues/3471#issuecomment-2579230577.

For example:

```rs
#[derive(Accounts)]
pub struct Test<'info> {
    #[account(
        seeds = [b"hi"],
        seeds::program = System::id(),
        bump
    )]
    pub pda: UncheckedAccount<'info>,
}
```

Outputs (incorrectly):

```json
{
  "name": "pda",
  "pda": {
    "seeds": [
      {
        "kind": "const",
        "value": [
          104,
          105
        ]
      }
    ]
  }
}
```

This is because using external functions (`System::id()` in this example) is not currently supported (see https://github.com/coral-xyz/anchor/issues/2903), which means this is a bug that will lead to incorrect account resolution.

### Summary of changes

Fix missing `program::seed` resolution by changing the logic to the following:

- If both `seeds` and `seeds::program` get parsed succcessfuly, include both in the IDL
- If any of them fails to get parsed, skip `pda` field generation completely.

The above example now outputs (because `seeds::program` fails to get parsed):

```json
{ "name": "pda" }
```

This means there will be no error, but the user will need to manually find the address of the `pda` account.