### PR TITLE
docs: Add `engines.node` override in `package.json`

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,5 +30,8 @@
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
### Problem

Deploying docs started failing yesterday because our Node version from Vercel was set to v16:

```
Error: Node.js Version "16.x" is discontinued and must be upgraded. Please set Node.js Version to 22.x in your Project Settings to use Node.js 22. Learn More: http://vercel.link/node-version
```

[Vercel's documentation](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions#default-and-available-versions) states:

> By default, a new project uses the latest Node.js LTS version available on Vercel.
> 
> Current available versions are:
> 
> - 22.x (default)
> - 20.x
> - 18.x (retiring early 2025)
> - 16.x (deprecated, retiring January 31st, 2025)
> - Only major versions are available. Vercel automatically rolls out minor and patch updates when needed, such as to fix a security issue.

Meaning, the failure was completely unrelated to the new docs (https://github.com/coral-xyz/anchor/pull/3493).

### Summary of changes

Add `engines.node` override in `package.json` to `22.x` (current LTS).