### PR TITLE
Support for additional Token22 extensions

### DIFF
--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -203,6 +203,12 @@ pub enum ErrorCode {
     /// 2048 - An interest bearing extension rate authority constraint was violated
     #[msg("An interest bearing extension rate authority constraint was violated")]
     ConstraintMintInterestBearingRateAuthority,
+    /// 2049 - A default account state extension constraint was violated
+    #[msg("A default account state extension constraint was violated")]
+    ConstraintMintDefaultAccountStateExtension,
+    /// 2050 - A default account state extension state constraint was violated
+    #[msg("A default account state extension state constraint was violated")]
+    ConstraintMintDefaultAccountState,
 
     // Require
     /// 2500 - A require expression was violated

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -197,6 +197,12 @@ pub enum ErrorCode {
     /// 2046 - A transfer fee extension withheld authority constraint was violated
     #[msg("A transfer fee extension withheld authority constraint was violated")]
     ConstraintMintTransferFeeWithheldAuthority,
+    /// 2047 - An interest bearing extension constraint was violated
+    #[msg("An interest bearing extension constraint was violated")]
+    ConstraintMintInterestBearingExtension,
+    /// 2048 - An interest bearing extension rate authority constraint was violated
+    #[msg("An interest bearing extension rate authority constraint was violated")]
+    ConstraintMintInterestBearingRateAuthority,
 
     // Require
     /// 2500 - A require expression was violated

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -183,6 +183,11 @@ pub enum ErrorCode {
     /// 2042 - Account must be migrated before exiting
     #[msg("Account must be migrated before exiting")]
     AccountNotMigrated,
+    /// Extension constraints - cont.
+    ///
+    /// 2043 - A non-transferable extension constraint was violated
+    #[msg("A non-transferable extension constraint was violated")]
+    ConstraintMintNonTransferableExtension,
 
     // Require
     /// 2500 - A require expression was violated

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -188,6 +188,15 @@ pub enum ErrorCode {
     /// 2043 - A non-transferable extension constraint was violated
     #[msg("A non-transferable extension constraint was violated")]
     ConstraintMintNonTransferableExtension,
+    /// 2044 - A transfer fee extension constraint was violated
+    #[msg("A transfer fee extension constraint was violated")]
+    ConstraintMintTransferFeeExtension,
+    /// 2045 - A transfer fee extension config authority constraint was violated
+    #[msg("A transfer fee extension config authority constraint was violated")]
+    ConstraintMintTransferFeeConfigAuthority,
+    /// 2046 - A transfer fee extension withheld authority constraint was violated
+    #[msg("A transfer fee extension withheld authority constraint was violated")]
+    ConstraintMintTransferFeeWithheldAuthority,
 
     // Require
     /// 2500 - A require expression was violated

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -62,7 +62,7 @@ pub use {
     anchor_attribute_event::{emit, event},
     anchor_attribute_program::{declare_program, instruction, program},
     anchor_derive_accounts::Accounts,
-    anchor_derive_serde::{__erase, AnchorDeserialize, AnchorSerialize},
+    anchor_derive_serde::{AnchorDeserialize, AnchorSerialize, __erase},
     anchor_derive_space::InitSpace,
     borsh::ser::BorshSerialize as AnchorSerialize,
     const_crypto::ed25519::derive_program_address,

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -769,6 +769,7 @@ fn generate_constraint_init_group(
             permanent_delegate,
             transfer_hook_authority,
             transfer_hook_program_id,
+            non_transferable,
         } => {
             let token_program = match token_program {
                 Some(t) => t.to_token_stream(),
@@ -882,6 +883,10 @@ fn generate_constraint_init_group(
 
             if permanent_delegate.is_some() {
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::PermanentDelegate});
+            }
+
+            if non_transferable.is_some() {
+                extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::NonTransferable});
             }
 
             let mint_space = if extensions.is_empty() {
@@ -1027,6 +1032,12 @@ fn generate_constraint_init_group(
                                             token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #permanent_delegate.unwrap())?;
+                                    },
+                                    ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::NonTransferable => {
+                                        ::anchor_spl::token_interface::non_transferable_mint_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::NonTransferableMintInitialize {
+                                            token_program_id: #token_program.to_account_info(),
+                                            mint: #field.to_account_info(),
+                                        }))?;
                                     },
                                     // All extensions specified by the user should be implemented.
                                     // If this line runs, it means there is a bug in the codegen.
@@ -1588,6 +1599,18 @@ fn generate_constraint_mint(
         None => quote! {},
     };
 
+    let non_transferable_check = match &c.non_transferable {
+        Some(_) => {
+            quote! {
+                let non_transferable = ::anchor_spl::token_interface::get_mint_extension_data::<::anchor_spl::token_interface::spl_token_2022::extension::non_transferable::NonTransferable>(#account_ref);
+                if non_transferable.is_err() {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintNonTransferableExtension.into());
+                }
+            }
+        }
+        None => quote! {},
+    };
+
     quote! {
         {
             #decimal_check
@@ -1604,6 +1627,7 @@ fn generate_constraint_mint(
             #permanent_delegate_check
             #transfer_hook_authority_check
             #transfer_hook_program_id_check
+            #non_transferable_check
         }
     }
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -770,6 +770,10 @@ fn generate_constraint_init_group(
             transfer_hook_authority,
             transfer_hook_program_id,
             non_transferable,
+            transfer_fee_config_authority,
+            transfer_fee_withheld_authority,
+            transfer_fee_basis_points,
+            transfer_fee_max_fee,
         } => {
             let token_program = match token_program {
                 Some(t) => t.to_token_stream(),
@@ -834,6 +838,26 @@ fn generate_constraint_init_group(
                 None => quote! {},
             };
 
+            let transfer_fee_config_authority_check = match transfer_fee_config_authority {
+                Some(tfca) => check_scope.generate_check(tfca),
+                None => quote! {},
+            };
+
+            let transfer_fee_withheld_authority_check = match transfer_fee_withheld_authority {
+                Some(tfwa) => check_scope.generate_check(tfwa),
+                None => quote! {},
+            };
+
+            let transfer_fee_basis_points_check = match transfer_fee_basis_points {
+                Some(tfbp) => check_scope.generate_check(tfbp),
+                None => quote! {},
+            };
+
+            let transfer_fee_max_fee_check = match transfer_fee_max_fee {
+                Some(tfmf) => check_scope.generate_check(tfmf),
+                None => quote! {},
+            };
+
             let system_program_optional_check = check_scope.generate_check(system_program);
             let token_program_optional_check = check_scope.generate_check(&token_program);
             let rent_optional_check = check_scope.generate_check(rent);
@@ -854,6 +878,10 @@ fn generate_constraint_init_group(
                 #transfer_hook_authority_check
                 #transfer_hook_program_id_check
                 #permanent_delegate_check
+                #transfer_fee_config_authority_check
+                #transfer_fee_withheld_authority_check
+                #transfer_fee_basis_points_check
+                #transfer_fee_max_fee_check
             };
 
             let payer_optional_check = check_scope.generate_check(payer);
@@ -887,6 +915,11 @@ fn generate_constraint_init_group(
 
             if non_transferable.is_some() {
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::NonTransferable});
+            }
+
+            if transfer_fee_config_authority.is_some() || transfer_fee_withheld_authority.is_some() ||
+               transfer_fee_basis_points.is_some() || transfer_fee_max_fee.is_some() {
+                extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::TransferFeeConfig});
             }
 
             let mint_space = if extensions.is_empty() {
@@ -958,6 +991,26 @@ fn generate_constraint_init_group(
                     quote! { Option::<anchor_lang::prelude::Pubkey>::Some(#thpid.key()) }
                 }
                 None => quote! { Option::<anchor_lang::prelude::Pubkey>::None },
+            };
+
+            let transfer_fee_config_authority = match transfer_fee_config_authority {
+                Some(tfca) => quote! { Option::<anchor_lang::prelude::Pubkey>::Some(#tfca.key()) },
+                None => quote! { Option::<anchor_lang::prelude::Pubkey>::None },
+            };
+
+            let transfer_fee_withheld_authority = match transfer_fee_withheld_authority {
+                Some(tfwa) => quote! { Option::<anchor_lang::prelude::Pubkey>::Some(#tfwa.key()) },
+                None => quote! { Option::<anchor_lang::prelude::Pubkey>::None },
+            };
+
+            let transfer_fee_basis_points = match transfer_fee_basis_points {
+                Some(tfbp) => quote! { Option::<u16>::Some(#tfbp) },
+                None => quote! { Option::<u16>::None },
+            };
+
+            let transfer_fee_max_fee = match transfer_fee_max_fee {
+                Some(tfmf) => quote! { Option::<u64>::Some(#tfmf) },
+                None => quote! { Option::<u64>::None },
             };
 
             let create_account = generate_create_account(
@@ -1038,6 +1091,17 @@ fn generate_constraint_init_group(
                                             token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }))?;
+                                    },
+                                    ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::TransferFeeConfig => {
+                                        ::anchor_spl::token_interface::transfer_fee_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::TransferFeeInitialize {
+                                            token_program_id: #token_program.to_account_info(),
+                                            mint: #field.to_account_info(),
+                                        }),
+                                        #transfer_fee_config_authority.as_ref(),
+                                        #transfer_fee_withheld_authority.as_ref(),
+                                        #transfer_fee_basis_points.unwrap(),
+                                        #transfer_fee_max_fee.unwrap(),
+                                        )?;
                                     },
                                     // All extensions specified by the user should be implemented.
                                     // If this line runs, it means there is a bug in the codegen.
@@ -1611,6 +1675,43 @@ fn generate_constraint_mint(
         None => quote! {},
     };
 
+    let transfer_fee_config_authority_check = match &c.transfer_fee_config_authority {
+        Some(transfer_fee_config_authority) => {
+            let transfer_fee_config_authority_optional_check =
+                optional_check_scope.generate_check(transfer_fee_config_authority);
+            quote! {
+                let transfer_fee = ::anchor_spl::token_interface::get_mint_extension_data::<::anchor_spl::token_interface::spl_token_2022::extension::transfer_fee::TransferFeeConfig>(#account_ref);
+                if transfer_fee.is_err() {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintTransferFeeExtension.into());
+                }
+                #transfer_fee_config_authority_optional_check
+                if transfer_fee.unwrap().transfer_fee_config_authority != ::anchor_spl::token_2022_extensions::spl_pod::optional_keys::OptionalNonZeroPubkey::try_from(Some(#transfer_fee_config_authority.key()))? {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintTransferFeeConfigAuthority.into());
+                }
+            }
+        }
+        None => quote! {},
+    };
+
+    let transfer_fee_withheld_authority_check = match &c.transfer_fee_withheld_authority {
+        Some(transfer_fee_withheld_authority) => {
+            let transfer_fee_withheld_authority_optional_check =
+                optional_check_scope.generate_check(transfer_fee_withheld_authority);
+            quote! {
+                let transfer_fee = ::anchor_spl::token_interface::get_mint_extension_data::<::anchor_spl::token_interface::spl_token_2022::extension::transfer_fee::TransferFeeConfig>(#account_ref);
+                if transfer_fee.is_err() {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintTransferFeeExtension.into());
+                }
+                #transfer_fee_withheld_authority_optional_check
+                if transfer_fee.unwrap().withdraw_withheld_authority != ::anchor_spl::token_2022_extensions::spl_pod::optional_keys::OptionalNonZeroPubkey::try_from(Some(#transfer_fee_withheld_authority.key()))? {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintTransferFeeWithheldAuthority.into());
+                }
+            }
+        }
+        None => quote! {},
+    };
+
+
     quote! {
         {
             #decimal_check
@@ -1628,6 +1729,8 @@ fn generate_constraint_mint(
             #transfer_hook_authority_check
             #transfer_hook_program_id_check
             #non_transferable_check
+            #transfer_fee_config_authority_check
+            #transfer_fee_withheld_authority_check
         }
     }
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -774,6 +774,8 @@ fn generate_constraint_init_group(
             transfer_fee_withheld_authority,
             transfer_fee_basis_points,
             transfer_fee_max_fee,
+            interest_bearing_authority,
+            interest_bearing_rate,
         } => {
             let token_program = match token_program {
                 Some(t) => t.to_token_stream(),
@@ -858,6 +860,16 @@ fn generate_constraint_init_group(
                 None => quote! {},
             };
 
+            let interest_bearing_authority_check = match interest_bearing_authority {
+                Some(iba) => check_scope.generate_check(iba),
+                None => quote! {},
+            };
+
+            let interest_bearing_rate_check = match interest_bearing_rate {
+                Some(ibr) => check_scope.generate_check(ibr),
+                None => quote! {},
+            };
+
             let system_program_optional_check = check_scope.generate_check(system_program);
             let token_program_optional_check = check_scope.generate_check(&token_program);
             let rent_optional_check = check_scope.generate_check(rent);
@@ -882,6 +894,8 @@ fn generate_constraint_init_group(
                 #transfer_fee_withheld_authority_check
                 #transfer_fee_basis_points_check
                 #transfer_fee_max_fee_check
+                #interest_bearing_authority_check
+                #interest_bearing_rate_check
             };
 
             let payer_optional_check = check_scope.generate_check(payer);
@@ -920,6 +934,10 @@ fn generate_constraint_init_group(
             if transfer_fee_config_authority.is_some() || transfer_fee_withheld_authority.is_some() ||
                transfer_fee_basis_points.is_some() || transfer_fee_max_fee.is_some() {
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::TransferFeeConfig});
+            }
+
+            if interest_bearing_authority.is_some() || interest_bearing_rate.is_some() {
+                extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::InterestBearingConfig});
             }
 
             let mint_space = if extensions.is_empty() {
@@ -1013,6 +1031,16 @@ fn generate_constraint_init_group(
                 None => quote! { Option::<u64>::None },
             };
 
+            let interest_bearing_authority = match interest_bearing_authority {
+                Some(iba) => quote! { Option::<anchor_lang::prelude::Pubkey>::Some(#iba.key()) },
+                None => quote! { Option::<anchor_lang::prelude::Pubkey>::None },
+            };
+
+            let interest_bearing_rate = match interest_bearing_rate {
+                Some(ibr) => quote! { Option::<i16>::Some(#ibr) },
+                None => quote! { Option::<i16>::None },
+            };
+
             let create_account = generate_create_account(
                 field,
                 mint_space,
@@ -1101,6 +1129,15 @@ fn generate_constraint_init_group(
                                         #transfer_fee_withheld_authority.as_ref(),
                                         #transfer_fee_basis_points.unwrap(),
                                         #transfer_fee_max_fee.unwrap(),
+                                        )?;
+                                    },
+                                    ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::InterestBearingConfig => {
+                                        ::anchor_spl::token_interface::interest_bearing_mint_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::InterestBearingMintInitialize {
+                                            token_program_id: #token_program.to_account_info(),
+                                            mint: #field.to_account_info(),
+                                        }),
+                                        #interest_bearing_authority,
+                                        #interest_bearing_rate.unwrap(),
                                         )?;
                                     },
                                     // All extensions specified by the user should be implemented.
@@ -1711,6 +1748,24 @@ fn generate_constraint_mint(
         None => quote! {},
     };
 
+    let interest_bearing_authority_check = match &c.interest_bearing_authority {
+        Some(interest_bearing_authority) => {
+            let interest_bearing_authority_optional_check =
+                optional_check_scope.generate_check(interest_bearing_authority);
+            quote! {
+                let interest_bearing = ::anchor_spl::token_interface::get_mint_extension_data::<::anchor_spl::token_interface::spl_token_2022::extension::interest_bearing_mint::InterestBearingConfig>(#account_ref);
+                if interest_bearing.is_err() {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintInterestBearingExtension.into());
+                }
+                #interest_bearing_authority_optional_check
+                if interest_bearing.unwrap().rate_authority != ::anchor_spl::token_2022_extensions::spl_pod::optional_keys::OptionalNonZeroPubkey::try_from(Some(#interest_bearing_authority.key()))? {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintInterestBearingRateAuthority.into());
+                }
+            }
+        }
+        None => quote! {},
+    };
+
 
     quote! {
         {
@@ -1731,6 +1786,7 @@ fn generate_constraint_mint(
             #non_transferable_check
             #transfer_fee_config_authority_check
             #transfer_fee_withheld_authority_check
+            #interest_bearing_authority_check
         }
     }
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -938,8 +938,11 @@ fn generate_constraint_init_group(
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::NonTransferable});
             }
 
-            if transfer_fee_config_authority.is_some() || transfer_fee_withheld_authority.is_some() ||
-               transfer_fee_basis_points.is_some() || transfer_fee_max_fee.is_some() {
+            if transfer_fee_config_authority.is_some()
+                || transfer_fee_withheld_authority.is_some()
+                || transfer_fee_basis_points.is_some()
+                || transfer_fee_max_fee.is_some()
+            {
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::TransferFeeConfig});
             }
 
@@ -1053,8 +1056,12 @@ fn generate_constraint_init_group(
             };
 
             let default_account_state = match default_account_state {
-                Some(das) => quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::Some(#das) },
-                None => quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::None },
+                Some(das) => {
+                    quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::Some(#das) }
+                }
+                None => {
+                    quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::None }
+                }
             };
 
             let create_account = generate_create_account(
@@ -1805,7 +1812,6 @@ fn generate_constraint_mint(
         }
         None => quote! {},
     };
-
 
     quote! {
         {

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -776,6 +776,7 @@ fn generate_constraint_init_group(
             transfer_fee_max_fee,
             interest_bearing_authority,
             interest_bearing_rate,
+            default_account_state,
         } => {
             let token_program = match token_program {
                 Some(t) => t.to_token_stream(),
@@ -870,6 +871,11 @@ fn generate_constraint_init_group(
                 None => quote! {},
             };
 
+            let default_account_state_check = match default_account_state {
+                Some(das) => check_scope.generate_check(das),
+                None => quote! {},
+            };
+
             let system_program_optional_check = check_scope.generate_check(system_program);
             let token_program_optional_check = check_scope.generate_check(&token_program);
             let rent_optional_check = check_scope.generate_check(rent);
@@ -896,6 +902,7 @@ fn generate_constraint_init_group(
                 #transfer_fee_max_fee_check
                 #interest_bearing_authority_check
                 #interest_bearing_rate_check
+                #default_account_state_check
             };
 
             let payer_optional_check = check_scope.generate_check(payer);
@@ -938,6 +945,10 @@ fn generate_constraint_init_group(
 
             if interest_bearing_authority.is_some() || interest_bearing_rate.is_some() {
                 extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::InterestBearingConfig});
+            }
+
+            if default_account_state.is_some() {
+                extensions.push(quote! {::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::DefaultAccountState});
             }
 
             let mint_space = if extensions.is_empty() {
@@ -1041,6 +1052,11 @@ fn generate_constraint_init_group(
                 None => quote! { Option::<i16>::None },
             };
 
+            let default_account_state = match default_account_state {
+                Some(das) => quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::Some(#das) },
+                None => quote! { Option::<anchor_spl::token_2022::spl_token_2022::state::AccountState>::None },
+            };
+
             let create_account = generate_create_account(
                 field,
                 mint_space,
@@ -1139,6 +1155,12 @@ fn generate_constraint_init_group(
                                         #interest_bearing_authority,
                                         #interest_bearing_rate.unwrap(),
                                         )?;
+                                    },
+                                    ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::DefaultAccountState => {
+                                        ::anchor_spl::token_interface::default_account_state_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::DefaultAccountStateInitialize {
+                                            token_program_id: #token_program.to_account_info(),
+                                            mint: #field.to_account_info(),
+                                        }), #default_account_state.as_ref().unwrap())?;
                                     },
                                     // All extensions specified by the user should be implemented.
                                     // If this line runs, it means there is a bug in the codegen.
@@ -1766,6 +1788,24 @@ fn generate_constraint_mint(
         None => quote! {},
     };
 
+    let default_account_state_check = match &c.default_account_state {
+        Some(default_account_state) => {
+            let default_account_state_optional_check =
+                optional_check_scope.generate_check(default_account_state);
+            quote! {
+                let account_state = ::anchor_spl::token_interface::get_mint_extension_data::<::anchor_spl::token_interface::spl_token_2022::extension::default_account_state::DefaultAccountState>(#account_ref);
+                if account_state.is_err() {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintDefaultAccountStateExtension.into());
+                }
+                #default_account_state_optional_check
+                if account_state.unwrap().state != #default_account_state as u8 {
+                    return Err(anchor_lang::error::ErrorCode::ConstraintMintDefaultAccountState.into());
+                }
+            }
+        }
+        None => quote! {},
+    };
+
 
     quote! {
         {
@@ -1787,6 +1827,7 @@ fn generate_constraint_mint(
             #transfer_fee_config_authority_check
             #transfer_fee_withheld_authority_check
             #interest_bearing_authority_check
+            #default_account_state_check
         }
     }
 }

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -839,6 +839,8 @@ pub enum ConstraintToken {
     ExtensionTransferFeeWithheldAuthority(Context<ConstraintExtensionAuthority>),
     ExtensionTransferFeeBasisPoints(Context<ConstraintExtensionTransferFeeBasisPoints>),
     ExtensionTransferFeeMaxFee(Context<ConstraintExtensionTransferFeeMaxFee>),
+    ExtensionInterestBearingRateAuthority(Context<ConstraintExtensionAuthority>),
+    ExtensionInterestBearingRate(Context<ConstraintExtensionInterestBearingRate>),
 }
 
 impl Parse for ConstraintToken {
@@ -1093,6 +1095,11 @@ pub struct ConstraintExtensionTransferFeeMaxFee {
 }
 
 #[derive(Debug, Clone)]
+pub struct ConstraintExtensionInterestBearingRate {
+    pub rate: Expr,
+}
+
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum InitKind {
     Program {
@@ -1134,6 +1141,8 @@ pub enum InitKind {
         transfer_fee_withheld_authority: Option<Expr>,
         transfer_fee_basis_points: Option<Expr>,
         transfer_fee_max_fee: Option<Expr>,
+        interest_bearing_authority: Option<Expr>,
+        interest_bearing_rate: Option<Expr>,
     },
 }
 
@@ -1257,6 +1266,8 @@ pub struct ConstraintTokenMintGroup {
     pub transfer_fee_withheld_authority: Option<Expr>,
     pub transfer_fee_basis_points: Option<Expr>,
     pub transfer_fee_max_fee: Option<Expr>,
+    pub interest_bearing_authority: Option<Expr>,
+    pub interest_bearing_rate: Option<Expr>,
 }
 
 // Syntax context object for preserving metadata about the inner item.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -841,6 +841,7 @@ pub enum ConstraintToken {
     ExtensionTransferFeeMaxFee(Context<ConstraintExtensionTransferFeeMaxFee>),
     ExtensionInterestBearingRateAuthority(Context<ConstraintExtensionAuthority>),
     ExtensionInterestBearingRate(Context<ConstraintExtensionInterestBearingRate>),
+    ExtensionDefaultAccountState(Context<ConstraintExtensionDefaultAccountState>),
 }
 
 impl Parse for ConstraintToken {
@@ -1100,6 +1101,11 @@ pub struct ConstraintExtensionInterestBearingRate {
 }
 
 #[derive(Debug, Clone)]
+pub struct ConstraintExtensionDefaultAccountState {
+    pub state: Expr,
+}
+
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum InitKind {
     Program {
@@ -1143,6 +1149,7 @@ pub enum InitKind {
         transfer_fee_max_fee: Option<Expr>,
         interest_bearing_authority: Option<Expr>,
         interest_bearing_rate: Option<Expr>,
+        default_account_state: Option<Expr>,
     },
 }
 
@@ -1268,6 +1275,7 @@ pub struct ConstraintTokenMintGroup {
     pub transfer_fee_max_fee: Option<Expr>,
     pub interest_bearing_authority: Option<Expr>,
     pub interest_bearing_rate: Option<Expr>,
+    pub default_account_state: Option<Expr>,
 }
 
 // Syntax context object for preserving metadata about the inner item.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -835,6 +835,10 @@ pub enum ConstraintToken {
     ExtensionTokenHookProgramId(Context<ConstraintExtensionTokenHookProgramId>),
     ExtensionPermanentDelegate(Context<ConstraintExtensionPermanentDelegate>),
     ExtensionNonTransferable(Context<ConstraintExtensionNonTransferable>),
+    ExtensionTransferFeeConfigAuthority(Context<ConstraintExtensionAuthority>),
+    ExtensionTransferFeeWithheldAuthority(Context<ConstraintExtensionAuthority>),
+    ExtensionTransferFeeBasisPoints(Context<ConstraintExtensionTransferFeeBasisPoints>),
+    ExtensionTransferFeeMaxFee(Context<ConstraintExtensionTransferFeeMaxFee>),
 }
 
 impl Parse for ConstraintToken {
@@ -1079,6 +1083,16 @@ pub struct ConstraintExtensionPermanentDelegate {
 pub struct ConstraintExtensionNonTransferable {}
 
 #[derive(Debug, Clone)]
+pub struct ConstraintExtensionTransferFeeBasisPoints {
+    pub basis_points: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintExtensionTransferFeeMaxFee {
+    pub max_fee: Expr,
+}
+
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum InitKind {
     Program {
@@ -1116,6 +1130,10 @@ pub enum InitKind {
         transfer_hook_authority: Option<Expr>,
         transfer_hook_program_id: Option<Expr>,
         non_transferable: Option<()>,
+        transfer_fee_config_authority: Option<Expr>,
+        transfer_fee_withheld_authority: Option<Expr>,
+        transfer_fee_basis_points: Option<Expr>,
+        transfer_fee_max_fee: Option<Expr>,
     },
 }
 
@@ -1235,6 +1253,10 @@ pub struct ConstraintTokenMintGroup {
     pub transfer_hook_authority: Option<Expr>,
     pub transfer_hook_program_id: Option<Expr>,
     pub non_transferable: Option<()>,
+    pub transfer_fee_config_authority: Option<Expr>,
+    pub transfer_fee_withheld_authority: Option<Expr>,
+    pub transfer_fee_basis_points: Option<Expr>,
+    pub transfer_fee_max_fee: Option<Expr>,
 }
 
 // Syntax context object for preserving metadata about the inner item.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -834,6 +834,7 @@ pub enum ConstraintToken {
     ExtensionTokenHookAuthority(Context<ConstraintExtensionAuthority>),
     ExtensionTokenHookProgramId(Context<ConstraintExtensionTokenHookProgramId>),
     ExtensionPermanentDelegate(Context<ConstraintExtensionPermanentDelegate>),
+    ExtensionNonTransferable(Context<ConstraintExtensionNonTransferable>),
 }
 
 impl Parse for ConstraintToken {
@@ -1075,6 +1076,9 @@ pub struct ConstraintExtensionPermanentDelegate {
 }
 
 #[derive(Debug, Clone)]
+pub struct ConstraintExtensionNonTransferable {}
+
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum InitKind {
     Program {
@@ -1111,6 +1115,7 @@ pub enum InitKind {
         permanent_delegate: Option<Expr>,
         transfer_hook_authority: Option<Expr>,
         transfer_hook_program_id: Option<Expr>,
+        non_transferable: Option<()>,
     },
 }
 
@@ -1229,6 +1234,7 @@ pub struct ConstraintTokenMintGroup {
     pub permanent_delegate: Option<Expr>,
     pub transfer_hook_authority: Option<Expr>,
     pub transfer_hook_program_id: Option<Expr>,
+    pub non_transferable: Option<()>,
 }
 
 // Syntax context object for preserving metadata about the inner item.

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -323,12 +323,14 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                         .unwrap_or_else(|| ident.span());
 
                     match kw.as_str() {
-                        "authority" => ConstraintToken::ExtensionInterestBearingRateAuthority(Context::new(
-                            span,
-                            ConstraintExtensionAuthority {
-                                authority: stream.parse()?,
-                            },
-                        )),
+                        "authority" => {
+                            ConstraintToken::ExtensionInterestBearingRateAuthority(Context::new(
+                                span,
+                                ConstraintExtensionAuthority {
+                                    authority: stream.parse()?,
+                                },
+                            ))
+                        }
                         "rate" => ConstraintToken::ExtensionInterestBearingRate(Context::new(
                             span,
                             ConstraintExtensionInterestBearingRate {
@@ -958,35 +960,40 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 .expect("bump must be provided with seeds"),
             program_seed: into_inner!(program_seed).map(|id| id.program_seed),
         });
-        let associated_token =
-            match (
-                associated_token_mint,
-                associated_token_authority,
-                &associated_token_token_program,
-            ) {
-                (Some(mint), Some(auth), _) => Some(ConstraintAssociatedToken {
-                    wallet: auth.into_inner().auth,
-                    mint: mint.into_inner().mint,
-                    token_program: associated_token_token_program
-                        .as_ref()
-                        .map(|a| a.clone().into_inner().token_program),
-                }),
-                (Some(mint), None, _) => return Err(ParseError::new(
+        let associated_token = match (
+            associated_token_mint,
+            associated_token_authority,
+            &associated_token_token_program,
+        ) {
+            (Some(mint), Some(auth), _) => Some(ConstraintAssociatedToken {
+                wallet: auth.into_inner().auth,
+                mint: mint.into_inner().mint,
+                token_program: associated_token_token_program
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().token_program),
+            }),
+            (Some(mint), None, _) => {
+                return Err(ParseError::new(
                     mint.span(),
                     "authority must be provided to specify an associated token program derived \
                      address",
-                )),
-                (None, Some(auth), _) => return Err(ParseError::new(
+                ))
+            }
+            (None, Some(auth), _) => {
+                return Err(ParseError::new(
                     auth.span(),
                     "mint must be provided to specify an associated token program derived address",
-                )),
-                (None, None, Some(token_program)) => return Err(ParseError::new(
+                ))
+            }
+            (None, None, Some(token_program)) => {
+                return Err(ParseError::new(
                     token_program.span(),
                     "mint and authority must be provided to specify an associated token program \
                      derived address",
-                )),
-                _ => None,
-            };
+                ))
+            }
+            _ => None,
+        };
         if let Some(associated_token) = &associated_token {
             if seeds.is_some() {
                 return Err(ParseError::new(
@@ -1031,7 +1038,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             &extension_transfer_fee_max_fee,
             &extension_interest_bearing_authority,
             &extension_interest_bearing_rate,
-            &extension_default_account_state
+            &extension_default_account_state,
         ) {
             (
                 None,
@@ -1123,8 +1130,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 default_account_state: extension_default_account_state
                     .as_ref()
                     .map(|a| a.clone().into_inner().state),
-        }),
-    };
+            }),
+        };
 
         Ok(ConstraintGroup {
             init: init
@@ -1159,10 +1166,11 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                     .map(|tp| tp.into_inner().token_program),
                             }
                         } else if let Some(d) = &mint_decimals {
-                            let init_transfer_fee = extension_transfer_fee_config_authority.is_some() ||
-                                extension_transfer_fee_withheld_authority.is_some() ||
-                                extension_transfer_fee_basis_points.is_some() ||
-                                extension_transfer_fee_max_fee.is_some();
+                            let init_transfer_fee = extension_transfer_fee_config_authority
+                                .is_some()
+                                || extension_transfer_fee_withheld_authority.is_some()
+                                || extension_transfer_fee_basis_points.is_some()
+                                || extension_transfer_fee_max_fee.is_some();
                             InitKind::Mint {
                                 decimals: d.clone().into_inner().decimals,
                                 owner: match &mint_authority {
@@ -1204,34 +1212,59 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                 transfer_hook_program_id: extension_transfer_hook_program_id
                                     .map(|thpid| thpid.into_inner().program_id),
                                 non_transferable: extension_non_transferable.map(|_| ()),
-                                transfer_fee_config_authority: extension_transfer_fee_config_authority.map(|tfca| tfca.into_inner().authority),
-                                transfer_fee_withheld_authority: extension_transfer_fee_withheld_authority.map(|tfwa| tfwa.into_inner().authority),
-                                transfer_fee_basis_points: match (&extension_transfer_fee_basis_points, init_transfer_fee) {
+                                transfer_fee_config_authority:
+                                    extension_transfer_fee_config_authority
+                                        .map(|tfca| tfca.into_inner().authority),
+                                transfer_fee_withheld_authority:
+                                    extension_transfer_fee_withheld_authority
+                                        .map(|tfwa| tfwa.into_inner().authority),
+                                transfer_fee_basis_points: match (
+                                    &extension_transfer_fee_basis_points,
+                                    init_transfer_fee,
+                                ) {
                                     (Some(tfbp), _) => Some(tfbp.clone().into_inner().basis_points),
-                                    (None, true) => return Err(ParseError::new(
-                                        d.span(),
-                                        "fee basis points must be provided to initialize a mint with transfer fee extension"
-                                    )),
-                                    _ => None
+                                    (None, true) => {
+                                        return Err(ParseError::new(
+                                            d.span(),
+                                            "fee basis points must be provided to initialize a \
+                                             mint with transfer fee extension",
+                                        ))
+                                    }
+                                    _ => None,
                                 },
-                                transfer_fee_max_fee:  match (&extension_transfer_fee_max_fee, init_transfer_fee) {
+                                transfer_fee_max_fee: match (
+                                    &extension_transfer_fee_max_fee,
+                                    init_transfer_fee,
+                                ) {
                                     (Some(tfmf), _) => Some(tfmf.clone().into_inner().max_fee),
-                                    (None, true) => return Err(ParseError::new(
-                                        d.span(),
-                                        "maximum fee must be provided to initialize a mint with transfer fee extension"
-                                    )),
-                                    _ => None
+                                    (None, true) => {
+                                        return Err(ParseError::new(
+                                            d.span(),
+                                            "maximum fee must be provided to initialize a mint \
+                                             with transfer fee extension",
+                                        ))
+                                    }
+                                    _ => None,
                                 },
-                                interest_bearing_authority: extension_interest_bearing_authority.as_ref().map(|iba| iba.clone().into_inner().authority),
-                                interest_bearing_rate: match (&extension_interest_bearing_rate, &extension_interest_bearing_authority) {
+                                interest_bearing_authority: extension_interest_bearing_authority
+                                    .as_ref()
+                                    .map(|iba| iba.clone().into_inner().authority),
+                                interest_bearing_rate: match (
+                                    &extension_interest_bearing_rate,
+                                    &extension_interest_bearing_authority,
+                                ) {
                                     (Some(ibr), _) => Some(ibr.clone().into_inner().rate),
-                                    (None, Some(_)) => return Err(ParseError::new(
-                                        d.span(),
-                                        "rate must be provided to initialize a mint with interest bearing extension"
-                                    )),
-                                    _ => None
+                                    (None, Some(_)) => {
+                                        return Err(ParseError::new(
+                                            d.span(),
+                                            "rate must be provided to initialize a mint with \
+                                             interest bearing extension",
+                                        ))
+                                    }
+                                    _ => None,
                                 },
-                                default_account_state: extension_default_account_state.map(|das| das.into_inner().state),
+                                default_account_state: extension_default_account_state
+                                    .map(|das| das.into_inner().state),
                             }
                         } else {
                             InitKind::Program {
@@ -1337,9 +1370,15 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             ConstraintToken::ExtensionTransferFeeMaxFee(c) => {
                 self.add_extension_transfer_fee_max_fee(c)
             }
-            ConstraintToken::ExtensionInterestBearingRateAuthority(c) => self.add_extension_interest_bearing_authority(c),
-            ConstraintToken::ExtensionInterestBearingRate(c) => self.add_extension_interest_bearing_rate(c),
-            ConstraintToken::ExtensionDefaultAccountState(c) => self.add_extension_default_account_state(c),
+            ConstraintToken::ExtensionInterestBearingRateAuthority(c) => {
+                self.add_extension_interest_bearing_authority(c)
+            }
+            ConstraintToken::ExtensionInterestBearingRate(c) => {
+                self.add_extension_interest_bearing_rate(c)
+            }
+            ConstraintToken::ExtensionDefaultAccountState(c) => {
+                self.add_extension_default_account_state(c)
+            }
         }
     }
 
@@ -2043,5 +2082,4 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         self.extension_default_account_state.replace(c);
         Ok(())
     }
-
 }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -311,6 +311,33 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                         _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
                     }
                 }
+                "interest_bearing" => {
+                    stream.parse::<Token![:]>()?;
+                    stream.parse::<Token![:]>()?;
+                    let kw = stream.call(Ident::parse_any)?.to_string();
+                    stream.parse::<Token![=]>()?;
+
+                    let span = ident
+                        .span()
+                        .join(stream.span())
+                        .unwrap_or_else(|| ident.span());
+
+                    match kw.as_str() {
+                        "authority" => ConstraintToken::ExtensionInterestBearingRateAuthority(Context::new(
+                            span,
+                            ConstraintExtensionAuthority {
+                                authority: stream.parse()?,
+                            },
+                        )),
+                        "rate" => ConstraintToken::ExtensionInterestBearingRate(Context::new(
+                            span,
+                            ConstraintExtensionInterestBearingRate {
+                                rate: stream.parse()?,
+                            },
+                        )),
+                        _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
+                    }
+                }
                 _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
             }
         }
@@ -599,6 +626,8 @@ pub struct ConstraintGroupBuilder<'ty> {
     pub extension_transfer_fee_basis_points:
         Option<Context<ConstraintExtensionTransferFeeBasisPoints>>,
     pub extension_transfer_fee_max_fee: Option<Context<ConstraintExtensionTransferFeeMaxFee>>,
+    pub extension_interest_bearing_authority: Option<Context<ConstraintExtensionAuthority>>,
+    pub extension_interest_bearing_rate: Option<Context<ConstraintExtensionInterestBearingRate>>,
     pub bump: Option<Context<ConstraintTokenBump>>,
     pub program_seed: Option<Context<ConstraintProgramSeed>>,
     pub realloc: Option<Context<ConstraintRealloc>>,
@@ -650,6 +679,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_fee_withheld_authority: None,
             extension_transfer_fee_basis_points: None,
             extension_transfer_fee_max_fee: None,
+            extension_interest_bearing_authority: None,
+            extension_interest_bearing_rate: None,
             bump: None,
             program_seed: None,
             realloc: None,
@@ -868,6 +899,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_fee_withheld_authority,
             extension_transfer_fee_basis_points,
             extension_transfer_fee_max_fee,
+            extension_interest_bearing_authority,
+            extension_interest_bearing_rate,
             bump,
             program_seed,
             realloc,
@@ -972,8 +1005,12 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             &extension_transfer_fee_withheld_authority,
             &extension_transfer_fee_basis_points,
             &extension_transfer_fee_max_fee,
+            &extension_interest_bearing_authority,
+            &extension_interest_bearing_rate,
         ) {
             (
+                None,
+                None,
                 None,
                 None,
                 None,
@@ -1051,6 +1088,12 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 transfer_fee_max_fee: extension_transfer_fee_max_fee
                     .as_ref()
                     .map(|a| a.clone().into_inner().max_fee),
+                interest_bearing_authority: extension_interest_bearing_authority
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().authority),
+                interest_bearing_rate: extension_interest_bearing_rate
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().rate),
             }),
         };
 
@@ -1147,6 +1190,15 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                     (None, true) => return Err(ParseError::new(
                                         d.span(),
                                         "maximum fee must be provided to initialize a mint with transfer fee extension"
+                                    )),
+                                    _ => None
+                                },
+                                interest_bearing_authority: extension_interest_bearing_authority.as_ref().map(|iba| iba.clone().into_inner().authority),
+                                interest_bearing_rate: match (&extension_interest_bearing_rate, &extension_interest_bearing_authority) {
+                                    (Some(ibr), _) => Some(ibr.clone().into_inner().rate),
+                                    (None, Some(_)) => return Err(ParseError::new(
+                                        d.span(),
+                                        "rate must be provided to initialize a mint with interest bearing extension"
                                     )),
                                     _ => None
                                 },
@@ -1255,6 +1307,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             ConstraintToken::ExtensionTransferFeeMaxFee(c) => {
                 self.add_extension_transfer_fee_max_fee(c)
             }
+            ConstraintToken::ExtensionInterestBearingRateAuthority(c) => self.add_extension_interest_bearing_authority(c),
+            ConstraintToken::ExtensionInterestBearingRate(c) => self.add_extension_interest_bearing_rate(c),
         }
     }
 
@@ -1916,4 +1970,33 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         self.extension_transfer_fee_max_fee.replace(c);
         Ok(())
     }
+
+    fn add_extension_interest_bearing_authority(
+        &mut self,
+        c: Context<ConstraintExtensionAuthority>,
+    ) -> ParseResult<()> {
+        if self.extension_interest_bearing_authority.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension interest bearing authority already provided",
+            ));
+        }
+        self.extension_interest_bearing_authority.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_interest_bearing_rate(
+        &mut self,
+        c: Context<ConstraintExtensionInterestBearingRate>,
+    ) -> ParseResult<()> {
+        if self.extension_interest_bearing_rate.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension interest bearing rate already provided",
+            ));
+        }
+        self.extension_interest_bearing_rate.replace(c);
+        Ok(())
+    }
+
 }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -338,6 +338,27 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                         _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
                     }
                 }
+                "default_account_state" => {
+                    stream.parse::<Token![:]>()?;
+                    stream.parse::<Token![:]>()?;
+                    let kw = stream.call(Ident::parse_any)?.to_string();
+                    stream.parse::<Token![=]>()?;
+
+                    let span = ident
+                        .span()
+                        .join(stream.span())
+                        .unwrap_or_else(|| ident.span());
+
+                    match kw.as_str() {
+                        "state" => ConstraintToken::ExtensionDefaultAccountState(Context::new(
+                            span,
+                            ConstraintExtensionDefaultAccountState {
+                                state: stream.parse()?,
+                            },
+                        )),
+                        _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
+                    }
+                }
                 _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
             }
         }
@@ -628,6 +649,7 @@ pub struct ConstraintGroupBuilder<'ty> {
     pub extension_transfer_fee_max_fee: Option<Context<ConstraintExtensionTransferFeeMaxFee>>,
     pub extension_interest_bearing_authority: Option<Context<ConstraintExtensionAuthority>>,
     pub extension_interest_bearing_rate: Option<Context<ConstraintExtensionInterestBearingRate>>,
+    pub extension_default_account_state: Option<Context<ConstraintExtensionDefaultAccountState>>,
     pub bump: Option<Context<ConstraintTokenBump>>,
     pub program_seed: Option<Context<ConstraintProgramSeed>>,
     pub realloc: Option<Context<ConstraintRealloc>>,
@@ -681,6 +703,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_fee_max_fee: None,
             extension_interest_bearing_authority: None,
             extension_interest_bearing_rate: None,
+            extension_default_account_state: None,
             bump: None,
             program_seed: None,
             realloc: None,
@@ -901,6 +924,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_fee_max_fee,
             extension_interest_bearing_authority,
             extension_interest_bearing_rate,
+            extension_default_account_state,
             bump,
             program_seed,
             realloc,
@@ -1007,8 +1031,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             &extension_transfer_fee_max_fee,
             &extension_interest_bearing_authority,
             &extension_interest_bearing_rate,
+            &extension_default_account_state
         ) {
             (
+                None,
                 None,
                 None,
                 None,
@@ -1094,8 +1120,11 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 interest_bearing_rate: extension_interest_bearing_rate
                     .as_ref()
                     .map(|a| a.clone().into_inner().rate),
-            }),
-        };
+                default_account_state: extension_default_account_state
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().state),
+        }),
+    };
 
         Ok(ConstraintGroup {
             init: init
@@ -1202,6 +1231,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                     )),
                                     _ => None
                                 },
