### PR TITLE
Fix `clippy 1.85.0`

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -456,7 +456,7 @@ pub fn zero_copy(
         Some(_attr) => quote! {},
         None => {
             if is_unsafe {
-                quote! {#[repr(packed)]}
+                quote! {#[repr(Rust, packed)]}
             } else {
                 quote! {#[repr(C)]}
             }

--- a/lang/tests/generics_test.rs
+++ b/lang/tests/generics_test.rs
@@ -28,6 +28,7 @@ where
 }
 
 #[account(zero_copy(unsafe))]
+#[repr(C)]
 pub struct FooAccount<const N: usize> {
     pub data: WrappedU8Array<N>,
 }

--- a/lang/tests/generics_test.rs
+++ b/lang/tests/generics_test.rs
@@ -28,7 +28,6 @@ where
 }
 
 #[account(zero_copy(unsafe))]
-#[repr(C)]
 pub struct FooAccount<const N: usize> {
     pub data: WrappedU8Array<N>,
 }


### PR DESCRIPTION
### Problem

[CI](https://github.com/coral-xyz/anchor/actions/runs/13607312706/job/38040299657#step:8:539) tests fail due to the new `clippy` lints coming from the latest stable Rust release (v1.85.0).

### Summary of changes

Fix `clippy::repr_packed_without_abi`.