### PR TITLE
fix(cli): resolve cfg directive warnings in default project templates (#3740)

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -37,7 +37,7 @@ pub fn create_program(name: &str, template: ProgramTemplate, with_mollusk: bool)
             program_path.join("Cargo.toml"),
             cargo_toml(name, with_mollusk),
         ),
-        (program_path.join("Xargo.toml"), xargo_toml().into()),
+        // Note: Xargo.toml is no longer needed for modern Solana builds using SBF
     ];
 
     let template_files = match template {
@@ -204,11 +204,17 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+anchor-debug = []
+custom-heap = []
+custom-panic = []
 {2}
 
 [dependencies]
 anchor-lang = "{3}"
 {4}
+
+[lints.rust]
+unexpected_cfgs = {{ level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }}
 "#,
         name,
         name.to_snake_case(),
@@ -216,12 +222,6 @@ anchor-lang = "{3}"
         VERSION,
         dev_dependencies,
     )
-}
-
-fn xargo_toml() -> &'static str {
-    r#"[target.bpfel-unknown-unknown.dependencies.std]
-features = []
-"#
 }
 
 /// Read the program keypair file or create a new one if it doesn't exist.


### PR DESCRIPTION
Fixes #3740

This pull request refines the Rust template for Solana programs in `cli/src/rust_template.rs`. Key updates include removing outdated configurations, adding new debugging and customization options, and introducing linting rules for better code quality.

### Removal of outdated configurations:
* Removed references to `Xargo.toml` as it is no longer needed for modern Solana builds using SBF. (`[cli/src/rust_template.rsL40-R40](diffhunk://#diff-caba398fa4ca1762b150abb98bffb6a49bb4398c43e900e588511209a88aa453L40-R40)`)
* Eliminated the `xargo_toml` function and its associated configuration for BPF targets, as it is now obsolete. (`[cli/src/rust_template.rsL221-L226](diffhunk://#diff-caba398fa4ca1762b150abb98bffb6a49bb4398c43e900e588511209a88aa453L221-L226)`)

### Addition of debugging and customization options:
* Added new features: `anchor-debug`, `custom-heap`, and `custom-panic` to enhance debugging and allow custom memory and error-handling configurations. (`[cli/src/rust_template.rsR207-R217](diffhunk://#diff-caba398fa4ca1762b150abb98bffb6a49bb4398c43e900e588511209a88aa453R207-R217)`)

### Code quality improvements:
* Introduced linting rules under `[lints.rust]` to warn about unexpected configurations, specifically targeting `cfg(target_os, values("solana"))`. (`[cli/src/rust_template.rsR207-R217](diffhunk://#diff-caba398fa4ca1762b150abb98bffb6a49bb4398c43e900e588511209a88aa453R207-R217)`)