### PR TITLE
cli: Upgrade `typescript` version of templates to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client, lang, spl: Upgrade Solana to v2 and SPL to the latest ([#3219](https://github.com/coral-xyz/anchor/pull/3219)).
 - cli: Install Solana from anza.xyz domain in Docker verifiable builds ([#3271](https://github.com/coral-xyz/anchor/pull/3271)).
 - spl: Upgrade SPL deps to latest ([#3346](https://github.com/coral-xyz/anchor/pull/3346)).
+- cli: Upgrade `typescript` version of templates to v5 ([#3480](https://github.com/coral-xyz/anchor/pull/3480)).
 
 ## [0.30.1] - 2024-06-20
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -432,7 +432,7 @@ pub fn ts_package_json(jest: bool, license: String) -> String {
     "jest": "^29.0.3",
     "prettier": "^2.6.2",
     "ts-jest": "^29.0.2",
-    "typescript": "^4.3.5"
+    "typescript": "^5.7.3"
   }}
 }}
 "#
@@ -455,7 +455,7 @@ pub fn ts_package_json(jest: bool, license: String) -> String {
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.0.0",
-    "typescript": "^4.3.5",
+    "typescript": "^5.7.3",
     "prettier": "^2.6.2"
   }}
 }}


### PR DESCRIPTION
### Problem

`typescript` dependency version generated with the default program templates is still using v4:

https://github.com/coral-xyz/anchor/blob/fe4073301e045dc8dd731504174afb1f5d31c5cd/cli/src/rust_template.rs#L435

https://github.com/coral-xyz/anchor/blob/fe4073301e045dc8dd731504174afb1f5d31c5cd/cli/src/rust_template.rs#L458

### Summary of changes

Upgrade `typescript` version of project templates to v5.