### PR TITLE
fix(idl): warn on unsupported seed syntax and fix init seed discovery 

### DIFF
--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -214,14 +214,9 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
             // CHECK FOR ERRORS:
             // If `any` seed failed to parse (returns Err), it means the user used syntax that IDL doesn't support
             if results.iter().any(|r| r.is_err()) {
-                // Instead of failing silently, we print a warning to stderr.
-                // usage of `eprintln!` ensures the user sees it in their terminal during build.
-                let name = acc.ident.to_string();
-                eprintln!(
-                    "WARNING: Anchor IDL generation skipped for PDA seeds in account '{}'. \
-                     Reason: Seeds contain unsupported complex expressions (e.g., function calls). \
-                     Workaround: Derive this PDA manually in your client.",
-                    name
+                warn_skipped_pda_seed(
+                    acc,
+                    "Seeds contain unsupported complex expressions (e.g., function calls)",
                 );
 
                 // Return None. This is safe; it simply omits the `pda` field from the JSON,
@@ -236,9 +231,16 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
                 Some(ConstraintSeedsGroup {
                     program_seed: Some(program),
                     ..
-                }) => parse_default(program)
-                    .map(|program| quote! { Some(#program) })
-                    .ok()?,
+                }) => match parse_default(program) {
+                    Ok(program) => quote! { Some(#program) },
+                    Err(_) => {
+                        warn_skipped_pda_seed(
+                            acc,
+                            "seeds::program contains unsupported complex expressions (e.g., function calls)",
+                        );
+                        return None;
+                    }
+                },
                 _ => quote! { None },
             };
 
@@ -309,6 +311,16 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
     }
 
     quote! { None }
+}
+
+fn warn_skipped_pda_seed(acc: &Field, reason: &str) {
+    let name = acc.ident.to_string();
+    eprintln!(
+        "WARNING: Anchor IDL generation skipped for PDA seeds in account '{}'. \
+         Reason: {}. \
+         Workaround: Derive this PDA manually in your client.",
+        name, reason
+    );
 }
 
 /// Parse a seeds constraint, extracting the `IdlSeed` types.

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -206,24 +206,31 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
     // Parse Seeds
     let pda = seed_constraints
         .and_then(|seed| {
-            // Try to parse every seed in the list.
-            // Collect into a Vec<Result> so we can inspect individual failures.
-            let results: Vec<Result<TokenStream, _>> =
-                seed.seeds.iter().map(parse_default).collect();
+            let mut parsed_seeds = Vec::new();
+            let mut unsupported_seeds = Vec::new();
 
-            // CHECK FOR ERRORS:
-            // If `any` seed failed to parse (returns Err), it means the user used syntax that IDL doesn't support
-            if results.iter().any(|r| r.is_err()) {
-                warn_skipped_pda_seed(
-                    acc,
-                    "Seeds contain unsupported complex expressions (e.g., function calls)",
-                );
+            for expr in seed.seeds.iter() {
+                match parse_default(expr) {
+                    Ok(parsed) => parsed_seeds.push(parsed),
+                    Err(_) => unsupported_seeds.push(expr),
+                }
+            }
+
+            if !unsupported_seeds.is_empty() {
+                for expr in unsupported_seeds {
+                    warn_skipped_pda_seed(
+                        acc,
+                        &format!(
+                            "Unsupported seed expression `{}`",
+                            expr.to_token_stream()
+                        ),
+                    );
+                }
 
                 // Return None. This is safe; it simply omits the `pda` field from the JSON,
                 None
             } else {
-                // If all seeds parsed correctly, unwrap them and return the vector.
-                Some(results.into_iter().map(|r| r.unwrap()).collect::<Vec<_>>())
+                Some(parsed_seeds)
             }
         })
         .and_then(|seeds| {
@@ -236,7 +243,10 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
                     Err(_) => {
                         warn_skipped_pda_seed(
                             acc,
-                            "seeds::program contains unsupported complex expressions (e.g., function calls)",
+                            &format!(
+                                "seeds::program contains unsupported expression `{}`",
+                                program.to_token_stream()
+                            ),
                         );
                         return None;
                     }
@@ -532,4 +542,98 @@ fn get_relations(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
         .flatten()
         .collect::<Vec<_>>();
     quote! { vec![#(#relations.into()),*] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn test_get_pda_supported_seeds() {
+        let accounts: AccountsStruct = parse_quote! {
+            pub struct Test<'info> {
+                #[account(seeds = [b"pool", token_a.key().as_ref()], bump)]
+                pub pool: AccountInfo<'info>,
+            }
+        };
+        let field = match &accounts.fields[0] {
+            AccountField::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        let pda = get_pda(field, &accounts);
+        let pda_str = pda.to_string();
+        assert!(pda_str.contains("IdlPda"));
+    }
+
+    #[test]
+    fn test_get_pda_unsupported_seeds() {
+        let accounts: AccountsStruct = parse_quote! {
+            pub struct Test<'info> {
+                #[account(seeds = [b"pool", &max_key(a, b)], bump)]
+                pub pool: AccountInfo<'info>,
+            }
+        };
+        let field = match &accounts.fields[0] {
+            AccountField::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        let pda = get_pda(field, &accounts);
+        let pda_str = pda.to_string();
+        assert_eq!(pda_str, "None");
+    }
+
+    #[test]
+    fn test_get_pda_init_seeds() {
+        let accounts: AccountsStruct = parse_quote! {
+            pub struct Test<'info> {
+                #[account(init, seeds = [b"pool"], bump, payer = payer, space = 8)]
+                pub pool: AccountInfo<'info>,
+                #[account(mut)]
+                pub payer: Signer<'info>,
+                pub system_program: Program<'info, System>,
+            }
+        };
+        let field = match &accounts.fields[0] {
+            AccountField::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        let pda = get_pda(field, &accounts);
+        let pda_str = pda.to_string();
+        assert!(pda_str.contains("IdlPda"));
+    }
+
+    #[test]
+    fn test_get_pda_unsupported_seeds_program() {
+        let accounts: AccountsStruct = parse_quote! {
+            pub struct Test<'info> {
+                #[account(seeds = [b"pool"], bump, seeds::program = &custom_program(x))]
+                pub pool: AccountInfo<'info>,
+            }
+        };
+        let field = match &accounts.fields[0] {
+            AccountField::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        let pda = get_pda(field, &accounts);
+        let pda_str = pda.to_string();
+        assert_eq!(pda_str, "None");
+    }
+
+    #[test]
+    fn test_get_pda_multiple_unsupported_seeds() {
+        let accounts: AccountsStruct = parse_quote! {
+            pub struct Test<'info> {
+                #[account(seeds = [b"pool", &max_key(a, b), &min_key(c, d)], bump)]
+                pub pool: AccountInfo<'info>,
+            }
+        };
+        let field = match &accounts.fields[0] {
+            AccountField::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        let pda = get_pda(field, &accounts);
+        let pda_str = pda.to_string();
+        assert_eq!(pda_str, "None");
+    }
 }


### PR DESCRIPTION
This PR addresses two issues regarding how the IDL generator processes PDA seeds:

1.  **Silent Failures on Complex Seeds:** Previously, if a seed contained syntax not supported by the IDL parser (e.g., function calls or complex expressions), the parser would return an `Err`. The existing implementation used `.ok()`, which silently swallowed the error and removed the `pda` field from the generated IDL entirely. This left developers confused as to why their IDL was incomplete.
2.  **Seed Discovery in `init`:** It improves the resolution of seeds defined within the `init` constraint, ensuring they are correctly located even if not present at the top level.

### Changes

* Refactored `get_pda` in `lang/syn/src/idl/accounts.rs`.
* Replaced the error-swallowing `.ok()` chain with an explicit check for parsing errors.
* Added an `eprintln!` warning. Now, if seeds cannot be parsed, the build continues (returning `None` for the PDA), but the user is explicitly warned in the terminal.

### Reproduction / Example Case

**Given this account struct with a custom function call in seeds:**

```rust
#[account(
    init,
    seeds = [
        b"pool",
        &max_key(token_a.key(), token_b.key()) // <--- Unsupported by IDL parser
    ],
    bump,
    payer = payer,
    space = 8 + Pool::INIT_SPACE
)]
pub pool: AccountLoader<'info, Pool>,


```

### Before:

* `anchor` build succeeds.
* The generated IDL is missing the pda field for pool.
* No warning is shown. The developer assumes the IDL is correct until their client code fails.

### After 

* `anchor` build succeeds.
* The generated IDL is still missing the pda field (correct, as we cannot represent logic in JSON).

### Terminal Output:

```bash 
  WARNING: Anchor IDL generation skipped for PDA seeds in account `Pool`. 
  Reason: Seeds contain unsupported complex expressions (e.g., function calls). 
  Workaround: Derive this PDA manually in your client.
```

### Motivation
This improves the Developer Experience (DX) significantly. Developers often use helper functions in seeds. Without this warning, they waste time debugging client-side errors ("ConstraintSeeds") without realizing the IDL itself generated incomplete data. This change makes the limitation explicit.