### PR TITLE
docs: Add shell completions section to installation page

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -788,3 +788,44 @@ validator.
 
 </Step>
 </Steps>
+
+## Shell Completions
+
+Shell completions can be generated for [`bash`](#bash), [`fish`](#fish) and
+[`zsh`](#zsh).
+
+### Bash
+
+```shell title="Terminal"
+mkdir -p $HOME/.local/share/bash-completion/completions
+anchor completions bash > $HOME/.local/share/bash-completion/completions/anchor
+avm completions bash > $HOME/.local/share/bash-completion/completions/avm
+exec bash
+```
+
+### Fish
+
+```shell title="Terminal"
+mkdir -p $HOME/.config/fish/completions
+anchor completions fish > $HOME/.config/fish/completions/anchor.fish
+avm completions fish > $HOME/.config/fish/completions/avm.fish
+source $HOME/.config/fish/config.fish
+```
+
+### Zsh
+
+First ensure the following is in your `.zshrc` file. If using `oh-my-zsh` this
+step can be skipped.
+
+```shell title="Terminal"
+autoload -U compinit
+compinit -i
+```
+
+Next run:
+
+```shell title="Terminal"
+anchor completions zsh | sudo tee /usr/local/share/zsh/site-functions/_anchor
+avm completions zsh | sudo tee /usr/local/share/zsh/site-functions/_avm
+exec zsh
+```

--- a/docs/content/docs/updates/release-notes/0-31-0.mdx
+++ b/docs/content/docs/updates/release-notes/0-31-0.mdx
@@ -149,7 +149,7 @@ the `idl fetch` command, which does not convert legacy IDLs.
 ### Shell completions
 
 You can now generate shell completions, see
-[Generating Shell Completions](/docs/installation#generating-shell-completions).
+[Shell Completions](/docs/installation#shell-completions).
 
 ## Lang
 


### PR DESCRIPTION
### Problem

v0.31.0 supports shell completions (https://github.com/coral-xyz/anchor/pull/3251) and the old docs had a section about how to generate them, but that section got lost during the new docs migration (https://github.com/coral-xyz/anchor/pull/3493).

We also have [Shell completions](https://www.anchor-lang.com/docs/updates/release-notes/0-31-0#shell-completions) section in the latest release notes, but it has [a broken link](https://www.anchor-lang.com/docs/installation#generating-shell-completions).

### Summary of changes

Add shell completions section to the installation page.

Closes https://github.com/coral-xyz/anchor/issues/3536