### PR TITLE
cli: Fix using deprecated commitment `recent` in migration scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,12 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## [Unreleased]
 
-- 
-
 ### Features
 
 ### Fixes
 
 - docker: Upgrade `node` to 20.18.0 LTS ([#3179](https://github.com/solana-foundation/anchor/pull/3687)).
+- cli: Fix using deprecated commitment `recent` in migration scripts ([#3725](https://github.com/coral-xyz/anchor/pull/3725)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- docker: Upgrade `node` to 20.18.0 LTS ([#3179](https://github.com/solana-foundation/anchor/pull/3687)).
+- docker: Upgrade `node` to 20.18.0 LTS ([#3687](https://github.com/solana-foundation/anchor/pull/3687)).
 - cli: Fix using deprecated commitment `recent` in migration scripts ([#3725](https://github.com/coral-xyz/anchor/pull/3725)).
 
 ### Breaking

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -256,15 +256,12 @@ const anchor = require('@coral-xyz/anchor');
 const userScript = require("{script_path}");
 
 async function main() {{
-    const url = "{cluster_url}";
-    const preflightCommitment = 'recent';
-    const connection = new anchor.web3.Connection(url, preflightCommitment);
+    const connection = new anchor.web3.Connection(
+      "{cluster_url}",
+      anchor.AnchorProvider.defaultOptions().commitment
+    );
     const wallet = anchor.Wallet.local();
-
-    const provider = new anchor.AnchorProvider(connection, wallet, {{
-        preflightCommitment,
-        commitment: 'recent',
-    }});
+    const provider = new anchor.AnchorProvider(connection, wallet);
 
     // Run the user's deploy script.
     userScript(provider);
@@ -282,15 +279,12 @@ pub fn deploy_ts_script_host(cluster_url: &str, script_path: &str) -> String {
 const userScript = require("{script_path}");
 
 async function main() {{
-    const url = "{cluster_url}";
-    const preflightCommitment = 'recent';
-    const connection = new anchor.web3.Connection(url, preflightCommitment);
+    const connection = new anchor.web3.Connection(
+      "{cluster_url}",
+      anchor.AnchorProvider.defaultOptions().commitment
+    );
     const wallet = anchor.Wallet.local();
-
-    const provider = new anchor.AnchorProvider(connection, wallet, {{
-        preflightCommitment,
-        commitment: 'recent',
-    }});
+    const provider = new anchor.AnchorProvider(connection, wallet);
 
     // Run the user's deploy script.
     userScript(provider);


### PR DESCRIPTION
### Problem

As described in https://github.com/solana-foundation/anchor/issues/3679, the generated migration script specifies `recent` as the commitment and preflight commitment, which is either deprecated or no longer works depending on the version used.

### Summary of changes

Use Anchor's default commitment and preflight commitment in the migration script rather than specifying `recent`.

The last argument of `AnchorProvider`'s constructor can be omitted after https://github.com/solana-foundation/anchor/pull/2843, which makes it use the Anchor's default commitment (`processed` at the time of writing).

Fixes https://github.com/solana-foundation/anchor/issues/3679