### PR TITLE
docs: Add package manager documentation

### DIFF
--- a/docs/content/docs/references/anchor-toml.mdx
+++ b/docs/content/docs/references/anchor-toml.mdx
@@ -219,5 +219,6 @@ Override toolchain data in the workspace similar to
 ```toml
 [toolchain]
 anchor_version = "0.31.0"    # `anchor-cli` version to use(requires `avm`)
-solana_version = "2.1.0"    # Solana version to use(applies to all Solana tools)
+solana_version = "2.1.0"     # Solana version to use(applies to all Solana tools)
+package_manager = "yarn"     # JS package manager to use
 ```

--- a/docs/content/docs/updates/release-notes/0-31-0.mdx
+++ b/docs/content/docs/updates/release-notes/0-31-0.mdx
@@ -146,6 +146,27 @@ various commands do this conversion automatically, meaning you'll be able to
 work with both specs without having to switch versions. The only exception is
 the `idl fetch` command, which does not convert legacy IDLs.
 
+### Package manager
+
+Anchor has been using `yarn` as the default JS package manager, but some people
+want to use other package managers. Changing the package manager to use wasn't
+easy, as certain commands required `yarn` to be installed to function properly.
+This is no longer the case, and you can simply specify the package manager to
+use from `Anchor.toml`:
+
+```toml
+[toolchain]
+package_manager = "npm"
+```
+
+or when creating a new workspace:
+
+```
+anchor init <NAME> --package-manager npm
+```
+
+Supported values: `npm`, `yarn`, `pnpm` (default: `yarn`)
+
 ### Shell completions
 
 You can now generate shell completions, see


### PR DESCRIPTION
### Problem

Both the CLI and `Anchor.toml` supports customizing package manager in v0.31, but it's not documented.

### Summary of changes

- Add `toolchain.package_manager` field documentation in `Anchor.toml`
- Add package manager section to v0.31.0 release notes

Closes https://github.com/coral-xyz/anchor/issues/3600