### PR TITLE
feat: clients common trait impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add pausable mint extension support ([#4092](https://github.com/solana-foundation/anchor/pull/4092)).
 - cli: Resolve the target directory via `cargo metadata` to support target directory overrides ([#3817](https://github.com/solana-foundation/anchor/pull/3817)).
 - spl: Added `token_metadata_remove_key` to support removing keys from token metadata extension ([#3717](https://github.com/solana-foundation/anchor/pull/3717)).
+- lang: Derive `Clone`, `Debug`, `Copy`, and `Default` on generated client / CPI account structs and instruction args where the field types allow it ([#4085](https://github.com/solana-foundation/anchor/pull/4085)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -147,7 +147,9 @@ pub fn convert_idl_type_def_to_ts(
     };
 
     let attrs = {
-        let debug_attr = quote!(#[derive(Debug)]);
+        let debug_attr = can_derive_debug(ty_def, ty_defs)
+            .then_some(quote!(#[derive(Debug)]))
+            .unwrap_or_default();
 
         let default_attr =
             can_derive_default(ty_def, ty_defs).then_some(quote!(#[derive(Default)]));
@@ -166,8 +168,8 @@ pub fn convert_idl_type_def_to_ts(
             .into_compile_error(),
         };
 
-        let clone_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)
-            .then(|| quote!(#[derive(Clone)]))
+        let clone_attr = can_derive_clone(ty_def, ty_defs)
+            .then_some(quote!(#[derive(Clone)]))
             .unwrap_or_default();
 
         let copy_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)
@@ -318,6 +320,30 @@ fn can_derive_copy(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
+fn can_derive_clone(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
+    match &ty_def.ty {
+        IdlTypeDefTy::Struct { fields } => {
+            can_derive_common(fields.as_ref(), ty_defs, can_derive_clone_ty)
+        }
+        IdlTypeDefTy::Enum { variants } => variants.iter().all(|variant| {
+            can_derive_common(variant.fields.as_ref(), ty_defs, can_derive_clone_ty)
+        }),
+        IdlTypeDefTy::Type { alias } => can_derive_clone_ty(alias, ty_defs),
+    }
+}
+
+fn can_derive_debug(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
+    match &ty_def.ty {
+        IdlTypeDefTy::Struct { fields } => {
+            can_derive_common(fields.as_ref(), ty_defs, can_derive_debug_ty)
+        }
+        IdlTypeDefTy::Enum { variants } => variants.iter().all(|variant| {
+            can_derive_common(variant.fields.as_ref(), ty_defs, can_derive_debug_ty)
+        }),
+        IdlTypeDefTy::Type { alias } => can_derive_debug_ty(alias, ty_defs),
+    }
+}
+
 fn can_derive_default(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
     match &ty_def.ty {
         IdlTypeDefTy::Struct { fields } => {
@@ -329,7 +355,7 @@ fn can_derive_default(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+pub fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_copy_ty(inner, ty_defs),
         IdlType::Array(inner, len) => {
@@ -356,7 +382,37 @@ fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-fn can_derive_default_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+pub fn can_derive_clone_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+    match ty {
+        IdlType::Option(inner) => can_derive_clone_ty(inner, ty_defs),
+        IdlType::Vec(inner) => can_derive_clone_ty(inner, ty_defs),
+        IdlType::Array(inner, _) => can_derive_clone_ty(inner, ty_defs),
+        IdlType::Defined { name, .. } => ty_defs
+            .iter()
+            .find(|ty_def| &ty_def.name == name)
+            .map(|ty_def| can_derive_clone(ty_def, ty_defs))
+            .expect("Type def must exist"),
+        IdlType::Generic(_) => false,
+        _ => true,
+    }
+}
+
+pub fn can_derive_debug_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+    match ty {
+        IdlType::Option(inner) => can_derive_debug_ty(inner, ty_defs),
+        IdlType::Vec(inner) => can_derive_debug_ty(inner, ty_defs),
+        IdlType::Array(inner, _) => can_derive_debug_ty(inner, ty_defs),
+        IdlType::Defined { name, .. } => ty_defs
+            .iter()
+            .find(|ty_def| &ty_def.name == name)
+            .map(|ty_def| can_derive_debug(ty_def, ty_defs))
+            .expect("Type def must exist"),
+        IdlType::Generic(_) => false,
+        _ => true,
+    }
+}
+
+pub fn can_derive_default_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_default_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_default_ty(inner, ty_defs),
@@ -490,4 +546,494 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
             });
             all
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anchor_lang_idl::types::{
+        IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlSerialization, IdlType,
+        IdlTypeDef, IdlTypeDefTy,
+    };
+
+    fn create_test_idl_types() -> Vec<IdlTypeDef> {
+        vec![
+            // Simple struct with copyable types
+            IdlTypeDef {
+                name: "SimpleStruct".to_string(),
+                ty: IdlTypeDefTy::Struct {
+                    fields: Some(IdlDefinedFields::Named(vec![IdlField {
+                        name: "value".to_string(),
+                        ty: IdlType::U64,
+                        docs: vec![],
+                    }])),
+                },
+                generics: vec![],
+                docs: vec![],
+                serialization: IdlSerialization::Borsh,
+                repr: None,
+            },
+            // Struct with non-copyable types
+            IdlTypeDef {
+                name: "NonCopyStruct".to_string(),
+                ty: IdlTypeDefTy::Struct {
+                    fields: Some(IdlDefinedFields::Named(vec![IdlField {
+                        name: "data".to_string(),
+                        ty: IdlType::String,
+                        docs: vec![],
+                    }])),
+                },
+                generics: vec![],
+                docs: vec![],
+                serialization: IdlSerialization::Borsh,
+                repr: None,
+            },
+            // Enum with copyable variants
+            IdlTypeDef {
+                name: "SimpleEnum".to_string(),
+                ty: IdlTypeDefTy::Enum {
+                    variants: vec![
+                        anchor_lang_idl::types::IdlEnumVariant {
+                            name: "Variant1".to_string(),
+                            fields: None,
+                        },
+                        anchor_lang_idl::types::IdlEnumVariant {
+                            name: "Variant2".to_string(),
+                            fields: Some(IdlDefinedFields::Named(vec![IdlField {
+                                name: "value".to_string(),
+                                ty: IdlType::U32,
+                                docs: vec![],
+                            }])),
+                        },
+                    ],
+                },
+                generics: vec![],
+                docs: vec![],
+                serialization: IdlSerialization::Borsh,
+                repr: None,
+            },
+            // Type alias
+            IdlTypeDef {
+                name: "TypeAlias".to_string(),
+                ty: IdlTypeDefTy::Type {
+                    alias: IdlType::U128,
+                },
+                generics: vec![],
+                docs: vec![],
+                serialization: IdlSerialization::Borsh,
+                repr: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_can_derive_copy_ty() {
+        let ty_defs = create_test_idl_types();
+
+        // Test basic copyable types
+        assert!(can_derive_copy_ty(&IdlType::U8, &ty_defs));
+        assert!(can_derive_copy_ty(&IdlType::U64, &ty_defs));
+        assert!(can_derive_copy_ty(&IdlType::Bool, &ty_defs));
+        assert!(can_derive_copy_ty(&IdlType::Pubkey, &ty_defs));
+
+        // Test non-copyable types
+        assert!(!can_derive_copy_ty(&IdlType::String, &ty_defs));
+        assert!(!can_derive_copy_ty(&IdlType::Bytes, &ty_defs));
+        assert!(!can_derive_copy_ty(
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &ty_defs
+        ));
+
+        // Test Option with copyable inner type
+        assert!(can_derive_copy_ty(
+            &IdlType::Option(Box::new(IdlType::U64)),
+            &ty_defs
+        ));
+        assert!(!can_derive_copy_ty(
+            &IdlType::Option(Box::new(IdlType::String)),
+            &ty_defs
+        ));
+
+        // Test Array with copyable inner type
+        assert!(can_derive_copy_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
+            &ty_defs
+        ));
+        assert!(!can_derive_copy_ty(
+            &IdlType::Array(Box::new(IdlType::String), IdlArrayLen::Value(5)),
+            &ty_defs
+        ));
+
+        // Test Array with generic length (should not be copyable)
+        assert!(!can_derive_copy_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Generic("N".to_string())),
+            &ty_defs
+        ));
+
+        // Test defined types
+        assert!(can_derive_copy_ty(
+            &IdlType::Defined {
+                name: "SimpleStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+        assert!(!can_derive_copy_ty(
+            &IdlType::Defined {
+                name: "NonCopyStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+
+        // Test generic types (should not be copyable)
+        assert!(!can_derive_copy_ty(
+            &IdlType::Generic("T".to_string()),
+            &ty_defs
+        ));
+    }
+
+    #[test]
+    fn test_can_derive_clone_ty() {
+        let ty_defs = create_test_idl_types();
+
+        // Test basic cloneable types
+        assert!(can_derive_clone_ty(&IdlType::U8, &ty_defs));
+        assert!(can_derive_clone_ty(&IdlType::String, &ty_defs));
+        assert!(can_derive_clone_ty(&IdlType::Bytes, &ty_defs));
+
+        // Test Vec with cloneable inner type
+        assert!(can_derive_clone_ty(
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &ty_defs
+        ));
+        assert!(can_derive_clone_ty(
+            &IdlType::Vec(Box::new(IdlType::String)),
+            &ty_defs
+        ));
+
+        // Test Array with cloneable inner type
+        assert!(can_derive_clone_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
+            &ty_defs
+        ));
+
+        // Test Option with cloneable inner type
+        assert!(can_derive_clone_ty(
+            &IdlType::Option(Box::new(IdlType::String)),
+            &ty_defs
+        ));
+
+        // Test defined types
+        assert!(can_derive_clone_ty(
+            &IdlType::Defined {
+                name: "SimpleStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+        assert!(can_derive_clone_ty(
+            &IdlType::Defined {
+                name: "NonCopyStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+
+        // Test generic types (should not be cloneable)
+        assert!(!can_derive_clone_ty(
+            &IdlType::Generic("T".to_string()),
+            &ty_defs
+        ));
+    }
+
+    #[test]
+    fn test_can_derive_debug_ty() {
+        let ty_defs = create_test_idl_types();
+
+        // Test basic debuggable types
+        assert!(can_derive_debug_ty(&IdlType::U8, &ty_defs));
+        assert!(can_derive_debug_ty(&IdlType::String, &ty_defs));
+        assert!(can_derive_debug_ty(&IdlType::Bytes, &ty_defs));
+
+        // Test Vec with debuggable inner type
+        assert!(can_derive_debug_ty(
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &ty_defs
+        ));
+
+        // Test Array with debuggable inner type
+        assert!(can_derive_debug_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
+            &ty_defs
+        ));
+
+        // Test Option with debuggable inner type
+        assert!(can_derive_debug_ty(
+            &IdlType::Option(Box::new(IdlType::String)),
+            &ty_defs
+        ));
+
+        // Test defined types
+        assert!(can_derive_debug_ty(
+            &IdlType::Defined {
+                name: "SimpleStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+        assert!(can_derive_debug_ty(
+            &IdlType::Defined {
+                name: "NonCopyStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+
+        // Test generic types (should not be debuggable)
+        assert!(!can_derive_debug_ty(
+            &IdlType::Generic("T".to_string()),
+            &ty_defs
+        ));
+    }
+
+    #[test]
+    fn test_can_derive_default_ty() {
+        let ty_defs = create_test_idl_types();
+
+        // Test basic defaultable types
+        assert!(can_derive_default_ty(&IdlType::U8, &ty_defs));
+        assert!(can_derive_default_ty(&IdlType::String, &ty_defs));
+        assert!(can_derive_default_ty(&IdlType::Bool, &ty_defs));
+
+        // Test Vec (should be defaultable)
+        assert!(can_derive_default_ty(
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &ty_defs
+        ));
+
+        // Test Array with small fixed size (should be defaultable)
+        assert!(can_derive_default_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
+            &ty_defs
+        ));
+
+        // Test Array with large fixed size (should not be defaultable)
+        assert!(!can_derive_default_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(100)),
+            &ty_defs
+        ));
+
+        // Test Array with generic length (should not be defaultable)
+        assert!(!can_derive_default_ty(
+            &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Generic("N".to_string())),
+            &ty_defs
+        ));
+
+        // Test Option with defaultable inner type
+        assert!(can_derive_default_ty(
+            &IdlType::Option(Box::new(IdlType::String)),
+            &ty_defs
+        ));
+
+        // Test defined types
+        assert!(can_derive_default_ty(
+            &IdlType::Defined {
+                name: "SimpleStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+        assert!(can_derive_default_ty(
+            &IdlType::Defined {
+                name: "NonCopyStruct".to_string(),
+                generics: vec![],
+            },
+            &ty_defs
+        ));
+
+        // Test generic types (should not be defaultable)
+        assert!(!can_derive_default_ty(
+            &IdlType::Generic("T".to_string()),
+            &ty_defs
+        ));
+    }
+
+    #[test]
+    fn test_can_derive_copy() {
+        let ty_defs = create_test_idl_types();
+
+        // Test struct with copyable fields
+        let simple_struct = &ty_defs[0];
+        assert!(can_derive_copy(simple_struct, &ty_defs));
+
+        // Test struct with non-copyable fields
+        let non_copy_struct = &ty_defs[1];
+        assert!(!can_derive_copy(non_copy_struct, &ty_defs));
+
+        // Test enum with copyable variants
+        let simple_enum = &ty_defs[2];
+        assert!(can_derive_copy(simple_enum, &ty_defs));
+
+        // Test type alias
+        let type_alias = &ty_defs[3];
+        assert!(can_derive_copy(type_alias, &ty_defs));
+    }
+
+    #[test]
+    fn test_can_derive_clone() {
+        let ty_defs = create_test_idl_types();
+
+        // Test struct with cloneable fields
+        let simple_struct = &ty_defs[0];
+        assert!(can_derive_clone(simple_struct, &ty_defs));
+
+        // Test struct with cloneable fields (String is cloneable)
+        let non_copy_struct = &ty_defs[1];
+        assert!(can_derive_clone(non_copy_struct, &ty_defs));
+
+        // Test enum with cloneable variants
+        let simple_enum = &ty_defs[2];
+        assert!(can_derive_clone(simple_enum, &ty_defs));
+
+        // Test type alias
+        let type_alias = &ty_defs[3];
+        assert!(can_derive_clone(type_alias, &ty_defs));
+    }
+
+    #[test]
+    fn test_can_derive_debug() {
+        let ty_defs = create_test_idl_types();
+
+        // Test struct with debuggable fields
+        let simple_struct = &ty_defs[0];
+        assert!(can_derive_debug(simple_struct, &ty_defs));
+
+        // Test struct with debuggable fields
+        let non_copy_struct = &ty_defs[1];
+        assert!(can_derive_debug(non_copy_struct, &ty_defs));
+
+        // Test enum with debuggable variants
+        let simple_enum = &ty_defs[2];
+        assert!(can_derive_debug(simple_enum, &ty_defs));
+
+        // Test type alias
+        let type_alias = &ty_defs[3];
+        assert!(can_derive_debug(type_alias, &ty_defs));
+    }
+
+    #[test]
+    fn test_can_derive_default() {
+        let ty_defs = create_test_idl_types();
+
+        // Test struct with defaultable fields
+        let simple_struct = &ty_defs[0];
+        assert!(can_derive_default(simple_struct, &ty_defs));
+
+        // Test struct with defaultable fields
+        let non_copy_struct = &ty_defs[1];
+        assert!(can_derive_default(non_copy_struct, &ty_defs));
+
+        // Test enum (should not be defaultable)
+        let simple_enum = &ty_defs[2];
+        assert!(!can_derive_default(simple_enum, &ty_defs));
+
+        // Test type alias
+        let type_alias = &ty_defs[3];
+        assert!(can_derive_default(type_alias, &ty_defs));
+    }
+
+    #[test]
+    fn test_convert_idl_type_to_str() {
+        // Test basic types
+        assert_eq!(convert_idl_type_to_str(&IdlType::Bool, false), "bool");
+        assert_eq!(convert_idl_type_to_str(&IdlType::U8, false), "u8");
+        assert_eq!(convert_idl_type_to_str(&IdlType::U64, false), "u64");
+        assert_eq!(convert_idl_type_to_str(&IdlType::String, false), "String");
+        assert_eq!(convert_idl_type_to_str(&IdlType::Pubkey, false), "Pubkey");
+
+        // Test Option
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Option(Box::new(IdlType::U64)), false),
+            "Option<u64>"
+        );
+
+        // Test Vec
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Vec(Box::new(IdlType::String)), false),
+            "Vec<String>"
+        );
+
+        // Test Array with value length
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Array(
+                Box::new(IdlType::U8),
+                IdlArrayLen::Value(10)
+            ), false),
+            "[u8; 10]"
+        );
+
+        // Test Array with generic length
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Array(
+                Box::new(IdlType::U8),
+                IdlArrayLen::Generic("N".to_string())
+            ), false),
+            "[u8; N]"
+        );
+
+        // Test defined type without generics
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Defined {
+                name: "MyStruct".to_string(),
+                generics: vec![],
+            }, false),
+            "MyStruct"
+        );
+
+        // Test defined type with generics
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Defined {
+                name: "MyStruct".to_string(),
+                generics: vec![
+                    IdlGenericArg::Type { ty: IdlType::U64 },
+                    IdlGenericArg::Const {
+                        value: "10".to_string()
+                    },
+                ],
+            }, false),
+            "MyStruct<u64,10>"
+        );
+
+        // Test generic type
+        assert_eq!(
+            convert_idl_type_to_str(&IdlType::Generic("T".to_string()), false),
+            "T"
+        );
+    }
+
+    #[test]
+    fn test_gen_discriminator() {
+        let disc = [1, 2, 3, 4, 5, 6, 7, 8];
+        let result = gen_discriminator(&disc);
+        let expected = quote! { [1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8] };
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_gen_docs() {
+        let docs = vec!["First line".to_string(), "Second line".to_string()];
+        let result = gen_docs(&docs);
+        let expected = quote! {
+            #[doc = " First line"]
+            #[doc = " Second line"]
+        };
+        assert_eq!(result.to_string(), expected.to_string());
+
+        // Test empty docs
+        let empty_docs = vec![];
+        let result = gen_docs(&empty_docs);
+        let expected = quote! {};
+        assert_eq!(result.to_string(), expected.to_string());
+    }
 }

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -147,9 +147,7 @@ pub fn convert_idl_type_def_to_ts(
     };
 
     let attrs = {
-        let debug_attr = can_derive_debug(ty_def, ty_defs)
-            .then_some(quote!(#[derive(Debug)]))
-            .unwrap_or_default();
+        let debug_attr = quote!(#[derive(Debug)]);
 
         let default_attr =
             can_derive_default(ty_def, ty_defs).then_some(quote!(#[derive(Default)]));
@@ -168,8 +166,8 @@ pub fn convert_idl_type_def_to_ts(
             .into_compile_error(),
         };
 
-        let clone_attr = can_derive_clone(ty_def, ty_defs)
-            .then_some(quote!(#[derive(Clone)]))
+        let clone_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)
+            .then(|| quote!(#[derive(Clone)]))
             .unwrap_or_default();
 
         let copy_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)
@@ -550,45 +548,42 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use anchor_lang_idl::types::{
-        IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlSerialization, IdlType,
-        IdlTypeDef, IdlTypeDefTy,
+    use {
+        super::*,
+        anchor_lang_idl::types::{
+            IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlSerialization, IdlType,
+            IdlTypeDef, IdlTypeDefTy,
+        },
     };
+
+    fn struct_def(name: &str, fields: Vec<IdlField>) -> IdlTypeDef {
+        IdlTypeDef {
+            name: name.to_string(),
+            ty: IdlTypeDefTy::Struct {
+                fields: Some(IdlDefinedFields::Named(fields)),
+            },
+            generics: vec![],
+            docs: vec![],
+            serialization: IdlSerialization::Borsh,
+            repr: None,
+        }
+    }
+
+    fn field(name: &str, ty: IdlType) -> IdlField {
+        IdlField {
+            name: name.to_string(),
+            ty,
+            docs: vec![],
+        }
+    }
 
     fn create_test_idl_types() -> Vec<IdlTypeDef> {
         vec![
-            // Simple struct with copyable types
-            IdlTypeDef {
-                name: "SimpleStruct".to_string(),
-                ty: IdlTypeDefTy::Struct {
-                    fields: Some(IdlDefinedFields::Named(vec![IdlField {
-                        name: "value".to_string(),
-                        ty: IdlType::U64,
-                        docs: vec![],
-                    }])),
-                },
-                generics: vec![],
-                docs: vec![],
-                serialization: IdlSerialization::Borsh,
-                repr: None,
-            },
-            // Struct with non-copyable types
-            IdlTypeDef {
-                name: "NonCopyStruct".to_string(),
-                ty: IdlTypeDefTy::Struct {
-                    fields: Some(IdlDefinedFields::Named(vec![IdlField {
-                        name: "data".to_string(),
-                        ty: IdlType::String,
-                        docs: vec![],
-                    }])),
-                },
-                generics: vec![],
-                docs: vec![],
-                serialization: IdlSerialization::Borsh,
-                repr: None,
-            },
-            // Enum with copyable variants
+            // [0] Simple struct with copyable types
+            struct_def("SimpleStruct", vec![field("value", IdlType::U64)]),
+            // [1] Struct with non-copyable (but cloneable/debuggable/defaultable) types
+            struct_def("NonCopyStruct", vec![field("data", IdlType::String)]),
+            // [2] Enum with copyable variants
             IdlTypeDef {
                 name: "SimpleEnum".to_string(),
                 ty: IdlTypeDefTy::Enum {
@@ -599,11 +594,10 @@ mod tests {
                         },
                         anchor_lang_idl::types::IdlEnumVariant {
                             name: "Variant2".to_string(),
-                            fields: Some(IdlDefinedFields::Named(vec![IdlField {
-                                name: "value".to_string(),
-                                ty: IdlType::U32,
-                                docs: vec![],
-                            }])),
+                            fields: Some(IdlDefinedFields::Named(vec![field(
+                                "value",
+                                IdlType::U32,
+                            )])),
                         },
                     ],
                 },
@@ -612,7 +606,7 @@ mod tests {
                 serialization: IdlSerialization::Borsh,
                 repr: None,
             },
-            // Type alias
+            // [3] Type alias
             IdlTypeDef {
                 name: "TypeAlias".to_string(),
                 ty: IdlTypeDefTy::Type {
@@ -623,6 +617,30 @@ mod tests {
                 serialization: IdlSerialization::Borsh,
                 repr: None,
             },
+            // [4] Struct containing a generic param — should not derive Clone/Debug/Default/Copy
+            struct_def(
+                "GenericStruct",
+                vec![field("inner", IdlType::Generic("T".to_string()))],
+            ),
+            // [5] Struct with an array too large to derive Default (>32 elements)
+            struct_def(
+                "LargeArrayStruct",
+                vec![field(
+                    "buf",
+                    IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(64)),
+                )],
+            ),
+            // [6] Struct that references NonCopyStruct — propagates clone/debug/default but not copy
+            struct_def(
+                "WrapperStruct",
+                vec![field(
+                    "inner",
+                    IdlType::Defined {
+                        name: "NonCopyStruct".to_string(),
+                        generics: vec![],
+                    },
+                )],
+            ),
         ]
     }
 
@@ -941,81 +959,117 @@ mod tests {
         // Test type alias
         let type_alias = &ty_defs[3];
         assert!(can_derive_default(type_alias, &ty_defs));
+
+        // Generic-bearing struct: Default has no T: Default bound expansion, so reject
+        let generic_struct = &ty_defs[4];
+        assert!(!can_derive_default(generic_struct, &ty_defs));
+
+        // Struct with an oversize array — std Default impls only go up to 32 elements
+        let large_array_struct = &ty_defs[5];
+        assert!(!can_derive_default(large_array_struct, &ty_defs));
+
+        // Wrapper around NonCopyStruct: inherits Default-able (String: Default)
+        let wrapper = &ty_defs[6];
+        assert!(can_derive_default(wrapper, &ty_defs));
+    }
+
+    #[test]
+    fn test_generic_struct_rejects_clone_debug_copy() {
+        // Regression coverage: a defined type whose field is `IdlType::Generic("T")`
+        // can't safely derive Clone/Debug/Copy from a procedural macro because the
+        // derive expansion would need a `T: Clone` bound we don't synthesise.
+        let ty_defs = create_test_idl_types();
+        let generic_struct = &ty_defs[4];
+
+        assert!(!can_derive_clone(generic_struct, &ty_defs));
+        assert!(!can_derive_debug(generic_struct, &ty_defs));
+        assert!(!can_derive_copy(generic_struct, &ty_defs));
+    }
+
+    #[test]
+    fn test_wrapper_struct_inherits_non_copy() {
+        // A struct wrapping NonCopyStruct should be Clone+Debug+Default-able but NOT Copy.
+        let ty_defs = create_test_idl_types();
+        let wrapper = &ty_defs[6];
+
+        assert!(can_derive_clone(wrapper, &ty_defs));
+        assert!(can_derive_debug(wrapper, &ty_defs));
+        assert!(can_derive_default(wrapper, &ty_defs));
+        assert!(!can_derive_copy(wrapper, &ty_defs));
+    }
+
+    #[test]
+    fn test_can_derive_ty_defined_lookup() {
+        // `_ty` helpers must walk through `IdlType::Defined` and pick up the wrapped
+        // type-def's trait status, not assume the defined type is always derivable.
+        let ty_defs = create_test_idl_types();
+
+        let wrapper_ref = IdlType::Defined {
+            name: "WrapperStruct".to_string(),
+            generics: vec![],
+        };
+        assert!(can_derive_clone_ty(&wrapper_ref, &ty_defs));
+        assert!(can_derive_debug_ty(&wrapper_ref, &ty_defs));
+        assert!(!can_derive_copy_ty(&wrapper_ref, &ty_defs));
+
+        let large_array_ref = IdlType::Defined {
+            name: "LargeArrayStruct".to_string(),
+            generics: vec![],
+        };
+        assert!(!can_derive_default_ty(&large_array_ref, &ty_defs));
     }
 
     #[test]
     fn test_convert_idl_type_to_str() {
-        // Test basic types
-        assert_eq!(convert_idl_type_to_str(&IdlType::Bool, false), "bool");
-        assert_eq!(convert_idl_type_to_str(&IdlType::U8, false), "u8");
-        assert_eq!(convert_idl_type_to_str(&IdlType::U64, false), "u64");
-        assert_eq!(convert_idl_type_to_str(&IdlType::String, false), "String");
-        assert_eq!(convert_idl_type_to_str(&IdlType::Pubkey, false), "Pubkey");
+        fn s(ty: &IdlType) -> String {
+            convert_idl_type_to_str(ty, false).unwrap()
+        }
 
-        // Test Option
-        assert_eq!(
-            convert_idl_type_to_str(&IdlType::Option(Box::new(IdlType::U64)), false),
-            "Option<u64>"
-        );
+        assert_eq!(s(&IdlType::Bool), "bool");
+        assert_eq!(s(&IdlType::U8), "u8");
+        assert_eq!(s(&IdlType::U64), "u64");
+        assert_eq!(s(&IdlType::String), "String");
+        assert_eq!(s(&IdlType::Pubkey), "Pubkey");
 
-        // Test Vec
-        assert_eq!(
-            convert_idl_type_to_str(&IdlType::Vec(Box::new(IdlType::String)), false),
-            "Vec<String>"
-        );
+        assert_eq!(s(&IdlType::Option(Box::new(IdlType::U64))), "Option<u64>");
+        assert_eq!(s(&IdlType::Vec(Box::new(IdlType::String))), "Vec<String>");
 
-        // Test Array with value length
         assert_eq!(
-            convert_idl_type_to_str(
-                &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
-                false
-            ),
+            s(&IdlType::Array(
+                Box::new(IdlType::U8),
+                IdlArrayLen::Value(10)
+            )),
             "[u8; 10]"
         );
-
-        // Test Array with generic length
         assert_eq!(
-            convert_idl_type_to_str(
-                &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Generic("N".to_string())),
-                false
-            ),
+            s(&IdlType::Array(
+                Box::new(IdlType::U8),
+                IdlArrayLen::Generic("N".to_string())
+            )),
             "[u8; N]"
         );
 
-        // Test defined type without generics
         assert_eq!(
-            convert_idl_type_to_str(
-                &IdlType::Defined {
-                    name: "MyStruct".to_string(),
-                    generics: vec![],
-                },
-                false
-            ),
+            s(&IdlType::Defined {
+                name: "MyStruct".to_string(),
+                generics: vec![],
+            }),
             "MyStruct"
         );
-
-        // Test defined type with generics
         assert_eq!(
-            convert_idl_type_to_str(
-                &IdlType::Defined {
-                    name: "MyStruct".to_string(),
-                    generics: vec![
-                        IdlGenericArg::Type { ty: IdlType::U64 },
-                        IdlGenericArg::Const {
-                            value: "10".to_string()
-                        },
-                    ],
-                },
-                false
-            ),
+            s(&IdlType::Defined {
+                name: "MyStruct".to_string(),
+                generics: vec![
+                    IdlGenericArg::Type { ty: IdlType::U64 },
+                    IdlGenericArg::Const {
+                        value: "10".to_string()
+                    },
+                ],
+            }),
             "MyStruct<u64,10>"
         );
 
-        // Test generic type
-        assert_eq!(
-            convert_idl_type_to_str(&IdlType::Generic("T".to_string()), false),
-            "T"
-        );
+        assert_eq!(s(&IdlType::Generic("T".to_string())), "T");
     }
 
     #[test]

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -966,42 +966,48 @@ mod tests {
 
         // Test Array with value length
         assert_eq!(
-            convert_idl_type_to_str(&IdlType::Array(
-                Box::new(IdlType::U8),
-                IdlArrayLen::Value(10)
-            ), false),
+            convert_idl_type_to_str(
+                &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(10)),
+                false
+            ),
             "[u8; 10]"
         );
 
         // Test Array with generic length
         assert_eq!(
-            convert_idl_type_to_str(&IdlType::Array(
-                Box::new(IdlType::U8),
-                IdlArrayLen::Generic("N".to_string())
-            ), false),
+            convert_idl_type_to_str(
+                &IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Generic("N".to_string())),
+                false
+            ),
             "[u8; N]"
         );
 
         // Test defined type without generics
         assert_eq!(
-            convert_idl_type_to_str(&IdlType::Defined {
-                name: "MyStruct".to_string(),
-                generics: vec![],
-            }, false),
+            convert_idl_type_to_str(
+                &IdlType::Defined {
+                    name: "MyStruct".to_string(),
+                    generics: vec![],
+                },
+                false
+            ),
             "MyStruct"
         );
 
         // Test defined type with generics
         assert_eq!(
-            convert_idl_type_to_str(&IdlType::Defined {
-                name: "MyStruct".to_string(),
-                generics: vec![
-                    IdlGenericArg::Type { ty: IdlType::U64 },
-                    IdlGenericArg::Const {
-                        value: "10".to_string()
-                    },
-                ],
-            }, false),
+            convert_idl_type_to_str(
+                &IdlType::Defined {
+                    name: "MyStruct".to_string(),
+                    generics: vec![
+                        IdlGenericArg::Type { ty: IdlType::U64 },
+                        IdlGenericArg::Const {
+                            value: "10".to_string()
+                        },
+                    ],
+                },
+                false
+            ),
             "MyStruct<u64,10>"
         );
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -385,6 +385,10 @@ pub fn can_derive_clone_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
         IdlType::Option(inner) => can_derive_clone_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_clone_ty(inner, ty_defs),
         IdlType::Array(inner, _) => can_derive_clone_ty(inner, ty_defs),
+        #[allow(
+            clippy::expect_used,
+            reason = "IDL cross-references are guaranteed consistent by Anchor tooling"
+        )]
         IdlType::Defined { name, .. } => ty_defs
             .iter()
             .find(|ty_def| &ty_def.name == name)
@@ -400,6 +404,10 @@ pub fn can_derive_debug_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
         IdlType::Option(inner) => can_derive_debug_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_debug_ty(inner, ty_defs),
         IdlType::Array(inner, _) => can_derive_debug_ty(inner, ty_defs),
+        #[allow(
+            clippy::expect_used,
+            reason = "IDL cross-references are guaranteed consistent by Anchor tooling"
+        )]
         IdlType::Defined { name, .. } => ty_defs
             .iter()
             .find(|ty_def| &ty_def.name == name)
@@ -547,6 +555,11 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "tests construct fixtures with known shape and only feed valid IDL types"
+)]
 mod tests {
     use {
         super::*,

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -104,6 +104,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
 
 fn gen_cpi_return_type() -> proc_macro2::TokenStream {
     quote! {
+        #[derive(Debug, Clone, Copy)]
         pub struct Return<T> {
             phantom: std::marker::PhantomData<T>,
             program_id: anchor_lang::solana_program::pubkey::Pubkey,

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -1,5 +1,6 @@
 use {
     super::common::{
+        can_derive_clone_ty, can_derive_copy_ty, can_derive_debug_ty, can_derive_default_ty,
         convert_idl_type_to_syn_type, gen_discriminator, get_all_instruction_accounts,
         get_canonical_program_id,
     },
@@ -70,9 +71,39 @@ fn gen_internal_args_mod(idl: &Idl) -> proc_macro2::TokenStream {
             }
         };
 
+        // Generate conditional derives based on field types
+        let copy_attr = ix
+            .args
+            .iter()
+            .map(|field| &field.ty)
+            .all(|ty| can_derive_copy_ty(ty, &idl.types))
+            .then_some(quote!(#[derive(Copy)]));
+        let clone_attr = ix
+            .args
+            .iter()
+            .map(|field| &field.ty)
+            .all(|ty| can_derive_clone_ty(ty, &idl.types))
+            .then_some(quote!(#[derive(Clone)]));
+        let debug_attr = ix
+            .args
+            .iter()
+            .map(|field| &field.ty)
+            .all(|ty| can_derive_debug_ty(ty, &idl.types))
+            .then_some(quote!(#[derive(Debug)]));
+        let default_attr = ix
+            .args
+            .iter()
+            .map(|field| &field.ty)
+            .all(|ty| can_derive_default_ty(ty, &idl.types))
+            .then_some(quote!(#[derive(Default)]));
+
         quote! {
             /// Instruction argument
             #[derive(AnchorSerialize, AnchorDeserialize)]
+            #copy_attr
+            #clone_attr
+            #debug_attr
+            #default_attr
             #ix_struct
 
             #impl_discriminator

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -193,7 +193,7 @@ pub fn generate(
             #(#re_exports)*
 
             #struct_doc
-            #[derive(anchor_lang::AnchorSerialize)]
+            #[derive(anchor_lang::AnchorSerialize, Debug, Default, Copy, Clone)]
             pub struct #name {
                 #(#account_struct_fields),*
             }

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -197,6 +197,7 @@ pub fn generate(
             #(#re_exports)*
 
             #struct_doc
+            #[derive(Debug, Clone)]
             pub struct #name #generics {
                 #(#account_struct_fields),*
             }

--- a/lang/syn/src/codegen/accounts/bumps.rs
+++ b/lang/syn/src/codegen/accounts/bumps.rs
@@ -69,7 +69,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         .unzip();
 
     quote! {
-        #[derive(Debug)]
+        #[derive(Debug, Clone, Copy)]
         pub struct #bumps_name {
             #(#bump_fields),*
         }

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -90,6 +90,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             use std::marker::PhantomData;
 
 
+            #[derive(Debug, Clone, Copy)]
             pub struct Return<T> {
                 phantom: std::marker::PhantomData<T>,
                 program_id: anchor_lang::solana_program::pubkey::Pubkey,

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -10,12 +10,9 @@ fn can_derive_common_trait(ty: &Type) -> bool {
     match ty {
         // Primitives - always support Clone/Debug
         Type::Path(path) if path.qself.is_none() => {
-            let segments = &path.path.segments;
-            if segments.is_empty() {
+            let Some(last_segment) = path.path.segments.last() else {
                 return false;
-            }
-            // Use last segment to handle fully qualified paths like std::vec::Vec<T>
-            let last_segment = segments.last().unwrap();
+            };
             let ident_str = last_segment.ident.to_string();
 
             // Check for primitives

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -97,17 +97,16 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 })
                 .collect();
 
-            // Check if all argument types can derive Clone and Debug
-            // Note: all() returns true for empty iterators, so no need to check is_empty()
-            let can_derive_traits = ix
+            // Conditionally derive Clone and Debug if every arg type supports them.
+            // `all()` is true for empty iterators, so unit instructions always get the derives.
+            let extra_derives: Vec<proc_macro2::TokenStream> = if ix
                 .args
                 .iter()
-                .all(|arg| can_derive_common_trait(&arg.raw_arg.ty));
-
-            let traits_attr = if can_derive_traits {
-                quote!(Clone, Debug,)
+                .all(|arg| can_derive_common_trait(&arg.raw_arg.ty))
+            {
+                vec![quote!(Clone), quote!(Debug)]
             } else {
-                quote!()
+                vec![]
             };
 
             let impls = {
@@ -138,7 +137,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize, #traits_attr)]
+                    #[derive(AnchorSerialize, AnchorDeserialize #(, #extra_derives)*)]
                     pub struct #ix_name_camel;
 
                     #impls
@@ -147,7 +146,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize, #traits_attr)]
+                    #[derive(AnchorSerialize, AnchorDeserialize #(, #extra_derives)*)]
                     pub struct #ix_name_camel {
                         #(#raw_args),*
                     }
@@ -170,5 +169,61 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
 
             #(#variants)*
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::can_derive_common_trait, syn::parse_quote};
+
+    #[test]
+    fn primitives_and_std_types_derive() {
+        assert!(can_derive_common_trait(&parse_quote!(u8)));
+        assert!(can_derive_common_trait(&parse_quote!(i128)));
+        assert!(can_derive_common_trait(&parse_quote!(bool)));
+        assert!(can_derive_common_trait(&parse_quote!(String)));
+        assert!(can_derive_common_trait(&parse_quote!(Pubkey)));
+    }
+
+    #[test]
+    fn fully_qualified_paths_resolve_to_last_segment() {
+        // `std::vec::Vec<u8>` should be recognised as a `Vec` of a primitive.
+        assert!(can_derive_common_trait(&parse_quote!(std::vec::Vec<u8>)));
+        assert!(can_derive_common_trait(&parse_quote!(
+            ::std::option::Option<u64>
+        )));
+    }
+
+    #[test]
+    fn option_and_vec_recurse_into_inner() {
+        assert!(can_derive_common_trait(&parse_quote!(Option<u64>)));
+        assert!(can_derive_common_trait(&parse_quote!(Vec<String>)));
+        // Inner user-defined type makes the wrapper undecidable.
+        assert!(!can_derive_common_trait(&parse_quote!(Option<MyType>)));
+        assert!(!can_derive_common_trait(&parse_quote!(Vec<MyType>)));
+    }
+
+    #[test]
+    fn arrays_tuples_and_references_recurse() {
+        assert!(can_derive_common_trait(&parse_quote!([u8; 32])));
+        assert!(can_derive_common_trait(&parse_quote!((u8, bool, String))));
+        assert!(can_derive_common_trait(&parse_quote!(&u8)));
+
+        assert!(!can_derive_common_trait(&parse_quote!([MyType; 4])));
+        assert!(!can_derive_common_trait(&parse_quote!((u8, MyType))));
+    }
+
+    #[test]
+    fn user_defined_types_are_conservative() {
+        // Without name resolution we can't know whether `MyType` is Clone/Debug.
+        assert!(!can_derive_common_trait(&parse_quote!(MyType)));
+        assert!(!can_derive_common_trait(&parse_quote!(some_mod::MyType)));
+    }
+
+    #[test]
+    fn exotic_types_rejected() {
+        // Trait objects, fn pointers, impl traits — none are supported.
+        assert!(!can_derive_common_trait(&parse_quote!(dyn std::fmt::Debug)));
+        assert!(!can_derive_common_trait(&parse_quote!(fn(u8) -> u8)));
     }
 }

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -14,8 +14,9 @@ fn can_derive_common_trait(ty: &Type) -> bool {
             if segments.is_empty() {
                 return false;
             }
-            let first_segment = &segments[0];
-            let ident_str = first_segment.ident.to_string();
+            // Use last segment to handle fully qualified paths like std::vec::Vec<T>
+            let last_segment = segments.last().unwrap();
+            let ident_str = last_segment.ident.to_string();
 
             // Check for primitives
             if matches!(
@@ -43,7 +44,7 @@ fn can_derive_common_trait(ty: &Type) -> bool {
 
             // For Option<T> and Vec<T>, check the inner type first
             if ident_str == "Option" || ident_str == "Vec" {
-                if let syn::PathArguments::AngleBracketed(args) = &first_segment.arguments {
+                if let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments {
                     if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
                         return can_derive_common_trait(inner_ty);
                     }
@@ -97,11 +98,11 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 .collect();
 
             // Check if all argument types can derive Clone and Debug
-            let can_derive_traits = ix.args.is_empty()
-                || ix
-                    .args
-                    .iter()
-                    .all(|arg| can_derive_common_trait(&arg.raw_arg.ty));
+            // Note: all() returns true for empty iterators, so no need to check is_empty()
+            let can_derive_traits = ix
+                .args
+                .iter()
+                .all(|arg| can_derive_common_trait(&arg.raw_arg.ty));
 
             let traits_attr = if can_derive_traits {
                 quote!(Clone, Debug,)

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -59,7 +59,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
                     pub struct #ix_name_camel;
 
                     #impls
@@ -68,7 +68,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
                     pub struct #ix_name_camel {
                         #(#raw_args),*
                     }

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -2,7 +2,71 @@ use {
     crate::{codegen::program::common::*, parser, Program},
     heck::CamelCase,
     quote::{quote, quote_spanned, ToTokens},
+    syn::Type,
 };
+
+/// Returns true for primitives, common std types, and types wrapped in Option/Vec.
+fn can_derive_common_trait(ty: &Type) -> bool {
+    match ty {
+        // Primitives - always support Clone/Debug
+        Type::Path(path) if path.qself.is_none() => {
+            let segments = &path.path.segments;
+            if segments.is_empty() {
+                return false;
+            }
+            let first_segment = &segments[0];
+            let ident_str = first_segment.ident.to_string();
+
+            // Check for primitives
+            if matches!(
+                ident_str.as_str(),
+                "bool"
+                    | "i8"
+                    | "i16"
+                    | "i32"
+                    | "i64"
+                    | "i128"
+                    | "isize"
+                    | "u8"
+                    | "u16"
+                    | "u32"
+                    | "u64"
+                    | "u128"
+                    | "usize"
+                    | "f32"
+                    | "f64"
+                    | "char"
+                    | "str"
+            ) {
+                return true;
+            }
+
+            // For Option<T> and Vec<T>, check the inner type first
+            if ident_str == "Option" || ident_str == "Vec" {
+                if let syn::PathArguments::AngleBracketed(args) = &first_segment.arguments {
+                    if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                        return can_derive_common_trait(inner_ty);
+                    }
+                }
+                // If we can't extract the inner type, Vec/Option themselves support Clone/Debug
+                return true;
+            }
+
+            // Check for common std types that support Clone/Debug
+            if matches!(ident_str.as_str(), "String" | "Pubkey") {
+                return true;
+            }
+
+            // For user-defined types, we can't verify at macro time
+            false
+        }
+        Type::Array(arr) => can_derive_common_trait(&arr.elem),
+        Type::Tuple(tuple) => tuple.elems.iter().all(can_derive_common_trait),
+        Type::Reference(reference) => can_derive_common_trait(&reference.elem),
+        // For other types, be conservative
+        _ => false,
+    }
+}
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let variants: Vec<proc_macro2::TokenStream> = program
@@ -31,6 +95,20 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     ts
                 })
                 .collect();
+
+            // Check if all argument types can derive Clone and Debug
+            let can_derive_traits = ix.args.is_empty()
+                || ix
+                    .args
+                    .iter()
+                    .all(|arg| can_derive_common_trait(&arg.raw_arg.ty));
+
+            let traits_attr = if can_derive_traits {
+                quote!(Clone, Debug,)
+            } else {
+                quote!()
+            };
+
             let impls = {
                 let discriminator = match ix.overrides.as_ref() {
                     Some(overrides) if overrides.discriminator.is_some() => {
@@ -59,7 +137,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, #traits_attr)]
                     pub struct #ix_name_camel;
 
                     #impls
@@ -68,7 +146,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 quote! {
                     #(#ix_cfgs)*
                     /// Instruction.
-                    #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+                    #[derive(AnchorSerialize, AnchorDeserialize, #traits_attr)]
                     pub struct #ix_name_camel {
                         #(#raw_args),*
                     }


### PR DESCRIPTION
Things added extra here:
- CPI Return Type (Return)
   Clone + Copy: It's a lightweight wrapper around PhantomData

- CPI Accounts (AccountInfo wrappers)
   Clone add because devs might call the same program multiple times with the same accounts

- Copy for Bumps.

Closes #3857