### PR TITLE
fix: use doc_cfg not doc_auto_cfg

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! An RPC client to interact with Solana programs written in [`anchor_lang`].
 //!

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Anchor ⚓ is a framework for Solana's Sealevel runtime providing several
 //! convenient developer tools.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod codegen;
 pub mod parser;

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Anchor CPI wrappers for popular programs in the Solana ecosystem.
 


### PR DESCRIPTION
Recently, `doc_auto_cfg` feature was merged into `doc_cfg` causing a lot of docs.rs builds to fail [including those for anchor](https://docs.rs/crate/anchor-lang/0.32.1/builds/2572806)

This PR ideally fixes it. 