### PR TITLE
Make `Provider` require publicKey instead of wallet in accounts resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 ### Fixes
+ - client: Make `Provider` require publicKey instead of wallet in accounts resolver ([#3613](https://github.com/coral-xyz/anchor/pull/3613))
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 ## [Unreleased]
 
 ### Features
+ - ts: Make `Provider` require publicKey instead of wallet in accounts resolver ([#3613](https://github.com/coral-xyz/anchor/pull/3613))
 
 ### Fixes
- - client: Make `Provider` require publicKey instead of wallet in accounts resolver ([#3613](https://github.com/coral-xyz/anchor/pull/3613))
 
 ### Breaking
 

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -81,7 +81,7 @@ export class AccountsResolver<IDL extends Idl> {
     let depth = 0;
     while (
       (await this.resolvePdasAndRelations(this._idlIx.accounts)) +
-      (await this.resolveCustom()) >
+        (await this.resolveCustom()) >
       0
     ) {
       depth++;
@@ -334,7 +334,7 @@ export class AccountsResolver<IDL extends Idl> {
 
               this.set([...path, name], pubkey);
             }
-          } catch { }
+          } catch {}
 
           try {
             if (account.relations) {
@@ -346,7 +346,7 @@ export class AccountsResolver<IDL extends Idl> {
                 this.set([...path, name], account[name]);
               }
             }
-          } catch { }
+          } catch {}
         }
       }
     }

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -81,7 +81,7 @@ export class AccountsResolver<IDL extends Idl> {
     let depth = 0;
     while (
       (await this.resolvePdasAndRelations(this._idlIx.accounts)) +
-        (await this.resolveCustom()) >
+      (await this.resolveCustom()) >
       0
     ) {
       depth++;
@@ -279,12 +279,12 @@ export class AccountsResolver<IDL extends Idl> {
         if ((account.signer || account.address) && !this.get([...path, name])) {
           // Default signers to the provider
           if (account.signer) {
-            if (!this._provider.wallet) {
+            if (!this._provider.publicKey) {
               throw new Error(
-                "This function requires the `Provider` interface implementor to have a `wallet` field."
+                "This function requires the `Provider` interface implementor to have a `publicKey` field."
               );
             }
-            this.set([...path, name], this._provider.wallet.publicKey);
+            this.set([...path, name], this._provider.publicKey);
           }
 
           // Set based on `address` field
@@ -334,7 +334,7 @@ export class AccountsResolver<IDL extends Idl> {
 
               this.set([...path, name], pubkey);
             }
-          } catch {}
+          } catch { }
 
           try {
             if (account.relations) {
@@ -346,7 +346,7 @@ export class AccountsResolver<IDL extends Idl> {
                 this.set([...path, name], account[name]);
               }
             }
-          } catch {}
+          } catch { }
         }
       }
     }


### PR DESCRIPTION
Fixes #3584

`ts/packages/anchor/src/program/accounts-resolver.ts` enforces a `Provider` with a wallet but wallet is necessary for `AnchorProvider` and not necessarily for other custom provider.

This PR Removes this enforcement and only checks enforcement that `Provider`'s public key is set which matches with all other requirements.

This allows a user to implement their own custom Provider which doesn't necessarily keep a `Wallet` inside it (and thus no private key) and allows custom logic for signing and sending transactions. 