### PR TITLE
fix(idl): Respect `offset = ...` in IDL generation for custom errors

### DIFF
--- a/lang/syn/src/idl/error.rs
+++ b/lang/syn/src/idl/error.rs
@@ -12,6 +12,13 @@ pub fn gen_idl_print_fn_error(error: &Error) -> TokenStream {
         "__anchor_private_print_idl_error_{}",
         error.ident.to_string().to_snake_case()
     );
+    let offset = match &error.args {
+        Some(args) => {
+            let offset = &args.offset;
+            quote! { #offset }
+        }
+        None => quote! { ::anchor_lang::error::ERROR_CODE_OFFSET },
+    };
 
     let error_codes = error
         .codes
@@ -26,7 +33,7 @@ pub fn gen_idl_print_fn_error(error: &Error) -> TokenStream {
 
             quote! {
                 #idl::IdlErrorCode {
-                    code: anchor_lang::error::ERROR_CODE_OFFSET + #id,
+                    code: #offset + #id,
                     name: #name.into(),
                     msg: #msg,
                 }

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -680,9 +680,8 @@ impl Parse for ErrorArgs {
             return Err(ParseError::new(offset_span, "expected keyword offset"));
         }
         stream.parse::<Token![=]>()?;
-        Ok(ErrorArgs {
-            offset: stream.parse()?,
-        })
+        let offset: LitInt = stream.parse()?;
+        Ok(ErrorArgs { offset })
     }
 }
 

--- a/tests/idl/idls/new.json
+++ b/tests/idl/idls/new.json
@@ -413,18 +413,22 @@
   ],
   "errors": [
     {
-      "code": 6000,
+      "code": 500000,
       "name": "SomeError",
       "msg": "Example error."
     },
     {
-      "code": 6001,
+      "code": 500001,
       "name": "OtherError",
       "msg": "Another error."
     },
     {
-      "code": 6002,
+      "code": 500002,
       "name": "ErrorWithoutMsg"
+    },
+    {
+      "code": 500500,
+      "name": "WithDiscrim"
     }
   ],
   "types": [

--- a/tests/idl/programs/idl/src/lib.rs
+++ b/tests/idl/programs/idl/src/lib.rs
@@ -300,13 +300,14 @@ pub struct Initialize2<'info> {
 #[derive(Accounts)]
 pub struct CauseError {}
 
-#[error_code]
+#[error_code(offset = 500_000)]
 pub enum ErrorCode {
     #[msg("Example error.")]
     SomeError,
     #[msg("Another error.")]
     OtherError,
     ErrorWithoutMsg,
+    WithDiscrim = 500,
 }
 
 mod some_other_module {


### PR DESCRIPTION
Closes #4039

This issue led to a mismatch between generated IDLs and generated code if a custom `offset` was used with the error code.
[Regex-based GH search](https://grep.app/search?f.lang=Rust&regexp=true&q=%5C%23%5C%5Berror_code%5C%28offset+%3D+%5B0-9%5D%2B%5C%29%5C%5D%5Cnpub+enum+%5Cw%2B+%7B%5Cn%28.*%5Cn%29*%5Cs%2B%5Cw%2B+%3D+) indicates the impact of this was likely low.