### PR TITLE
Fix AVM instability with `solana-verify`

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -430,29 +430,32 @@ pub fn install_version(
         )?;
     }
 
-    println!("Installing solana-verify...");
-    let solana_verify_install_output = Command::new("cargo")
-        .args([
-            "install",
-            "solana-verify",
-            "--git",
-            "https://github.com/Ellipsis-Labs/solana-verifiable-build",
-            "--rev",
-            "568cb334709e88b9b45fc24f1f440eecacf5db54",
-            "--root",
-            AVM_HOME.to_str().unwrap(),
-            "--force",
-            "--locked",
-        ])
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .output()
-        .map_err(|e| anyhow!("`cargo install` for `solana-verify` failed: {e}"))?;
+    let is_at_least_0_32 = version >= Version::new(0, 32, 0);
+    if is_at_least_0_32 {
+        println!("Installing solana-verify...");
+        let solana_verify_install_output = Command::new("cargo")
+            .args([
+                "install",
+                "solana-verify",
+                "--git",
+                "https://github.com/Ellipsis-Labs/solana-verifiable-build",
+                "--rev",
+                "568cb334709e88b9b45fc24f1f440eecacf5db54",
+                "--root",
+                AVM_HOME.to_str().unwrap(),
+                "--force",
+                "--locked",
+            ])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .output()
+            .map_err(|e| anyhow!("`cargo install` for `solana-verify` failed: {e}"))?;
 
-    if !solana_verify_install_output.status.success() {
-        return Err(anyhow!("Failed to install `solana-verify`"));
+        if !solana_verify_install_output.status.success() {
+            return Err(anyhow!("Failed to install `solana-verify`"));
+        }
+        println!("solana-verify successfully installed.");
     }
-    println!("solana-verify successfully installed.");
 
     // If .version file is empty or not parseable, write the newly installed version to it
     if current_version().is_err() {

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -308,7 +308,7 @@ pub fn install_version(
     }
 
     let is_commit = matches!(install_target, InstallTarget::Commit(_));
-    let is_older_than_v0_31_0 = version < Version::parse("0.31.0")?;
+    let is_older_than_v0_31_0 = version < Version::new(0, 31, 0);
     if from_source || is_commit || is_older_than_v0_31_0 {
         // Build from source using `cargo install`
         let mut args: Vec<String> = vec![

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -459,7 +459,7 @@ pub fn install_version(
     use_version(Some(version))
 }
 
-const SOLANA_VERIFY_VERSION: Version = Version::new(0, 4, 7);
+const SOLANA_VERIFY_VERSION: Version = Version::new(0, 4, 11);
 
 /// Check if `solana-verify` is both installed and >= [`SOLANA_VERIFY_VERSION`].
 fn solana_verify_installed() -> Result<bool> {

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -514,7 +514,6 @@ fn install_solana_verify() -> Result<()> {
 /// Install `solana-verify` by building from Git sources
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn install_solana_verify_from_source() -> Result<()> {
-    const SOLANA_VERIFY_COMMIT: &str = "568cb334709e88b9b45fc24f1f440eecacf5db54";
     println!("Installing solana-verify from source...");
     let status = Command::new("cargo")
         .args([
@@ -523,7 +522,7 @@ fn install_solana_verify_from_source() -> Result<()> {
             "--git",
             "https://github.com/Ellipsis-Labs/solana-verifiable-build",
             "--rev",
-            SOLANA_VERIFY_COMMIT,
+            &format!("v{SOLANA_VERIFY_VERSION}"),
             "--root",
             AVM_HOME.to_str().unwrap(),
             "--force",

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -36,7 +36,6 @@ pub enum Commands {
         #[clap(long)]
         /// Install `solana-verify` as well
         verify: bool,
-
     },
     #[clap(about = "Uninstall a version of Anchor")]
     Uninstall {

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -33,6 +33,10 @@ pub enum Commands {
         #[clap(long)]
         /// Build from source code rather than downloading prebuilt binaries
         from_source: bool,
+        #[clap(long)]
+        /// Install `solana-verify` as well
+        verify: bool,
+
     },
     #[clap(about = "Uninstall a version of Anchor")]
     Uninstall {
@@ -80,13 +84,14 @@ pub fn entry(opts: Cli) -> Result<()> {
             path,
             force,
             from_source,
+            verify,
         } => {
             let install_target = if let Some(path) = path {
                 InstallTarget::Path(path.into())
             } else {
                 parse_install_target(&version_or_commit.unwrap())?
             };
-            avm::install_version(install_target, force, from_source)
+            avm::install_version(install_target, force, from_source, verify)
         }
         Commands::Uninstall { version } => avm::uninstall_version(&version),
         Commands::List {} => avm::list_versions(),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1921,7 +1921,8 @@ pub fn verify(
     println!("Verifying program {program_id}");
     let verify_path = AVM_HOME.join("bin").join("solana-verify");
     if !verify_path.exists() {
-        install_with_avm(env!("CARGO_PKG_VERSION"), true).context("installing Anchor with solana-verify")?;
+        install_with_avm(env!("CARGO_PKG_VERSION"), true)
+            .context("installing Anchor with solana-verify")?;
     }
 
     let status = std::process::Command::new(verify_path)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1919,7 +1919,12 @@ pub fn verify(
     command_args.extend(args);
 
     println!("Verifying program {program_id}");
-    let status = std::process::Command::new("solana-verify")
+    let verify_path = AVM_HOME.join("bin").join("solana-verify");
+    if !verify_path.exists() {
+        install_with_avm(env!("CARGO_PKG_VERSION"), true).context("installing Anchor with solana-verify")?;
+    }
+
+    let status = std::process::Command::new(verify_path)
         .arg("verify-from-repo")
         .args(&command_args)
         .stdout(std::process::Stdio::inherit())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -10,7 +10,7 @@ use anchor_lang::solana_program::bpf_loader_upgradeable;
 use anchor_lang::{AccountDeserialize, AnchorDeserialize, AnchorSerialize, Discriminator};
 use anchor_lang_idl::convert::convert_idl;
 use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
 use clap::{CommandFactory, Parser};
 use dirs::home_dir;
@@ -41,6 +41,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Stdio};
 use std::str::FromStr;
 use std::string::ToString;
+use std::sync::LazyLock;
 
 mod checks;
 pub mod config;
@@ -52,6 +53,16 @@ pub const DOCKER_BUILDER_VERSION: &str = VERSION;
 
 /// Default RPC port
 pub const DEFAULT_RPC_PORT: u16 = 8899;
+
+pub static AVM_HOME: LazyLock<PathBuf> = LazyLock::new(|| {
+    if let Ok(avm_home) = std::env::var("AVM_HOME") {
+        PathBuf::from(avm_home)
+    } else {
+        let mut user_home = dirs::home_dir().expect("Could not find home directory");
+        user_home.push(".avm");
+        user_home
+    }
+});
 
 #[derive(Debug, Parser)]
 #[clap(version = VERSION)]
@@ -662,17 +673,10 @@ fn override_toolchain(cfg_override: &ConfigOverride) -> Result<RestoreToolchainC
                         "`anchor` {anchor_version} is not installed with `avm`. Installing...\n"
                     );
 
-                    let exit_status = std::process::Command::new("avm")
-                        .arg("install")
-                        .arg(anchor_version)
-                        .spawn()?
-                        .wait()?;
-                    if !exit_status.success() {
+                    if let Err(e) = install_with_avm(anchor_version, false) {
                         eprintln!(
-                            "Failed to install `anchor` {anchor_version}, \
-                            using {current_version} instead"
+                            "Failed to install `anchor`: {e}, using {current_version} instead"
                         );
-
                         return Ok(restore_cbs);
                     }
                 }
@@ -690,6 +694,23 @@ fn override_toolchain(cfg_override: &ConfigOverride) -> Result<RestoreToolchainC
     }
 
     Ok(restore_cbs)
+}
+
+/// Installs Anchor using AVM, passing `--force` (and optionally) installing
+/// `solana-verify`.
+fn install_with_avm(version: &str, verify: bool) -> Result<()> {
+    let mut cmd = std::process::Command::new("avm");
+    cmd.arg("install");
+    cmd.arg(version);
+    cmd.arg("--force");
+    if verify {
+        cmd.arg("--verify");
+    }
+    let status = cmd.status().context("running AVM")?;
+    if !status.success() {
+        bail!("failed to install `anchor` {version} with avm");
+    }
+    Ok(())
 }
 
 /// Restore toolchain to how it was before the command was run.


### PR DESCRIPTION
Closes #3864

Best reviewed commit-by-commit

AVM:
- `avm install` now takes `--verify`, which installs `solana-verify`
- This option is only accepted when version >= 0.32
- On Linux and Mac, `solana-verify` is installed from GH binary releases
- On other platforms, it is built from the equivalent source code
- `solana-verify` is not reinstalled if the version installed in the AVM directory is >= 0.4.7

CLI:
- Invoking `anchor verify` will check if `solana-verify` is installed by AVM before installing it
- The version of `solana-verify` is NOT used