### PR TITLE
docs: Fix broken links in v0.31.0 release notes

### DIFF
--- a/docs/content/docs/updates/release-notes/0-31-0.mdx
+++ b/docs/content/docs/updates/release-notes/0-31-0.mdx
@@ -115,8 +115,8 @@ now builds the IDL with `my-feature` enabled.
 If you make a change to your program, but the API of the program stays the same,
 building the IDL is pointless and takes additional time.
 
-Similar to [`--no-idl` flag on builds](./0.30.0#no-idl-flag-on-builds), now you
-can use:
+Similar to [`--no-idl` flag on builds](./0-30-0#--no-idl-flag-on-builds), now
+you can use:
 
 ```
 anchor test --no-idl
@@ -282,7 +282,7 @@ means you can't have any other discriminators that start with `1`, e.g.
 `[1, 2 , 3, 4]`, as it would not be unique.
 
 This change also enables using non-Anchor programs with both Rust (via
-[`declare_program!`](./0.30.0#dependency-free-program-declaration)) and in the
+[`declare_program!`](./0-30-0#dependency-free-program-declaration)) and in the
 TS client.
 
 ### `Discriminator` trait


### PR DESCRIPTION
### Problem

A couple of links that refer to older release notes are currently broken due to the new docs migration (https://github.com/solana-foundation/anchor/pull/3493).

The old docs used normal semantic versioning for release note file names e.g. for `0.30.0.md`, but the new docs use version with dashes e.g. `0-30-0.mdx`. This means all links that don't use the file name with dashes no longer works e.g.

https://github.com/solana-foundation/anchor/blob/12508d4858a1a500484414bdc8ab6788d196ac50/docs/content/docs/updates/release-notes/0-31-0.mdx#L118

### Summary of changes

Fix broken links in v0.31.0 release notes.