### PR TITLE
Update bytemuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,18 +867,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
bytemuck's Pod implementation creates a struct that looks like StructWithoutPadding([u8; <size of TestZeroCopyStruct>]) and transmutes it as part of checking that the derive is sound.

Likely due to better dead code analysis, Rust 1.89 notices that the array is never read directly and emits a warning about this. Newer versions of bytemuck use a different approach that don't fire a warning.

Update both crates to avoid this causing CI to fail.