### PR TITLE
lang: Fix using `data` as an instruction parameter name in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix using `Pubkey` constants with `seeds::program` ([#3559](https://github.com/coral-xyz/anchor/pull/3559)).
 - lang: Fix instructions with no accounts causing compilation errors when using `declare_program!` ([#3567](https://github.com/coral-xyz/anchor/pull/3567)).
 - idl: Fix using account or arg values for `seeds::program` ([#3570](https://github.com/coral-xyz/anchor/pull/3570)).
+- lang: Fix using `data` as an instruction parameter name in `declare_program!` ([#3574](https://github.com/coral-xyz/anchor/pull/3574)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -71,9 +71,10 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
                 #(#args),*
             ) -> #ret_type {
                 let ix = {
+                    let ix = internal::args::#arg_value;
                     let mut data = Vec::with_capacity(256);
                     data.extend_from_slice(&#discriminator);
-                    AnchorSerialize::serialize(&internal::args::#arg_value, &mut data)
+                    AnchorSerialize::serialize(&ix, &mut data)
                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotSerialize)?;
 
                     let accounts = ctx.to_account_metas(None);

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -45,6 +45,31 @@
       "args": []
     },
     {
+      "name": "test_compilation_data_as_parameter_name",
+      "discriminator": [
+        225,
+        145,
+        68,
+        92,
+        146,
+        206,
+        248,
+        206
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
       "name": "test_compilation_defined_type_param",
       "discriminator": [
         61,

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables)]
+
 use anchor_lang::prelude::*;
 
 declare_id!("Externa111111111111111111111111111111111111");
@@ -44,6 +46,14 @@ pub mod external {
     // Compilation test for whether a custom return type can be specified in `cpi` client
     pub fn test_compilation_return_type(_ctx: Context<TestCompilation>) -> Result<bool> {
         Ok(true)
+    }
+
+    // Compilation test for whether `data` can be used as an instruction parameter name
+    pub fn test_compilation_data_as_parameter_name(
+        _ctx: Context<TestCompilation>,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        Ok(())
     }
 
     // Compilation test for an instruction with no accounts


### PR DESCRIPTION
### Problem

Having an instruction parameter named `data` results in a compilation error when used with `declare_program!` 

```
error[E0382]: borrow of moved value: `data`
 --> programs/declare-program/src/lib.rs:5:1
  |
5 | declare_program!(external);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | |
  | value borrowed here after move
  | move occurs because `data` has type `Vec<u8>`, which does not implement the `Copy` trait
  |
  = note: this error originates in the macro `declare_program` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This happens because that identifier is being used internally here:

https://github.com/coral-xyz/anchor/blob/b6b4f11a5c4b36e73dd13f9da1289af5ab242e95/lang/attribute/program/src/declare_program/mods/cpi.rs#L74

### Summary of changes

- Fix being unable to use `data` as an instruction parameter name in `declare_program!`
- Add a compilation test

Fixes https://github.com/coral-xyz/anchor/issues/3572