### PR TITLE
Fix/realloc and prelude

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -514,7 +514,6 @@ pub mod prelude {
     };
     pub use crate::solana_program::account_info::{next_account_info, AccountInfo};
     pub use crate::solana_program::instruction::AccountMeta;
-    pub use crate::solana_program::msg;
     pub use crate::solana_program::program_error::ProgramError;
     pub use crate::solana_program::pubkey::Pubkey;
     pub use crate::solana_program::sysvar::clock::Clock;
@@ -526,6 +525,7 @@ pub mod prelude {
     pub use crate::solana_program::sysvar::slot_history::SlotHistory;
     pub use crate::solana_program::sysvar::stake_history::StakeHistory;
     pub use crate::solana_program::sysvar::Sysvar as SolanaSysvar;
+    pub use crate::solana_program::*;
     pub use anchor_attribute_error::*;
     pub use borsh;
     pub use error::*;

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -416,7 +416,6 @@ fn generate_constraint_realloc(
     let account_name = field.to_string();
     let new_space = &c.space;
     let payer = &c.payer;
-    let zero = &c.zero;
 
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, field);
     let payer_optional_check = optional_check_scope.generate_check(payer);
@@ -465,7 +464,7 @@ fn generate_constraint_realloc(
                 **__field_info.lamports.borrow_mut() = __field_info.lamports().checked_sub(__lamport_amt).unwrap();
             }
 
-            __field_info.realloc(#new_space, #zero)?;
+            __field_info.resize(#new_space)?;
             __reallocs.insert(#field.key());
         }
     }

--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -236,7 +236,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
                         .checked_sub(idl_ref.lamports())
                         .unwrap(),
                 )?;
-                idl_ref.realloc(new_account_space, false)?;
+                idl_ref.resize(new_account_space)?;
             }
 
             Ok(())


### PR DESCRIPTION
- Fix deprecated warnings. 
- Improve `prelude` with wildcard exports