+                                default_account_state: extension_default_account_state.map(|das| das.into_inner().state),
                             }
                         } else {
                             InitKind::Program {
@@ -1309,6 +1339,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             }
             ConstraintToken::ExtensionInterestBearingRateAuthority(c) => self.add_extension_interest_bearing_authority(c),
             ConstraintToken::ExtensionInterestBearingRate(c) => self.add_extension_interest_bearing_rate(c),
+            ConstraintToken::ExtensionDefaultAccountState(c) => self.add_extension_default_account_state(c),
         }
     }
 
@@ -1996,6 +2027,20 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             ));
         }
         self.extension_interest_bearing_rate.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_default_account_state(
+        &mut self,
+        c: Context<ConstraintExtensionDefaultAccountState>,
+    ) -> ParseResult<()> {
+        if self.extension_default_account_state.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension default account state already provided",
+            ));
+        }
+        self.extension_default_account_state.replace(c);
         Ok(())
     }
 

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -266,6 +266,51 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     ident.span(),
                     ConstraintExtensionNonTransferable {},
                 )),
+                "transfer_fee" => {
+                    stream.parse::<Token![:]>()?;
+                    stream.parse::<Token![:]>()?;
+                    let kw = stream.call(Ident::parse_any)?.to_string();
+                    stream.parse::<Token![=]>()?;
+
+                    let span = ident
+                        .span()
+                        .join(stream.span())
+                        .unwrap_or_else(|| ident.span());
+
+                    match kw.as_str() {
+                        "config_authority" => {
+                            ConstraintToken::ExtensionTransferFeeConfigAuthority(Context::new(
+                                span,
+                                ConstraintExtensionAuthority {
+                                    authority: stream.parse()?,
+                                },
+                            ))
+                        }
+                        "withheld_authority" => {
+                            ConstraintToken::ExtensionTransferFeeWithheldAuthority(Context::new(
+                                span,
+                                ConstraintExtensionAuthority {
+                                    authority: stream.parse()?,
+                                },
+                            ))
+                        }
+                        "basis_points" => {
+                            ConstraintToken::ExtensionTransferFeeBasisPoints(Context::new(
+                                span,
+                                ConstraintExtensionTransferFeeBasisPoints {
+                                    basis_points: stream.parse()?,
+                                },
+                            ))
+                        }
+                        "max_fee" => ConstraintToken::ExtensionTransferFeeMaxFee(Context::new(
+                            span,
+                            ConstraintExtensionTransferFeeMaxFee {
+                                max_fee: stream.parse()?,
+                            },
+                        )),
+                        _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
+                    }
+                }
                 _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
             }
         }
