### PR TITLE
fix(idl): Disable Locale in camelCase

### DIFF
--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -321,7 +321,7 @@ export function convertIdlToCamelCase<I extends Idl>(idl: I) {
 
   // `my_account.field` is getting converted to `myAccountField` but we
   // need `myAccount.field`.
-  const toCamelCase = (s: any) => s.split(".").map(camelCase).join(".");
+  const toCamelCase = (s: any) => s.split(".").map((part: any) => camelCase(part, { locale: false })).join(".");
 
   const recursivelyConvertNamesToCamelCase = (obj: Record<string, any>) => {
     for (const key in obj) {

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -266,7 +266,7 @@ export type IdlTypeGeneric = {
 export type IdlDiscriminator = number[];
 
 export function isCompositeAccounts(
-  accountItem: IdlInstructionAccountItem
+  accountItem: IdlInstructionAccountItem,
 ): accountItem is IdlInstructionAccounts {
   return "accounts" in accountItem;
 }
@@ -321,7 +321,11 @@ export function convertIdlToCamelCase<I extends Idl>(idl: I) {
 
   // `my_account.field` is getting converted to `myAccountField` but we
   // need `myAccount.field`.
-  const toCamelCase = (s: any) => s.split(".").map((part: any) => camelCase(part, { locale: false })).join(".");
+  const toCamelCase = (s: any) =>
+    s
+      .split(".")
+      .map((part: any) => camelCase(part, { locale: false }))
+      .join(".");
 
   const recursivelyConvertNamesToCamelCase = (obj: Record<string, any>) => {
     for (const key in obj) {
@@ -344,7 +348,7 @@ export function handleDefinedFields<U, N, T>(
   fields: IdlDefinedFields | undefined,
   unitCb: () => U,
   namedCb: (fields: IdlDefinedFieldsNamed) => N,
-  tupleCb: (fields: IdlDefinedFieldsTuple) => T
+  tupleCb: (fields: IdlDefinedFieldsTuple) => T,
 ) {
   // Unit
   if (!fields?.length) return unitCb();


### PR DESCRIPTION
This PR aims to resolve the issue where the user's system local results in an IDL being parsed into objects with incorrect keys, thereby resolving #3844 