### PR TITLE
security: require pinned docker images

### DIFF
--- a/.github/workflows/no-unpinned-docker.yaml
+++ b/.github/workflows/no-unpinned-docker.yaml
@@ -1,0 +1,15 @@
+name: No Unpinned Docker Images
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - run: chmod 755 ./docker/check-docker-pin.sh
+      - run: ./docker/check-docker-pin.sh

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -4,7 +4,7 @@
 # is released on GitHub.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:1ec65b2719518e27d4d25f104d93f9fac60dc437f81452302406825c46fcc9cb
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/check-docker-pin.sh
+++ b/docker/check-docker-pin.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script checks that all our Docker images are pinned to a specific SHA256 hash.
+#
+# References as to why...
+#   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
+#   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
+#
+# Explanation of regex ignore choices
+#   - We ignore sha256 because it suggests that the image dep is pinned
+
+git ls-files -z | grep -z "Dockerfile*" | xargs -r -0 grep -s "FROM" | egrep -v 'sha256'
+if [ $? -eq 0 ]; then
+   echo "[!] Unpinned docker files" >&2
+   exit 1
+else
+   echo "[+] No unpinned docker files"
+fi


### PR DESCRIPTION
**Summary of Changes**

This PR introduces the following improvements to enhance Docker image security and CI enforcement:

- **Docker image pinning**: Adds a SHA256 digest to Docker image references to ensure builds always use a specific, trusted image version. This mitigates the risk of supply chain attacks via compromised or mutable tags.
- **Linting script**: Introduces a simple bash script to detect unpinned Docker image references in the codebase.
- **CI enforcement**: Adds a GitHub Action workflow that runs on master to check for any unpinned image references, ensuring compliance from now on.