### PR TITLE
Updated Rust macro link

### DIFF
--- a/docs/content/docs/basics/program-structure.mdx
+++ b/docs/content/docs/basics/program-structure.mdx
@@ -6,7 +6,7 @@ description:
 ---
 
 The Anchor framework uses
-[Rust macros](https://rust-book.cs.brown.edu/ch20-06-macros.html) to reduce
+[Rust macros](https://rust-book.cs.brown.edu/ch20-05-macros.html?highlight=macros#macros) to reduce
 boilerplate code and simplify the implementation of common security checks
 required for writing Solana programs.
 


### PR DESCRIPTION
Rust macro link was failing with error "page not found". Created this pull request to update the same.