### PR TITLE
feat(lang): update mollusk test template dependencies

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -179,8 +179,7 @@ fn cargo_toml(name: &str, with_mollusk: bool) -> String {
     let dev_dependencies = if with_mollusk {
         r#"
 [dev-dependencies]
-mollusk-svm = "=0.0.15"
-solana-program = "~2.1"
+mollusk-svm = "~0.4"
 "#
     } else {
         ""


### PR DESCRIPTION
Updates the mollusk-svm dev-dependency to the latest version (~0.4).

Removes the explicit solana-program dev dependency from the generated test template, as it is not strictly required for writing mollusk tests.