@@ -549,6 +594,11 @@ pub struct ConstraintGroupBuilder<'ty> {
     pub extension_transfer_hook_program_id: Option<Context<ConstraintExtensionTokenHookProgramId>>,
     pub extension_permanent_delegate: Option<Context<ConstraintExtensionPermanentDelegate>>,
     pub extension_non_transferable: Option<Context<ConstraintExtensionNonTransferable>>,
+    pub extension_transfer_fee_config_authority: Option<Context<ConstraintExtensionAuthority>>,
+    pub extension_transfer_fee_withheld_authority: Option<Context<ConstraintExtensionAuthority>>,
+    pub extension_transfer_fee_basis_points:
+        Option<Context<ConstraintExtensionTransferFeeBasisPoints>>,
+    pub extension_transfer_fee_max_fee: Option<Context<ConstraintExtensionTransferFeeMaxFee>>,
     pub bump: Option<Context<ConstraintTokenBump>>,
     pub program_seed: Option<Context<ConstraintProgramSeed>>,
     pub realloc: Option<Context<ConstraintRealloc>>,
@@ -596,6 +646,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_hook_program_id: None,
             extension_permanent_delegate: None,
             extension_non_transferable: None,
+            extension_transfer_fee_config_authority: None,
+            extension_transfer_fee_withheld_authority: None,
+            extension_transfer_fee_basis_points: None,
+            extension_transfer_fee_max_fee: None,
             bump: None,
             program_seed: None,
             realloc: None,
