### PR TITLE
Added Custom error when using init on SystemAccount

### DIFF
--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -94,14 +94,11 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         .collect();
 
     for field in &init_fields {
-        match &field.ty {
-            Ty::SystemAccount => {
-                return Err(ParseError::new(
-                    field.ident.span(),
-                    "cannot use `init` on a SystemAccount; Remove `init` or change the type to `UncheckedAccount`.",
-                ));
-            }
-            _ => {},
+        if matches!(field.ty, Ty::SystemAccount) {
+            return Err(ParseError::new(
+                field.ident.span(),
+                "cannot use `init` on a SystemAccount; Remove `init` or change the type to `UncheckedAccount`.",
+            ));
         }
     }
 

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -97,7 +97,11 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         if matches!(field.ty, Ty::SystemAccount) {
             return Err(ParseError::new(
                 field.ident.span(),
-                "cannot use `init` on a SystemAccount; Remove `init` or change the type to `UncheckedAccount`.",
+                "Cannot use `init` on a `SystemAccount`. \
+                    The `SystemAccount` type represents an already-existing account \
+                    owned by the system program and cannot be initialized. \
+                    If you need to create a new account, use a more specific account type \
+                    or `UncheckedAccount` and perform manual initialization instead.",
             ));
         }
     }

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -93,6 +93,18 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         })
         .collect();
 
+    for field in &init_fields {
+        match &field.ty {
+            Ty::SystemAccount => {
+                return Err(ParseError::new(
+                    field.ident.span(),
+                    "cannot use `init` on a SystemAccount; Remove `init` or change the type to `UncheckedAccount`.",
+                ));
+            }
+            _ => {},
+        }
+    }
+
     if !init_fields.is_empty() {
         // init needs system program.
 


### PR DESCRIPTION
This PR resolves #3826  by adding a compile-time error when a SystemAccount is used with the #[account(init)] constraint.