### PR TITLE
idl: Fix defined types with unsupported fields not producing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- idl: Fix defined types with unsupported fields not producing an error ([#4088](https://github.com/solana-foundation/anchor/pull/4088)).
+
 ### Breaking
 
 ## [0.32.1] - 2025-10-09
@@ -24,7 +26,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Fix deprecation warnings on alloc and add solana-program to prelude
   ([#3975](https://github.com/solana-foundation/anchor/pull/3975)).
-- cli: Fix race condition that could happen when deploying a program 
+- cli: Fix race condition that could happen when deploying a program
   ([#3976](https://github.com/solana-foundation/anchor/pull/3976)).
 
 ### Breaking

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::{spanned::Spanned, Result};
 
 use super::common::{get_idl_module_path, get_no_docs};
 use crate::parser::docs;
@@ -22,7 +22,7 @@ pub fn impl_idl_build_union(item: &syn::ItemUnion) -> TokenStream {
     impl_idl_build(
         &item.ident,
         &item.generics,
-        Err(anyhow!("Unions are not supported")),
+        Err(syn::Error::new_spanned(item, "Unions are not supported")),
     )
 }
 
@@ -33,10 +33,11 @@ fn impl_idl_build(
     type_def: Result<(TokenStream, Vec<syn::TypePath>)>,
 ) -> TokenStream {
     let idl = get_idl_module_path();
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let idl_build_trait = quote!(anchor_lang::idl::build::IdlBuild);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let (idl_type_def, insert_defined) = match type_def {
+        Err(e) => return e.into_compile_error(),
         Ok((ts, defined)) => (
             quote! { Some(#ts) },
             quote! {
@@ -48,7 +49,6 @@ fn impl_idl_build(
                 );*
             },
         ),
-        _ => (quote! { None }, quote! {}),
     };
 
     quote! {
@@ -612,7 +612,12 @@ pub fn gen_idl_type(
                                 defined.extend(def);
                                 quote! { #idl::IdlGenericArg::Type { ty: #ty } }
                             }
-                            _ => return Err(anyhow!("Unsupported generic argument: {arg:#?}")),
+                            _ => {
+                                return Err(syn::Error::new(
+                                    arg.span(),
+                                    "Unsupported generic argument",
+                                ))
+                            }
                         };
                         generics.push(generic);
                     }
@@ -635,7 +640,7 @@ pub fn gen_idl_type(
             }
             _ => gen_idl_type(&reference.elem, generic_params),
         },
-        _ => Err(anyhow!("Unknown type: {ty:#?}")),
+        _ => Err(syn::Error::new_spanned(ty, "Unsupported type")),
     }
 }
 


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/solana-foundation/anchor/issues/4073, defined types (structs and enums) do not get included in the IDL if they contain unsupported type(s).

For example, with the following type:

```rs
pub struct BrokenType {
    x: (u32, u32),
}
```

IDL build successfully, but there is no type definition for `BrokenType` in the `types` section. This is not only unintuitive, but it also breaks other parts of the framework e.g. `declare_program!` and TS package usage.

### Summary of changes

Make unsupported field types of defined types produce an error instead of omitting the type definition altogether.

Example error output:

```
error: Unsupported type
  --> programs/name/src/lib.rs:37:8
   |
37 |     x: (u32, u32),
   |        ^^^^^^^^^^

```

**Note:** This is a fix but also a breaking change because, although unlikely, programs that compiled before this change might not compile after this change if they are using unsupported types in their public API.

Fixes https://github.com/solana-foundation/anchor/issues/4073