### PR TITLE
lang: Fix instructions with no accounts causing compilation errors when using `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix using constant identifiers as generic arguments ([#3522](https://github.com/coral-xyz/anchor/pull/3522)).
 - client: Remove `std::process::exit` usage ([#3544](https://github.com/coral-xyz/anchor/pull/3544)).
 - idl: Fix using `Pubkey` constants with `seeds::program` ([#3559](https://github.com/coral-xyz/anchor/pull/3559)).
+- lang: Fix instructions with no accounts causing compilation errors when using `declare_program!` ([#3567](https://github.com/coral-xyz/anchor/pull/3567)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -26,6 +26,12 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
         let method_name = format_ident!("{}", ix.name);
         let accounts_ident = format_ident!("{}", ix.name.to_camel_case());
 
+        let accounts_generic = if ix.accounts.is_empty() {
+           quote!()
+        } else {
+            quote!(<'info>)
+        };
+
         let args = ix.args.iter().map(|arg| {
             let name = format_ident!("{}", arg.name);
             let ty = convert_idl_type_to_syn_type(&arg.ty);
@@ -61,7 +67,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
 
         quote! {
             pub fn #method_name<'a, 'b, 'c, 'info>(
-                ctx: anchor_lang::context::CpiContext<'a, 'b, 'c, 'info, accounts::#accounts_ident<'info>>,
+                ctx: anchor_lang::context::CpiContext<'a, 'b, 'c, 'info, accounts::#accounts_ident #accounts_generic>,
                 #(#args),*
             ) -> #ret_type {
                 let ix = {

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -74,6 +74,21 @@
       ]
     },
     {
+      "name": "test_compilation_no_accounts",
+      "discriminator": [
+        194,
+        91,
+        205,
+        217,
+        51,
+        10,
+        247,
+        201
+      ],
+      "accounts": [],
+      "args": []
+    },
+    {
       "name": "test_compilation_return_type",
       "discriminator": [
         174,

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -45,12 +45,20 @@ pub mod external {
     pub fn test_compilation_return_type(_ctx: Context<TestCompilation>) -> Result<bool> {
         Ok(true)
     }
+
+    // Compilation test for an instruction with no accounts
+    pub fn test_compilation_no_accounts(_ctx: Context<TestCompilationNoAccounts>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
 pub struct TestCompilation<'info> {
     pub signer: Signer<'info>,
 }
+
+#[derive(Accounts)]
+pub struct TestCompilationNoAccounts {}
 
 #[derive(Accounts)]
 pub struct Init<'info> {


### PR DESCRIPTION
### Problem

Instructions with no accounts result in compilation errors when they're used with `declare_program!`.

For example, using an IDL that has an instruction like the one mentioned in https://github.com/coral-xyz/anchor/issues/3514#issuecomment-2619567456

```json
{
  "name": "refresh_reserves_batch",
  "discriminator": [144, 110, 26, 103, 162, 204, 252, 147],
  "accounts": [],
  "args": [
    {
      "name": "skip_price_updates",
      "type": "bool"
    }
  ]
}
```

results in:

```
error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
 --> programs/name/src/lib.rs:5:1
  |
5 | declare_program!(kamino);
  | ^^^^^^^^^^^^^^^^^^^^^^^^- help: remove these generics
  | |
  | expected 0 lifetime arguments
  |
```

A similar issue (https://github.com/coral-xyz/anchor/issues/1628) with the `cpi` feature has existed roughly since the creation of Anchor, but this one is specifically for the `cpi` module generated using `declare_program!`. The benefit of using the IDL + macro approach here is that we have access to all instruction information (unlike with the `cpi` feature, where we only have access to the token stream), which we can then use to decide whether to add the generic lifetime or not.

### Summary of changes

Fix instructions with no accounts causing compilation errors when using `declare_program!` by conditionally adding the lifetime parameter only when the instruction accounts are not empty.

Fixes https://github.com/coral-xyz/anchor/issues/3514