### PR TITLE
refactor: extract `solana-account` from `solana-sdk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "futures",
  "regex",
  "serde",
+ "solana-account",
  "solana-account-decoder",
  "solana-pubsub-client",
  "solana-rpc-client",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,6 +25,7 @@ solana-account-decoder = "2"
 solana-pubsub-client = "2"
 solana-rpc-client = "2"
 solana-rpc-client-api = "2"
+solana-account = "2"
 solana-sdk = "2"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -74,6 +74,7 @@ use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
 use futures::{Future, StreamExt};
 use regex::Regex;
+use solana_account::Account;
 use solana_account_decoder::UiAccountEncoding;
 use solana_pubsub_client::nonblocking::pubsub_client::{PubsubClient, PubsubClientError};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
@@ -86,7 +87,6 @@ use solana_rpc_client_api::{
     filter::{Memcmp, RpcFilterType},
     response::{Response as RpcResponse, RpcLogsResponse},
 };
-use solana_sdk::account::Account;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::{AccountMeta, Instruction};

--- a/docs/content/docs/testing/mollusk.mdx
+++ b/docs/content/docs/testing/mollusk.mdx
@@ -52,7 +52,8 @@ checks on the result. In both cases, the result is also returned.
 ```rust
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::Account, instruction::{AccountMeta, Instruction}, pubkey::Pubkey},
+    solana_account::Account,
+    solana_sdk::{instruction::{AccountMeta, Instruction}, pubkey::Pubkey},
 };
 
 let program_id = Pubkey::new_unique();
@@ -85,8 +86,8 @@ To apply checks via `process_and_validate_instruction`, developers can use the
 ```rust
 use {
     mollusk_svm::{Mollusk, result::Check},
+    solana_account::Account,
     solana_sdk::{
-        account::Account,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey
         system_instruction,
@@ -145,7 +146,8 @@ the final result is also returned.
 ```rust
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::Account, pubkey::Pubkey, system_instruction},
+    solana_account::Account,
+    solana_sdk::{pubkey::Pubkey, system_instruction},
 };
 
 let mollusk = Mollusk::default();
@@ -186,7 +188,8 @@ returned by the method is the final result of the last instruction in the chain.
 ```rust
 use {
     mollusk_svm::{Mollusk, result::Check},
-    solana_sdk::{account::Account, pubkey::Pubkey, system_instruction},
+    solana_account::Account,
+    solana_sdk::{pubkey::Pubkey, system_instruction},
 };
 
 let mollusk = Mollusk::default();

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -3,8 +3,8 @@
 use {
     anchor_client::{
         anchor_lang::Discriminator,
+        solana_account::Account,
         solana_sdk::{
-            account::Account,
             commitment_config::CommitmentConfig,
             pubkey::Pubkey,
             signature::{Keypair, Signer},


### PR DESCRIPTION
### Problem

`anchor-cli`, `anchor-client` and examples still use bloated `solana-sdk` crate

### Solution 

as a part of migration mentioned in https://github.com/solana-foundation/anchor/issues/3884 `solana-account` was extracted from `solana-sdk` and reexported in `anchor-client` alongside with `solana-sdk` for now