### PR TITLE
cli: Fix not respecting `provider.cluster` in `keys sync` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - docker: Upgrade `node` to 20.18.0 LTS ([#3687](https://github.com/solana-foundation/anchor/pull/3687)).
 - cli: Fix using deprecated commitment `recent` in migration scripts ([#3725](https://github.com/coral-xyz/anchor/pull/3725)).
+- cli: Fix not respecting `provider.cluster` in `keys sync` command ([#3761](https://github.com/coral-xyz/anchor/pull/3761)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4595,6 +4595,9 @@ fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Res
             .build()
             .unwrap();
 
+        let cfg_cluster = cfg.provider.cluster.to_owned();
+        println!("Syncing program ids for the configured cluster ({cfg_cluster})\n");
+
         let mut changed_src = false;
         for program in cfg.get_programs(program_name)? {
             // Get the pubkey from the keypair file
@@ -4628,7 +4631,12 @@ fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Res
             }
 
             // Handle declaration in Anchor.toml
-            'outer: for programs in cfg.programs.values_mut() {
+            'outer: for (cluster, programs) in &mut cfg.programs {
+                // Only change if the configured cluster matches the program's cluster
+                if cluster != &cfg_cluster {
+                    continue;
+                }
+
                 for (name, deployment) in programs {
                     // Skip other programs
                     if name != &program.lib_name {


### PR DESCRIPTION
### Problem

As explained in https://github.com/solana-foundation/anchor/issues/3678, `anchor keys sync` command does not take the configured `provider.cluster` into account.

### Summary of changes

Respect `provider.cluster` in the `anchor keys sync` command. 

Essentially, program entries in `Anchor.toml` will only get updated if the configured cluster matches the program's cluster. Cluster configuration is the same as in other commands i.e. both `--provider.cluster` argument and `provider.cluster` in `Anchor.toml` can be used to configure cluster (the former has priority).

Fixes https://github.com/solana-foundation/anchor/issues/3678