### PR TITLE
ci: Fix `avm` tests

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -52,9 +52,9 @@ jobs:
       - run: cargo build
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
+      - run: cargo test --workspace --exclude avm
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1
+      - run: cargo test --package avm -- --test-threads=1
       # Init local borsh package
       - run: cd ts/packages/borsh && yarn --frozen-lockfile && yarn build
       - run: cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build


### PR DESCRIPTION
### Problem

Reusable tests workflow runs `avm` tests twice, which sometimes causes the CI to fail due to GitHub rate-limits.

https://github.com/coral-xyz/anchor/blob/16e166cae1b92e1e096794e2213c5bceb9df2288/.github/workflows/reusable-tests.yaml#L53-L57

As the comment suggests, this doesn't seem to be intent of the initial author.

### Summary of changes

Exclude `avm` from the initial `cargo test` command, and run `avm` as single-threaded separately afterwards.

Additionally, remove the redundant formatting (`cargo fmt`) and linting (`cargo clippy`) commands specific to `avm`, since the initial runs already take care of this process.