### PR TITLE
remove hard-coded `target` directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - client: Add versioned tx support ([#4207](https://github.com/solana-foundation/anchor/pull/4207)).
 - cli: Add `edition` and `rust-version` to template ([#4048](https://github.com/solana-foundation/anchor/pull/4048))
 - lang: Add `program_id` verification to CPI return values ([#4411](https://github.com/solana-foundation/anchor/pull/4411)).
+- cli: Resolve the target directory via `cargo metadata` so custom target locations (e.g. `CARGO_TARGET_DIR`, workspace-level overrides) work across build, test, deploy and IDL paths ([#3817](https://github.com/solana-foundation/anchor/pull/3817)).
 
 ### Fixes
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{get_keypair, is_hidden, keys_sync, AbsolutePath, DEFAULT_RPC_PORT},
+    crate::{get_keypair, is_hidden, keys_sync, target_dir, AbsolutePath, DEFAULT_RPC_PORT},
     anchor_client::Cluster,
     anchor_lang_idl::types::Idl,
     anyhow::{anyhow, bail, Context, Error, Result},
@@ -224,7 +224,7 @@ impl WithPath<Config> {
             let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
             let lib_name = cargo.lib_name()?;
 
-            let idl_filepath = Path::new("target")
+            let idl_filepath = target_dir()
                 .join("idl")
                 .join(&lib_name)
                 .with_extension("json");
@@ -549,7 +549,7 @@ impl Config {
                         let config_dir = p.parent().unwrap();
                         // Make sure the program id is correct (only on the initial build)
                         let mut cfg = Config::from_path(&p)?;
-                        let deploy_dir = config_dir.join("target").join("deploy");
+                        let deploy_dir = target_dir().join("deploy");
                         if !deploy_dir.exists() && !cfg.programs.contains_key(&Cluster::Localnet) {
                             println!("Updating program ids...");
                             fs::create_dir_all(deploy_dir)?;
@@ -1450,7 +1450,7 @@ impl Program {
 
     // Lazily initializes the keypair file with a new key if it doesn't exist.
     pub fn keypair_file(&self) -> Result<WithPath<File>> {
-        let deploy_dir_path = Path::new("target").join("deploy");
+        let deploy_dir_path = target_dir().join("deploy");
         fs::create_dir_all(&deploy_dir_path)
             .with_context(|| format!("Error creating directory with path: {deploy_dir_path:?}"))?;
         let path = std::env::current_dir()
@@ -1471,7 +1471,7 @@ impl Program {
     }
 
     pub fn binary_path(&self, verifiable: bool) -> PathBuf {
-        let path = Path::new("target")
+        let path = target_dir()
             .join(if verifiable { "verifiable" } else { "deploy" })
             .join(&self.lib_name)
             .with_extension("so");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -224,7 +224,7 @@ impl WithPath<Config> {
             let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
             let lib_name = cargo.lib_name()?;
 
-            let idl_filepath = target_dir()
+            let idl_filepath = target_dir()?
                 .join("idl")
                 .join(&lib_name)
                 .with_extension("json");
@@ -549,7 +549,7 @@ impl Config {
                         let config_dir = p.parent().unwrap();
                         // Make sure the program id is correct (only on the initial build)
                         let mut cfg = Config::from_path(&p)?;
-                        let deploy_dir = target_dir().join("deploy");
+                        let deploy_dir = target_dir()?.join("deploy");
                         if !deploy_dir.exists() && !cfg.programs.contains_key(&Cluster::Localnet) {
                             println!("Updating program ids...");
                             fs::create_dir_all(deploy_dir)?;
@@ -1450,7 +1450,7 @@ impl Program {
 
     // Lazily initializes the keypair file with a new key if it doesn't exist.
     pub fn keypair_file(&self) -> Result<WithPath<File>> {
-        let deploy_dir_path = target_dir().join("deploy");
+        let deploy_dir_path = target_dir()?.join("deploy");
         fs::create_dir_all(&deploy_dir_path)
             .with_context(|| format!("Error creating directory with path: {deploy_dir_path:?}"))?;
         let path = std::env::current_dir()
@@ -1470,15 +1470,15 @@ impl Program {
         Ok(WithPath::new(file, path))
     }
 
-    pub fn binary_path(&self, verifiable: bool) -> PathBuf {
-        let path = target_dir()
+    pub fn binary_path(&self, verifiable: bool) -> Result<PathBuf> {
+        let path = target_dir()?
             .join(if verifiable { "verifiable" } else { "deploy" })
             .join(&self.lib_name)
             .with_extension("so");
 
-        std::env::current_dir()
+        Ok(std::env::current_dir()
             .expect("Must have current dir")
-            .join(path)
+            .join(path))
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -47,7 +47,7 @@ use {
         path::{Path, PathBuf},
         process::{Child, ExitStatus, Stdio},
         string::ToString,
-        sync::LazyLock,
+        sync::{LazyLock, OnceLock},
     },
 };
 
@@ -1418,7 +1418,7 @@ fn init(
     // Build the program.
     rust_template::create_program(&project_name, template, Some(&test_template))?;
 
-    let program_id = rust_template::get_or_create_program_id(&rust_name, target_dir());
+    let program_id = rust_template::get_or_create_program_id(&rust_name, target_dir()?);
     let mut localnet = BTreeMap::new();
     localnet.insert(
         rust_name,
@@ -1590,7 +1590,7 @@ fn new(
                 programs.insert(
                     name.clone(),
                     ProgramDeployment {
-                        address: rust_template::get_or_create_program_id(&name, target_dir()),
+                        address: rust_template::get_or_create_program_id(&name, target_dir()?),
                         path: None,
                         idl: None,
                     },
@@ -1827,13 +1827,13 @@ pub fn build(
 
     let idl_out = match idl {
         Some(idl) => Some(PathBuf::from(idl)),
-        None => Some(target_dir().join("idl")),
+        None => Some(target_dir()?.join("idl")),
     };
     fs::create_dir_all(idl_out.as_ref().unwrap())?;
 
     let idl_ts_out = match idl_ts {
         Some(idl_ts) => Some(PathBuf::from(idl_ts)),
-        None => Some(target_dir().join("types")),
+        None => Some(target_dir()?.join("types")),
     };
     fs::create_dir_all(idl_ts_out.as_ref().unwrap())?;
 
@@ -2000,7 +2000,7 @@ fn build_cwd_verifiable(
 ) -> Result<()> {
     // Create output dirs.
     let workspace_dir = cfg.path().parent().unwrap().canonicalize()?;
-    let target_dir = target_dir();
+    let target_dir = target_dir()?;
     fs::create_dir_all(target_dir.join("verifiable"))?;
     fs::create_dir_all(target_dir.join("idl"))?;
     fs::create_dir_all(target_dir.join("types"))?;
@@ -3484,7 +3484,7 @@ fn validator_flags(
     let mut flags = Vec::new();
     for mut program in cfg.read_all_programs()? {
         let verifiable = false;
-        let binary_path = program.binary_path(verifiable).display().to_string();
+        let binary_path = program.binary_path(verifiable)?.display().to_string();
         // Use the [programs.cluster] override and fallback to the keypair
         // files if no override is given.
         let address = programs
@@ -3508,7 +3508,7 @@ fn validator_flags(
             idl.address = address;
 
             // Persist it.
-            let idl_out = target_dir()
+            let idl_out = target_dir()?
                 .join("idl")
                 .join(&idl.metadata.name)
                 .with_extension("json");
@@ -3659,7 +3659,7 @@ fn surfpool_flags(
         if let Some(idl) = program.idl.as_mut() {
             // Creating the idl files
             idl.address = address;
-            let idl_out = target_dir()
+            let idl_out = target_dir()?
                 .join("idl")
                 .join(&idl.metadata.name)
                 .with_extension("json");
@@ -3869,7 +3869,7 @@ fn stream_solana_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<Lo
 
     // Subscribe to logs for all workspace programs
     for program in config.read_all_programs()? {
-        let idl_path = target_dir()
+        let idl_path = target_dir()?
             .join("idl")
             .join(&program.lib_name)
             .with_extension("json");
@@ -4190,7 +4190,7 @@ fn clean(cfg_override: &ConfigOverride) -> Result<()> {
     };
 
     let dot_anchor_dir = workspace_root.join(".anchor");
-    let target_dir = crate::target_dir();
+    let target_dir = crate::target_dir()?;
     let deploy_dir = target_dir.join("deploy");
 
     if dot_anchor_dir.exists() {
@@ -4251,7 +4251,7 @@ fn deploy(
         println!("Upgrade authority: {keypair}");
 
         for program in cfg.get_programs(program_name)? {
-            let binary_path = program.binary_path(verifiable);
+            let binary_path = program.binary_path(verifiable)?;
 
             println!("Deploying program {:?}...", program.lib_name);
             println!("Program path: {}...", binary_path.display());
@@ -4901,18 +4901,16 @@ fn localnet(
     })?
 }
 
-/// Return the cargo build artifacts directory. Caches the result assuming that
-/// a single run will only work with a single rust workspace. Exits the process
-/// if the directory cannot be determined.
-pub fn target_dir() -> PathBuf {
-    static TARGET_DIR: LazyLock<Result<PathBuf>> = LazyLock::new(target_dir_no_cache);
-    match TARGET_DIR.as_ref() {
-        Ok(path) => path.clone(),
-        Err(e) => {
-            eprintln!("Error: {e:?}");
-            std::process::exit(1);
-        }
+/// Return the cargo build artifacts directory. The successful result is
+/// cached.
+pub fn target_dir() -> Result<&'static Path> {
+    static TARGET_DIR: OnceLock<PathBuf> = OnceLock::new();
+    if let Some(path) = TARGET_DIR.get() {
+        return Ok(path.as_path());
     }
+    let path = target_dir_no_cache()?;
+    let _ = TARGET_DIR.set(path);
+    Ok(TARGET_DIR.get().expect("just set").as_path())
 }
 
 /// Return the cargo build artifacts directory.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4939,8 +4939,8 @@ fn target_dir_no_cache() -> Result<PathBuf> {
 }
 
 // with_workspace ensures the current working directory is always the top level
-// where the `Anchor.toml` file is located, before and after the closure
-// invocation.
+// workspace directory, i.e., where the `Anchor.toml` file is located, before
+// and after the closure invocation.
 //
 // The closure passed into this function must never change the working directory
 // to be outside the workspace. Doing so will have undefined behavior.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -23,6 +23,7 @@ use {
     regex::{Regex, RegexBuilder},
     rust_template::{ProgramTemplate, TestTemplate},
     semver::{Version, VersionReq},
+    serde::Deserialize,
     serde_json::{json, Map, Value as JsonValue},
     solana_cli_config::Config as SolanaCliConfig,
     solana_commitment_config::CommitmentConfig,
@@ -1399,20 +1400,6 @@ fn init(
     let package_manager_cmd = package_manager.to_string();
     cfg.toolchain.package_manager = Some(package_manager);
 
-    let mut localnet = BTreeMap::new();
-    let program_id = rust_template::get_or_create_program_id(&rust_name);
-    localnet.insert(
-        rust_name,
-        ProgramDeployment {
-            address: program_id,
-            path: None,
-            idl: None,
-        },
-    );
-    cfg.programs.insert(Cluster::Localnet, localnet);
-    let toml = cfg.to_string();
-    fs::write("Anchor.toml", toml)?;
-
     // Initialize .gitignore file
     fs::write(".gitignore", rust_template::git_ignore())?;
 
@@ -1430,6 +1417,20 @@ fn init(
 
     // Build the program.
     rust_template::create_program(&project_name, template, Some(&test_template))?;
+
+    let program_id = rust_template::get_or_create_program_id(&rust_name, target_dir());
+    let mut localnet = BTreeMap::new();
+    localnet.insert(
+        rust_name,
+        ProgramDeployment {
+            address: program_id,
+            path: None,
+            idl: None,
+        },
+    );
+    cfg.programs.insert(Cluster::Localnet, localnet);
+    let toml = cfg.to_string();
+    fs::write("Anchor.toml", toml)?;
 
     // Build the migrations directory.
     let migrations_path = Path::new("migrations");
@@ -1589,7 +1590,7 @@ fn new(
                 programs.insert(
                     name.clone(),
                     ProgramDeployment {
-                        address: rust_template::get_or_create_program_id(&name),
+                        address: rust_template::get_or_create_program_id(&name, target_dir()),
                         path: None,
                         idl: None,
                     },
@@ -1826,13 +1827,13 @@ pub fn build(
 
     let idl_out = match idl {
         Some(idl) => Some(PathBuf::from(idl)),
-        None => Some(cfg_parent.join("target").join("idl")),
+        None => Some(target_dir().join("idl")),
     };
     fs::create_dir_all(idl_out.as_ref().unwrap())?;
 
     let idl_ts_out = match idl_ts {
         Some(idl_ts) => Some(PathBuf::from(idl_ts)),
-        None => Some(cfg_parent.join("target").join("types")),
+        None => Some(target_dir().join("types")),
     };
     fs::create_dir_all(idl_ts_out.as_ref().unwrap())?;
 
@@ -1999,7 +2000,7 @@ fn build_cwd_verifiable(
 ) -> Result<()> {
     // Create output dirs.
     let workspace_dir = cfg.path().parent().unwrap().canonicalize()?;
-    let target_dir = workspace_dir.join("target");
+    let target_dir = target_dir();
     fs::create_dir_all(target_dir.join("verifiable"))?;
     fs::create_dir_all(target_dir.join("idl"))?;
     fs::create_dir_all(target_dir.join("types"))?;
@@ -2031,8 +2032,7 @@ fn build_cwd_verifiable(
             let idl = generate_idl(cfg, skip_lint, no_docs, &cargo_args)?;
             // Write out the JSON file.
             println!("Writing the IDL file");
-            let out_file = workspace_dir
-                .join("target")
+            let out_file = target_dir
                 .join("idl")
                 .join(&idl.metadata.name)
                 .with_extension("json");
@@ -2040,8 +2040,7 @@ fn build_cwd_verifiable(
 
             // Write out the TypeScript type.
             println!("Writing the .ts file");
-            let ts_file = workspace_dir
-                .join("target")
+            let ts_file = target_dir
                 .join("types")
                 .join(&idl.metadata.name)
                 .with_extension("ts");
@@ -3509,7 +3508,7 @@ fn validator_flags(
             idl.address = address;
 
             // Persist it.
-            let idl_out = Path::new("target")
+            let idl_out = target_dir()
                 .join("idl")
                 .join(&idl.metadata.name)
                 .with_extension("json");
@@ -3660,7 +3659,7 @@ fn surfpool_flags(
         if let Some(idl) = program.idl.as_mut() {
             // Creating the idl files
             idl.address = address;
-            let idl_out = Path::new("target")
+            let idl_out = target_dir()
                 .join("idl")
                 .join(&idl.metadata.name)
                 .with_extension("json");
@@ -3870,7 +3869,7 @@ fn stream_solana_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<Lo
 
     // Subscribe to logs for all workspace programs
     for program in config.read_all_programs()? {
-        let idl_path = Path::new("target")
+        let idl_path = target_dir()
             .join("idl")
             .join(&program.lib_name)
             .with_extension("json");
@@ -4191,7 +4190,7 @@ fn clean(cfg_override: &ConfigOverride) -> Result<()> {
     };
 
     let dot_anchor_dir = workspace_root.join(".anchor");
-    let target_dir = workspace_root.join("target");
+    let target_dir = crate::target_dir();
     let deploy_dir = target_dir.join("deploy");
 
     if dot_anchor_dir.exists() {
@@ -4902,9 +4901,48 @@ fn localnet(
     })?
 }
 
+/// Return the cargo build artifacts directory. Caches the result assuming that
+/// a single run will only work with a single rust workspace. Exits the process
+/// if the directory cannot be determined.
+pub fn target_dir() -> PathBuf {
+    static TARGET_DIR: LazyLock<Result<PathBuf>> = LazyLock::new(target_dir_no_cache);
+    match TARGET_DIR.as_ref() {
+        Ok(path) => path.clone(),
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Return the cargo build artifacts directory.
+fn target_dir_no_cache() -> Result<PathBuf> {
+    // `cargo metadata` produces a JSON blob from which we extract the
+    // `target_directory` field.
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version=1"])
+        .output()
+        .context("Failed to execute 'cargo metadata'")?;
+
+    if !output.status.success() {
+        let stderr_msg = String::from_utf8_lossy(&output.stderr);
+        bail!("'cargo metadata' failed with: {stderr_msg}");
+    }
+
+    #[derive(Deserialize)]
+    struct CargoMetadata {
+        target_directory: PathBuf,
+    }
+
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)
+        .context("Failed to parse 'cargo metadata' output")?;
+
+    Ok(metadata.target_directory)
+}
+
 // with_workspace ensures the current working directory is always the top level
-// workspace directory, i.e., where the `Anchor.toml` file is located, before
-// and after the closure invocation.
+// where the `Anchor.toml` file is located, before and after the closure
+// invocation.
 //
 // The closure passed into this function must never change the working directory
 // to be outside the workspace. Doing so will have undefined behavior.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2237,14 +2237,10 @@ fn docker_build_bpf(
 
     // Copy the binary out of the docker image.
     println!("Copying out the build artifacts");
-    let out_file = cfg_parent
-        .canonicalize()?
-        .join(
-            Path::new("target")
-                .join("verifiable")
-                .join(&binary_name)
-                .with_extension("so"),
-        )
+    let out_file = crate::target_dir()?
+        .join("verifiable")
+        .join(&binary_name)
+        .with_extension("so")
         .display()
         .to_string();
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -296,7 +296,7 @@ fn deploy_workspace(
     }
 
     for program in programs {
-        let binary_path = program.binary_path(verifiable);
+        let binary_path = program.binary_path(verifiable)?;
 
         println!("\nDeploying program: {}", program.lib_name);
 
@@ -495,7 +495,7 @@ pub fn program_deploy(
         let programs = get_programs_from_workspace(cfg_override, program_name.clone())?;
 
         let program = &programs[0];
-        let binary_path = program.binary_path(false); // false = not verifiable build
+        let binary_path = program.binary_path(false)?; // false = not verifiable build
 
         println!("Deploying program: {}", program.lib_name);
 
@@ -994,7 +994,7 @@ fn program_write_buffer(
         }
 
         let program = &programs[0];
-        let binary_path = program.binary_path(false);
+        let binary_path = program.binary_path(false)?;
 
         println!("Writing buffer for program: {}", program.lib_name);
 
@@ -1374,7 +1374,7 @@ pub fn program_upgrade(
         let programs = get_programs_from_workspace(cfg_override, program_name.clone())?;
 
         let program = &programs[0];
-        let binary_path = program.binary_path(false); // false = not verifiable build
+        let binary_path = program.binary_path(false)?; // false = not verifiable build
 
         println!("Upgrading program: {}", program.lib_name);
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         config::{Config, Manifest, Program, WithPath},
-        ConfigOverride, ProgramCommand,
+        target_dir, ConfigOverride, ProgramCommand,
     },
     anchor_lang_idl::types::Idl,
     anyhow::{anyhow, bail, Result},
@@ -102,8 +102,7 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
         }
 
         // Try to read IDL if it exists (will be None for non-Anchor programs)
-        let idl_filepath = current_dir
-            .join("target")
+        let idl_filepath = target_dir()?
             .join("idl")
             .join(&lib_name)
             .with_extension("json");
@@ -538,12 +537,14 @@ pub fn program_deploy(
             .and_then(|s| s.to_str())
             .ok_or_else(|| anyhow!("Invalid program filepath"))?;
 
-        let keypair_path = format!("target/deploy/{}-keypair.json", program_name);
+        let keypair_path = target_dir()?
+            .join("deploy")
+            .join(format!("{program_name}-keypair.json"));
         Keypair::read_from_file(&keypair_path).map_err(|e| {
             anyhow!(
                 "Failed to read program keypair from {}: {}. Use --program-keypair to specify a \
                  custom location.",
-                keypair_path,
+                keypair_path.display(),
                 e
             )
         })?
@@ -657,7 +658,10 @@ pub fn program_deploy(
             .ok_or_else(|| anyhow!("Invalid program filepath"))?;
 
         // Look for IDL file in target/idl/{program_name}.json
-        let idl_filepath: PathBuf = format!("target/idl/{}.json", program_name).into();
+        let idl_filepath = target_dir()?
+            .join("idl")
+            .join(program_name)
+            .with_extension("json");
 
         if Path::new(&idl_filepath).exists() {
             // Read and update the IDL with the program address

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -54,7 +54,7 @@ pub fn create_program(
 
     create_files(&common_files)?;
 
-    let target_path = crate::target_dir();
+    let target_path = crate::target_dir()?;
 
     // Remove the stub version
     fs::remove_file(&lib_rs_path)?;

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -37,6 +37,7 @@ pub fn create_program(
     test_template: Option<&TestTemplate>,
 ) -> Result<()> {
     let program_path = Path::new("programs").join(name);
+    let lib_rs_path = program_path.join("src").join("lib.rs");
     let common_files = vec![
         ("Cargo.toml".into(), workspace_manifest()),
         ("rust-toolchain.toml".into(), rust_toolchain_toml()),
@@ -44,8 +45,19 @@ pub fn create_program(
             program_path.join("Cargo.toml"),
             cargo_toml(name, test_template),
         ),
-        // Note: Xargo.toml is no longer needed for modern Solana builds using SBF
+        // One of the create_program_template_* functions will write the full
+        // lib.rs, but we need an empty stub for now so cargo won't throw an
+        // error when asking it where the `target` dir is located.
+        (lib_rs_path.clone(), "".into()),
+        // Note: Xargo.toml is no longer needed for modern Solana builds using SBF.
     ];
+
+    create_files(&common_files)?;
+
+    let target_path = crate::target_dir();
+
+    // Remove the stub version
+    fs::remove_file(&lib_rs_path)?;
 
     let template_files = match template {
         ProgramTemplate::Single => {
@@ -53,12 +65,14 @@ pub fn create_program(
                 "Note: Using single-file template. For better code organization and \
                  maintainability, consider using --template multiple (default)."
             );
-            create_program_template_single(name, &program_path)
+            create_program_template_single(name, &program_path, target_path)
         }
-        ProgramTemplate::Multiple => create_program_template_multiple(name, &program_path),
+        ProgramTemplate::Multiple => {
+            create_program_template_multiple(name, &program_path, target_path)
+        }
     };
 
-    create_files(&[common_files, template_files].concat())
+    create_files(&template_files)
 }
 
 /// Helper to create a rust-toolchain.toml at the workspace root
@@ -73,7 +87,7 @@ profile = "minimal"
 }
 
 /// Create a program with a single `lib.rs` file.
-fn create_program_template_single(name: &str, program_path: &Path) -> Files {
+fn create_program_template_single(name: &str, program_path: &Path, target_path: &Path) -> Files {
     vec![(
         program_path.join("src").join("lib.rs"),
         format!(
@@ -94,14 +108,14 @@ pub mod {} {{
 #[derive(Accounts)]
 pub struct Initialize {{}}
 "#,
-            get_or_create_program_id(name),
+            get_or_create_program_id(name, target_path),
             name.to_snake_case(),
         ),
     )]
 }
 
 /// Create a program with multiple files for instructions, state...
-fn create_program_template_multiple(name: &str, program_path: &Path) -> Files {
+fn create_program_template_multiple(name: &str, program_path: &Path, target_path: &Path) -> Files {
     let src_path = program_path.join("src");
     vec![
         (
@@ -129,7 +143,7 @@ pub mod {} {{
     }}
 }}
 "#,
-                get_or_create_program_id(name),
+                get_or_create_program_id(name, target_path),
                 name.to_snake_case(),
             ),
         ),
@@ -224,6 +238,12 @@ solana-message = "3.0.1"
 solana-transaction = "3.0.2"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# blake3 (transitively dep from litesvm/solana-*) requires constant_time_eq
+# ^0.4. 0.4.3 requires rustc 1.95.
+constant_time_eq = "=0.4.2"
 "#
         }
         _ => "",
@@ -269,8 +289,9 @@ unexpected_cfgs = {{ level = "warn", check-cfg = ['cfg(target_os, values("solana
 }
 
 /// Read the program keypair file or create a new one if it doesn't exist.
-pub fn get_or_create_program_id(name: &str) -> Pubkey {
-    let keypair_path = Path::new("target")
+pub fn get_or_create_program_id(name: &str, target_path: impl AsRef<Path>) -> Pubkey {
+    let keypair_path = target_path
+        .as_ref()
         .join("deploy")
         .join(format!("{}-keypair.json", name.to_snake_case()));
 
@@ -889,21 +910,57 @@ fn create_program_template_litesvm_test(name: &str, tests_path: &Path) -> Files 
 use {{
     anchor_lang::{{solana_program::instruction::Instruction, InstructionData, ToAccountMetas}},
     litesvm::LiteSVM,
+    solana_keypair::Keypair,
     solana_message::{{Message, VersionedMessage}},
     solana_signer::Signer,
-    solana_keypair::Keypair,
     solana_transaction::versioned::VersionedTransaction,
 }};
+
+/// Resolve the workspace's deploy directory
+#[cfg(test)]
+fn deploy_dir() -> &'static std::path::Path {{
+    static DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    DIR.get_or_init(|| {{
+        #[derive(serde::Deserialize)]
+        struct Metadata {{
+            target_directory: std::path::PathBuf,
+        }}
+
+        let out = std::process::Command::new("cargo")
+            .args(["metadata", "--no-deps", "--format-version=1"])
+            .output()
+            .expect("Failed to run `cargo metadata`");
+
+        if !out.status.success() {{
+            panic!(
+                "cargo metadata failed:\n{{}}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }}
+
+        let metadata: Metadata =
+            serde_json::from_slice(&out.stdout).expect("Failed to parse cargo metadata JSON");
+
+        metadata.target_directory.join("deploy")
+    }})
+}}
+
+#[cfg(test)]
+fn get_program_bytes(name: &str) -> Vec<u8> {{
+    let path = deploy_dir().join(format!("{{}}.so", name));
+    std::fs::read(&path)
+        .unwrap_or_else(|_| panic!("Could not read program bytes at {{}}", path.display()))
+}}
 
 #[test]
 fn test_initialize() {{
     let program_id = {0}::id();
     let payer = Keypair::new();
     let mut svm = LiteSVM::new();
-    let bytes = include_bytes!("../../../target/deploy/{0}.so");
-    svm.add_program(program_id, bytes).unwrap();
+    let bytes = get_program_bytes("{0}");
+    svm.add_program(program_id, &bytes).unwrap();
     svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
-    
+
     let instruction = Instruction::new_with_bytes(
         program_id,
         &{0}::instruction::Initialize {{}}.data(),

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -240,10 +240,6 @@ solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
-# blake3 (transitively dep from litesvm/solana-*) requires constant_time_eq
-# ^0.4. 0.4.3 requires rustc 1.95.
-constant_time_eq = "=0.4.2"
 "#
         }
         _ => "",

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -238,8 +238,6 @@ solana-message = "3.0.1"
 solana-transaction = "3.0.2"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 "#
         }
         _ => "",
@@ -912,49 +910,16 @@ use {{
     solana_transaction::versioned::VersionedTransaction,
 }};
 
-/// Resolve the workspace's deploy directory
-#[cfg(test)]
-fn deploy_dir() -> &'static std::path::Path {{
-    static DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
-    DIR.get_or_init(|| {{
-        #[derive(serde::Deserialize)]
-        struct Metadata {{
-            target_directory: std::path::PathBuf,
-        }}
-
-        let out = std::process::Command::new("cargo")
-            .args(["metadata", "--no-deps", "--format-version=1"])
-            .output()
-            .expect("Failed to run `cargo metadata`");
-
-        if !out.status.success() {{
-            panic!(
-                "cargo metadata failed:\n{{}}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }}
-
-        let metadata: Metadata =
-            serde_json::from_slice(&out.stdout).expect("Failed to parse cargo metadata JSON");
-
-        metadata.target_directory.join("deploy")
-    }})
-}}
-
-#[cfg(test)]
-fn get_program_bytes(name: &str) -> Vec<u8> {{
-    let path = deploy_dir().join(format!("{{}}.so", name));
-    std::fs::read(&path)
-        .unwrap_or_else(|_| panic!("Could not read program bytes at {{}}", path.display()))
-}}
-
 #[test]
 fn test_initialize() {{
     let program_id = {0}::id();
     let payer = Keypair::new();
     let mut svm = LiteSVM::new();
-    let bytes = get_program_bytes("{0}");
-    svm.add_program(program_id, &bytes).unwrap();
+    let bytes = include_bytes!(concat!(
+        env!("CARGO_TARGET_TMPDIR"),
+        "/../deploy/{0}.so"
+    ));
+    svm.add_program(program_id, bytes).unwrap();
     svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
 
     let instruction = Instruction::new_with_bytes(

--- a/tests/bench/tests/binary-size.ts
+++ b/tests/bench/tests/binary-size.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import * as fs from "fs/promises";
 import path from "path";
 
@@ -9,8 +10,12 @@ describe("Binary size", () => {
   const binarySize: BinarySize = {};
 
   it("Measure binary size", async () => {
+    const output = execSync("cargo metadata --no-deps --format-version=1", {
+      encoding: "utf8",
+    });
+    const metadata = JSON.parse(output);
     const stat = await fs.stat(
-      path.join("target", "deploy", `${IDL.metadata.name}.so`)
+      path.join(metadata.target_directory, "deploy", `${IDL.metadata.name}.so`)
     );
     binarySize[IDL.metadata.name] = stat.size;
   });

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -1,5 +1,6 @@
 import * as toml from "toml";
 import camelcase from "camelcase";
+import { execSync } from "child_process";
 import { Program } from "./program/index.js";
 import { isBrowser } from "./utils/common.js";
 import { Idl } from "./idl.js";
@@ -54,7 +55,23 @@ const workspace = new Proxy(
         //
         // To avoid the above problem with numbers, read the `idl` directory and
         // compare the camelCased  version of both file names and `programName`.
-        const idlDirPath = path.join("target", "idl");
+        let metadata: { target_directory: string };
+        try {
+          const output = execSync(
+            "cargo metadata --no-deps --format-version=1",
+            {
+              encoding: "utf8",
+            }
+          );
+          metadata = JSON.parse(output);
+        } catch (err) {
+          throw new Error(
+            `Failed to run 'cargo metadata'. Ensure Rust and Cargo are installed and the project is valid.\nOriginal error: ${
+              err instanceof Error ? err.message : err
+            }`
+          );
+        }
+        const idlDirPath = path.join(metadata.target_directory, "idl");
         const fileName = fs
           .readdirSync(idlDirPath)
           .find((name) => camelcase(path.parse(name).name) === programName);

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -5,6 +5,29 @@ import { Program } from "./program/index.js";
 import { isBrowser } from "./utils/common.js";
 import { Idl } from "./idl.js";
 
+let cargoTargetDirectoryCache: string | undefined;
+
+function getCargoTargetDirectory(): string {
+  if (cargoTargetDirectoryCache !== undefined) {
+    return cargoTargetDirectoryCache;
+  }
+  let metadata: { target_directory: string };
+  try {
+    const output = execSync("cargo metadata --no-deps --format-version=1", {
+      encoding: "utf8",
+    });
+    metadata = JSON.parse(output);
+  } catch (err) {
+    throw new Error(
+      `Failed to run 'cargo metadata'. Ensure Rust and Cargo are installed and the project is valid.\nOriginal error: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+  }
+  cargoTargetDirectoryCache = metadata.target_directory;
+  return cargoTargetDirectoryCache;
+}
+
 /**
  * The `workspace` namespace provides a convenience API to automatically
  * search for and deserialize [[Program]] objects defined by compiled IDLs
@@ -55,23 +78,7 @@ const workspace = new Proxy(
         //
         // To avoid the above problem with numbers, read the `idl` directory and
         // compare the camelCased  version of both file names and `programName`.
-        let metadata: { target_directory: string };
-        try {
-          const output = execSync(
-            "cargo metadata --no-deps --format-version=1",
-            {
-              encoding: "utf8",
-            }
-          );
-          metadata = JSON.parse(output);
-        } catch (err) {
-          throw new Error(
-            `Failed to run 'cargo metadata'. Ensure Rust and Cargo are installed and the project is valid.\nOriginal error: ${
-              err instanceof Error ? err.message : err
-            }`
-          );
-        }
-        const idlDirPath = path.join(metadata.target_directory, "idl");
+        const idlDirPath = path.join(getCargoTargetDirectory(), "idl");
         const fileName = fs
           .readdirSync(idlDirPath)
           .find((name) => camelcase(path.parse(name).name) === programName);


### PR DESCRIPTION
Anchor is not playing nice with Rust workspaces.  If you try to place your Anchor based project as a member in a Rust workspace, the cargo build commands issued by Anchor will place build artifacts in the `target/` directory at the top of the *Rust* workspace, while other Anchor tooling assumes that the `target/` directory is located at the top of the "Anchor workspace" (where `Anchor.toml` is located). The workaround people have been using before this pull request is to add a symbolic link from `rust-workspace/anchor-member/target` to `rust-workspace/target`.

Others in the PR issue were having problems because Anchor was not respecting the `CARGO_TARGET_DIR` environment variable.

This PR fixes both problems by asking `cargo` (via the `cargo metadata` command) what directory is currently being used for build artifacts.

Fixes #958

