### PR TITLE
lint: Add dylint-based linting framework

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,6 +46,7 @@ mod account;
 mod checks;
 pub mod config;
 mod keygen;
+mod lint;
 mod program;
 pub mod rust_template;
 
@@ -410,6 +411,25 @@ pub enum Command {
         #[clap(subcommand)]
         subcmd: ProgramCommand,
     },
+    /// Run Anchor lints on this workspace.
+    Lint {
+        #[clap(flatten)]
+        cmd: LintCommand,
+    },
+}
+
+#[derive(Debug, Parser)]
+
+pub struct LintCommand {
+    /// Git repository containing dylint library packages
+    #[clap(long, default_value = lint::DEFAULT_LINT_REPO)]
+    git: String,
+    /// Path containing dylint library packages
+    #[clap(long)]
+    path: Option<String>,
+    /// Subdirectories of the `--path`/`--git` argument containing lint library packages e.g. `lints/*`
+    #[clap(long)]
+    pattern: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -1322,6 +1342,7 @@ fn process_command(opts: Opts) -> Result<()> {
         Command::ShowAccount { cmd } => account::show_account(&opts.cfg_override, cmd),
         Command::Keygen { subcmd } => keygen::keygen(&opts.cfg_override, subcmd),
         Command::Program { subcmd } => program::program(&opts.cfg_override, subcmd),
+        Command::Lint { cmd } => lint::run(cmd),
     }
 }
 

--- a/cli/src/lint.rs
+++ b/cli/src/lint.rs
@@ -1,0 +1,111 @@
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+use crate::LintCommand;
+
+pub(crate) const DEFAULT_LINT_REPO: &str = "https://github.com/otter-sec/anchor-lints";
+const DEFAULT_PATTERN: &str = "lints/*";
+
+/// Runs Anchor-specific lints on the workspace
+pub fn run(command: LintCommand) -> Result<()> {
+    // Clap autopopulates `git` with `DEFAULT_GIT_REPO`, so user may not have specified it manually
+    ensure_dylint()?;
+    let mut cmd = Command::new("cargo");
+    cmd.arg("dylint");
+    match command {
+        // Default git repo provided or left blank
+        LintCommand {
+            git,
+            path: None,
+            pattern,
+        } if git == DEFAULT_LINT_REPO => {
+            cmd.args([
+                "--git",
+                git.as_ref(),
+                "--pattern",
+                pattern.as_deref().unwrap_or(DEFAULT_PATTERN),
+            ]);
+        }
+        // Path provided and git is default/left blank
+        LintCommand {
+            git,
+            path: Some(path),
+            pattern: Some(pattern),
+        } if git == DEFAULT_LINT_REPO => {
+            cmd.args(["--path", path.as_ref(), "--pattern", &pattern]);
+        }
+        // Custom `--git` and `--pattern` provided
+        LintCommand {
+            git,
+            pattern: Some(pattern),
+            path: None,
+        } => {
+            cmd.args(["--git", git.as_ref(), "--pattern", &pattern]);
+        }
+        // Path provided but no pattern
+        LintCommand {
+            git,
+            path: Some(_),
+            pattern: Some(_),
+        } if git == DEFAULT_LINT_REPO => {
+            bail!("`--pattern` must be provided");
+        }
+        // Custom git but no pattern
+        LintCommand { pattern: None, .. } => {
+            bail!("`--pattern` must be provided");
+        }
+        // Path provided but `--git` also overridden
+        LintCommand { path: Some(_), .. } => {
+            bail!("cannot provide both `--git` and `--path`");
+        }
+    }
+
+    let status = cmd.status().context("executing dylint")?;
+    if !status.success() {
+        bail!("dylint did not execute successfully");
+    }
+    Ok(())
+}
+
+/// Ensures dylint is installed
+fn ensure_dylint() -> Result<()> {
+    let output = Command::new("cargo")
+        .arg("install")
+        .arg("--list")
+        .output()?;
+    let mut has_cargo_dylint = false;
+    let mut has_dylint_link = false;
+    for line in String::from_utf8(output.stdout)
+        .context("parsing `cargo install --list` output")?
+        .lines()
+    {
+        let line = line.trim();
+        if line == "cargo-dylint" {
+            has_cargo_dylint = true;
+        } else if line == "dylint-link" {
+            has_dylint_link = true;
+        }
+        if has_cargo_dylint && has_dylint_link {
+            break;
+        }
+    }
+    if has_cargo_dylint && has_dylint_link {
+        return Ok(());
+    }
+
+    eprintln!("Installing required packages");
+    let mut cmd = Command::new("cargo");
+    cmd.arg("install");
+    if !has_cargo_dylint {
+        cmd.arg("cargo-dylint@5.0.0");
+    }
+    if !has_dylint_link {
+        cmd.arg("dylint-link@5.0.0");
+    }
+    cmd.arg("--locked");
+    if !cmd.status().context("installing dylint")?.success() {
+        bail!("installing dylint failed");
+    }
+    Ok(())
+}

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -89,4 +89,8 @@ thiserror = "1"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(target_os, values("solana"))']
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(dylint_lib, values(any()))',
+    'cfg(dylint, values(any()))',
+]