@@ -810,6 +864,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_hook_program_id,
             extension_permanent_delegate,
             extension_non_transferable,
+            extension_transfer_fee_config_authority,
+            extension_transfer_fee_withheld_authority,
+            extension_transfer_fee_basis_points,
+            extension_transfer_fee_max_fee,
             bump,
             program_seed,
             realloc,
@@ -843,40 +901,35 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 .expect("bump must be provided with seeds"),
             program_seed: into_inner!(program_seed).map(|id| id.program_seed),
         });
-        let associated_token = match (
-            associated_token_mint,
-            associated_token_authority,
-            &associated_token_token_program,
-        ) {
-            (Some(mint), Some(auth), _) => Some(ConstraintAssociatedToken {
-                wallet: auth.into_inner().auth,
-                mint: mint.into_inner().mint,
-                token_program: associated_token_token_program
-                    .as_ref()
-                    .map(|a| a.clone().into_inner().token_program),
-            }),
-            (Some(mint), None, _) => {
-                return Err(ParseError::new(
+        let associated_token =
+            match (
+                associated_token_mint,
+                associated_token_authority,
+                &associated_token_token_program,
+            ) {
+                (Some(mint), Some(auth), _) => Some(ConstraintAssociatedToken {
+                    wallet: auth.into_inner().auth,
+                    mint: mint.into_inner().mint,
+                    token_program: associated_token_token_program
+                        .as_ref()
+                        .map(|a| a.clone().into_inner().token_program),
+                }),
+                (Some(mint), None, _) => return Err(ParseError::new(
                     mint.span(),
                     "authority must be provided to specify an associated token program derived \
                      address",
-                ))
-            }
-            (None, Some(auth), _) => {
-                return Err(ParseError::new(
+                )),
+                (None, Some(auth), _) => return Err(ParseError::new(
                     auth.span(),
                     "mint must be provided to specify an associated token program derived address",
-                ))
-            }
-            (None, None, Some(token_program)) => {
-                return Err(ParseError::new(
+                )),
+                (None, None, Some(token_program)) => return Err(ParseError::new(
                     token_program.span(),
                     "mint and authority must be provided to specify an associated token program \
                      derived address",
-                ))
-            }
-            _ => None,
-        };
+                )),
+                _ => None,
+            };
         if let Some(associated_token) = &associated_token {
             if seeds.is_some() {
                 return Err(ParseError::new(
@@ -915,8 +968,16 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             &extension_transfer_hook_program_id,
             &extension_permanent_delegate,
             &extension_non_transferable,
+            &extension_transfer_fee_config_authority,
+            &extension_transfer_fee_withheld_authority,
+            &extension_transfer_fee_basis_points,
+            &extension_transfer_fee_max_fee,
         ) {
             (
+                None,
+                None,
+                None,
+                None,
                 None,
                 None,
                 None,
@@ -977,9 +1038,19 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 transfer_hook_program_id: extension_transfer_hook_program_id
                     .as_ref()
                     .map(|a| a.clone().into_inner().program_id),
-                non_transferable: extension_non_transferable
+                non_transferable: extension_non_transferable.as_ref().map(|_| ()),
+                transfer_fee_config_authority: extension_transfer_fee_config_authority
                     .as_ref()
-                    .map(|_| ()),
+                    .map(|a| a.clone().into_inner().authority),
+                transfer_fee_withheld_authority: extension_transfer_fee_withheld_authority
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().authority),
+                transfer_fee_basis_points: extension_transfer_fee_basis_points
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().basis_points),
+                transfer_fee_max_fee: extension_transfer_fee_max_fee
+                    .as_ref()
+                    .map(|a| a.clone().into_inner().max_fee),
             }),
         };
 
