### PR TITLE
lang: Raise an error when argument parsing fails

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -1,6 +1,9 @@
 use {
     crate::{
-        parser::{docs, program::ctx_accounts_ident},
+        parser::{
+            docs,
+            program::{ctx_accounts_ident, function_type, FunctionType},
+        },
         FallbackFn, Ix, IxArg, IxReturn, Overrides,
     },
     syn::{
@@ -18,24 +21,30 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
         .ok_or_else(|| ParseError::new(program_mod.span(), "program content not provided"))?
         .1;
 
-    let ixs = mod_content
-        .iter()
-        .filter_map(|item| match item {
-            syn::Item::Fn(item_fn) => {
-                let (ctx, _) = parse_args(item_fn).ok()?;
-                ctx_accounts_ident(&ctx.raw_arg).ok()?;
-                Some(item_fn)
-            }
-            _ => None,
-        })
-        .map(|method: &syn::ItemFn| {
+    let mut handlers = Vec::new();
+    let mut fallback = Vec::new();
+    let mut errors = Vec::new();
+    for func in mod_content.iter().filter_map(|item| match item {
+        syn::Item::Fn(method) => Some(method),
+        _ => None,
+    }) {
+        match function_type(func) {
+            FunctionType::IxHandler => handlers.push(func),
+            FunctionType::Fallback => fallback.push(func),
+            FunctionType::Error(error) => errors.push(error),
+        }
+    }
+
+    let ixs = handlers
+        .into_iter()
+        .map(|method| {
             let (ctx, args) = parse_args(method)?;
+            let anchor_ident = ctx_accounts_ident(&ctx.raw_arg)?;
             let overrides = parse_overrides(&method.attrs)?;
             let docs = docs::parse(&method.attrs);
             let cfgs = parse_cfg(method);
             let returns = parse_return(method)?;
-            let anchor_ident = ctx_accounts_ident(&ctx.raw_arg)?;
-            Ok(Ix {
+            Ok(Some(Ix {
                 raw_method: method.clone(),
                 ident: method.sig.ident.clone(),
                 docs,
@@ -44,37 +53,27 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
                 anchor_ident,
                 returns,
                 overrides,
-            })
+            }))
         })
+        .filter_map(|ix| ix.transpose())
         .collect::<ParseResult<Vec<Ix>>>()?;
 
-    let fallback_fn = {
-        let fallback_fns = mod_content
-            .iter()
-            .filter_map(|item| match item {
-                syn::Item::Fn(item_fn) => {
-                    let (ctx, _args) = parse_args(item_fn).ok()?;
-                    if ctx_accounts_ident(&ctx.raw_arg).is_ok() {
-                        return None;
-                    }
-                    Some(item_fn)
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        if fallback_fns.len() > 1 {
-            #[allow(clippy::indexing_slicing, reason = "guarded by len() > 1 check above")]
+    let fallback_fn = match *fallback.as_slice() {
+        [] => None,
+        [f] => Some(FallbackFn {
+            raw_method: f.clone(),
+        }),
+        [_, f2, ..] => {
             return Err(ParseError::new(
-                fallback_fns[0].span(),
+                f2.span(),
                 "More than one fallback function found",
             ));
         }
-        fallback_fns
-            .first()
-            .map(|method: &&syn::ItemFn| FallbackFn {
-                raw_method: (*method).clone(),
-            })
     };
+
+    if let Some(e) = errors.pop() {
+        return Err(e);
+    }
 
     Ok((ixs, fallback_fn))
 }
@@ -101,7 +100,7 @@ pub fn parse_args(method: &syn::ItemFn) -> ParseResult<(IxArg, Vec<IxArg>)> {
                 let docs = docs::parse(&arg.attrs);
                 let ident = match &*arg.pat {
                     syn::Pat::Ident(ident) => &ident.ident,
-                    _ => return Err(ParseError::new(arg.pat.span(), "expected argument name")),
+                    _ => return Err(ParseError::new(arg.pat.span(), "expected named argument")),
                 };
                 Ok(IxArg {
                     name: ident.clone(),
@@ -111,7 +110,7 @@ pub fn parse_args(method: &syn::ItemFn) -> ParseResult<(IxArg, Vec<IxArg>)> {
             }
             syn::FnArg::Receiver(_) => Err(ParseError::new(
                 arg.span(),
-                "expected a typed argument not self",
+                "expected a typed argument, not self",
             )),
         })
         .collect::<ParseResult<_>>()?;
@@ -152,7 +151,7 @@ pub fn parse_return(method: &syn::ItemFn) -> ParseResult<IxReturn> {
                     return Err(ParseError::new(
                         ty.span(),
                         "expected generic return type to be a type",
-                    ))
+                    ));
                 }
             };
             Ok(IxReturn { ty })

--- a/lang/syn/src/parser/program/mod.rs
+++ b/lang/syn/src/parser/program/mod.rs
@@ -20,6 +20,113 @@ pub fn parse(program_mod: syn::ItemMod) -> ParseResult<Program> {
     })
 }
 
+/// Whether a function in a program is an ix handler, a fallback fn or unrecognized
+enum FunctionType {
+    /// Regular instruction handler - takes a `Context<Account>` and other arguments
+    IxHandler,
+    /// Fallback method - takes `(&Pubkey, &[AccountInfo], &[u8])`
+    Fallback,
+    /// Invalid method type, raises an error
+    Error(ParseError),
+}
+
+/// Identify a function type via the parameters
+fn function_type(method: &syn::ItemFn) -> FunctionType {
+    let inputs = method
+        .sig
+        .inputs
+        .iter()
+        .map(|arg| {
+            let syn::FnArg::Typed(arg) = arg else {
+                return Err(ParseError::new(
+                    arg.span(),
+                    "handlers may not take receivers",
+                ));
+            };
+            Ok(&arg.ty)
+        })
+        .collect::<ParseResult<Vec<_>>>();
+
+    let inputs = match inputs {
+        Ok(i) => i,
+        Err(e) => {
+            return FunctionType::Error(e);
+        }
+    };
+
+    fn valid_fallback(program_id: &syn::Type, accounts: &syn::Type, data: &syn::Type) -> bool {
+        // Check for &Pubkey
+        let syn::Type::Reference(program_id) = program_id else {
+            return false;
+        };
+        let syn::Type::Path(program_id_path) = program_id.elem.as_ref() else {
+            return false;
+        };
+        if !program_id_path.path.is_ident("Pubkey") {
+            return false;
+        }
+
+        // Check for &[AccountInfo]
+        let syn::Type::Reference(accounts) = accounts else {
+            return false;
+        };
+        let syn::Type::Slice(accounts_slice) = accounts.elem.as_ref() else {
+            return false;
+        };
+        let syn::Type::Path(accounts_slice_inner) = accounts_slice.elem.as_ref() else {
+            return false;
+        };
+        let Some(segment) = accounts_slice_inner.path.segments.last() else {
+            return false;
+        };
+        if segment.ident != "AccountInfo" {
+            return false;
+        }
+
+        // Check for &[u8]
+        let syn::Type::Reference(data) = data else {
+            return false;
+        };
+        let syn::Type::Slice(data_slice) = data.elem.as_ref() else {
+            return false;
+        };
+        let syn::Type::Path(data_slice_inner) = data_slice.elem.as_ref() else {
+            return false;
+        };
+        if !data_slice_inner.path.is_ident("u8") {
+            return false;
+        }
+
+        true
+    }
+
+    fn valid_handler(context: &syn::Type) -> bool {
+        let syn::Type::Path(context) = context else {
+            return false;
+        };
+        let Some(segment) = context.path.segments.last() else {
+            return false;
+        };
+        matches!(segment,
+            syn::PathSegment {
+                ident,
+                arguments: syn::PathArguments::AngleBracketed(_),
+            } if ident == "Context"
+        )
+    }
+
+    match inputs.as_slice() {
+        [program_id, accounts, data] if valid_fallback(program_id, accounts, data) => {
+            FunctionType::Fallback
+        }
+        [context, ..] if valid_handler(context) => FunctionType::IxHandler,
+        _ => FunctionType::Error(ParseError::new(
+            method.span(),
+            "handlers must take a `Context<...>` argument",
+        )),
+    }
+}
+
 fn ctx_accounts_ident(path_ty: &syn::PatType) -> ParseResult<proc_macro2::Ident> {
     let p = match &*path_ty.ty {
         syn::Type::Path(p) => &p.path,
@@ -50,7 +157,7 @@ fn ctx_accounts_ident(path_ty: &syn::PatType) -> ParseResult<proc_macro2::Ident>
             return Err(ParseError::new(
                 generic_ty.span(),
                 "expected Accounts struct type",
-            ))
+            ));
         }
     };
     Ok(path.segments[0].ident.clone())

--- a/lang/syn/src/parser/program/mod.rs
+++ b/lang/syn/src/parser/program/mod.rs
@@ -43,7 +43,7 @@ fn function_type(method: &syn::ItemFn) -> FunctionType {
                     "handlers may not take receivers",
                 ));
             };
