### PR TITLE
Fix incorrect space recommendation description in docs

### DIFF
--- a/docs/content/docs/references/space.mdx
+++ b/docs/content/docs/references/space.mdx
@@ -25,8 +25,8 @@ In addition to the space for the account data, you have to add `8` to the
 | u128/i128  | 16                            |
 | [T;amount] | space(T) \* amount            | e.g. space([u16;32]) = 2 \* 32 = 64                                                             |
 | Pubkey     | 32                            |
-| Vec\<T>    | 4 + (space(T) \* amount)      | Account size is fixed so account should be initialized with sufficient space from the beginning |
-| String     | 4 + length of string in bytes | Account size is fixed so account should be initialized with sufficient space from the beginning |
+| Vec\<T>    | 4 + (space(T) \* amount)      |
+| String     | 4 + length of string in bytes |
 | Option\<T> | 1 + (space(T))                |
 | Enum       | 1 \+ Largest Variant Size     | e.g. Enum \{ A, B \{ val: u8 \}, C \{ val: u16 \} \} \-\> 1 \+ space(u16) = 3                   |
 | f32        | 4                             | serialization will fail for NaN                                                                 |


### PR DESCRIPTION
It's prob still good to recommend allocing enough space at the beginning, but we shouldn't explicitly say it's not possible, since account size hasn't been fixed for a while now, as you can realloc size. 