### PR TITLE
lang: Handle invalid camel case ident more gracefully

### DIFF
--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -1,4 +1,5 @@
 use crate::IxArg;
+use anyhow::Result;
 use heck::CamelCase;
 use quote::quote;
 
@@ -23,11 +24,11 @@ pub fn gen_discriminator(namespace: &str, name: impl ToString) -> proc_macro2::T
     format!("&{discriminator:?}").parse().unwrap()
 }
 
-pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> proc_macro2::TokenStream {
+pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> Result<proc_macro2::TokenStream> {
     let ix_arg_names: Vec<&syn::Ident> = args.iter().map(|arg| &arg.name).collect();
-    let ix_name_camel = generate_ix_variant_name(name);
+    let ix_name_camel = generate_ix_variant_name(name)?;
 
-    if args.is_empty() {
+    let variant = if args.is_empty() {
         quote! {
             #ix_name_camel
         }
@@ -37,10 +38,10 @@ pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> proc_macro2::TokenStre
                 #(#ix_arg_names),*
             }
         }
-    }
+    };
+    Ok(variant)
 }
 
-pub fn generate_ix_variant_name(name: &str) -> proc_macro2::TokenStream {
-    let n = name.to_camel_case();
-    n.parse().unwrap()
+pub fn generate_ix_variant_name(name: &str) -> Result<syn::Ident> {
+    Ok(syn::parse_str(&name.to_camel_case())?)
 }

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -13,12 +13,21 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let cpi_method = {
                 let name = &ix.raw_method.sig.ident;
                 let name_str = name.to_string();
-                let ix_variant = generate_ix_variant(&name_str, &ix.args);
+                let ix_variant = match generate_ix_variant(&name_str, &ix.args) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let err = e.to_string();
+                        return quote! { compile_error!(concat!("error generating ix variant: `", #err, "`")) };
+                    }
+                };
                 let method_name = &ix.ident;
                 let args: Vec<&syn::PatType> = ix.args.iter().map(|arg| &arg.raw_arg).collect();
-                let discriminator = {
-                    let name = generate_ix_variant_name(&name_str);
-                    quote! { <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR }
+                let discriminator = match generate_ix_variant_name(&name_str) {
+                    Ok(name) => quote! { <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR },
+                    Err(e) => {
+                        let err = e.to_string();
+                        return quote! { compile_error!(concat!("error generating ix variant name: `", #err, "`")) };
+                    }
                 };
                 let ret_type = &ix.returns.ty.to_token_stream();
                 let ix_cfgs = &ix.cfgs;

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -99,8 +99,21 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let ix_arg_names: Vec<&syn::Ident> = ix.args.iter().map(|arg| &arg.name).collect();
             let ix_method_name = &ix.raw_method.sig.ident;
             let ix_method_name_str = ix_method_name.to_string();
-            let ix_name = generate_ix_variant_name(&ix_method_name_str);
-            let variant_arm = generate_ix_variant(&ix_method_name_str, &ix.args);
+            let ix_name = match generate_ix_variant_name(&ix_method_name_str) {
+                Ok(name) => quote! { #name },
+                Err(e) => {
+                    let err = e.to_string();
+                    return quote! { compile_error!(concat!("error generating ix variant name: `", #err, "`")) };
+                }
+            };
+            let variant_arm = match generate_ix_variant(&ix_method_name_str, &ix.args) {
+                Ok(v) => v,
+                Err(e) => {
+                    let err = e.to_string();
+                    return quote! { compile_error!(concat!("error generating ix variant arm: `", #err, "`")) };
+                }
+            };
+
             let ix_name_log = format!("Instruction: {ix_name}");
             let anchor = &ix.anchor_ident;
             let ret_type = &ix.returns.ty.to_token_stream();


### PR DESCRIPTION
Closes #4017

`Ident::new` panics on invalid identifiers; `syn::parse_str` is the recommended alternative for untrusted input.