### PR TITLE
feat: clients common trait impl

### DIFF
--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -103,6 +103,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
 
 fn gen_cpi_return_type() -> proc_macro2::TokenStream {
     quote! {
+        #[derive(Debug, Clone, Copy)]
         pub struct Return<T> {
             phantom: std::marker::PhantomData<T>
         }

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -168,7 +168,7 @@ pub fn generate(
             #(#re_exports)*
 
             #struct_doc
-            #[derive(anchor_lang::AnchorSerialize)]
+            #[derive(anchor_lang::AnchorSerialize, Debug, Default, Copy, Clone)]
             pub struct #name {
                 #(#account_struct_fields),*
             }

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -182,6 +182,7 @@ pub fn generate(
             #(#re_exports)*
 
             #struct_doc
+            #[derive(Debug, Clone)]
             pub struct #name #generics {
                 #(#account_struct_fields),*
             }

--- a/lang/syn/src/codegen/accounts/bumps.rs
+++ b/lang/syn/src/codegen/accounts/bumps.rs
@@ -72,7 +72,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         .unzip();
 
     quote! {
-        #[derive(Debug)]
+        #[derive(Debug, Clone, Copy)]
         pub struct #bumps_name {
             #(#bump_fields),*
         }

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -76,6 +76,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             use std::marker::PhantomData;
 
 
+            #[derive(Debug, Clone, Copy)]
             pub struct Return<T> {
                 phantom: std::marker::PhantomData<T>
             }

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -54,7 +54,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
                     pub struct #ix_name_camel;
 
                     #impls
@@ -63,7 +63,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
                     pub struct #ix_name_camel {
                         #(#raw_args),*
                     }


### PR DESCRIPTION
Things added extra here: 
1. CPI Return Type (Return<T>)
Clone + Copy: It's a lightweight wrapper around PhantomData

2. CPI Accounts (AccountInfo wrappers)
Clone add because devs might call the same program multiple times with the same accounts

3. Copy for Bumps.

Closes #3857