### PR TITLE
chore: Format `src/idl.ts`

### DIFF
--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -266,7 +266,7 @@ export type IdlTypeGeneric = {
 export type IdlDiscriminator = number[];
 
 export function isCompositeAccounts(
-  accountItem: IdlInstructionAccountItem,
+  accountItem: IdlInstructionAccountItem
 ): accountItem is IdlInstructionAccounts {
   return "accounts" in accountItem;
 }
@@ -348,7 +348,7 @@ export function handleDefinedFields<U, N, T>(
   fields: IdlDefinedFields | undefined,
   unitCb: () => U,
   namedCb: (fields: IdlDefinedFieldsNamed) => N,
-  tupleCb: (fields: IdlDefinedFieldsTuple) => T,
+  tupleCb: (fields: IdlDefinedFieldsTuple) => T
 ) {
   // Unit
   if (!fields?.length) return unitCb();


### PR DESCRIPTION
#3845 changed the formatting, causing CI to fail