@@ -1016,6 +1087,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                     .map(|tp| tp.into_inner().token_program),
                             }
                         } else if let Some(d) = &mint_decimals {
+                            let init_transfer_fee = extension_transfer_fee_config_authority.is_some() ||
+                                extension_transfer_fee_withheld_authority.is_some() ||
+                                extension_transfer_fee_basis_points.is_some() ||
+                                extension_transfer_fee_max_fee.is_some();
                             InitKind::Mint {
                                 decimals: d.clone().into_inner().decimals,
                                 owner: match &mint_authority {
@@ -1057,6 +1132,24 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                 transfer_hook_program_id: extension_transfer_hook_program_id
                                     .map(|thpid| thpid.into_inner().program_id),
                                 non_transferable: extension_non_transferable.map(|_| ()),
+                                transfer_fee_config_authority: extension_transfer_fee_config_authority.map(|tfca| tfca.into_inner().authority),
+                                transfer_fee_withheld_authority: extension_transfer_fee_withheld_authority.map(|tfwa| tfwa.into_inner().authority),
+                                transfer_fee_basis_points: match (&extension_transfer_fee_basis_points, init_transfer_fee) {
+                                    (Some(tfbp), _) => Some(tfbp.clone().into_inner().basis_points),
+                                    (None, true) => return Err(ParseError::new(
+                                        d.span(),
+                                        "fee basis points must be provided to initialize a mint with transfer fee extension"
+                                    )),
+                                    _ => None
+                                },
+                                transfer_fee_max_fee:  match (&extension_transfer_fee_max_fee, init_transfer_fee) {
+                                    (Some(tfmf), _) => Some(tfmf.clone().into_inner().max_fee),
+                                    (None, true) => return Err(ParseError::new(
+                                        d.span(),
+                                        "maximum fee must be provided to initialize a mint with transfer fee extension"
+                                    )),
+                                    _ => None
+                                },
                             }
                         } else {
                             InitKind::Program {
@@ -1149,8 +1242,18 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 self.add_extension_permanent_delegate(c)
             }
             ConstraintToken::Dup(c) => self.add_dup(c),
-            ConstraintToken::ExtensionNonTransferable(c) => {
-                self.add_extension_non_transferable(c)
+            ConstraintToken::ExtensionNonTransferable(c) => self.add_extension_non_transferable(c),
+            ConstraintToken::ExtensionTransferFeeConfigAuthority(c) => {
+                self.add_extension_transfer_fee_config_authority(c)
+            }
+            ConstraintToken::ExtensionTransferFeeWithheldAuthority(c) => {
+                self.add_extension_transfer_fee_withheld_authority(c)
+            }
+            ConstraintToken::ExtensionTransferFeeBasisPoints(c) => {
+                self.add_extension_transfer_fee_basis_points(c)
+            }
+            ConstraintToken::ExtensionTransferFeeMaxFee(c) => {
+                self.add_extension_transfer_fee_max_fee(c)
             }
         }
     }
@@ -1755,6 +1858,62 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             ));
         }
         self.extension_non_transferable.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_transfer_fee_config_authority(
+        &mut self,
+        c: Context<ConstraintExtensionAuthority>,
+    ) -> ParseResult<()> {
+        if self.extension_transfer_fee_config_authority.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension transfer fee config authority already provided",
+            ));
+        }
+        self.extension_transfer_fee_config_authority.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_transfer_fee_withheld_authority(
+        &mut self,
+        c: Context<ConstraintExtensionAuthority>,
+    ) -> ParseResult<()> {
+        if self.extension_transfer_fee_withheld_authority.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension transfer fee withheld authority already provided",
+            ));
+        }
+        self.extension_transfer_fee_withheld_authority.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_transfer_fee_basis_points(
+        &mut self,
+        c: Context<ConstraintExtensionTransferFeeBasisPoints>,
+    ) -> ParseResult<()> {
+        if self.extension_transfer_fee_basis_points.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension transfer fee basis points already provided",
+            ));
+        }
+        self.extension_transfer_fee_basis_points.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_transfer_fee_max_fee(
+        &mut self,
+        c: Context<ConstraintExtensionTransferFeeMaxFee>,
+    ) -> ParseResult<()> {
+        if self.extension_transfer_fee_max_fee.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension transfer fee maximum fee already provided",
+            ));
+        }
+        self.extension_transfer_fee_max_fee.replace(c);
         Ok(())
     }
 }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -262,6 +262,10 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                         _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
                     }
                 }
