### PR TITLE
idl: Fix using `Pubkey` constants with `seeds::program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix adding `derive`s and `repr`s to type alias definitions in `declare_program!` ([#3504](https://github.com/coral-xyz/anchor/pull/3504)).
 - idl: Fix using constant identifiers as generic arguments ([#3522](https://github.com/coral-xyz/anchor/pull/3522)).
 - client: Remove `std::process::exit` usage ([#3544](https://github.com/coral-xyz/anchor/pull/3544)).
+- idl: Fix using `Pubkey` constants with `seeds::program` ([#3559](https://github.com/coral-xyz/anchor/pull/3559)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -366,20 +366,10 @@ fn parse_seed(seed: &syn::Expr, accounts: &AccountsStruct) -> Result<TokenStream
                     }
                 })
                 .unwrap_or_else(|| {
-                    // Not all types can be converted to `Vec<u8>` with `.into` call e.g. `Pubkey`.
-                    // This is problematic for `seeds::program` but a hacky way to handle this
-                    // scenerio is to check whether the last segment of the path ends with `ID`.
-                    let seed = path
-                        .path
-                        .segments
-                        .last()
-                        .filter(|seg| seg.ident.to_string().ends_with("ID"))
-                        .map(|_| quote! { #seed.as_ref() })
-                        .unwrap_or_else(|| quote! { #seed });
                     quote! {
                         #idl::IdlSeed::Const(
                             #idl::IdlSeedConst {
-                                value: #seed.into(),
+                                value: AsRef::<[u8]>::as_ref(&#seed).into(),
                             }
                         )
                     }

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -63,6 +63,10 @@ pub mod pda_derivation {
     pub fn call_expr_with_no_args(_ctx: Context<CallExprWithNoArgs>) -> Result<()> {
         Ok(())
     }
+
+    pub fn pubkey_const(_ctx: Context<PubkeyConst>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -222,6 +226,18 @@ pub struct CallExprWithNoArgs<'info> {
         bump
     )]
     pub pda: UncheckedAccount<'info>,
+}
+
+const PUBKEY_CONST: Pubkey = pubkey!("4LVUJzLugULF1PemZ1StknKJEEtJM6rJZaGijpNqCouG");
+
+#[derive(Accounts)]
+pub struct PubkeyConst<'info> {
+    #[account(
+        seeds = [],
+        seeds::program = PUBKEY_CONST,
+        bump
+    )]
+    pub acc: UncheckedAccount<'info>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -146,4 +146,8 @@ describe("typescript", () => {
   it("Can resolve call expressions with no arguments", async () => {
     await program.methods.callExprWithNoArgs().rpc();
   });
+
+  it("Can use `Pubkey` constants with `seeds::program`", async () => {
+    await program.methods.pubkeyConst().rpc();
+  });
 });


### PR DESCRIPTION
### Problem

Using `Pubkey` constants with `seeds::program`:

```rs
const PUBKEY_CONST: Pubkey = pubkey!("4LVUJzLugULF1PemZ1StknKJEEtJM6rJZaGijpNqCouG");

#[derive(Accounts)]
pub struct PubkeyConst<'info> {
    #[account(
        seeds = [],
        seeds::program = PUBKEY_CONST,
        bump
    )]
    pub acc: UncheckedAccount<'info>,
}
```

results in the following compile error:

```
error[E0277]: the trait bound `std::vec::Vec<u8>: From<anchor_lang::prelude::Pubkey>` is not satisfied
   --> programs/pda-derivation/src/lib.rs:233:10
    |
233 | #[derive(Accounts)]
    |          ^^^^^^^^ the trait `From<anchor_lang::prelude::Pubkey>` is not implemented for `std::vec::Vec<u8>`
    |
    = help: the following other types implement trait `From<T>`:
              `std::vec::Vec<u8>` implements `From<&str>`
              `std::vec::Vec<u8>` implements `From<ByteString>`
              `std::vec::Vec<u8>` implements `From<CString>`
              `std::vec::Vec<u8>` implements `From<std::string::String>`
    = note: required for `anchor_lang::prelude::Pubkey` to implement `Into<std::vec::Vec<u8>>`
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `pda-derivation` (lib test) due to 1 previous error
Error: Building IDL failed. Run `ANCHOR_LOG=true anchor idl build` to see the logs.
```

This is because we don't have a reliable way to decide the seed expression's actual type inside macros. As a workaround, the IDL generation assumes the type to be `Pubkey` if the identifier ends with `ID`:

https://github.com/coral-xyz/anchor/blob/fa381028b6c28ab865644ac9ab02948ba30a89a2/lang/syn/src/idl/accounts.rs#L369-L378

However, this means if people don't append the `ID` suffix, it likely won't compile (e.g. https://github.com/coral-xyz/anchor/issues/3558).

### Summary of changes

Fix using `Pubkey` constants with `seeds::program` in IDL generation by using `AsRef::<[u8]>::as_ref` before using `Into::into`. 

Fixes https://github.com/coral-xyz/anchor/issues/3558