### PR TITLE
cli: Add {pre,post}-{build,test,deploy} hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add support for tuple types in space calculation ([#3744](https://github.com/solana-foundation/anchor/pull/3744)).
 - lang: Add missing pubkey const generation ([#3677](https://github.com/solana-foundation/anchor/pull/3677)).
 - cli: Add the Minimum Supported Rust Version (MSRV) to the Rust template, since an arbitrary compiler version isn't supported ([#3873](https://github.com/solana-foundation/anchor/pull/3873)).
+- cli: Add `hooks` section to `Anchor.toml` ([#3862](https://github.com/solana-foundation/anchor/pull/3862)).
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::config::{
-    get_default_ledger_path, BootstrapMode, BuildConfig, Config, ConfigOverride, Manifest,
-    PackageManager, ProgramArch, ProgramDeployment, ProgramWorkspace, ScriptsConfig, TestValidator,
-    WithPath, SHUTDOWN_WAIT, STARTUP_WAIT,
+    get_default_ledger_path, BootstrapMode, BuildConfig, Config, ConfigOverride, HookType,
+    Manifest, PackageManager, ProgramArch, ProgramDeployment, ProgramWorkspace, ScriptsConfig,
+    TestValidator, WithPath, SHUTDOWN_WAIT, STARTUP_WAIT,
 };
 use anchor_client::Cluster;
 use anchor_lang::idl::{IdlAccount, IdlInstruction, ERASED_AUTHORITY};
@@ -1333,6 +1333,8 @@ pub fn build(
         fs::create_dir_all(cfg_parent.join(&cfg.workspace.types))?;
     };
 
+    cfg.run_hooks(HookType::PreBuild)?;
+
     let cargo = Manifest::discover()?;
     let build_config = BuildConfig {
         verifiable,
@@ -1390,6 +1392,7 @@ pub fn build(
             &arch,
         )?,
     }
+    cfg.run_hooks(HookType::PostBuild)?;
 
     set_workspace_dir_or_exit();
 
@@ -2989,6 +2992,9 @@ fn test(
         if (!is_localnet || skip_local_validator) && !skip_deploy {
             deploy(cfg_override, None, None, false, true, vec![])?;
         }
+
+        cfg.run_hooks(HookType::PreTest)?;
+
         let mut is_first_suite = true;
         if let Some(test_script) = cfg.scripts.get_mut("test") {
             is_first_suite = false;
@@ -3057,6 +3063,7 @@ fn test(
                 )?;
             }
         }
+        cfg.run_hooks(HookType::PostTest)?;
         Ok(())
     })
 }
@@ -3566,6 +3573,7 @@ fn deploy(
         let client = create_client(&url);
         let solana_args = add_recommended_deployment_solana_args(&client, solana_args)?;
 
+        cfg.run_hooks(HookType::PreDeploy)?;
         // Deploy the programs.
         println!("Deploying cluster: {url}");
         println!("Upgrade authority: {keypair}");
@@ -3676,6 +3684,7 @@ fn deploy(
         }
 
         println!("Deploy success");
+        cfg.run_hooks(HookType::PostDeploy)?;
 
         Ok(())
     })

--- a/docs/content/docs/references/anchor-toml.mdx
+++ b/docs/content/docs/references/anchor-toml.mdx
@@ -238,3 +238,23 @@ Example:
 [toolchain]
 package_manager = "pnpm"
 ```
+
+### hooks
+
+The `hooks` table allows you to configure commands that may be run at specific stages of the build/test/deploy pipeline.
+
+Example:
+```toml
+[hooks]
+# Accepts kebab-case names...
+pre-build = "echo foo"
+# ...and snake-case names
+post_build = "echo bar"
+# Accepts a list of commands, run in series
+pre-test = ["echo 1", "echo 2"]
+# Non-zero exit codes will abort the CLI
+post-test = "exit 1"
+# Unused hooks may be omitted
+# pre-deploy = []
+# post-deploy = []
+```


### PR DESCRIPTION
Based on #1796
Closes #219

Example usage:
```toml
[hooks]
# Accepts kebab-case names...
pre-build = "echo foo"
# ...and snake-case names
post_build = "echo bar"
# Accepts a list of commands, run in series
pre-test = ["echo 1", "echo 2"]
# Non-zero exit codes will abort the CLI
post-test = "exit 1"
# Unused hooks may be omitted
# pre-deploy = []
# post-deploy = []
```

Invalid keys result in an error:
```
Error: Unable to deserialize config: TOML parse error at line 22, column 1
   |
22 | foobar = ""
   | ^^^^^^
unknown field `foobar`, expected one of `pre-build`, `pre_build`, `post-build`, `post_build`, `pre-test`, `pre_test`, `post-test`, `post_test`, `pre-deploy`, `pre_deploy`, `post-deploy`, `post_deploy`
```