### PR TITLE
fix: Update `proc-macro2` usage for latest nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- idl: Update `proc-macro2` usage for latest nightly ([#3663](https://github.com/solana-foundation/anchor/pull/3663))
 - cli, docker: Replace `backpackapp/build` Docker image with `solanafoundation/anchor` ([#3619](https://github.com/coral-xyz/anchor/pull/3619)).
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -495,13 +495,16 @@ pub fn gen_idl_type(
                 use super::{common::find_path, external::get_external_type};
                 use crate::parser::context::CrateContext;
                 use quote::ToTokens;
+
                 if let Some(source_path) = proc_macro2::Span::call_site().local_file() {
-                    if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
+                    if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse)
+                    {
                         let name = path.path.segments.last().unwrap().ident.to_string();
                         let alias = ctx.type_aliases().find(|ty| ty.ident == name);
                         if let Some(alias) = alias {
                             if let Some(segment) = path.path.segments.last() {
-                                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+                                {
                                     let inners = args
                                         .args
                                         .iter()
@@ -511,7 +514,9 @@ pub fn gen_idl_type(
                                                     inner_ty.path.to_token_stream().to_string()
                                                 }
                                                 _ => {
-                                                    unimplemented!("Inner type not implemented: {ty:?}")
+                                                    unimplemented!(
+                                                        "Inner type not implemented: {ty:?}"
+                                                    )
                                                 }
                                             },
                                             syn::GenericArgument::Const(c) => {
@@ -522,7 +527,9 @@ pub fn gen_idl_type(
                                         .collect::<Vec<_>>();
 
                                     let outer = match &*alias.ty {
-                                        syn::Type::Path(outer_ty) => outer_ty.path.to_token_stream(),
+                                        syn::Type::Path(outer_ty) => {
+                                            outer_ty.path.to_token_stream()
+                                        }
                                         syn::Type::Array(outer_ty) => outer_ty.to_token_stream(),
                                         _ => unimplemented!("Type not implemented: {:?}", alias.ty),
                                     }
@@ -533,8 +540,12 @@ pub fn gen_idl_type(
                                         .params
                                         .iter()
                                         .map(|param| match param {
-                                            syn::GenericParam::Const(param) => param.ident.to_string(),
-                                            syn::GenericParam::Type(param) => param.ident.to_string(),
+                                            syn::GenericParam::Const(param) => {
+                                                param.ident.to_string()
+                                            }
+                                            syn::GenericParam::Type(param) => {
+                                                param.ident.to_string()
+                                            }
                                             _ => panic!("Lifetime parameters are not allowed"),
                                         })
                                         .enumerate()

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -498,7 +498,8 @@ pub fn gen_idl_type(
 
                 let source_path = match proc_macro2::Span::call_site().local_file() {
                     Some(source_path) => source_path,
-                    None => return Err(anyhow!("No source path found")),
+                    // If no path was found, just return an empty path and let the find_path function handle it
+                    None => std::path::PathBuf::new(),
                 };
 
                 if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -496,7 +496,7 @@ pub fn gen_idl_type(
                 use crate::parser::context::CrateContext;
                 use quote::ToTokens;
 
-                let source_path = proc_macro2::Span::call_site().source_file().path();
+                let source_path = proc_macro2::Span::call_site().file();
                 if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
                     let name = path.path.segments.last().unwrap().ident.to_string();
                     let alias = ctx.type_aliases().find(|ty| ty.ident == name);

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -497,8 +497,10 @@ pub fn gen_idl_type(
                 use quote::ToTokens;
 
                 // If no path was found, just return an empty path and let the find_path function handle it
-                let source_path = proc_macro2::Span::call_site().local_file().unwrap_or(std::path::PathBuf::new());
-    
+                let source_path = proc_macro2::Span::call_site()
+                    .local_file()
+                    .unwrap_or_default();
+
                 if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
                     let name = path.path.segments.last().unwrap().ident.to_string();
                     let alias = ctx.type_aliases().find(|ty| ty.ident == name);

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -496,12 +496,9 @@ pub fn gen_idl_type(
                 use crate::parser::context::CrateContext;
                 use quote::ToTokens;
 
-                let source_path = match proc_macro2::Span::call_site().local_file() {
-                    Some(source_path) => source_path,
-                    // If no path was found, just return an empty path and let the find_path function handle it
-                    None => std::path::PathBuf::new(),
-                };
-
+                // If no path was found, just return an empty path and let the find_path function handle it
+                let source_path = proc_macro2::Span::call_site().local_file().unwrap_or(std::path::PathBuf::new());
+    
                 if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
                     let name = path.path.segments.last().unwrap().ident.to_string();
                     let alias = ctx.type_aliases().find(|ty| ty.ident == name);

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -496,90 +496,83 @@ pub fn gen_idl_type(
                 use crate::parser::context::CrateContext;
                 use quote::ToTokens;
 
-                if let Some(source_path) = proc_macro2::Span::call_site().local_file() {
-                    if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse)
-                    {
-                        let name = path.path.segments.last().unwrap().ident.to_string();
-                        let alias = ctx.type_aliases().find(|ty| ty.ident == name);
-                        if let Some(alias) = alias {
-                            if let Some(segment) = path.path.segments.last() {
-                                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-                                {
-                                    let inners = args
-                                        .args
-                                        .iter()
-                                        .map(|arg| match arg {
-                                            syn::GenericArgument::Type(ty) => match ty {
-                                                syn::Type::Path(inner_ty) => {
-                                                    inner_ty.path.to_token_stream().to_string()
-                                                }
-                                                _ => {
-                                                    unimplemented!(
-                                                        "Inner type not implemented: {ty:?}"
-                                                    )
-                                                }
-                                            },
-                                            syn::GenericArgument::Const(c) => {
-                                                c.to_token_stream().to_string()
-                                            }
-                                            _ => unimplemented!("Arg not implemented: {arg:?}"),
-                                        })
-                                        .collect::<Vec<_>>();
+                let source_path = match proc_macro2::Span::call_site().local_file() {
+                    Some(source_path) => source_path,
+                    None => return Err(anyhow!("No source path found")),
+                };
 
-                                    let outer = match &*alias.ty {
-                                        syn::Type::Path(outer_ty) => {
-                                            outer_ty.path.to_token_stream()
+                if let Ok(Ok(ctx)) = find_path("lib.rs", &source_path).map(CrateContext::parse) {
+                    let name = path.path.segments.last().unwrap().ident.to_string();
+                    let alias = ctx.type_aliases().find(|ty| ty.ident == name);
+                    if let Some(alias) = alias {
+                        if let Some(segment) = path.path.segments.last() {
+                            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                                let inners = args
+                                    .args
+                                    .iter()
+                                    .map(|arg| match arg {
+                                        syn::GenericArgument::Type(ty) => match ty {
+                                            syn::Type::Path(inner_ty) => {
+                                                inner_ty.path.to_token_stream().to_string()
+                                            }
+                                            _ => {
+                                                unimplemented!("Inner type not implemented: {ty:?}")
+                                            }
+                                        },
+                                        syn::GenericArgument::Const(c) => {
+                                            c.to_token_stream().to_string()
                                         }
-                                        syn::Type::Array(outer_ty) => outer_ty.to_token_stream(),
-                                        _ => unimplemented!("Type not implemented: {:?}", alias.ty),
-                                    }
-                                    .to_string();
+                                        _ => unimplemented!("Arg not implemented: {arg:?}"),
+                                    })
+                                    .collect::<Vec<_>>();
 
-                                    let resolved_alias = alias
-                                        .generics
-                                        .params
-                                        .iter()
-                                        .map(|param| match param {
-                                            syn::GenericParam::Const(param) => {
-                                                param.ident.to_string()
-                                            }
-                                            syn::GenericParam::Type(param) => {
-                                                param.ident.to_string()
-                                            }
-                                            _ => panic!("Lifetime parameters are not allowed"),
-                                        })
-                                        .enumerate()
-                                        .fold(outer, |acc, (i, cur)| {
-                                            let inner = &inners[i];
-                                            // The spacing of the `outer` variable can differ between
-                                            // versions, e.g. `[T; N]` and `[T ; N]`
-                                            acc.replace(&format!(" {cur} "), &format!(" {inner} "))
-                                                .replace(&format!(" {cur},"), &format!(" {inner},"))
-                                                .replace(&format!("[{cur} "), &format!("[{inner} "))
-                                                .replace(&format!("[{cur};"), &format!("[{inner};"))
-                                                .replace(&format!(" {cur}]"), &format!(" {inner}]"))
-                                        });
-                                    if let Ok(ty) = syn::parse_str(&resolved_alias) {
-                                        return gen_idl_type(&ty, generic_params);
-                                    }
+                                let outer = match &*alias.ty {
+                                    syn::Type::Path(outer_ty) => outer_ty.path.to_token_stream(),
+                                    syn::Type::Array(outer_ty) => outer_ty.to_token_stream(),
+                                    _ => unimplemented!("Type not implemented: {:?}", alias.ty),
                                 }
-                            };
+                                .to_string();
 
-                            // Non-generic type alias e.g. `type UnixTimestamp = i64`
-                            return gen_idl_type(&*alias.ty, generic_params);
-                        }
-
-                        // Handle external types
-                        let is_external = ctx
-                            .structs()
-                            .map(|s| s.ident.to_string())
-                            .chain(ctx.enums().map(|e| e.ident.to_string()))
-                            .find(|defined| defined == &name)
-                            .is_none();
-                        if is_external {
-                            if let Ok(Some(ty)) = get_external_type(&name, source_path) {
-                                return gen_idl_type(&ty, generic_params);
+                                let resolved_alias = alias
+                                    .generics
+                                    .params
+                                    .iter()
+                                    .map(|param| match param {
+                                        syn::GenericParam::Const(param) => param.ident.to_string(),
+                                        syn::GenericParam::Type(param) => param.ident.to_string(),
+                                        _ => panic!("Lifetime parameters are not allowed"),
+                                    })
+                                    .enumerate()
+                                    .fold(outer, |acc, (i, cur)| {
+                                        let inner = &inners[i];
+                                        // The spacing of the `outer` variable can differ between
+                                        // versions, e.g. `[T; N]` and `[T ; N]`
+                                        acc.replace(&format!(" {cur} "), &format!(" {inner} "))
+                                            .replace(&format!(" {cur},"), &format!(" {inner},"))
+                                            .replace(&format!("[{cur} "), &format!("[{inner} "))
+                                            .replace(&format!("[{cur};"), &format!("[{inner};"))
+                                            .replace(&format!(" {cur}]"), &format!(" {inner}]"))
+                                    });
+                                if let Ok(ty) = syn::parse_str(&resolved_alias) {
+                                    return gen_idl_type(&ty, generic_params);
+                                }
                             }
+                        };
+
+                        // Non-generic type alias e.g. `type UnixTimestamp = i64`
+                        return gen_idl_type(&*alias.ty, generic_params);
+                    }
+
+                    // Handle external types
+                    let is_external = ctx
+                        .structs()
+                        .map(|s| s.ident.to_string())
+                        .chain(ctx.enums().map(|e| e.ident.to_string()))
+                        .find(|defined| defined == &name)
+                        .is_none();
+                    if is_external {
+                        if let Ok(Some(ty)) = get_external_type(&name, source_path) {
+                            return gen_idl_type(&ty, generic_params);
                         }
                     }
                 }


### PR DESCRIPTION
As of nightly-2025-04-16, `SourceFile` and the methods around it [don't exist anymore](https://github.com/rust-lang/rust/pull/139671), so anyone updating rust or installing rust won't be able to compile the idl anymore. `proc-macro2` [already updated](https://github.com/dtolnay/proc-macro2/pull/497), this PR updates anchor accordingly. Note that this will require users to update to the latest nightly (and will break users with an older nightly). Idk if this counts as a breaking change since it only affects nightly...

Fixes https://github.com/solana-foundation/anchor/issues/3662