### PR TITLE
fix: add `anchor-spl/idl-build` in idl-build feature list in documentation

### DIFF
--- a/docs/content/docs/tokens/index.mdx
+++ b/docs/content/docs/tokens/index.mdx
@@ -24,7 +24,7 @@ simplifies the process of interacting with Solana's Token Programs in an Anchor
 program. This crate includes instructions and account types for both the
 original Token Program and the newer Token Extension Program (Token 2022).
 
-Simply add the `anchor-spl` crate as a dependency to your program. For a
+Simply add the `anchor-spl` crate as a dependency to your program and add `"anchor-spl/idl-build"` to idl-build feature list in `Cargo.toml`. For a
 walkthrough of how to create an Anchor program locally, see the
 [quickstart page](/docs/quickstart/local).
 
@@ -33,6 +33,12 @@ cargo add anchor-spl
 ```
 
 ```toml title="Cargo.toml"
+[features]
+idl-build = [
+    "anchor-lang/idl-build",
+    "anchor-spl/idl-build",
+]
+
 [dependencies]
 anchor-lang = "0.30.1"
 anchor-spl = "0.30.1"


### PR DESCRIPTION
I'm trying to follow the doc to create a token mint locally. However, I met the following compilation error: 
```
error[E0277]: the trait bound `anchor_spl::token_interface::Mint: Discriminator` is not satisfied
  --> programs/sol-example/src/lib.rs:29:39
   |
29 |     pub mint: InterfaceAccount<'info, Mint>,
   |                                       ^^^^ the trait `Discriminator` is not implemented for `anchor_spl::token_interface::Mint`
```
from the struct 
```
#[derive(Accounts)]
pub struct CreateMint<'info> {
    #[account(mut)]
    pub signer: Signer<'info>,
    #[account(
        init,
        payer = signer,
        mint::decimals = 6,
        mint::authority = signer.key(),
        mint::freeze_authority = signer.key(),
    )]

    pub mint: InterfaceAccount<'info, Mint>,
    pub token_program: Interface<'info, TokenInterface>,
    pub system_program: Program<'info, System>,
}
```

I tracked #3151 and #2745 and found that the documentation doesn't mention the `anchor-spl/idl-build` feature, which causes the compilation error. This PR adds this requirement to the documentation.