### PR TITLE
lang: Fix `bytemuck_derive` build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "bincode",
  "borsh 0.10.3",
  "bytemuck",
+ "bytemuck_derive",
  "solana-program",
  "thiserror",
 ]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -58,3 +58,8 @@ borsh = "0.10.3"
 bytemuck = "1"
 solana-program = "2"
 thiserror = "1"
+
+# v1.9 specifies `rust-version = "1.84"`, which causes compatibility issues with Solana build
+# tools' Rust version (1.79.0 at the time of writing this comment).
+# TODO: Remove when the Solana version we use comes with Rust version >= 1.84
+bytemuck_derive = ">1.0.0, <1.9"


### PR DESCRIPTION
### Problem

`anchor-lang` doesn't compile due to an update to the [`bytemuck_derive` crate](https://crates.io/crates/bytemuck_derive).

```
error: rustc 1.79.0-dev is not supported by the following package:

                 Note that this is the rustc version that ships with Solana tools and not your system's rustc version. Use `solana-install update` or head over to https://docs.solanalabs.com/cli/install to install a newer version.
  bytemuck_derive@1.9.2 requires rustc 1.84
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.79.0-dev
```

As the error message suggests, the latest version of the `bytemuck_derive` crate [specifies MSRV as 1.84](https://github.com/Lokathor/bytemuck/blob/66569e6cc7b3c7a7edadeb80219aa23386ed7554/derive/Cargo.toml#L12C1-L12C22), which is incompatible with the Rust version coming from the latest Solana version (1.79.0).

This is one of the issues with Rust's dependency management where even though `anchor-lang` only depends on `bytemuck`, and doesn't have its `derive` feature enabled, `cargo` refuses to build even when `bytemuck_derive` is an optional dependency that isn't enabled.

In stable Rust 1.84, `cargo` supports trying to fallback to a supported version instead of returning an error, which should fix many issues similar to this one. See:

- [Rust 1.84.0 release notes](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html#cargo-considers-rust-versions-for-dependency-version-selection)
- https://rust-lang.github.io/rfcs/3537-msrv-resolver.html
- https://github.com/rust-lang/rfcs/pull/3537
- https://github.com/rust-lang/cargo/issues/9930

### Summary of changes

Add `bytemuck_derive` version requirement to be `>1.0.0, <1.9`.

This is a short term fix that will be removed once Solana build tools are on Rust >=1.84 (currently 1.79.0).

Fixes https://github.com/coral-xyz/anchor/issues/3606