### PR TITLE
lang: Allow deprecated `AccountInfo` in injected IDL instructions

### DIFF
--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -172,6 +172,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         mod __private {
             use super::*;
             /// __idl mod defines handlers for injected Anchor IDL instructions.
+            #[allow(deprecated, reason = "instructions make use of deprecated `AccountInfo`")]
             pub mod __idl {
                 use super::*;
 


### PR DESCRIPTION
#3854 introduced a deprecation warning which appeared on all projects due to generated IDL code. This silences the warnings

This can be removed once #3798 lands