-            Ok(&arg.ty)
+            Ok(arg)
         })
         .collect::<ParseResult<Vec<_>>>();
 
@@ -54,50 +54,9 @@ fn function_type(method: &syn::ItemFn) -> FunctionType {
         }
     };
 
-    fn valid_fallback(program_id: &syn::Type, accounts: &syn::Type, data: &syn::Type) -> bool {
-        // Check for &Pubkey
-        let syn::Type::Reference(program_id) = program_id else {
-            return false;
-        };
-        let syn::Type::Path(program_id_path) = program_id.elem.as_ref() else {
-            return false;
-        };
-        if !program_id_path.path.is_ident("Pubkey") {
-            return false;
-        }
-
-        // Check for &[AccountInfo]
-        let syn::Type::Reference(accounts) = accounts else {
-            return false;
-        };
-        let syn::Type::Slice(accounts_slice) = accounts.elem.as_ref() else {
-            return false;
-        };
-        let syn::Type::Path(accounts_slice_inner) = accounts_slice.elem.as_ref() else {
-            return false;
-        };
-        let Some(segment) = accounts_slice_inner.path.segments.last() else {
-            return false;
-        };
-        if segment.ident != "AccountInfo" {
-            return false;
-        }
-
-        // Check for &[u8]
-        let syn::Type::Reference(data) = data else {
-            return false;
-        };
-        let syn::Type::Slice(data_slice) = data.elem.as_ref() else {
-            return false;
-        };
-        let syn::Type::Path(data_slice_inner) = data_slice.elem.as_ref() else {
-            return false;
-        };
-        if !data_slice_inner.path.is_ident("u8") {
-            return false;
-        }
-
-        true
+    fn named_args(args: &[&syn::PatType]) -> bool {
+        args.iter()
+            .all(|arg| matches!(&*arg.pat, syn::Pat::Ident(_)))
     }
 
     fn valid_handler(context: &syn::Type) -> bool {
@@ -116,10 +75,8 @@ fn function_type(method: &syn::ItemFn) -> FunctionType {
     }
 
     match inputs.as_slice() {
-        [program_id, accounts, data] if valid_fallback(program_id, accounts, data) => {
-            FunctionType::Fallback
-        }
-        [context, ..] if valid_handler(context) => FunctionType::IxHandler,
+        [context, ..] if valid_handler(&context.ty) => FunctionType::IxHandler,
+        [_, _, _] if named_args(&inputs) => FunctionType::Fallback,
         _ => FunctionType::Error(ParseError::new(
             method.span(),
             "handlers must take a `Context<...>` argument",

--- a/lang/syn/tests/program_parse.rs
+++ b/lang/syn/tests/program_parse.rs
@@ -1,0 +1,59 @@
+#[test]
+fn fallback_accepts_qualified_type_paths() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            pub fn default<'info>(
+                _program_id: &anchor_lang::prelude::Pubkey,
+                _accounts: &[anchor_lang::prelude::AccountInfo<'info>],
+                _data: &[u8],
+            ) -> anchor_lang::Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    assert!(program.fallback_fn.is_some());
+}
+
+#[test]
+fn fallback_accepts_type_aliases() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            type ProgramId = Pubkey;
+            type AccountInfos<'info> = [AccountInfo<'info>];
+            type InstructionData = [u8];
+
+            pub fn default<'info>(
+                _program_id: &ProgramId,
+                _accounts: &AccountInfos<'info>,
+                _data: &InstructionData,
+            ) -> Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    assert!(program.fallback_fn.is_some());
+}
+
+#[test]
+fn underscore_instruction_arg_is_rejected() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            pub fn initialize(ctx: Context<Initialize>, _: u8) -> Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    );
+
+    let err = program.unwrap_err().to_string();
+    assert_eq!(err, "expected named argument");
+}


### PR DESCRIPTION
Closes #1979 (by reporting an error instead of silently ignoring the ix)
`filter_map` originally filtered out both non-functions, and functions with parse errors in their signature - this meant that any errors would cause the entire ix to be discarded rather than reported to the user.
Use of `_` arguments now properly raises the error:
```rs
error: expected named argument
 --> programs/demo/src/lib.rs:9:50
  |
9 |     pub fn initialize(ctx: Context<Initialize>, _: u8) -> Result<()> {
  |                                                 ^
```