### PR TITLE
cli: Use camelCase for program name in `anchor.workspace` templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix instructions with no accounts causing compilation errors when using `declare_program!` ([#3567](https://github.com/coral-xyz/anchor/pull/3567)).
 - idl: Fix using account or arg values for `seeds::program` ([#3570](https://github.com/coral-xyz/anchor/pull/3570)).
 - lang: Fix using `data` as an instruction parameter name in `declare_program!` ([#3574](https://github.com/coral-xyz/anchor/pull/3574)).
+- cli: Use camelCase for program name in `anchor.workspace` templates ([#3581](https://github.com/coral-xyz/anchor/pull/3581)).
 
 ### Breaking
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -348,7 +348,7 @@ describe("{}", () => {{
 }});
 "#,
         name,
-        name.to_pascal_case(),
+        name.to_lower_camel_case(),
     )
 }
 
@@ -369,7 +369,7 @@ describe("{}", () => {{
 }});
 "#,
         name,
-        name.to_pascal_case(),
+        name.to_lower_camel_case(),
     )
 }
 
@@ -486,7 +486,7 @@ describe("{}", () => {{
         name.to_pascal_case(),
         name.to_snake_case(),
         name,
-        name.to_pascal_case(),
+        name.to_lower_camel_case(),
         name.to_pascal_case(),
     )
 }
@@ -513,7 +513,7 @@ describe("{}", () => {{
         name.to_pascal_case(),
         name.to_snake_case(),
         name,
-        name.to_pascal_case(),
+        name.to_lower_camel_case(),
         name.to_pascal_case(),
     )
 }


### PR DESCRIPTION
### Problem

The TS test template code uses PascalCase for `anchor.workspace` property accessors.

Example (from `anchor init program-name`):

```ts
const program = anchor.workspace.ProgramName as Program<ProgramName>;
```

Given camelCase is the case convention in JS/TS for property accessors, and this is pretty much the only place where we use PascalCase when accessing a property in the whole library, it would be better to also use camelCase here to make casing consistent.

### Summary of changes

Use camelCase for program name in `anchor.workspace` templates:

```ts
const program = anchor.workspace.programName as Program<ProgramName>;
```

**Note:** This change only affects the generated templates, and using PascalCase (or pretty much any other case) still works (https://github.com/coral-xyz/anchor/pull/2579).