### PR TITLE
lang: Remove `bytemuck_derive` version requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,6 @@ dependencies = [
  "bincode",
  "borsh 0.10.3",
  "bytemuck",
- "bytemuck_derive",
  "solana-program",
  "thiserror",
 ]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -58,8 +58,3 @@ borsh = "0.10.3"
 bytemuck = "1"
 solana-program = "2"
 thiserror = "1"
-
-# v1.9 specifies `rust-version = "1.84"`, which causes compatibility issues with Solana build
-# tools' Rust version (1.79.0 at the time of writing this comment).
-# TODO: Remove when the Solana version we use comes with Rust version >= 1.84
-bytemuck_derive = ">1.0.0, <1.9"


### PR DESCRIPTION
### Problem

We added version requirement for the `bytemuck_derive` crate (https://github.com/solana-foundation/anchor/pull/3610) in order to fix some compatibility issues (https://github.com/coral-xyz/anchor/issues/3606).

However, the latest version of the `bytemuck_derive` crate changed `rust-version` to `1.61` (from `1.84`), meaning we no longer need to have additional version requirements for the `bytemuck_derive` crate.

### Summary of changes

Remove the `bytemuck_derive` version requirement.