### PR TITLE
Fix `clippy 1.86.0`

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -251,7 +251,7 @@ pub fn install_version(
         let target = core::str::from_utf8(&output.stdout)?
             .lines()
             .find(|line| line.starts_with("host:"))
-            .and_then(|line| line.split(':').last())
+            .and_then(|line| line.split(':').next_back())
             .ok_or_else(|| anyhow!("`host` not found from `rustc -vV` output"))?
             .trim();
         let ext = if cfg!(target_os = "windows") {

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -23,7 +23,7 @@ use std::ops::DerefMut;
 /// for example, the [`Account`](crate::accounts::account::Account). Namely,
 /// one must call
 /// - `load_init` after initializing an account (this will ignore the missing
-///    account discriminator that gets added only after the user's instruction code)
+///   account discriminator that gets added only after the user's instruction code)
 /// - `load` when the account is not mutable
 /// - `load_mut` when the account is mutable
 ///

--- a/lang/src/accounts/interface.rs
+++ b/lang/src/accounts/interface.rs
@@ -59,9 +59,9 @@ use std::ops::Deref;
 /// The required constraints are as follows:
 ///
 /// - `program` is the account of the program itself.
-///    Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
-///    Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
-///    will be `None` if it's not).
+///   Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
+///   Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
+///   will be `None` if it's not).
 /// - `program_data`'s constraint checks that its upgrade authority is the `authority` account.
 /// - Finally, `authority` needs to sign the transaction.
 ///

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -59,9 +59,9 @@ use std::ops::Deref;
 /// The required constraints are as follows:
 ///
 /// - `program` is the account of the program itself.
-///    Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
-///    Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
-///    will be `None` if it's not).
+///   Its constraint checks that `program_data` is the account that contains the program's upgrade authority.
+///   Implicitly, this checks that `program` is a BPFUpgradeable program (`program.programdata_address()?`
+///   will be `None` if it's not).
 /// - `program_data`'s constraint checks that its upgrade authority is the `authority` account.
 /// - Finally, `authority` needs to sign the transaction.
 ///

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -129,7 +129,9 @@ pub fn parse_return(method: &syn::ItemFn) -> ParseResult<IxReturn> {
             // Assume unit return by default
             let default_generic_arg = syn::GenericArgument::Type(syn::parse_str("()").unwrap());
             let generic_args = match &ty.path.segments.last().unwrap().arguments {
-                syn::PathArguments::AngleBracketed(params) => params.args.iter().last().unwrap(),
+                syn::PathArguments::AngleBracketed(params) => {
+                    params.args.iter().next_back().unwrap()
+                }
                 _ => &default_generic_arg,
             };
             let ty = match generic_args {


### PR DESCRIPTION
### Problem

[CI is red](https://github.com/solana-foundation/anchor/actions/runs/14366711110/job/40281293790) due to the new `clippy` lints (Rust v1.86.0).

### Summary of changes

- Fix [`clippy::double-ended-iterator-last`](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last)
- Fix [`clippy::doc-overindented-list-items`](https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items)