### PR TITLE
Fix `clippy 1.84.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fix altering user-provided lib names ([#3467](https://github.com/coral-xyz/anchor/pull/3467)).
 - idl: Fix missing `program::seed` resolution ([#3474](https://github.com/coral-xyz/anchor/pull/3474)).
 - lang: Fix adding `derive`s and `repr`s to type alias definitions in `declare_program!` ([#3504](https://github.com/coral-xyz/anchor/pull/3504)).
+- spl: Add `anchor-debug` feature ([#3511](https://github.com/coral-xyz/anchor/pull/3511)).
 
 ### Breaking
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -221,7 +221,7 @@ pub struct EventUnsubscriber<'a> {
     _lifetime_marker: PhantomData<&'a Handle>,
 }
 
-impl<'a> EventUnsubscriber<'a> {
+impl EventUnsubscriber<'_> {
     async fn unsubscribe_internal(mut self) {
         if let Some(unsubscribe) = self.rx.recv().await {
             unsubscribe().await;
@@ -522,7 +522,7 @@ pub struct RequestBuilder<'a, C, S: 'a> {
 }
 
 // Shared implementation for all RequestBuilders
-impl<'a, C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'a, C, S> {
+impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, S> {
     #[must_use]
     pub fn payer(mut self, payer: C) -> Self {
         self.payer = payer;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -679,6 +679,7 @@ fn parse_logs_response<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
         if let Ok(mut execution) = Execution::new(&mut logs) {
             // Create a new peekable iterator so that we can peek at the next log whilst iterating
             let mut logs_iter = logs.iter().peekable();
+            let regex = Regex::new(r"^Program (.*) invoke.*$").unwrap();
 
             while let Some(l) = logs_iter.next() {
                 // Parse the log.
@@ -714,9 +715,8 @@ fn parse_logs_response<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
                     // a panic during the next iteration.
                     if let Some(&next_log) = logs_iter.peek() {
                         if next_log.ends_with("invoke [1]") {
-                            let re = Regex::new(r"^Program (.*) invoke.*$").unwrap();
                             let next_instruction =
-                                re.captures(next_log).unwrap().get(1).unwrap().as_str();
+                                regex.captures(next_log).unwrap().get(1).unwrap().as_str();
                             // Within this if block, there will always be a regex match.
                             // Therefore it's safe to unwrap and the captured program ID
                             // at index 1 can also be safely unwrapped.

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -17,7 +17,7 @@ pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> 
 pub fn is_account(attr: &&syn::Attribute) -> bool {
     attr.path
         .get_ident()
-        .map_or(false, |ident| ident == "account")
+        .is_some_and(|ident| ident == "account")
 }
 
 // Parses a single constraint from a parse stream for `#[account(<STREAM>)]`.

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -14,7 +14,7 @@ pub fn parse(accounts_struct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {
         .find(|a| {
             a.path
                 .get_ident()
-                .map_or(false, |ident| ident == "instruction")
+                .is_some_and(|ident| ident == "instruction")
         })
         .map(|ix_attr| ix_attr.parse_args_with(Punctuated::<Expr, Comma>::parse_terminated))
         .transpose()?;

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -12,6 +12,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["associated_token", "mint", "token", "token_2022", "token_2022_extensions"]
+anchor-debug = ["anchor-lang/anchor-debug"]
 associated_token = ["spl-associated-token-account"]
 devnet = []
 governance = []


### PR DESCRIPTION
### Problem

`clippy` checks in [CI](https://github.com/coral-xyz/anchor/actions/runs/12949427478/job/36162323678) fail after the new Rust release (v1.84.0).

### Summary of changes

- Fix `clippy::unnecessary-map-or`
- Fix `clippy::needless-lifetimes`
- Fix `clippy::regex-creation-in-loops`
- Fix "unexpected `cfg` condition value: `anchor-debug`" error in `anchor-spl` (this triggers warnings during regular compilation, unrelated to `clippy`)