### PR TITLE
Fix typos in comments

### DIFF
--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -38,7 +38,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         // we can't leverage the try_accounts implementation for zero and init.
                         if f.is_optional {
                             // Thus, this block essentially reimplements the try_accounts 
-                            // behavior with optional accounts minus the deserialziation.
+                            // behavior with optional accounts minus the deserialization.
                             let empty_behavior = if cfg!(feature = "allow-missing-optionals") {
                                 quote!{ None }
                             } else {

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -79,7 +79,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         /// instructions, where each method handler in the `#[program]` mod is
         /// associated with a struct defining the input arguments to the
         /// method. These should be used directly, when one wants to serialize
-        /// Anchor instruction data, for example, when speciying
+        /// Anchor instruction data, for example, when specifying
         /// instructions on a client.
         pub mod instruction {
             use super::*;


### PR DESCRIPTION


**Description:**  
- Corrected spelling mistakes in code comments for clarity and professionalism.
