### PR TITLE
cleanup: Remove temporary unwrap from proc_macro2 Span call_site

### DIFF
--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -497,7 +497,6 @@ pub fn gen_idl_type(
 
                 // If no path was found, just return an empty path and let the find_path function handle it
                 let source_path = proc_macro2::Span::call_site()
-                    .unwrap()
                     .local_file()
                     .unwrap_or_default();
 

--- a/tests/auction-house/Cargo.lock
+++ b/tests/auction-house/Cargo.lock
@@ -1087,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/tests/spl/metadata/Cargo.lock
+++ b/tests/spl/metadata/Cargo.lock
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
In #3842 [unwrap()](https://docs.rs/proc-macro2/latest/proc_macro2/struct.Span.html#method.unwrap) was used on the `call_site()` function which converts `proc_macro2::Span` to `proc_macro::Span` to avoid using Nightly rust with proc_macro2 for IDL building. 
Starting from [proc_macro2 version 1.0.100](https://github.com/dtolnay/proc-macro2/releases/tag/1.0.100) (anchor-syn already [pulls in highest version number](https://github.com/solana-foundation/anchor/blob/master/lang/syn/Cargo.toml#L30)) the `local_file()` function got stabilised so we can remove the temporary type conversion, make the code more readable, and avoid possible problems in the future with `Available on wrap_proc_macro only.` feature flag that wraps that `unwrap()` function on `proc_macro2::Span`.
