### PR TITLE
idl: Fix using account or arg values for `seeds::program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Remove `std::process::exit` usage ([#3544](https://github.com/coral-xyz/anchor/pull/3544)).
 - idl: Fix using `Pubkey` constants with `seeds::program` ([#3559](https://github.com/coral-xyz/anchor/pull/3559)).
 - lang: Fix instructions with no accounts causing compilation errors when using `declare_program!` ([#3567](https://github.com/coral-xyz/anchor/pull/3567)).
+- idl: Fix using account or arg values for `seeds::program` ([#3570](https://github.com/coral-xyz/anchor/pull/3570)).
 
 ### Breaking
 

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -67,6 +67,14 @@ pub mod pda_derivation {
     pub fn pubkey_const(_ctx: Context<PubkeyConst>) -> Result<()> {
         Ok(())
     }
+
+    pub fn seeds_program_account(_ctx: Context<SeedsProgramAccount>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn seeds_program_arg(_ctx: Context<SeedsProgramArg>, _some_program: Pubkey) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -238,6 +246,28 @@ pub struct PubkeyConst<'info> {
         bump
     )]
     pub acc: UncheckedAccount<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SeedsProgramAccount<'info> {
+    #[account(
+        seeds = [b"*"],
+        seeds::program = some_program,
+        bump
+    )]
+    pub pda: UncheckedAccount<'info>,
+    pub some_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(some_program: Pubkey)]
+pub struct SeedsProgramArg<'info> {
+    #[account(
+        seeds = [b"*"],
+        seeds::program = some_program,
+        bump
+    )]
+    pub pda: UncheckedAccount<'info>,
 }
 
 #[account]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -150,4 +150,12 @@ describe("typescript", () => {
   it("Can use `Pubkey` constants with `seeds::program`", async () => {
     await program.methods.pubkeyConst().rpc();
   });
+
+  it("Can use accounts with `seeds::program`", async () => {
+    await program.methods.seedsProgramAccount().rpc();
+  });
+
+  it("Can use arguments with `seeds::program`", async () => {
+    await program.methods.seedsProgramArg(anchor.web3.PublicKey.default).rpc();
+  });
 });


### PR DESCRIPTION
### Problem

Passing an account or an argument to `seeds::program` results in a compile error.

For example, using the following accounts struct:

```rs
#[derive(Accounts)]
pub struct Test<'info> {
    #[account(
        seeds = [b"*"],
        seeds::program = some_program,
        bump
    )]
    pub pda: UncheckedAccount<'info>,
    pub some_program: Program<'info, System>,
}
```

and running `anchor idl build` results in:

```
error[E0425]: cannot find value `some_program` in this scope
  --> programs/program/src/lib.rs:20:26
   |
20 |         seeds::program = some_program,
   |                          ^^^^^^^^^^^^ not found in this scope
```

Dynamic values are generally not supported, but we have a few exceptions for accounts and arguments. Given this kind usage already works for regular seeds, it should also work for `seeds::program`.

### Summary of changes

Fix being unable to use account or argument values for `seeds::program` during IDL generation.

Fixes https://github.com/coral-xyz/anchor/issues/3471