### PR TITLE
remove .to_string() for i128/u128 deserialization

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ portpicker = "0.1.1"
 regex = "1.8.3"
 reqwest = { version = "0.11.4", default-features = false, features = ["multipart", "blocking", "rustls-tls"] }
 semver = "1.0.4"
-serde = { version = "1.0.122", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "2.1.0"
 solana-cli-config = "2"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2858,12 +2858,10 @@ fn deserialize_idl_type_to_json(
         }
         IdlType::F64 => json!(<f64 as AnchorDeserialize>::deserialize(data)?),
         IdlType::U128 => {
-            // TODO: Remove to_string once serde_json supports u128 deserialization
-            json!(<u128 as AnchorDeserialize>::deserialize(data)?.to_string())
+            json!(<u128 as AnchorDeserialize>::deserialize(data)?)
         }
         IdlType::I128 => {
-            // TODO: Remove to_string once serde_json supports i128 deserialization
-            json!(<i128 as AnchorDeserialize>::deserialize(data)?.to_string())
+            json!(<i128 as AnchorDeserialize>::deserialize(data)?)
         }
         IdlType::U256 => todo!("Upon completion of u256 IDL standard"),
         IdlType::I256 => todo!("Upon completion of i256 IDL standard"),


### PR DESCRIPTION
serde_json now supports direct serialization of i128/u128 values, so we no longer
need to convert them to strings. Cleaned up code and removed related TODOs.