### PR TITLE
Correct explanation of token extension initialization

### DIFF
--- a/docs/content/docs/tokens/extensions.mdx
+++ b/docs/content/docs/tokens/extensions.mdx
@@ -24,11 +24,11 @@ consideration when designing your token, as you'll need to plan ahead for which
 features you want your token to support.
 The exceptions to this, which require the account to be initialized before they are added, are:
 
-- cpi-guard
-- memo-transfer
-- token-group
-- token-member
-- token-metadata
+- `cpi-guard`
+- `memo-transfer`
+- `token-group`
+- `token-member`
+- `token-metadata`
 
 <Callout type="info">
   Some extensions are incompatible with each other and cannot be enabled

--- a/docs/content/docs/tokens/extensions.mdx
+++ b/docs/content/docs/tokens/extensions.mdx
@@ -17,13 +17,18 @@ Program
 
 Each extension adds specific state that is usually initialized during mint or token
 account creation. When initializing either type of account, you can enable
-multiple extensions simultaneously to add different functionality. However most extensions cannot be 
-added after an account is created - you must include all desired extensions during the 
-initial account creation, the exceptions to this are the `CPI-guard`, `Memo-transfer`, 
-`Token-group`, `Token-member` and `Token-metadata` extenstions which actually require the account
-to be initialized before they are added.
-. This is an important consideration when designing your 
-token, as you'll need to plan ahead for which features you want your token to support.
+multiple extensions simultaneously to add different functionality. However,
+most extensions cannot be added after an account is created - you must include all
+desired extensions during the initial account creation. This is an important
+consideration when designing your token, as you'll need to plan ahead for which
+features you want your token to support.
+The exceptions to this, which require the account to be initialized before they are added, are:
+
+- cpi-guard
+- memo-transfer
+- token-group
+- token-member
+- token-metadata
 
 <Callout type="info">
   Some extensions are incompatible with each other and cannot be enabled

--- a/docs/content/docs/tokens/extensions.mdx
+++ b/docs/content/docs/tokens/extensions.mdx
@@ -17,11 +17,12 @@ Program
 
 Each extension adds specific state that is usually initialized during mint or token
 account creation. When initializing either type of account, you can enable
-multiple extensions simultaneously to add different functionality. However,
-with exception of certain extensions which are the `CPI-guard`, `Memo-transfer`, 
-`Token-group`, `Token-member` and `Token-metadata` extensions cannot be 
+multiple extensions simultaneously to add different functionality. However most extensions cannot be 
 added after an account is created - you must include all desired extensions during the 
-initial account creation. This is an important consideration when designing your 
+initial account creation, the exceptions to this are the `CPI-guard`, `Memo-transfer`, 
+`Token-group`, `Token-member` and `Token-metadata` extenstions which actually require the account
+to be initialized before they are added.
+. This is an important consideration when designing your 
 token, as you'll need to plan ahead for which features you want your token to support.
 
 <Callout type="info">

--- a/docs/content/docs/tokens/extensions.mdx
+++ b/docs/content/docs/tokens/extensions.mdx
@@ -15,13 +15,14 @@ the implementation of these extension instructions in the Token Extensions
 Program
 [source code](https://github.com/solana-program/token-2022/tree/main/program/src/extension).
 
-Each extension adds specific state that must be initialized during mint or token
+Each extension adds specific state that is usually initialized during mint or token
 account creation. When initializing either type of account, you can enable
 multiple extensions simultaneously to add different functionality. However,
-extensions cannot be added after an account is created - you must include all
-desired extensions during the initial account creation. This is an important
-consideration when designing your token, as you'll need to plan ahead for which
-features you want your token to support.
+with exception of certain extensions which are the `CPI-guard`, `Memo-transfer`, 
+`Token-group`, `Token-member` and `Token-metadata` extensions cannot be 
+added after an account is created - you must include all desired extensions during the 
+initial account creation. This is an important consideration when designing your 
+token, as you'll need to plan ahead for which features you want your token to support.
 
 <Callout type="info">
   Some extensions are incompatible with each other and cannot be enabled


### PR DESCRIPTION
The explanation says that all token extensions require initialization before the token/mint account is created, but this is not true for the [`CPI-guard`](https://github.com/solana-program/token-2022/blob/4adc1409eb4fd2c5fc3583a58e46c41f1d113176/program/src/extension/cpi_guard/processor.rs#L21), [`Memo-transfer`](https://github.com/solana-program/token-2022/blob/4adc1409eb4fd2c5fc3583a58e46c41f1d113176/program/src/extension/memo_transfer/processor.rs#L20), [`Token-group`](https://github.com/solana-program/token-2022/blob/4adc1409eb4fd2c5fc3583a58e46c41f1d113176/program/src/extension/token_group/processor.rs#L45), [`Token-member`](https://github.com/solana-program/token-2022/blob/4adc1409eb4fd2c5fc3583a58e46c41f1d113176/program/src/extension/token_group/processor.rs#L145), [`Token-metadata`](https://github.com/solana-program/token-2022/blob/4adc1409eb4fd2c5fc3583a58e46c41f1d113176/program/src/extension/token_group/processor.rs#L145), they actually require the token mint/account to already be initialized before the extension is added.