### PR TITLE
docs: fix typo

### DIFF
--- a/tests/cfo/programs/cfo/src/lib.rs
+++ b/tests/cfo/programs/cfo/src/lib.rs
@@ -964,7 +964,7 @@ fn is_stake_reward_ready(accounts: &DropStakeReward) -> Result<()> {
     Ok(())
 }
 
-// Redefintions.
+// Redefinitions.
 //
 // The following types are redefined so that they can be parsed into the IDL,
 // since Anchor doesn't yet support idl parsing across multiple crates.

--- a/tests/lockup/programs/registry/src/lib.rs
+++ b/tests/lockup/programs/registry/src/lib.rs
@@ -1011,7 +1011,7 @@ pub struct ExpireReward<'info> {
 
 #[account]
 pub struct Registrar {
-    /// Priviledged account.
+    /// Privileged account.
     pub authority: Pubkey,
     /// Nonce to derive the program-derived address owning the vaults.
     pub nonce: u8,


### PR DESCRIPTION
`Redefintions` to `Redefinitions`
`Priviledged` to `Privileged`
