### PR TITLE
feat: add support for tuple types in space calculation

### DIFF
--- a/lang/derive/space/src/lib.rs
+++ b/lang/derive/space/src/lib.rs
@@ -151,6 +151,15 @@ fn len_from_type(ty: Type, attrs: &mut Option<VecDeque<TokenStream2>>) -> TokenS
                 }
             }
         }
+        Type::Tuple(ty_tuple) => {
+            let recurse = ty_tuple
+                .elems
+                .iter()
+                .map(|t| len_from_type(t.clone(), attrs));
+            quote! {
+                (0 #(+ #recurse)*)
+            }
+        }
         _ => panic!("Type {ty:?} is not supported"),
     }
 }

--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -255,7 +255,6 @@ fn test_nested_tuple_complexity() {
     // = 1 + (1 + 2) + (4 + (8 + 16)) = 1 + 3 + (4 + 24) = 1 + 3 + 28 = 32
     let complex_nested_size = 1 + (1 + 2) + (4 + (8 + 16)); // 32
 
-    
     assert!(TestTupleStruct::INIT_SPACE >= deeply_nested_size + complex_nested_size);
 }
 

--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -206,7 +206,7 @@ fn test_unit_struct() {
 
 #[test]
 fn test_basic_tuple() {
-    assert_eq!(TestTupleStruct::INIT_SPACE >= 31, true);
+    assert!(TestTupleStruct::INIT_SPACE >= 31);
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn test_tuple_with_options() {
 #[test]
 fn test_tuple_with_arrays() {
     // array_tuple: ([u8; 4], u16) = (4 * 1) + 2 = 6
-    let array_tuple_size = (4 * 1) + 2; // 6
+    let array_tuple_size = 4 + 2; // 6
 
     // tuple_array_nested: (u8, ([u16; 2], u32)) = 1 + ((2 * 2) + 4) = 1 + (4 + 4) = 9
     let tuple_array_nested_size = 1 + ((2 * 2) + 4); // 9

--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -109,6 +109,37 @@ pub struct TestUnnamedStruct(
 #[derive(InitSpace)]
 pub struct TestUnitStruct;
 
+#[derive(InitSpace)]
+pub struct TestTupleStruct {
+    pub test_tuple: (u8, u16, u32, u64, u128),
+    pub mixed_tuple: (bool, f32, f64, i8, i16, i32, i64, i128),
+
+    pub nested_tuple: (u8, (u16, u32, u64, u128)),
+    pub deeply_nested: (u8, (u16, (u32, (u64, u128)))),
+    pub complex_nested: (bool, (u8, u16), (u32, (u64, u128))),
+
+    pub option_tuple: Option<(u8, u16, u32, u64, u128)>,
+    pub tuple_with_option: (u8, Option<u16>, u32),
+    pub nested_option_tuple: (u8, Option<(u16, u32)>, u64),
+
+    pub pubkey_tuple: (Pubkey, u64),
+    pub tuple_with_pubkeys: (Pubkey, Pubkey, u8),
+
+    pub struct_tuple: (ChildStruct, u8),
+    pub nested_struct_tuple: (u8, (ChildStruct, u16)),
+
+    pub single_tuple: (u64,),
+    pub single_nested: ((u8,),),
+
+    pub empty_tuple: (),
+    pub tuple_with_empty: (u8, (), u16),
+
+    pub array_tuple: ([u8; 4], u16),
+    pub tuple_array_nested: (u8, ([u16; 2], u32)),
+
+    pub ultimate_complex: (u8, (bool, Option<(u16, u32)>, ChildStruct), Pubkey),
+}
+
 #[test]
 fn test_empty_struct() {
     assert_eq!(TestEmptyAccount::INIT_SPACE, 0);
@@ -171,4 +202,81 @@ fn test_unnamed_struct() {
 #[test]
 fn test_unit_struct() {
     assert_eq!(TestUnitStruct::INIT_SPACE, 0)
+}
+
+#[test]
+fn test_basic_tuple() {
+    assert_eq!(TestTupleStruct::INIT_SPACE >= 31, true);
+}
+
+#[test]
+fn test_tuple_space_calculations() {
+    let basic_tuple_size = 1 + 2 + 4 + 8 + 16; // 31
+
+    let mixed_tuple_size = 1 + 4 + 8 + 1 + 2 + 4 + 8 + 16; // 44
+
+    let nested_tuple_size = 1 + (2 + 4 + 8 + 16); // 31
+
+    let option_tuple_size = 1 + (1 + 2 + 4 + 8 + 16); // 32
+
+    let pubkey_tuple_size = 32 + 8; // 40
+
+    let single_tuple_size = 8;
+
+    let empty_tuple_size = 0;
+
+    let minimum_expected_size = basic_tuple_size
+        + mixed_tuple_size
+        + nested_tuple_size
+        + option_tuple_size
+        + pubkey_tuple_size
+        + single_tuple_size
+        + empty_tuple_size;
+
+    assert!(TestTupleStruct::INIT_SPACE >= minimum_expected_size);
+}
+
+#[test]
+fn test_tuple_with_structs() {
+    // Test that tuples containing other structs work correctly
+    // struct_tuple: (ChildStruct, u8) = ChildStruct::INIT_SPACE + 1
+    let expected_struct_tuple_contribution = ChildStruct::INIT_SPACE + 1;
+
+    assert!(TestTupleStruct::INIT_SPACE >= expected_struct_tuple_contribution);
+}
+
+#[test]
+fn test_nested_tuple_complexity() {
+    // Test deeply_nested: (u8, (u16, (u32, (u64, u128))))
+    // = 1 + (2 + (4 + (8 + 16))) = 1 + (2 + (4 + 24)) = 1 + (2 + 28) = 1 + 30 = 31
+    let deeply_nested_size = 1 + 2 + 4 + 8 + 16; // 31
+
+    // Test complex_nested: (bool, (u8, u16), (u32, (u64, u128)))
+    // = 1 + (1 + 2) + (4 + (8 + 16)) = 1 + 3 + (4 + 24) = 1 + 3 + 28 = 32
+    let complex_nested_size = 1 + (1 + 2) + (4 + (8 + 16)); // 32
+
+    // These should be included in the total calculation
+    assert!(TestTupleStruct::INIT_SPACE >= deeply_nested_size + complex_nested_size);
+}
+
+#[test]
+fn test_tuple_with_options() {
+    // tuple_with_option: (u8, Option<u16>, u32) = 1 + (1 + 2) + 4 = 8
+    let tuple_with_option_size = 1 + (1 + 2) + 4; // 8
+
+    // nested_option_tuple: (u8, Option<(u16, u32)>, u64) = 1 + (1 + (2 + 4)) + 8 = 16
+    let nested_option_tuple_size = 1 + (1 + (2 + 4)) + 8; // 16
+
+    assert!(TestTupleStruct::INIT_SPACE >= tuple_with_option_size + nested_option_tuple_size);
+}
+
+#[test]
+fn test_tuple_with_arrays() {
+    // array_tuple: ([u8; 4], u16) = (4 * 1) + 2 = 6
+    let array_tuple_size = (4 * 1) + 2; // 6
+
+    // tuple_array_nested: (u8, ([u16; 2], u32)) = 1 + ((2 * 2) + 4) = 1 + (4 + 4) = 9
+    let tuple_array_nested_size = 1 + ((2 * 2) + 4); // 9
+
+    assert!(TestTupleStruct::INIT_SPACE >= array_tuple_size + tuple_array_nested_size);
 }

--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -110,6 +110,7 @@ pub struct TestUnnamedStruct(
 pub struct TestUnitStruct;
 
 #[derive(InitSpace)]
+#[allow(clippy::type_complexity)]
 pub struct TestTupleStruct {
     pub test_tuple: (u8, u16, u32, u64, u128),
     pub mixed_tuple: (bool, f32, f64, i8, i16, i32, i64, i128),
@@ -206,7 +207,8 @@ fn test_unit_struct() {
 
 #[test]
 fn test_basic_tuple() {
-    assert!(TestTupleStruct::INIT_SPACE >= 31);
+    let basic_tuple_size = 1 + 2 + 4 + 8 + 16; // 31
+    assert!(TestTupleStruct::INIT_SPACE >= basic_tuple_size);
 }
 
 #[test]

--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -255,7 +255,7 @@ fn test_nested_tuple_complexity() {
     // = 1 + (1 + 2) + (4 + (8 + 16)) = 1 + 3 + (4 + 24) = 1 + 3 + 28 = 32
     let complex_nested_size = 1 + (1 + 2) + (4 + (8 + 16)); // 32
 
-    // These should be included in the total calculation
+    
     assert!(TestTupleStruct::INIT_SPACE >= deeply_nested_size + complex_nested_size);
 }
 


### PR DESCRIPTION
This commit introduces the ability to handle tuple types in the space calculation logic. 

- A new `TestTupleStruct` is added to validate various tuple configurations, including nested and option types, ensuring accurate space calculations through comprehensive unit tests.

Helps to Close: #3704 