+                "non_transferable" => ConstraintToken::ExtensionNonTransferable(Context::new(
+                    ident.span(),
+                    ConstraintExtensionNonTransferable {},
+                )),
                 _ => return Err(ParseError::new(ident.span(), "Invalid attribute")),
             }
         }
@@ -544,6 +548,7 @@ pub struct ConstraintGroupBuilder<'ty> {
     pub extension_transfer_hook_authority: Option<Context<ConstraintExtensionAuthority>>,
     pub extension_transfer_hook_program_id: Option<Context<ConstraintExtensionTokenHookProgramId>>,
     pub extension_permanent_delegate: Option<Context<ConstraintExtensionPermanentDelegate>>,
+    pub extension_non_transferable: Option<Context<ConstraintExtensionNonTransferable>>,
     pub bump: Option<Context<ConstraintTokenBump>>,
     pub program_seed: Option<Context<ConstraintProgramSeed>>,
     pub realloc: Option<Context<ConstraintRealloc>>,
@@ -590,6 +595,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_hook_authority: None,
             extension_transfer_hook_program_id: None,
             extension_permanent_delegate: None,
+            extension_non_transferable: None,
             bump: None,
             program_seed: None,
             realloc: None,
@@ -803,6 +809,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_transfer_hook_authority,
             extension_transfer_hook_program_id,
             extension_permanent_delegate,
