### PR TITLE
Deprecate AccountInfo usage with compile-time warning in Accounts macro

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -77,7 +77,9 @@ pub use anchor_attribute_program::interface;
 pub type Result<T> = std::result::Result<T, error::Error>;
 
 // Deprecated message for AccountInfo usage in Accounts struct
-#[deprecated(note = "Use `UncheckedAccount` instead of `AccountInfo` for safer unchecked accounts.")]
+#[deprecated(
+    note = "Use `UncheckedAccount` instead of `AccountInfo` for safer unchecked accounts."
+)]
 pub fn deprecated_account_info_usage() {}
 
 /// A data structure of validated accounts that can be deserialized from the

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -76,6 +76,10 @@ pub use anchor_attribute_program::interface;
 
 pub type Result<T> = std::result::Result<T, error::Error>;
 
+// Deprecated message for AccountInfo usage in Accounts struct
+#[deprecated(note = "Use `UncheckedAccount` instead of `AccountInfo` for safer unchecked accounts.")]
+pub fn deprecated_account_info_usage() {}
+
 /// A data structure of validated accounts that can be deserialized from the
 /// input to a Solana program. Implementations of this trait should perform any
 /// and all requisite constraint checks on accounts to ensure the accounts

--- a/lang/src/system_program.rs
+++ b/lang/src/system_program.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use crate::prelude::*;
 use solana_program::pubkey::Pubkey;
 

--- a/lang/src/vec.rs
+++ b/lang/src/vec.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use crate::{Accounts, Result, ToAccountInfos, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -282,6 +282,7 @@ pub struct Field {
     pub constraints: ConstraintGroup,
     pub ty: Ty,
     pub is_optional: bool,
+    pub ty_span: Span,
     /// IDL Doc comment
     pub docs: Option<Vec<String>>,
 }

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -315,6 +315,7 @@ pub fn parse_account_field(f: &syn::Field) -> ParseResult<AccountField> {
                 ty,
                 is_optional,
                 constraints: account_constraints,
+                ty_span: f.ty.span(),
                 docs,
             })
         }

--- a/lang/tests/generics_test.rs
+++ b/lang/tests/generics_test.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(dead_code, deprecated)]
 
 use anchor_lang::prelude::borsh::maybestd::io::Write;
 use anchor_lang::prelude::*;

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::solana_program::pubkey::Pubkey;

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/default_account_state.rs
+++ b/spl/src/token_2022_extensions/default_account_state.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/group_member_pointer.rs
+++ b/spl/src/token_2022_extensions/group_member_pointer.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/immutable_owner.rs
+++ b/spl/src/token_2022_extensions/immutable_owner.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl/src/token_2022_extensions/interest_bearing_mint.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/memo_transfer.rs
+++ b/spl/src/token_2022_extensions/memo_transfer.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl/src/token_2022_extensions/metadata_pointer.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/mint_close_authority.rs
+++ b/spl/src/token_2022_extensions/mint_close_authority.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/non_transferable.rs
+++ b/spl/src/token_2022_extensions/non_transferable.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/permanent_delegate.rs
+++ b/spl/src/token_2022_extensions/permanent_delegate.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/token_group.rs
+++ b/spl/src/token_2022_extensions/token_group.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;

--- a/spl/src/token_2022_extensions/transfer_hook.rs
+++ b/spl/src/token_2022_extensions/transfer_hook.rs
@@ -1,3 +1,5 @@
+// Avoiding AccountInfo deprecated msg in anchor context
+#![allow(deprecated)]
 use anchor_lang::solana_program::account_info::AccountInfo;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::Result;


### PR DESCRIPTION
Addresses #2794 

Adds compile-time deprecation warning for AccountInfo in #[Accounts] structs, suggesting UncheckedAccount, ensures it doesn't break existing code. Includes modifications to try_accounts.rs and lib.rs. 
Also contains modifications in all internal anchor files where AccountInfo is being used in an Accounts struct to avoid deprecated warning in anchor internal context.
<img width="2760" height="1502" alt="image" src="https://github.com/user-attachments/assets/9631c268-0973-4f1b-9f57-a8fe596a60f7" />

Warning in Accounts struct points to the AccountInfo type for clarity, with rust-analyzer or using cargo build, using the exact Span of the field type.

<img width="1051" height="590" alt="image" src="https://github.com/user-attachments/assets/d1058d1b-c0ca-4478-b126-1d02d471889f" />
<img width="993" height="386" alt="image" src="https://github.com/user-attachments/assets/bcc9dab7-7dd1-423e-9612-2f15da295265" />

