### PR TITLE
docs: fix link to #install-dependencies section

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -405,7 +405,7 @@ error: could not exec the linker cc = note: Permission denied (os error 13)
 If you see this error message, follow these steps:
 
 1. Install the dependencies listed in the
-   [Linux](/docs/intro/installation#install-dependencies) section at the top of
+   [Linux](#install-dependencies) section at the top of
    this page.
 2. Retry installing the Anchor CLI.
 


### PR DESCRIPTION
link is broken on this [page](https://www.anchor-lang.com/docs/installation). after my changes it will be fixed. 