### PR TITLE
Replace `backpackapp/build` Docker image with `solanafoundation/anchor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- cli, docker: Replace `backpackapp/build` Docker image with `solanafoundation/anchor` ([#3619](https://github.com/coral-xyz/anchor/pull/3619)).
+
 ### Breaking
 
 ## [0.31.0] - 2025-03-08

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -504,7 +504,7 @@ impl Config {
             .anchor_version
             .as_deref()
             .unwrap_or(crate::DOCKER_BUILDER_VERSION);
-        format!("backpackapp/build:v{version}")
+        format!("solanafoundation/anchor:v{version}")
     }
 
     pub fn discover(cfg_override: &ConfigOverride) -> Result<Option<WithPath<Config>>> {

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,17 +1,9 @@
-WORKDIR=$(PWD)
-#
 # Anchor version.
-#
 ANCHOR_CLI=v0.31.0
-#
 # Solana toolchain.
-#
 SOLANA_CLI=v2.1.0
-#
 # Build version should match the Anchor cli version.
-#
-IMG_ORG ?= backpackapp
-IMG_VER ?= $(ANCHOR_CLI)
+VERSIONED_IMG_NAME=solanafoundation/anchor:$(ANCHOR_CLI)
 
 .PHONY: build build-push build-shell publish
 
@@ -21,14 +13,14 @@ build: build/Dockerfile
 	@docker build \
 	--build-arg ANCHOR_CLI=$(ANCHOR_CLI) \
 	--build-arg SOLANA_CLI=$(SOLANA_CLI) \
-	$@ -t $(IMG_ORG)/$@:$(IMG_VER)
+	$@ -t $(VERSIONED_IMG_NAME)
 
 build-push:
-	@docker push $(IMG_ORG)/build:$(IMG_VER)
+	@docker push $(VERSIONED_IMG_NAME)
 
 build-shell:
 	@docker run -ti --rm --net=host \
 		-v $(WORKDIR)/..:/workdir \
-		$(IMG_ORG)/build:$(IMG_VER) bash
+		$(VERSIONED_IMG_NAME) bash
 
 publish: build build-push

--- a/docs/content/docs/references/verifiable-builds.mdx
+++ b/docs/content/docs/references/verifiable-builds.mdx
@@ -37,12 +37,12 @@ If the program has an IDL, it will also check the IDL deployed on chain matches.
 ## Images
 
 A docker image for each version of Anchor is published on
-[Docker Hub](https://hub.docker.com/r/backpackapp/build). They are tagged in the
-form `backpackapp/build:<version>`. For example, to get the image for Anchor
-`v0.31.0` one can run
+[Docker Hub](https://hub.docker.com/r/solanafoundation/anchor). They are tagged
+in the form `solanafoundation/anchor:<version>`. For example, to get the image
+for Anchor `v0.31.0` one can run
 
 ```shell
-docker pull backpackapp/build:v0.31.0
+docker pull solanafoundation/anchor:v0.31.0
 ```
 
 ## Removing an Image


### PR DESCRIPTION
### Problem

[`backpackapp/build`](https://hub.docker.com/r/backpackapp/build) image doesn't have the v0.31.0 tag (https://github.com/coral-xyz/anchor/issues/3585), as we are unable to update the image.

### Summary of changes

Replace `backpackapp/build` Docker image with `solanafoundation/anchor` in CLI, Docker Makefile and docs.

**Note:** The new Docker image will start from v0.31.1 since v0.31.0 is broken due to an MSRV-related issue (https://github.com/coral-xyz/anchor/issues/3606). This means the Docker example in docs will be broken until v0.31.0 is out, but this is not as bad as it sounds because the current example is already broken due to `backpackapp/build:v0.31.0` being non-existent.