--- a/lang/build.rs
+++ b/lang/build.rs
@@ -1,0 +1,10 @@
+//! When building for linting, enable the `dylint` cfg to enable some utilities
+
+use std::env;
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=DYLINT_LIBS");
+    if env::var("DYLINT_LIBS").is_ok() {
+        println!("cargo::rustc-cfg=dylint");
+    }
+}

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -295,6 +295,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Owner + Clone> Account<'a, T
     ///
     /// This method also re-validates that the program owner has not
     /// changed since the initial validation
+    #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorAccountReload")]
     pub fn reload(&mut self) -> Result<()> {
         if self.info.owner != &T::owner() {
             return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -224,6 +224,7 @@ use std::ops::{Deref, DerefMut};
 /// ```
 /// to access mint accounts.
 #[derive(Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorAccount")]
 pub struct Account<'info, T: AccountSerialize + AccountDeserialize + Clone> {
     account: T,
     info: &'info AccountInfo<'info>,
@@ -284,6 +285,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Account<'a, T> {
     ///     ctx.accounts.user_to_create.set_inner(new_user);
     /// }
     /// ```
+    #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorAccountSetInner")]
     pub fn set_inner(&mut self, inner: T) {
         self.account = inner;
     }

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -93,6 +93,7 @@ use std::ops::DerefMut;
 /// }
 /// ```
 #[derive(Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorAccountLoader")]
 pub struct AccountLoader<'info, T: ZeroCopy + Owner> {
     acc_info: &'info AccountInfo<'info>,
     phantom: PhantomData<&'info T>,

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -158,6 +158,7 @@ use std::ops::{Deref, DerefMut};
 /// ```
 /// to access mint accounts.
 #[derive(Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorInterfaceAccount")]
 pub struct InterfaceAccount<'info, T: AccountSerialize + AccountDeserialize + Clone> {
     account: Account<'info, T>,
     // The owner here is used to make sure that changes aren't incorrectly propagated

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -35,6 +35,7 @@ use std::ops::Deref;
 ///
 /// When creating an account with `init`, the `payer` needs to sign the transaction.
 #[derive(Debug, Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSigner")]
 pub struct Signer<'info> {
     info: &'info AccountInfo<'info>,
 }

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 ///
 /// - `SystemAccount.info.owner == SystemProgram`
 #[derive(Debug, Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSystemAccount")]
 pub struct SystemAccount<'info> {
     info: &'info AccountInfo<'info>,
 }

