### PR TITLE
fix(test): Ensure All Nested Tests Run

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -639,7 +639,9 @@ impl TestTemplate {
                 if js {
                     format!("{pkg_manager_exec_cmd} mocha -t 1000000 tests/")
                 } else {
-                    format!("{pkg_manager_exec_cmd} ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts")
+                    format!(
+                        r#"{pkg_manager_exec_cmd} ts-mocha -p ./tsconfig.json -t 1000000 "tests/**/*.ts""#
+                    )
                 }
             }
             Self::Jest => {


### PR DESCRIPTION
This PR aims to resolve #3787 (i.e., an issue where nested tests fail to run in a `zsh` shell because of how the command is formatted) by expanding the glob so it runs across all package managers and shell types 