### PR TITLE
feat(syn): Relax Seeds Syntax

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -500,11 +500,6 @@ fn generate_constraint_init_group(
         Some(c) => match &c.seeds {
             SeedsExpr::List(_) => {
                 let seeds = &mut c.seeds.clone();
-
-                if let Some(pair) = seeds.pop() {
-                    seeds.push_value(pair.into_value());
-                }
-
                 let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
 
                 let validate_pda = if c.bump.is_some() {
@@ -1189,10 +1184,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
         let define_pda = match (&c.seeds, &c.bump) {
             // [list], no bump -> find_program_address + store __bump.
             (SeedsExpr::List(list), None) => {
-                let mut seeds = list.clone();
-                if let Some(pair) = seeds.pop() {
-                    seeds.push_value(pair.into_value());
-                }
+                let seeds = list.clone();
                 let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
 
                 quote! {
@@ -1206,10 +1198,7 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
 
             // [list], explicit bump -> create_program_address.
             (SeedsExpr::List(list), Some(b)) => {
-                let mut seeds = list.clone();
-                if let Some(pair) = seeds.pop() {
-                    seeds.push_value(pair.into_value());
-                }
+                let seeds = list.clone();
                 let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
 
                 quote! {

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -503,6 +503,11 @@ fn generate_constraint_init_group(
                 let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
 
                 let validate_pda = if c.bump.is_some() {
+                    // If the bump is provided with init *and target*, then force it to be the
+                    // canonical bump.
+                    //
+                    // Note that for `#[account(init, seeds)]`, find_program_address has already
+                    // been run in the init constraint find_pda variable.
                     let b = c.bump.as_ref().unwrap();
                     quote! {
                         if #field.key() != __pda_address {

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -497,71 +497,97 @@ fn generate_constraint_init_group(
     // PDA bump seeds.
     let (find_pda, seeds_with_bump) = match &c.seeds {
         None => (quote! {}, quote! {}),
-        Some(c) => {
-            let seeds = &mut c.seeds.clone();
+        Some(c) => match &c.seeds {
+            SeedsExpr::List(_) => {
+                let seeds = &mut c.seeds.clone();
 
-            // If the seeds came with a trailing comma, we need to chop it off
-            // before we interpolate them below.
-            if let Some(pair) = seeds.pop() {
-                seeds.push_value(pair.into_value());
-            }
+                if let Some(pair) = seeds.pop() {
+                    seeds.push_value(pair.into_value());
+                }
 
-            let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| {
-                quote! { #seeds, }
-            });
+                let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
 
-            let validate_pda = {
-                // If the bump is provided with init *and target*, then force it to be the
-                // canonical bump.
-                //
-                // Note that for `#[account(init, seeds)]`, find_program_address has already
-                // been run in the init constraint find_pda variable.
-                if c.bump.is_some() {
+                let validate_pda = if c.bump.is_some() {
                     let b = c.bump.as_ref().unwrap();
                     quote! {
                         if #field.key() != __pda_address {
-                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str).with_pubkeys((#field.key(), __pda_address)));
+                            return Err(anchor_lang::error::Error::from(
+                                anchor_lang::error::ErrorCode::ConstraintSeeds
+                            ).with_account_name(#name_str)
+                             .with_pubkeys((#field.key(), __pda_address)));
                         }
                         if __bump != #b {
-                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str).with_values((__bump, #b)));
+                            return Err(anchor_lang::error::Error::from(
+                                anchor_lang::error::ErrorCode::ConstraintSeeds
+                            ).with_account_name(#name_str)
+                             .with_values((__bump, #b)));
                         }
                     }
                 } else {
-                    // Init seeds but no bump. We already used the canonical to create bump so
-                    // just check the address.
-                    //
-                    // Note that for `#[account(init, seeds)]`, find_program_address has already
-                    // been run in the init constraint find_pda variable.
                     quote! {
                         if #field.key() != __pda_address {
-                            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str).with_pubkeys((#field.key(), __pda_address)));
+                            return Err(anchor_lang::error::Error::from(
+                                anchor_lang::error::ErrorCode::ConstraintSeeds
+                            ).with_account_name(#name_str)
+                             .with_pubkeys((#field.key(), __pda_address)));
                         }
                     }
-                }
-            };
-            let bump = if f.is_optional {
-                quote!(Some(__bump))
-            } else {
-                quote!(__bump)
-            };
+                };
 
-            (
-                quote! {
-                    let (__pda_address, __bump) = Pubkey::find_program_address(
-                        &[#maybe_seeds_plus_comma],
-                        __program_id,
-                    );
-                    __bumps.#field = #bump;
-                    #validate_pda
-                },
-                quote! {
-                    &[
-                        #maybe_seeds_plus_comma
-                        &[__bump][..]
-                    ][..]
-                },
-            )
-        }
+                let bump_tok = if f.is_optional {
+                    quote!(Some(__bump))
+                } else {
+                    quote!(__bump)
+                };
+
+                (
+                    quote! {
+                        let (__pda_address, __bump) = Pubkey::find_program_address(
+                            &[#maybe_seeds_plus_comma],
+                            __program_id,
+                        );
+                        __bumps.#field = #bump_tok;
+                        #validate_pda
+                    },
+                    quote! {
+                        &[
+                            #maybe_seeds_plus_comma
+                            &[__bump][..]
+                        ][..]
+                    },
+                )
+            }
+            SeedsExpr::Expr(expr) => {
+                let bump_tok = if f.is_optional {
+                    quote!(Some(__bump))
+                } else {
+                    quote!(__bump)
+                };
+
+                (
+                    quote! {
+                        let __seeds_slice: &[&[u8]] = #expr;
+                        let (__pda_address, __bump) =
+                            Pubkey::find_program_address(__seeds_slice, __program_id);
+                        __bumps.#field = #bump_tok;
+
+                        /* build signer slice at run‑time */
+                        let mut __signer_seeds_vec: ::std::vec::Vec<&[u8]> =
+                            __seeds_slice.to_vec();
+                        __signer_seeds_vec.push(&[__bump][..]);
+                        let __signer_seeds = __signer_seeds_vec;
+
+                        if #field.key() != __pda_address {
+                            return Err(anchor_lang::error::Error::from(
+                                anchor_lang::error::ErrorCode::ConstraintSeeds
+                            ).with_account_name(#name_str)
+                             .with_pubkeys((#field.key(), __pda_address)));
+                        }
+                    },
+                    quote! { &__signer_seeds[..] },
+                )
+            }
+        },
     };
 
     // Optional check idents
@@ -1145,8 +1171,6 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
         let name = &f.ident;
         let name_str = name.to_string();
 
-        let s = &mut c.seeds.clone();
-
         let deriving_program_id = c
             .program_seed
             .clone()
@@ -1154,38 +1178,87 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
             .map(|program_id| quote! { #program_id.key() })
             // Otherwise fall back to the current program's program_id.
             .unwrap_or(quote! { __program_id });
-
-        // If the seeds came with a trailing comma, we need to chop it off
-        // before we interpolate them below.
-        if let Some(pair) = s.pop() {
-            s.push_value(pair.into_value());
-        }
-
-        let maybe_seeds_plus_comma = (!s.is_empty()).then(|| {
-            quote! { #s, }
-        });
-        let bump = if f.is_optional {
+        // Convenience: how we store the bump so the caller can access it later.
+        let bump_store = if f.is_optional {
             quote!(Some(__bump))
         } else {
             quote!(__bump)
         };
 
-        // Not init here, so do all the checks.
-        let define_pda = match c.bump.as_ref() {
-            // Bump target not given. Find it.
+        if let SeedsExpr::List(list) = &c.seeds {
+            // Work on a *mutable* clone so we can pop / push safely.
+            let mut seeds = list.clone();
+
+            // If the list ends with a trailing comma, `pop()` returns `Pair::Punct`
+            // which we need to turn back into a value before pushing it again.
+            if let Some(pair) = seeds.pop() {
+                seeds.push_value(pair.into_value());
+            }
+
+            let maybe_seeds_plus_comma = (!seeds.is_empty()).then(|| quote! { #seeds, });
+
+            // How we obtain / validate the PDA depends on whether the user gave an
+            // explicit bump inside the attribute (`bump = <expr>`).
+            let define_pda = match &c.bump {
+                // Bump **not** supplied: use `find_program_address`.
+                None => quote! {
+                    let (__pda_address, __bump) = Pubkey::find_program_address(
+                        &[ #maybe_seeds_plus_comma ],
+                        &#deriving_program_id,
+                    );
+                    __bumps.#name = #bump_store;
+                },
+
+                // Bump supplied: use `create_program_address`.
+                Some(b) => quote! {
+                    let __pda_address = Pubkey::create_program_address(
+                        &[ #maybe_seeds_plus_comma &[#b][..] ],
+                        &#deriving_program_id,
+                    ).map_err(|_| anchor_lang::error::Error::from(
+                        anchor_lang::error::ErrorCode::ConstraintSeeds
+                    ).with_account_name(#name_str))?;
+                },
+            };
+
+            return quote! {
+                #define_pda
+
+                if #name.key() != __pda_address {
+                    return Err(anchor_lang::error::Error::from(
+                        anchor_lang::error::ErrorCode::ConstraintSeeds
+                    ).with_account_name(#name_str)
+                     .with_pubkeys((#name.key(), __pda_address)));
+                }
+            };
+        }
+
+        let expr = match &c.seeds {
+            SeedsExpr::Expr(e) => e, // The user‑supplied expression.
+            _ => unreachable!("handled list case above"),
+        };
+
+        // Build the PDA and (when needed) append the bump to create the signer
+        // slice used by downstream CPI helper functions.
+        let define_pda = match &c.bump {
+            // Bump not supplied
             None => quote! {
-                let (__pda_address, __bump) = Pubkey::find_program_address(
-                    &[#maybe_seeds_plus_comma],
-                    &#deriving_program_id,
-                );
-                __bumps.#name = #bump;
+                let __seeds_slice: &[&[u8]] = #expr;
+                let (__pda_address, __bump) =
+                    Pubkey::find_program_address(__seeds_slice, &#deriving_program_id);
+                __bumps.#name = #bump_store;
             },
-            // Bump target given. Use it.
+
+            // Bump supplied.
             Some(b) => quote! {
+                // Copy into a Vec so we can push the provided bump.
+                let mut __seeds_vec: ::std::vec::Vec<&[u8]> = #expr.to_vec();
+                __seeds_vec.push(&[#b][..]);
                 let __pda_address = Pubkey::create_program_address(
-                    &[#maybe_seeds_plus_comma &[#b][..]],
+                    &__seeds_vec[..],
                     &#deriving_program_id,
-                ).map_err(|_| anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str))?;
+                ).map_err(|_| anchor_lang::error::Error::from(
+                    anchor_lang::error::ErrorCode::ConstraintSeeds
+                ).with_account_name(#name_str))?;
             },
         };
         quote! {

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1250,9 +1250,11 @@ fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2
 
             // Bump supplied.
             Some(b) => quote! {
-                // Copy into a Vec so we can push the provided bump.
-                let mut __seeds_vec: ::std::vec::Vec<&[u8]> = #expr.to_vec();
-                __seeds_vec.push(&[#b][..]);
+                // Build a Vec<&[u8]> by concatenating the existing seed slice with the bump as its own seed.
+                let __bump_bytes = [#b];
+                let __seeds_vec: ::std::vec::Vec<&[u8]> =
+                    [#expr, &[&__bump_bytes[..]]].concat();
+
                 let __pda_address = Pubkey::create_program_address(
                     &__seeds_vec[..],
                     &#deriving_program_id,

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -884,7 +884,7 @@ pub enum SeedsExpr {
 }
 
 impl SeedsExpr {
-    /// Return the underlying `Punctuated` if this is the `List` form
+    /// Return the underlying `Punctuated` if this is the `List` form.
     fn list_mut(&mut self) -> Option<&mut Punctuated<Expr, Token![,]>> {
         match self {
             SeedsExpr::List(list) => Some(list),
@@ -892,6 +892,10 @@ impl SeedsExpr {
         }
     }
 
+    /// Mirrors `Punctuated::pop`: removes and returns the last element and its
+    /// trailing punctuation when this is the `List` variant. For the `Expr variant`,
+    /// which represents a single non-list seed expression, returns `None` because
+    /// there is no list to pop from.
     pub fn pop(&mut self) -> Option<syn::punctuated::Pair<Expr, Token![,]>> {
         self.list_mut()?.pop()
     }
@@ -902,6 +906,9 @@ impl SeedsExpr {
         }
     }
 
+    /// Mirrors `Punctuated::push_value`: pushes a value without punctuation onto
+    /// the underlying list when this is the `List` variant. No-op for the `Expr`
+    /// variant.
     pub fn is_empty(&self) -> bool {
         match self {
             SeedsExpr::List(list) => list.is_empty(),
@@ -917,6 +924,7 @@ impl SeedsExpr {
         }
     }
 
+    /// The number of seeds represented: `list.len()` for `List` and `1` for `Expr`.
     pub fn len(&self) -> usize {
         match self {
             SeedsExpr::List(list) => list.len(),

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -903,58 +903,6 @@ impl syn::parse::Parse for SeedsExpr {
     }
 }
 
-impl SeedsExpr {
-    /// Return the underlying `Punctuated` if this is the `List` form
-    fn list_mut(&mut self) -> Option<&mut Punctuated<Expr, Token![,]>> {
-        match self {
-            SeedsExpr::List(list) => Some(list),
-            SeedsExpr::Expr(_) => None,
-        }
-    }
-
-    pub fn pop(&mut self) -> Option<syn::punctuated::Pair<Expr, Token![,]>> {
-        self.list_mut()?.pop()
-    }
-
-    pub fn push_value(&mut self, value: Expr) {
-        if let Some(list) = self.list_mut() {
-            list.push_value(value);
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            SeedsExpr::List(list) => list.is_empty(),
-            SeedsExpr::Expr(_) => false, // Treat as “one seed”
-        }
-    }
-
-    /// Immutable iteration over every seed expression, regardless of variant
-    pub fn iter(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
-        match self {
-            SeedsExpr::List(list) => Box::new(list.iter()),
-            SeedsExpr::Expr(expr) => Box::new(std::iter::once(expr)),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            SeedsExpr::List(list) => list.len(),
-            SeedsExpr::Expr(_) => 1,
-        }
-    }
-}
-
-/// Allow `quote!{ #seeds }`
-impl quote::ToTokens for SeedsExpr {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self {
-            SeedsExpr::List(list) => list.to_tokens(tokens),
-            SeedsExpr::Expr(expr) => expr.to_tokens(tokens),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ConstraintSeedsGroup {
     pub is_init: bool,

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -910,6 +910,21 @@ impl SeedsExpr {
             SeedsExpr::Expr(_) => false, // Treat as “one seed”
         }
     }
+
+    /// Immutable iteration over every seed expression, regardless of variant
+    pub fn iter(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
+        match self {
+            SeedsExpr::List(list) => Box::new(list.iter()),
+            SeedsExpr::Expr(expr) => Box::new(std::iter::once(expr.as_ref())),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            SeedsExpr::List(list) => list.len(),
+            SeedsExpr::Expr(_) => 1,
+        }
+    }
 }
 
 /// Allow `quote!{ #seeds }`

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -883,6 +883,58 @@ pub enum SeedsExpr {
     Expr(Box<Expr>),
 }
 
+impl SeedsExpr {
+    /// Return the underlying `Punctuated` if this is the `List` form
+    fn list_mut(&mut self) -> Option<&mut Punctuated<Expr, Token![,]>> {
+        match self {
+            SeedsExpr::List(list) => Some(list),
+            SeedsExpr::Expr(_) => None,
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<syn::punctuated::Pair<Expr, Token![,]>> {
+        self.list_mut()?.pop()
+    }
+
+    pub fn push_value(&mut self, value: Expr) {
+        if let Some(list) = self.list_mut() {
+            list.push_value(value);
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            SeedsExpr::List(list) => list.is_empty(),
+            SeedsExpr::Expr(_) => false, // Treat as “one seed”
+        }
+    }
+
+    /// Immutable iteration over every seed expression, regardless of variant
+    pub fn iter(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
+        match self {
+            SeedsExpr::List(list) => Box::new(list.iter()),
+            SeedsExpr::Expr(expr) => Box::new(std::iter::once(expr.as_ref())),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            SeedsExpr::List(list) => list.len(),
+            SeedsExpr::Expr(_) => 1,
+        }
+    }
+}
+
+/// Allow `quote!{ #seeds }`
+impl quote::ToTokens for SeedsExpr {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            SeedsExpr::List(list) => list.to_tokens(tokens),
+            SeedsExpr::Expr(expr) => expr.to_tokens(tokens),
+        }
+    }
+}
+
 impl syn::parse::Parse for SeedsExpr {
     fn parse(stream: syn::parse::ParseStream) -> syn::parse::Result<Self> {
         if stream.peek(syn::token::Bracket) {

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -892,9 +892,7 @@ impl SeedsExpr {
         }
     }
 
-    pub fn pop(
-        &mut self,
-    ) -> Option<syn::punctuated::Pair<Expr, Token![,]>> {
+    pub fn pop(&mut self) -> Option<syn::punctuated::Pair<Expr, Token![,]>> {
         self.list_mut()?.pop()
     }
 

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -873,17 +873,27 @@ pub struct ConstraintInitGroup {
     pub kind: InitKind,
 }
 
+/// Seeds can be written as a literal slice (`[ a, b ]`) or any
+/// expression that produces `&[&[u8]]` at run time.
+#[derive(Debug, Clone)]
+pub enum SeedsExpr {
+    /// `[ b"prefix".as_ref(), key.as_ref() ]`
+    List(Punctuated<Expr, Token![,]>),
+    /// `pda_seeds(key)`
+    Expr(Box<Expr>),
+}
+
 #[derive(Debug, Clone)]
 pub struct ConstraintSeedsGroup {
     pub is_init: bool,
-    pub seeds: Punctuated<Expr, Token![,]>,
+    pub seeds: SeedsExpr,
     pub bump: Option<Expr>,         // None => bump was given without a target.
     pub program_seed: Option<Expr>, // None => use the current program's program_id.
 }
 
 #[derive(Debug, Clone)]
 pub struct ConstraintSeeds {
-    pub seeds: Punctuated<Expr, Token![,]>,
+    pub seeds: SeedsExpr,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -879,8 +879,8 @@ pub struct ConstraintInitGroup {
 pub enum SeedsExpr {
     /// Example: `[ b"prefix".as_ref(), key.as_ref() ]`
     List(Punctuated<Expr, Token![,]>),
-    /// Exampl: `pda_seeds(key)`
-    Expr(Box<Expr>),
+    /// Example: `pda_seeds(key)`
+    Expr(Expr),
 }
 
 impl SeedsExpr {
@@ -913,7 +913,7 @@ impl SeedsExpr {
     pub fn iter(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
         match self {
             SeedsExpr::List(list) => Box::new(list.iter()),
-            SeedsExpr::Expr(expr) => Box::new(std::iter::once(expr.as_ref())),
+            SeedsExpr::Expr(expr) => Box::new(std::iter::once(expr)),
         }
     }
 

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -880,7 +880,7 @@ pub enum SeedsExpr {
     /// Example: `[ b"prefix".as_ref(), key.as_ref() ]`
     List(Punctuated<Expr, Token![,]>),
     /// Example: `pda_seeds(key)`
-    Expr(Expr),
+    Expr(Box<Expr>),
 }
 
 impl syn::parse::Parse for SeedsExpr {
@@ -898,7 +898,7 @@ impl syn::parse::Parse for SeedsExpr {
 
             Ok(SeedsExpr::List(list))
         } else {
-            Ok(SeedsExpr::Expr(stream.parse()?))
+            Ok(SeedsExpr::Expr(Box::new(stream.parse()?)))
         }
     }
 }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::{bracketed, token, Expr, Ident, Token};
+use syn::{Expr, Ident, Token};
 
 pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);
@@ -365,14 +365,7 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     .join(stream.span())
                     .unwrap_or_else(|| ident.span());
 
-                let seeds_expr = if stream.peek(token::Bracket) {
-                    let content;
-                    let _bracket = bracketed!(content in stream);
-                    SeedsExpr::List(content.parse_terminated(Expr::parse)?)
-                } else {
-                    SeedsExpr::Expr(stream.parse()?)
-                };
-
+                let seeds_expr: SeedsExpr = stream.parse()?;
                 ConstraintToken::Seeds(Context::new(span, ConstraintSeeds { seeds: seeds_expr }))
             }
         }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::{bracketed, Token};
+use syn::{bracketed, token, Expr, Ident, Token};
 
 pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);
@@ -364,13 +364,18 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     .span()
                     .join(stream.span())
                     .unwrap_or_else(|| ident.span());
-                let seeds;
-                let bracket = bracketed!(seeds in stream);
+
+                let seeds_expr = if stream.peek(token::Bracket) {
+                    let content;
+                    let _bracket = bracketed!(content in stream);
+                    SeedsExpr::List(content.parse_terminated(Expr::parse)?)
+                } else {
+                    SeedsExpr::Expr(Box::new(stream.parse()?))
+                };
+
                 ConstraintToken::Seeds(Context::new(
-                    span.join(bracket.span).unwrap_or(span),
-                    ConstraintSeeds {
-                        seeds: seeds.parse_terminated(Expr::parse)?,
-                    },
+                    span,
+                    ConstraintSeeds { seeds: seeds_expr },
                 ))
             }
         }

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -373,10 +373,7 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     SeedsExpr::Expr(Box::new(stream.parse()?))
                 };
 
-                ConstraintToken::Seeds(Context::new(
-                    span,
-                    ConstraintSeeds { seeds: seeds_expr },
-                ))
+                ConstraintToken::Seeds(Context::new(span, ConstraintSeeds { seeds: seeds_expr }))
             }
         }
         "realloc" => {

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -370,7 +370,7 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     let _bracket = bracketed!(content in stream);
                     SeedsExpr::List(content.parse_terminated(Expr::parse)?)
                 } else {
-                    SeedsExpr::Expr(Box::new(stream.parse()?))
+                    SeedsExpr::Expr(stream.parse()?)
                 };
 
                 ConstraintToken::Seeds(Context::new(span, ConstraintSeeds { seeds: seeds_expr }))

--- a/lang/tests/seeds_compile.rs
+++ b/lang/tests/seeds_compile.rs
@@ -1,0 +1,51 @@
+//! Ensures the `seeds = …` attribute accepts both
+//!   1. A literal slice `[ … ]`, and
+//!   2. An arbitrary expression that evaluates to `&[&[u8]]`.
+//!
+//! The file only needs to **compile**; no runtime logic executes.
+//
+//! Implementation note on leaks: we leak a few bytes per call in
+//! `pda_seeds`.  That is harmless for on‑chain programs because the
+//! binary never unloads.  Once the Anchor tests can use nightly we can
+//! replace it with a `const fn` + `OnceLock` that avoids the leak.
+
+#![allow(dead_code)]
+
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+const PREFIX: &[u8] = b"prefix";
+
+/// Builds a `'static` seed slice from `key`
+fn pda_seeds(key: Pubkey) -> &'static [&'static [u8]] {
+    let key_bytes: &'static [u8; 32] = Box::leak(Box::new(key.to_bytes()));
+    // leak `[PREFIX, key_bytes]` and coerce to a slice
+    Box::leak(Box::new([PREFIX, key_bytes])) as &'static [&[u8]]
+}
+
+#[derive(Accounts)]
+pub struct LiteralSeeds<'info> {
+    #[account(
+        // Literal list parsed as `SeedsExpr::List`
+        seeds = [PREFIX, user.key().as_ref()],
+        bump
+    )]
+    pda: Account<'info, Dummy>,
+    user: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ExprSeeds<'info> {
+    #[account(
+        // Expression parsed as `SeedsExpr::Expr`
+        seeds = pda_seeds(user.key()),
+        bump
+    )]
+    pda: Account<'info, Dummy>,
+    user: Signer<'info>,
+}
+
+/// Dummy account so the structs derive cleanly
+#[account]
+pub struct Dummy {}

--- a/lang/tests/seeds_compile.rs
+++ b/lang/tests/seeds_compile.rs
@@ -32,6 +32,11 @@ pub struct LiteralSeeds<'info> {
         bump
     )]
     pda: Account<'info, Dummy>,
+    #[account(
+        // Literal list with a trailing comma parsed as `SeedsExpr::List`
+        seeds = [PREFIX, user.key().as_ref(),],
+        bump
+    )]
     user: Signer<'info>,
 }
 


### PR DESCRIPTION
This PR aims to relax the seeds syntax to resolve #3727. This change would allow for both `[ b"prefix".as_ref(), key.as_ref() ]` and `pda_seeds(key)` to be acceptable expressions in `seeds = ...`