--- a/lang/src/accounts/unchecked_account.rs
+++ b/lang/src/accounts/unchecked_account.rs
@@ -12,6 +12,7 @@ use std::ops::Deref;
 /// Explicit wrapper for AccountInfo types to emphasize
 /// that no checks are performed
 #[derive(Debug, Clone)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorUncheckedAccount")]
 pub struct UncheckedAccount<'info>(&'info AccountInfo<'info>);
 
 impl<'info> UncheckedAccount<'info> {

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -168,6 +168,7 @@ where
 ///     pub callee: Program<'info, Callee>,
 /// }
 /// ```
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiContext")]
 pub struct CpiContext<'a, 'b, 'c, 'info, T>
 where
     T: ToAccountMetas + ToAccountInfos<'info>,

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -21,6 +21,7 @@ use std::fmt;
 ///     Ok(())
 /// }
 /// ```
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorContext")]
 pub struct Context<'a, 'b, 'c, 'info, T: Bumps> {
     /// Currently executing program id.
     pub program_id: &'a Pubkey,
@@ -214,6 +215,7 @@ where
     }
 
     #[must_use]
+    #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiContextWithRemainingAccounts")]
     pub fn with_remaining_accounts(mut self, ra: Vec<AccountInfo<'info>>) -> Self {
         self.remaining_accounts = ra;
         self

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Enable `rustc_attrs` when linting so we can create diagnostic items
+#![cfg_attr(dylint, allow(internal_features))]
+#![cfg_attr(dylint, feature(rustc_attrs))]
 
 //! Anchor ⚓ is a framework for Solana's Sealevel runtime providing several
 //! convenient developer tools.
@@ -97,8 +100,41 @@ pub mod solana_program {
         pub use solana_sysvar::rent::*;
     }
     pub mod program {
+        use solana_account_info::AccountInfo;
         pub use solana_cpi::*;
-        pub use solana_invoke::{invoke, invoke_signed, invoke_signed_unchecked, invoke_unchecked};
+        use solana_instruction::Instruction;
+        use solana_program_entrypoint::ProgramResult;
+
+        #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiInvoke")]
+        pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {
+            solana_invoke::invoke(instruction, account_infos)
+        }
+
+        #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiInvokeUnchecked")]
+        pub fn invoke_unchecked(
+            instruction: &Instruction,
+            account_infos: &[AccountInfo],
+        ) -> ProgramResult {
+            solana_invoke::invoke_unchecked(instruction, account_infos)
+        }
+
+        #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiInvokeSigned")]
+        pub fn invoke_signed(
+            instruction: &Instruction,
+            account_infos: &[AccountInfo],
+            signers_seeds: &[&[&[u8]]],
+        ) -> ProgramResult {
+            solana_invoke::invoke_signed(instruction, account_infos, signers_seeds)
+        }
+
+        #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorCpiInvokeSignedUnchecked")]
+        pub fn invoke_signed_unchecked(
+            instruction: &Instruction,
+            account_infos: &[AccountInfo],
+            signers_seeds: &[&[&[u8]]],
+        ) -> ProgramResult {
+            solana_invoke::invoke_signed_unchecked(instruction, account_infos, signers_seeds)
+        }
     }
 
     pub mod bpf_loader_upgradeable {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -286,6 +286,7 @@ pub trait ToAccountInfos<'info> {
 
 /// Transformation to an `AccountInfo` struct.
 pub trait ToAccountInfo<'info> {
+    #[cfg_attr(dylint, rustc_diagnostic_item = "AnchorToAccountInfo")]
     fn to_account_info(&self) -> AccountInfo<'info>;
 }
 
@@ -536,7 +537,8 @@ pub mod prelude {
     };
     // Re-export the crate as anchor_lang for declare_program! macro
     pub use crate as anchor_lang;
-    pub use crate::solana_program::account_info::{next_account_info, AccountInfo};
+    pub use crate::solana_program::account_info::next_account_info;
+    pub use crate::solana_program::account_info::AccountInfo;
     pub use crate::solana_program::instruction::AccountMeta;
     pub use crate::solana_program::program_error::ProgramError;
     pub use crate::solana_program::pubkey::Pubkey;

--- a/lang/src/system_program.rs
+++ b/lang/src/system_program.rs
@@ -40,6 +40,7 @@ pub struct AdvanceNonceAccount<'info> {
     pub recent_blockhashes: AccountInfo<'info>,
 }
 
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSystemProgramAllocate")]
 pub fn allocate<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Allocate<'info>>,
     space: u64,
@@ -88,6 +89,7 @@ pub struct AllocateWithSeed<'info> {
     pub base: AccountInfo<'info>,
 }
 
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSystemProgramAssign")]
 pub fn assign<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Assign<'info>>,
     owner: &Pubkey,
