### PR TITLE
lang: Replace hardcoded discriminators with `Discriminator::DISCRIMINATOR`

### DIFF
--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -2,7 +2,7 @@ use anchor_lang_idl::types::Idl;
 use heck::CamelCase;
 use quote::{format_ident, quote};
 
-use super::common::{convert_idl_type_to_syn_type, gen_accounts_common, gen_discriminator};
+use super::common::{convert_idl_type_to_syn_type, gen_accounts_common};
 
 pub fn gen_cpi_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let cpi_instructions = gen_cpi_instructions(idl);
@@ -48,7 +48,6 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
                 }
             }
         };
-
 
         let (ret_type, ret_value) = match ix.returns.as_ref() {
             Some(ty) => {

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -49,7 +49,6 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
             }
         };
 
-        let discriminator = gen_discriminator(&ix.discriminator);
 
         let (ret_type, ret_value) = match ix.returns.as_ref() {
             Some(ty) => {
@@ -73,7 +72,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
                 let ix = {
                     let ix = internal::args::#arg_value;
                     let mut data = Vec::with_capacity(256);
-                    data.extend_from_slice(&#discriminator);
+                    data.extend_from_slice(internal::args::#accounts_ident::DISCRIMINATOR);
                     AnchorSerialize::serialize(&ix, &mut data)
                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotSerialize)?;
 

--- a/lang/attribute/program/src/declare_program/mods/events.rs
+++ b/lang/attribute/program/src/declare_program/mods/events.rs
@@ -21,7 +21,7 @@ pub fn gen_events_mod(idl: &Idl) -> proc_macro2::TokenStream {
             impl anchor_lang::Event for #name {
                 fn data(&self) -> Vec<u8> {
                     let mut data = Vec::with_capacity(256);
-                    data.extend_from_slice(&#discriminator);
+                    data.extend_from_slice(#name::DISCRIMINATOR);
                     self.serialize(&mut data).unwrap();
                     data
                 }


### PR DESCRIPTION
### Problem

There are some places where we're using hardcoded discriminators instead of the associated [`Discriminator::DISCRIMINATOR`](https://github.com/coral-xyz/anchor/blob/c869e11a83173355123c4109d3f37add1b3bd69d/lang/src/lib.rs#L324) constant in codegen.

For example the following section:

https://github.com/coral-xyz/anchor/blob/c869e11a83173355123c4109d3f37add1b3bd69d/lang/attribute/program/src/declare_program/mods/cpi.rs#L76

expands to something like:

```rs
data.extend_from_slice(&[142u8, 128u8, 47u8, 77u8, 15u8, 152u8, 240u8, 42u8]);
```

when we could just use the associated constant to make it simpler and less error-prone:

```rs
data.extend_from_slice(MyInstruction::DISCRIMINATOR);
```

### Summary of changes

Replace hardcoded discriminators in `declare_program!` with `Discriminator::DISCRIMINATOR`.