### PR TITLE
idl: Support PDA resolution of call expressions that don't have any arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Disallow account discriminators that can conflict with the `zero` constraint ([#3365](https://github.com/coral-xyz/anchor/pull/3365)).
 - cli: Include recommended solana args by default and add new `--max-retries` option to the `deploy` command ([#3354](https://github.com/coral-xyz/anchor/pull/3354)).
 - avm: Make installation download binaries by default ([#3445](https://github.com/coral-xyz/anchor/pull/3445)).
+- idl: Support PDA resolution of call expressions that don't have any arguments ([#3485](https://github.com/coral-xyz/anchor/pull/3485)).
 
 ### Fixes
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -342,6 +342,14 @@ fn parse_seed(seed: &syn::Expr, accounts: &AccountsStruct) -> Result<TokenStream
                 })
             }
         }
+        // Support call expressions that don't have any arguments e.g. `System::id()`
+        syn::Expr::Call(call) if call.args.is_empty() => Ok(quote! {
+            #idl::IdlSeed::Const(
+                #idl::IdlSeedConst {
+                    value: AsRef::<[u8]>::as_ref(&#seed).into(),
+                }
+            )
+        }),
         syn::Expr::Path(path) => {
             let seed = path
                 .path

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -59,6 +59,10 @@ pub mod pda_derivation {
     pub fn unsupported_program_seed(_ctx: Context<UnsupportedProgramSeed>) -> Result<()> {
         Ok(())
     }
+
+    pub fn call_expr_with_no_args(_ctx: Context<CallExprWithNoArgs>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -208,6 +212,16 @@ pub struct UnsupportedProgramSeed<'info> {
 
 fn external_function_with_an_argument(pk: &Pubkey) -> Pubkey {
     *pk
+}
+
+#[derive(Accounts)]
+pub struct CallExprWithNoArgs<'info> {
+    #[account(
+        seeds = [System::id().as_ref()],
+        seeds::program = System::id(),
+        bump
+    )]
+    pub pda: UncheckedAccount<'info>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -142,4 +142,8 @@ describe("typescript", () => {
     // @ts-expect-error
     expect(acc.pda).to.be.undefined;
   });
+
+  it("Can resolve call expressions with no arguments", async () => {
+    await program.methods.callExprWithNoArgs().rpc();
+  });
 });


### PR DESCRIPTION
### Problem

Call expressions that have no arguments do not get resolved automatically. For example:

```rs
#[derive(Accounts)]
pub struct CallExprWithNoArgs<'info> {
    #[account(
        seeds = [System::id().as_ref()],
        seeds::program = System::id(),
        bump
    )]
    pub pda: UncheckedAccount<'info>,
}
```

This generates the following account (with no resolution information):

```json
{ "name": "pda" }
```

However, we have all the necessary information to evaluate the key of `pda` during IDL build (because `System::id()` can be evaluated).

### Summary of changes

Support PDA resolution of call expressions that don't have any arguments.