+            extension_non_transferable,
             bump,
             program_seed,
             realloc,
@@ -907,8 +914,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             &extension_transfer_hook_authority,
             &extension_transfer_hook_program_id,
             &extension_permanent_delegate,
+            &extension_non_transferable,
         ) {
             (
+                None,
                 None,
                 None,
                 None,
@@ -968,6 +977,9 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 transfer_hook_program_id: extension_transfer_hook_program_id
                     .as_ref()
                     .map(|a| a.clone().into_inner().program_id),
+                non_transferable: extension_non_transferable
+                    .as_ref()
+                    .map(|_| ()),
             }),
         };
 
@@ -1044,6 +1056,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                                     .map(|tha| tha.into_inner().authority),
                                 transfer_hook_program_id: extension_transfer_hook_program_id
                                     .map(|thpid| thpid.into_inner().program_id),
+                                non_transferable: extension_non_transferable.map(|_| ()),
                             }
                         } else {
                             InitKind::Program {
@@ -1136,6 +1149,9 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 self.add_extension_permanent_delegate(c)
             }
             ConstraintToken::Dup(c) => self.add_dup(c),
+            ConstraintToken::ExtensionNonTransferable(c) => {
+                self.add_extension_non_transferable(c)
+            }
         }
     }
 
@@ -1725,6 +1741,20 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             return Err(ParseError::new(c.span(), "dup already provided"));
         }
         self.dup.replace(c);