@@ -157,6 +159,7 @@ pub struct AuthorizeNonceAccount<'info> {
     pub authorized: AccountInfo<'info>,
 }
 
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSystemProgramCreateAccount")]
 pub fn create_account<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, CreateAccount<'info>>,
     lamports: u64,
@@ -297,6 +300,7 @@ pub struct CreateNonceAccountWithSeed<'info> {
     pub rent: AccountInfo<'info>,
 }
 
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSystemProgramTransfer")]
 pub fn transfer<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Transfer<'info>>,
     lamports: u64,

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -46,3 +46,11 @@ spl-token-interface = { version = "2", optional = true }
 spl-token-2022-interface = { version = "2", optional = true }
 spl-token-group-interface = { version = "0.7", optional = true }
 spl-token-metadata-interface = { version = "0.8", optional = true }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(dylint_lib, values(any()))',
+    'cfg(dylint, values(any()))',
+]

--- a/spl/build.rs
+++ b/spl/build.rs
@@ -1,0 +1,10 @@
+//! When building for linting, enable the `dylint` cfg to enable some utilities
+
+use std::env;
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=DYLINT_LIBS");
+    if env::var("DYLINT_LIBS").is_ok() {
+        println!("cargo::rustc-cfg=dylint");
+    }
+}

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Enable `rustc_attrs` when linting so we can create diagnostic items
+#![cfg_attr(dylint, allow(internal_features))]
+#![cfg_attr(dylint, feature(rustc_attrs))]
 
 //! Anchor CPI wrappers for popular programs in the Solana ecosystem.
 

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 pub use spl_token::ID;
 pub use spl_token_interface as spl_token;
 
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSplTokenTransfer")]
 pub fn transfer<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Transfer<'info>>,
     amount: u64,
@@ -441,6 +442,7 @@ pub struct SyncNative<'info> {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Copy)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSplTokenAccount")]
 pub struct TokenAccount(spl_token::state::Account);
 
 impl TokenAccount {

--- a/spl/src/token_interface.rs
+++ b/spl/src/token_interface.rs
@@ -12,6 +12,7 @@ pub use crate::token_2022_extensions::*;
 static IDS: [Pubkey; 2] = [spl_token_interface::ID, spl_token_2022_interface::ID];
 
 #[derive(Clone, Debug, Default, PartialEq, Copy)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSplTokenInterfaceAccount")]
 pub struct TokenAccount(spl_token_2022::state::Account);
 
 impl anchor_lang::AccountDeserialize for TokenAccount {
@@ -41,6 +42,7 @@ impl Deref for TokenAccount {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Copy)]
+#[cfg_attr(dylint, rustc_diagnostic_item = "AnchorSplTokenMint")]
 pub struct Mint(spl_token_2022::state::Mint);
 
 impl anchor_lang::AccountDeserialize for Mint {


### PR DESCRIPTION
This introduces a new `anchor lint` command, based on [`dylint`](https://github.com/trailofbits/dylint/). This can be used with
```
anchor lint --path /path/to/anchor/ --pattern lints/example_lint
```
