### PR TITLE
client: Remove `std::process::exit` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix missing `program::seed` resolution ([#3474](https://github.com/coral-xyz/anchor/pull/3474)).
 - lang: Fix adding `derive`s and `repr`s to type alias definitions in `declare_program!` ([#3504](https://github.com/coral-xyz/anchor/pull/3504)).
 - idl: Fix using constant identifiers as generic arguments ([#3522](https://github.com/coral-xyz/anchor/pull/3522)).
+- client: Remove `std::process::exit` usage ([#3544](https://github.com/coral-xyz/anchor/pull/3544)).
 
 ### Breaking
 


### PR DESCRIPTION
### Problem

Client libraries pretty much should never use [`std::process::exit`](https://doc.rust-lang.org/std/process/fn.exit.html), but we do use it here:

https://github.com/coral-xyz/anchor/blob/13a6df923289c33a5ab479424a27d0c8f70b9f23/client/src/lib.rs#L690

### Summary of changes

Remove `std::process::exit` usage and gracefully handle the errors instead.