+        Ok(())
+    }
+
+    fn add_extension_non_transferable(
+        &mut self,
+        c: Context<ConstraintExtensionNonTransferable>,
+    ) -> ParseResult<()> {
+        if self.extension_non_transferable.is_some() {
+            return Err(ParseError::new(
+                c.span(),
+                "extension non-transferable already provided",
+            ));
+        }
+        self.extension_non_transferable.replace(c);
         Ok(())
     }
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
     token_2022::spl_token_2022::extension::{
         group_member_pointer::GroupMemberPointer, metadata_pointer::MetadataPointer,
         mint_close_authority::MintCloseAuthority, permanent_delegate::PermanentDelegate,
-        transfer_hook::TransferHook,
+        transfer_hook::TransferHook, non_transferable::NonTransferable,
     },
     token_interface::{
         get_mint_extension_data, spl_token_metadata_interface::state::TokenMetadata,
@@ -53,6 +53,7 @@ pub struct CreateMintAccount<'info> {
         extensions::transfer_hook::program_id = crate::ID,
         extensions::close_authority::authority = authority,
         extensions::permanent_delegate::delegate = authority,
+        extensions::non_transferable,
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
@@ -150,6 +151,7 @@ pub fn handler(ctx: Context<CreateMintAccount>, args: CreateMintAccountArgs) -> 
         group_member_pointer.member_address,
         OptionalNonZeroPubkey::try_from(mint_key)?
     );
+    let _ = get_mint_extension_data::<NonTransferable>(mint_data)?;
     // transfer minimum rent to mint account
     update_account_lamports_to_minimum_balance(
         ctx.accounts.mint.to_account_info(),
@@ -175,6 +177,7 @@ pub struct CheckMintExtensionConstraints<'info> {
         extensions::transfer_hook::program_id = crate::ID,
         extensions::close_authority::authority = authority,
         extensions::permanent_delegate::delegate = authority,
+        extensions::non_transferable,
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -3,9 +3,7 @@ use anchor_lang::{prelude::*, solana_program::entrypoint::ProgramResult};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token_2022::spl_token_2022::extension::{
-        group_member_pointer::GroupMemberPointer, metadata_pointer::MetadataPointer,
-        mint_close_authority::MintCloseAuthority, permanent_delegate::PermanentDelegate,
-        transfer_hook::TransferHook, non_transferable::NonTransferable,
+        group_member_pointer::GroupMemberPointer, metadata_pointer::MetadataPointer, mint_close_authority::MintCloseAuthority, non_transferable::NonTransferable, permanent_delegate::PermanentDelegate, transfer_fee::TransferFeeConfig, transfer_hook::TransferHook
     },
     token_interface::{
         get_mint_extension_data, spl_token_metadata_interface::state::TokenMetadata,
@@ -19,6 +17,8 @@ use crate::{
     update_account_lamports_to_minimum_balance, META_LIST_ACCOUNT_SEED,
 };
 
+const BASIS_POINTS: u16 = 100;
+const MAX_FEE: u64 = 10000;
 #[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct CreateMintAccountArgs {
     pub name: String,
@@ -54,6 +54,10 @@ pub struct CreateMintAccount<'info> {
         extensions::close_authority::authority = authority,
         extensions::permanent_delegate::delegate = authority,
         extensions::non_transferable,
+        extensions::transfer_fee::config_authority = authority,
+        extensions::transfer_fee::withheld_authority = authority,
+        extensions::transfer_fee::basis_points = BASIS_POINTS,
+        extensions::transfer_fee::max_fee = MAX_FEE,
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
@@ -152,6 +156,23 @@ pub fn handler(ctx: Context<CreateMintAccount>, args: CreateMintAccountArgs) -> 
         OptionalNonZeroPubkey::try_from(mint_key)?
     );
     let _ = get_mint_extension_data::<NonTransferable>(mint_data)?;
+    let transfer_fee = get_mint_extension_data::<TransferFeeConfig>(mint_data)?;
+    assert_eq!(
+        transfer_fee.transfer_fee_config_authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+    assert_eq!(
+        transfer_fee.withdraw_withheld_authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+    assert_eq!(
+        transfer_fee.newer_transfer_fee.transfer_fee_basis_points,
+        BASIS_POINTS.into()
+    );
+    assert_eq!(
+        transfer_fee.newer_transfer_fee.maximum_fee,
+        MAX_FEE.into()
+    );
     // transfer minimum rent to mint account
     update_account_lamports_to_minimum_balance(
         ctx.accounts.mint.to_account_info(),
@@ -178,6 +199,8 @@ pub struct CheckMintExtensionConstraints<'info> {
         extensions::close_authority::authority = authority,
         extensions::permanent_delegate::delegate = authority,
         extensions::non_transferable,
+        extensions::transfer_fee::config_authority = authority,
+        extensions::transfer_fee::withheld_authority = authority
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
 }


### PR DESCRIPTION
Hello,
this PR extends the original Token22 Extensions PR #2789 and adds support for additional token mint extensions, namely:
- transfer fee
- interest bearing
- non-transferable
- default account state

An example of initialization:
```rust
const BASIS_POINTS: u16 = 100;
const MAX_FEE: u64 = 10000;
const RATE: i16 = 100;

#[account(
    init,
    ...
    extensions::non_transferable,
    extensions::transfer_fee::config_authority = authority,
    extensions::transfer_fee::withheld_authority = authority,
    extensions::transfer_fee::basis_points = BASIS_POINTS,
    extensions::transfer_fee::max_fee = MAX_FEE,
    extensions::interest_bearing::authority = authority,
    extensions::interest_bearing::rate = RATE,
    extensions::default_account_state::state = AccountState::Frozen,
)]
pub mint: Box<InterfaceAccount<'info, Mint>>,
```

An example of constraints check:
```rust
#[account(
    extensions::non_transferable,
    extensions::transfer_fee::config_authority = authority,
    extensions::transfer_fee::withheld_authority = authority,
    extensions::interest_bearing::authority = authority,
    extensions::default_account_state::state = AccountState::Frozen,
)]
pub mint: Box<InterfaceAccount<'info, Mint>>,
```

Checking of constraints `extensions::transfer_fee::basis_points`, `extensions::transfer_fee::max_fee` and `extensions::interest_bearing::rate` is currently not supported.

Also I was wondering if it would not be better to have ex. `extensions::non_transferable = false` instead of only being able to check if the non-transferable extension is enabled?

Fixes #3088.

Let me know what you think. Thanks!