### PR TITLE
spl: small opt fn set_authority

### DIFF
--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -304,15 +304,10 @@ pub fn set_authority<'info>(
     authority_type: spl_token::instruction::AuthorityType,
     new_authority: Option<Pubkey>,
 ) -> Result<()> {
-    let mut spl_new_authority: Option<&Pubkey> = None;
-    if new_authority.is_some() {
-        spl_new_authority = new_authority.as_ref()
-    }
-
     let ix = spl_token::instruction::set_authority(
         &spl_token::ID,
         ctx.accounts.account_or_mint.key,
-        spl_new_authority,
+        new_authority.as_ref(),
         authority_type,
         ctx.accounts.current_authority.key,
         &[], // TODO: Support multisig signers.

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -341,15 +341,10 @@ pub fn set_authority<'info>(
     authority_type: spl_token_2022::instruction::AuthorityType,
     new_authority: Option<Pubkey>,
 ) -> Result<()> {
-    let mut spl_new_authority: Option<&Pubkey> = None;
-    if new_authority.is_some() {
-        spl_new_authority = new_authority.as_ref()
-    }
-
     let ix = spl_token_2022::instruction::set_authority(
         ctx.program.key,
         ctx.accounts.account_or_mint.key,
-        spl_new_authority,
+        new_authority.as_ref(),
         authority_type,
         ctx.accounts.current_authority.key,
         &[], // TODO: Support multisig signers.


### PR DESCRIPTION
Rust’s Option type already supports as_ref for converting Option<Pubkey> to Option<&Pubkey>

```rust
   pub const fn as_ref(&self) -> Option<&T> {
        match *self {
            Some(ref x) => Some(x),
            None => None,
        }
    }
```
Add explicit validation of the data length before conversion
```rust
pub const fn [from_le_bytes](https://doc.rust-lang.org/std/primitive.u64.html#method.from_le_bytes)(bytes: [[u8](https://doc.rust-lang.org/std/primitive.u8.html); [8](https://doc.rust-lang.org/std/primitive.array.html)]) -> [u64](https://doc.rust-lang.org/std/primitive.u64.html)
```