### PR TITLE
cli: Convert package managers to lowercase during serialization

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -377,6 +377,7 @@ pub struct ToolchainConfig {
 
 /// Package manager to use for the project.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum PackageManager {
     /// Use npm as the package manager.
     NPM,


### PR DESCRIPTION
### Problem

`[toolchain.package_manager]` field (added in https://github.com/coral-xyz/anchor/pull/3328) is serialized using the enum defaults, meaning it will be in PascalCase format due to Rust's enum variants being PascalCase by convention.

For example, using `anchor init program` results in the following `toolchain` section:

```toml
[toolchain]
package_manager = "Yarn"
```

Using `package_manager = "yarn"` doesn't work:

```
Error: Unable to deserialize config: TOML parse error at line 2, column 19
  |
2 | package_manager = "yarn"
```

 This is unintuitive, especially considering it's a lot more common to use lowercase when referring to package managers (and their commands) e.g. `yarn` or `npm`.

### Summary of changes

Convert package manager names to lowercase during serialization.