### PR TITLE
CLI: Make all paths absolute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
 name = "anchor-cli"
 version = "1.0.0"
 dependencies = [
+ "anchor-cli-macros",
  "anchor-client",
  "anchor-lang",
  "anchor-lang-idl",
@@ -239,6 +240,15 @@ dependencies = [
  "tiny-bip39",
  "toml 0.7.8",
  "walkdir",
+]
+
+[[package]]
+name = "anchor-cli-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "avm",
     "cli",
+    "cli/cli-macros",
     "client",
     "idl",
     "lang",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ dev = []
 idl-localnet-testing = []
 
 [dependencies]
+anchor-cli-macros = { path = "cli-macros" }
 anchor-client = { path = "../client", version = "1.0.0" }
 anchor-lang = { path = "../lang", version = "1.0.0" }
 anchor-lang-idl = { path = "../idl", version = "0.1.2", features = ["build", "convert"] }

--- a/cli/cli-macros/Cargo.toml
+++ b/cli/cli-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "anchor-cli-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+proc-macro2 = "1.0"
+syn = "2.0"

--- a/cli/cli-macros/src/lib.rs
+++ b/cli/cli-macros/src/lib.rs
@@ -1,6 +1,8 @@
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::{DataEnum, DataStruct, DeriveInput, Fields, parse_macro_input};
+use {
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
+    syn::{parse_macro_input, DataEnum, DataStruct, DeriveInput, Fields},
+};
 
 #[proc_macro_derive(AbsolutePath)]
 pub fn absolute_path_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/cli/cli-macros/src/lib.rs
+++ b/cli/cli-macros/src/lib.rs
@@ -1,0 +1,91 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DataEnum, DataStruct, DeriveInput, Fields, parse_macro_input};
+
+#[proc_macro_derive(AbsolutePath)]
+pub fn absolute_path_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let constructor = match input.data {
+        syn::Data::Struct(data_struct) => derive_struct(data_struct),
+        syn::Data::Enum(data_enum) => derive_enum(data_enum),
+        syn::Data::Union(_) => {
+            quote! { compile_error!("unions are not supported") }
+        }
+    };
+    let name = input.ident;
+
+    quote! {
+        // Some fields/commands in the CLI are deprecated
+        #[allow(deprecated)]
+        impl AbsolutePath for #name {
+            fn absolute(self) -> Self {
+                #constructor
+            }
+        }
+    }
+    .into()
+}
+
+fn derive_struct(input: DataStruct) -> TokenStream {
+    match input.fields {
+        Fields::Named(fields) => {
+            let members: Vec<_> = fields
+                .named
+                .into_iter()
+                .map(|field| field.ident.expect("named field"))
+                .collect();
+            quote! {
+                Self {
+                    #(#members: self.#members.absolute()),*
+                }
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let members: Vec<_> = (0..fields.unnamed.len()).map(syn::Index::from).collect();
+            quote! {
+                Self(
+                    #(self.#members.absolute()),*
+                )
+            }
+        }
+        Fields::Unit => quote! { Self },
+    }
+}
+
+fn derive_enum(input: DataEnum) -> TokenStream {
+    let variants = input.variants.into_iter().map(|variant| {
+        let name = variant.ident;
+        match variant.fields {
+            Fields::Named(fields) => {
+                let members: Vec<_> = fields
+                    .named
+                    .into_iter()
+                    .map(|field| field.ident.expect("named field"))
+                    .collect();
+                quote! {
+                    Self::#name { #(#members),* } => Self::#name {
+                        #(#members: #members.absolute()),*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let members: Vec<_> = (0..fields.unnamed.len())
+                    .map(|index| format_ident!("field_{index}"))
+                    .collect();
+                quote! {
+                    Self::#name(#(#members),*) => Self::#name(
+                        #(#members.absolute()),*
+                    )
+                }
+            }
+            Fields::Unit => quote! {
+                Self::#name => Self::#name
+            },
+        }
+    });
+    quote! {
+        match self {
+            #(#variants),*
+        }
+    }
+}

--- a/cli/src/abs_path.rs
+++ b/cli/src/abs_path.rs
@@ -1,0 +1,72 @@
+//! Defines the [`AbsolutePath`] trait and implementations for the various commands
+//! and sub-commands.
+
+use std::path::PathBuf;
+
+/// Used to get the absolute form of all paths within this type
+pub(crate) trait AbsolutePath: Sized {
+    /// Convert all [`PathBuf`]s within this to absolute.
+    fn absolute(self) -> Self;
+}
+
+impl AbsolutePath for PathBuf {
+    fn absolute(self) -> Self {
+        std::path::absolute(&self)
+            .unwrap_or_else(|e| panic!("failed to get absolute path for `{}`: {e}", self.display()))
+    }
+}
+
+impl<T: AbsolutePath> AbsolutePath for Option<T> {
+    fn absolute(self) -> Self {
+        self.map(T::absolute)
+    }
+}
+
+impl<T: AbsolutePath> AbsolutePath for Vec<T> {
+    fn absolute(self) -> Self {
+        self.into_iter().map(T::absolute).collect()
+    }
+}
+
+// For types with no paths, implement a no-op `absolute`
+macro_rules! impl_nop {
+    ($($ty:path),* $(,)?) => {
+        $(
+            impl AbsolutePath for $ty {
+                fn absolute(self) -> Self {
+                    self
+                }
+            }
+        )*
+    };
+}
+
+impl_nop! {
+    // Primitives
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    isize,
+    f32,
+    f64,
+
+    // std types
+    String,
+
+    // First-party types
+    anchor_client::Cluster,
+
+    // Third-party types
+    clap_complete::Shell,
+    solana_commitment_config::CommitmentLevel,
+    solana_pubkey::Pubkey,
+}

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,5 +1,8 @@
 use {
-    crate::config::{Config, ConfigOverride},
+    crate::{
+        config::{Config, ConfigOverride},
+        AbsolutePath,
+    },
     anyhow::{anyhow, Result},
     clap::Parser,
     solana_commitment_config::CommitmentConfig,
@@ -8,7 +11,7 @@ use {
     std::{fs::File, io::Write, path::PathBuf},
 };
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub struct ShowAccountCommand {
     /// Account address to show
     pub account_address: Pubkey,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -562,7 +562,7 @@ impl Config {
     }
 
     pub fn wallet_kp(&self) -> Result<Keypair> {
-        get_keypair(&self.provider.wallet.to_string())
+        get_keypair(Path::new(&self.provider.wallet.0))
     }
 
     pub fn run_hooks(&self, hook_type: HookType) -> Result<()> {
@@ -1431,7 +1431,7 @@ impl Program {
 
     pub fn keypair(&self) -> Result<Keypair> {
         let file = self.keypair_file()?;
-        get_keypair(file.path().to_str().unwrap())
+        get_keypair(file.path())
     }
 
     // Lazily initializes the keypair file with a new key if it doesn't exist.
@@ -1555,23 +1555,19 @@ pub struct RunbookExecution {
 macro_rules! home_path {
     ($my_struct:ident, $path:literal) => {
         #[derive(Clone, Debug)]
-        pub struct $my_struct(String);
+        pub struct $my_struct(::std::path::PathBuf);
 
         impl Default for $my_struct {
             fn default() -> Self {
-                $my_struct(
-                    home_dir()
-                        .unwrap()
-                        .join($path.replace('/', std::path::MAIN_SEPARATOR_STR))
-                        .display()
-                        .to_string(),
-                )
+                $my_struct(home_dir().unwrap().join($path))
             }
         }
 
         impl $my_struct {
             fn stringify_with_tilde(&self) -> String {
                 self.0
+                    .display()
+                    .to_string()
                     .replacen(home_dir().unwrap().to_str().unwrap(), "~", 1)
             }
         }
@@ -1580,13 +1576,13 @@ macro_rules! home_path {
             type Err = anyhow::Error;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                Ok(Self(s.to_owned()))
+                Ok(Self(::std::path::PathBuf::from(s)))
             }
         }
 
         impl fmt::Display for $my_struct {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}", self.0)
+                write!(f, "{}", self.0.display())
             }
         }
     };

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{get_keypair, is_hidden, keys_sync, DEFAULT_RPC_PORT},
+    crate::{get_keypair, is_hidden, keys_sync, AbsolutePath, DEFAULT_RPC_PORT},
     anchor_client::Cluster,
     anchor_lang_idl::types::Idl,
     anyhow::{anyhow, bail, Context, Error, Result},
@@ -35,7 +35,7 @@ use {
 
 pub const SURFPOOL_HOST: &str = "127.0.0.1";
 /// Wrapper around CommitmentLevel to support case-insensitive parsing
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AbsolutePath)]
 pub struct CaseInsensitiveCommitmentLevel(pub CommitmentLevel);
 
 impl FromStr for CaseInsensitiveCommitmentLevel {
@@ -64,7 +64,7 @@ pub trait Merge: Sized {
     fn merge(&mut self, _other: Self) {}
 }
 
-#[derive(Default, Debug, Parser)]
+#[derive(Default, Debug, Parser, AbsolutePath)]
 pub struct ConfigOverride {
     /// Cluster override.
     #[clap(global = true, long = "provider.cluster")]
@@ -339,7 +339,7 @@ pub struct Config {
     pub surfpool_config: Option<SurfpoolConfig>,
 }
 
-#[derive(ValueEnum, Parser, Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(ValueEnum, Parser, Clone, Copy, PartialEq, Eq, Debug, AbsolutePath)]
 pub enum ValidatorType {
     /// Use Surfpool validator (default)
     Surfpool,
@@ -354,7 +354,9 @@ pub struct ToolchainConfig {
 }
 
 /// Package manager to use for the project.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, Serialize, Deserialize, AbsolutePath,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageManager {
     /// Use npm as the package manager.
@@ -471,12 +473,27 @@ pub struct WorkspaceConfig {
     pub types: String,
 }
 
-#[derive(ValueEnum, Parser, Clone, PartialEq, Eq, Debug)]
+#[derive(ValueEnum, Parser, Clone, PartialEq, Eq, Debug, AbsolutePath)]
 pub enum BootstrapMode {
     None,
     Debian,
 }
 
+#[derive(ValueEnum, Parser, Clone, PartialEq, Eq, Debug, AbsolutePath)]
+pub enum ProgramArch {
+    Bpf,
+    Sbf,
+}
+
+impl ProgramArch {
+    /// Subcommand and any arguments to be passed to cargo
+    pub fn build_subcommand(&self) -> &[&'static str] {
+        match self {
+            Self::Bpf => &["build-bpf"],
+            Self::Sbf => &["build-sbf", "--tools-version", "v1.52"],
+        }
+    }
+}
 #[derive(Debug, Clone)]
 pub struct BuildConfig {
     pub verifiable: bool,
@@ -1554,7 +1571,7 @@ pub struct RunbookExecution {
 #[macro_export]
 macro_rules! home_path {
     ($my_struct:ident, $path:literal) => {
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, AbsolutePath)]
         pub struct $my_struct(::std::path::PathBuf);
 
         impl Default for $my_struct {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -308,6 +308,16 @@ impl WithPath<Config> {
     }
 }
 
+impl WalletPath {
+    fn resolve_relative_to(self, base: &Path) -> Self {
+        if self.0.is_relative() {
+            Self(base.join(self.0))
+        } else {
+            self
+        }
+    }
+}
+
 impl<T> std::ops::Deref for WithPath<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -479,21 +489,6 @@ pub enum BootstrapMode {
     Debian,
 }
 
-#[derive(ValueEnum, Parser, Clone, PartialEq, Eq, Debug, AbsolutePath)]
-pub enum ProgramArch {
-    Bpf,
-    Sbf,
-}
-
-impl ProgramArch {
-    /// Subcommand and any arguments to be passed to cargo
-    pub fn build_subcommand(&self) -> &[&'static str] {
-        match self {
-            Self::Bpf => &["build-bpf"],
-            Self::Sbf => &["build-sbf", "--tools-version", "v1.52"],
-        }
-    }
-}
 #[derive(Debug, Clone)]
 pub struct BuildConfig {
     pub verifiable: bool,
@@ -551,15 +546,17 @@ impl Config {
                     .path();
                 if let Some(filename) = p.file_name() {
                     if filename.to_str() == Some("Anchor.toml") {
+                        let config_dir = p.parent().unwrap();
                         // Make sure the program id is correct (only on the initial build)
                         let mut cfg = Config::from_path(&p)?;
-                        let deploy_dir = p.parent().unwrap().join("target").join("deploy");
+                        let deploy_dir = config_dir.join("target").join("deploy");
                         if !deploy_dir.exists() && !cfg.programs.contains_key(&Cluster::Localnet) {
                             println!("Updating program ids...");
                             fs::create_dir_all(deploy_dir)?;
                             keys_sync(&ConfigOverride::default(), None)?;
                             cfg = Config::from_path(&p)?;
                         }
+                        cfg.provider.wallet = cfg.provider.wallet.resolve_relative_to(config_dir);
 
                         return Ok(Some(WithPath::new(cfg, p)));
                     }

--- a/cli/src/keygen.rs
+++ b/cli/src/keygen.rs
@@ -12,7 +12,7 @@ use {
     std::{
         fs,
         io::{self, Write},
-        path::Path,
+        path::{Path, PathBuf},
     },
 };
 
@@ -87,7 +87,7 @@ pub fn keygen(_cfg_override: &ConfigOverride, cmd: KeygenCommand) -> Result<()> 
 }
 
 fn keygen_new(
-    outfile: Option<String>,
+    outfile: Option<PathBuf>,
     force: bool,
     no_passphrase: bool,
     silent: bool,
@@ -99,7 +99,7 @@ fn keygen_new(
         path.push(".config");
         path.push("solana");
         path.push("id.json");
-        path.to_str().unwrap().to_string()
+        path
     });
 
     // Check for overwrite
@@ -107,12 +107,12 @@ fn keygen_new(
         if !force {
             bail!(
                 "Refusing to overwrite {} without --force flag",
-                outfile_path
+                outfile_path.display()
             );
         }
         println!(
             "⚠️  Warning: Overwriting existing keypair at {}",
-            outfile_path
+            outfile_path.display()
         );
     }
 
@@ -162,9 +162,13 @@ fn keygen_new(
     if let Some(outdir) = Path::new(&outfile_path).parent() {
         fs::create_dir_all(outdir)?;
     }
-    keypair
-        .write_to_file(&outfile_path)
-        .map_err(|e| anyhow!("Failed to write keypair to {}: {}", outfile_path, e))?;
+    keypair.write_to_file(&outfile_path).map_err(|e| {
+        anyhow!(
+            "Failed to write keypair to {}: {}",
+            outfile_path.display(),
+            e
+        )
+    })?;
 
     // Set restrictive permissions (owner read/write only)
     #[cfg(unix)]
@@ -175,7 +179,7 @@ fn keygen_new(
         fs::set_permissions(&outfile_path, perms)?;
     }
 
-    print_step(&format!("Keypair saved to {}", outfile_path));
+    print_step(&format!("Keypair saved to {}", outfile_path.display()));
 
     let phrase: &str = mnemonic.phrase();
     let divider = "━".repeat(phrase.len().max(60));
@@ -201,13 +205,13 @@ fn keygen_new(
     Ok(())
 }
 
-fn keygen_pubkey(keypair_path: Option<String>) -> Result<()> {
+fn keygen_pubkey(keypair_path: Option<PathBuf>) -> Result<()> {
     let path = keypair_path.unwrap_or_else(|| {
         let mut p = home_dir().expect("home directory");
         p.push(".config");
         p.push("solana");
         p.push("id.json");
-        p.to_str().unwrap().to_string()
+        p
     });
 
     let keypair = get_keypair(&path)?;
@@ -216,7 +220,7 @@ fn keygen_pubkey(keypair_path: Option<String>) -> Result<()> {
 }
 
 fn keygen_recover(
-    outfile: Option<String>,
+    outfile: Option<PathBuf>,
     force: bool,
     _skip_seed_phrase_validation: bool,
     no_passphrase: bool,
@@ -230,7 +234,7 @@ fn keygen_recover(
         path.push(".config");
         path.push("solana");
         path.push("id.json");
-        path.to_str().unwrap().to_string()
+        path
     });
 
     // Check for overwrite
@@ -238,12 +242,12 @@ fn keygen_recover(
         if !force {
             bail!(
                 "Refusing to overwrite {} without --force flag",
-                outfile_path
+                outfile_path.display()
             );
         }
         println!(
             "⚠️  Warning: Overwriting existing keypair at {}",
-            outfile_path
+            outfile_path.display()
         );
     }
 
@@ -281,9 +285,13 @@ fn keygen_recover(
     if let Some(outdir) = Path::new(&outfile_path).parent() {
         fs::create_dir_all(outdir)?;
     }
-    keypair
-        .write_to_file(&outfile_path)
-        .map_err(|e| anyhow!("Failed to write keypair to {}: {}", outfile_path, e))?;
+    keypair.write_to_file(&outfile_path).map_err(|e| {
+        anyhow!(
+            "Failed to write keypair to {}: {}",
+            outfile_path.display(),
+            e
+        )
+    })?;
 
     // Set restrictive permissions (owner read/write only)
     #[cfg(unix)]
@@ -294,7 +302,7 @@ fn keygen_recover(
         fs::set_permissions(&outfile_path, perms)?;
     }
 
-    print_step(&format!("Keypair recovered to {}", outfile_path));
+    print_step(&format!("Keypair recovered to {}", outfile_path.display()));
 
     println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     println!("📋 Public Key: {}", keypair.pubkey());
@@ -303,7 +311,7 @@ fn keygen_recover(
     Ok(())
 }
 
-fn keygen_verify(pubkey: Pubkey, keypair_path: Option<String>) -> Result<()> {
+fn keygen_verify(pubkey: Pubkey, keypair_path: Option<PathBuf>) -> Result<()> {
     println!("\n🔍 Verifying keypair");
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
@@ -312,10 +320,10 @@ fn keygen_verify(pubkey: Pubkey, keypair_path: Option<String>) -> Result<()> {
         p.push(".config");
         p.push("solana");
         p.push("id.json");
-        p.to_str().unwrap().to_string()
+        p
     });
 
-    print_step(&format!("Loading keypair from {}", path));
+    print_step(&format!("Loading keypair from {}", path.display()));
     let keypair = get_keypair(&path)?;
 
     // Create a simple message to sign
@@ -356,12 +364,11 @@ mod tests {
         tempfile::{tempdir, TempDir},
     };
 
-    fn tmp_outfile_path(out_dir: &TempDir, name: &str) -> String {
-        let path = out_dir.path().join(name);
-        path.into_os_string().into_string().unwrap()
+    fn tmp_outfile_path(out_dir: &TempDir, name: &str) -> PathBuf {
+        out_dir.path().join(name)
     }
 
-    fn read_keypair_file(path: &str) -> Result<Keypair> {
+    fn read_keypair_file(path: &Path) -> Result<Keypair> {
         get_keypair(path)
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,6 +5,8 @@ use {
         SurfnetInfoResponse, SurfpoolConfig, TestValidator, ValidatorType, WithPath, SHUTDOWN_WAIT,
         STARTUP_WAIT, SURFPOOL_HOST,
     },
+    abs_path::AbsolutePath,
+    anchor_cli_macros::AbsolutePath,
     anchor_client::Cluster,
     anchor_lang::{
         prelude::UpgradeableLoaderState, solana_program::bpf_loader_upgradeable, AnchorDeserialize,
@@ -47,8 +49,6 @@ use {
         sync::LazyLock,
     },
 };
-use abs_path::AbsolutePath;
-use anchor_cli_macros::AbsolutePath;
 
 mod abs_path;
 mod account;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2599,7 +2599,7 @@ fn idl_init(
             program_id,
             idl_filepath: idl_filepath
                 .to_str()
-                .expect("path should be utf8")
+                .ok_or_else(|| anyhow!("IDL filepath is not valid UTF-8"))?
                 .to_string(),
             non_canonical,
         },
@@ -2650,7 +2650,7 @@ fn idl_upgrade(
             program_id,
             idl_filepath: idl_filepath
                 .to_str()
-                .expect("path should be utf8")
+                .ok_or_else(|| anyhow!("IDL filepath is not valid UTF-8"))?
                 .to_string(),
             non_canonical: false,
         },
@@ -2819,7 +2819,10 @@ fn idl_create_buffer(
         wallet_path,
         priority_fee,
         metadata::FundedIdlSubcommand::CreateBuffer {
-            filepath: filepath.to_str().expect("path should be utf8").to_string(),
+            filepath: filepath
+                .to_str()
+                .ok_or_else(|| anyhow!("IDL filepath is not valid UTF-8"))?
+                .to_string(),
         },
     );
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -47,7 +47,10 @@ use {
         sync::LazyLock,
     },
 };
+use abs_path::AbsolutePath;
+use anchor_cli_macros::AbsolutePath;
 
+mod abs_path;
 mod account;
 mod checks;
 pub mod config;
@@ -75,7 +78,7 @@ pub static AVM_HOME: LazyLock<PathBuf> = LazyLock::new(|| {
     }
 });
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 #[clap(version = VERSION)]
 pub struct Opts {
     #[clap(flatten)]
@@ -84,7 +87,7 @@ pub struct Opts {
     pub command: Command,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum Command {
     /// Initializes a workspace.
     Init {
@@ -366,9 +369,9 @@ pub enum Command {
         account_type: String,
         /// Address of the account to deserialize
         address: Pubkey,
-        /// IDL to use (defaults to workspace IDL)
+        /// Path of IDL to use (defaults to workspace IDL)
         #[clap(long)]
-        idl: Option<String>,
+        idl: Option<PathBuf>,
     },
     /// Generates shell completions.
     Completions {
@@ -416,7 +419,7 @@ pub enum Command {
     },
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum KeygenCommand {
     /// Generate a new keypair
     New {
@@ -465,7 +468,7 @@ pub enum KeygenCommand {
     },
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum KeysCommand {
     /// List all of the program keys.
     List,
@@ -477,7 +480,7 @@ pub enum KeysCommand {
     },
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum ProgramCommand {
     /// Deploy an upgradeable program
     Deploy {
@@ -634,7 +637,7 @@ pub enum ProgramCommand {
     },
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum IdlCommand {
     /// Initializes a program's IDL account. Can only be run once.
     Init {
@@ -770,13 +773,13 @@ pub enum IdlCommand {
     },
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum ClusterCommand {
     /// Prints common cluster urls.
     List,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, AbsolutePath)]
 pub enum ConfigCommand {
     /// Get configuration settings from the local Anchor.toml
     Get,
@@ -907,6 +910,8 @@ pub fn prepend_compute_unit_ix(
 }
 
 pub fn entry(opts: Opts) -> Result<()> {
+    let opts = opts.absolute();
+
     let restore_cbs = override_toolchain(&opts.cfg_override)?;
     let result = process_command(opts);
     restore_toolchain(restore_cbs)?;
@@ -2928,7 +2933,7 @@ fn account(
     cfg_override: &ConfigOverride,
     account_type: String,
     address: Pubkey,
-    idl_filepath: Option<String>,
+    idl_filepath: Option<PathBuf>,
 ) -> Result<()> {
     let (program_name, account_type_name) = account_type
         .split_once('.') // Split at first occurrence of dot

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -269,7 +269,7 @@ pub enum Command {
         program_name: Option<String>,
         /// Keypair of the program (filepath) (requires program-name)
         #[clap(long, requires = "program_name")]
-        program_keypair: Option<String>,
+        program_keypair: Option<PathBuf>,
         /// If true, deploy from path target/verifiable
         #[clap(short, long)]
         verifiable: bool,
@@ -292,7 +292,7 @@ pub enum Command {
         #[clap(short, long)]
         program_id: Pubkey,
         /// Filepath to the new program binary.
-        program_filepath: String,
+        program_filepath: PathBuf,
         /// Max times to retry on failure.
         #[clap(long, default_value = "0")]
         max_retries: u32,
@@ -422,7 +422,7 @@ pub enum KeygenCommand {
     New {
         /// Path to generated keypair file
         #[clap(short = 'o', long)]
-        outfile: Option<String>,
+        outfile: Option<PathBuf>,
         /// Overwrite the output file if it exists
         #[clap(short, long)]
         force: bool,
@@ -439,13 +439,13 @@ pub enum KeygenCommand {
     /// Display the pubkey for a given keypair
     Pubkey {
         /// Keypair filepath
-        keypair: Option<String>,
+        keypair: Option<PathBuf>,
     },
     /// Recover a keypair from a seed phrase
     Recover {
         /// Path to recovered keypair file
         #[clap(short = 'o', long)]
-        outfile: Option<String>,
+        outfile: Option<PathBuf>,
         /// Overwrite the output file if it exists
         #[clap(short, long)]
         force: bool,
@@ -461,7 +461,7 @@ pub enum KeygenCommand {
         /// Public key to verify
         pubkey: Pubkey,
         /// Keypair filepath (defaults to configured wallet)
-        keypair: Option<String>,
+        keypair: Option<PathBuf>,
     },
 }
 
@@ -483,13 +483,13 @@ pub enum ProgramCommand {
     Deploy {
         /// Program filepath (e.g., target/deploy/my_program.so).
         /// If not provided, discovers programs from workspace
-        program_filepath: Option<String>,
+        program_filepath: Option<PathBuf>,
         /// Program name to deploy (from workspace). Used when program_filepath is not provided
         #[clap(short, long)]
         program_name: Option<String>,
         /// Program keypair filepath (defaults to target/deploy/{program_name}-keypair.json)
         #[clap(long)]
-        program_keypair: Option<String>,
+        program_keypair: Option<PathBuf>,
         /// Upgrade authority keypair (defaults to configured wallet)
         #[clap(long)]
         upgrade_authority: Option<String>,
@@ -516,7 +516,7 @@ pub enum ProgramCommand {
     WriteBuffer {
         /// Program filepath (e.g., target/deploy/my_program.so).
         /// If not provided, discovers program from workspace using program_name
-        program_filepath: Option<String>,
+        program_filepath: Option<PathBuf>,
         /// Program name to write (from workspace). Used when program_filepath is not provided
         #[clap(short, long)]
         program_name: Option<String>,
@@ -579,7 +579,7 @@ pub enum ProgramCommand {
         program_id: Pubkey,
         /// Program filepath (e.g., target/deploy/my_program.so). If not provided, discovers from workspace
         #[clap(long)]
-        program_filepath: Option<String>,
+        program_filepath: Option<PathBuf>,
         /// Program name to upgrade (from workspace). Used when program_filepath is not provided
         #[clap(short, long)]
         program_name: Option<String>,
@@ -642,7 +642,7 @@ pub enum IdlCommand {
         /// If not provided, discovers program ID from IDL.
         program_id: Option<Pubkey>,
         #[clap(short, long)]
-        filepath: String,
+        filepath: PathBuf,
         #[clap(long)]
         priority_fee: Option<u64>,
         /// Create non-canonical metadata account (third-party metadata)
@@ -660,7 +660,7 @@ pub enum IdlCommand {
         /// If not provided, discovers program ID from IDL.
         program_id: Option<Pubkey>,
         #[clap(short, long)]
-        filepath: String,
+        filepath: PathBuf,
         #[clap(long)]
         priority_fee: Option<u64>,
         /// Allow running against a localnet cluster (disabled by default)
@@ -703,7 +703,7 @@ pub enum IdlCommand {
     /// Convert legacy IDLs (pre Anchor 0.30) to the new IDL spec
     Convert {
         /// Path to the IDL file
-        path: String,
+        path: PathBuf,
         /// Output file for the IDL (stdout if not specified)
         #[clap(short, long)]
         out: Option<String>,
@@ -715,10 +715,10 @@ pub enum IdlCommand {
     /// Generate TypeScript type for the IDL
     Type {
         /// Path to the IDL file
-        path: String,
+        path: PathBuf,
         /// Output file for the IDL (stdout if not specified)
         #[clap(short, long)]
-        out: Option<String>,
+        out: Option<PathBuf>,
     },
     /// Close a metadata account and recover rent
     Close {
@@ -735,7 +735,7 @@ pub enum IdlCommand {
     CreateBuffer {
         /// Path to the metadata file
         #[clap(short, long)]
-        filepath: String,
+        filepath: PathBuf,
         /// Priority fees in micro-lamports per compute unit
         #[clap(long)]
         priority_fee: Option<u64>,
@@ -787,13 +787,13 @@ pub enum ConfigCommand {
         url: Option<String>,
         /// Path to wallet keypair file to update the Anchor.toml file with
         #[clap(short = 'k', long = "keypair")]
-        keypair: Option<String>,
+        keypair: Option<PathBuf>,
     },
 }
 
-fn get_keypair(path: &str) -> Result<Keypair> {
+fn get_keypair(path: &Path) -> Result<Keypair> {
     solana_keypair::read_keypair_file(path)
-        .map_err(|_| anyhow!("Unable to read keypair file ({path})"))
+        .map_err(|_| anyhow!("Unable to read keypair file ({})", path.display()))
 }
 
 /// Format lamports as SOL with trailing zeros removed
@@ -2558,7 +2558,7 @@ fn idl(cfg_override: &ConfigOverride, subcmd: IdlCommand) -> Result<()> {
 fn idl_init(
     program_id: Option<Pubkey>,
     cfg_override: &ConfigOverride,
-    idl_filepath: String,
+    idl_filepath: PathBuf,
     priority_fee: Option<u64>,
     non_canonical: bool,
     allow_localnet: bool,
@@ -2592,7 +2592,10 @@ fn idl_init(
         priority_fee,
         metadata::FundedIdlSubcommand::Write {
             program_id,
-            idl_filepath,
+            idl_filepath: idl_filepath
+                .to_str()
+                .expect("path should be utf8")
+                .to_string(),
             non_canonical,
         },
     );
@@ -2609,7 +2612,7 @@ fn idl_init(
 fn idl_upgrade(
     program_id: Option<Pubkey>,
     cfg_override: &ConfigOverride,
-    idl_filepath: String,
+    idl_filepath: PathBuf,
     priority_fee: Option<u64>,
     allow_localnet: bool,
 ) -> Result<()> {
@@ -2640,12 +2643,15 @@ fn idl_upgrade(
         priority_fee,
         metadata::FundedIdlSubcommand::Write {
             program_id,
-            idl_filepath,
+            idl_filepath: idl_filepath
+                .to_str()
+                .expect("path should be utf8")
+                .to_string(),
             non_canonical: false,
         },
     );
     if !command.status()?.success() {
-        return Err(anyhow!("Failed to initialize IDL"));
+        return Err(anyhow!("Failed to upgrade IDL"));
     }
 
     println!("IDL upgraded.");
@@ -2735,7 +2741,7 @@ fn idl_fetch(
     Ok(())
 }
 
-fn idl_convert(path: String, out: Option<String>, program_id: Option<Pubkey>) -> Result<()> {
+fn idl_convert(path: PathBuf, out: Option<String>, program_id: Option<Pubkey>) -> Result<()> {
     let idl = fs::read(path)?;
 
     // Set the `metadata.address` field based on the given `program_id`
@@ -2761,7 +2767,7 @@ fn idl_convert(path: String, out: Option<String>, program_id: Option<Pubkey>) ->
     write_idl(&idl, out)
 }
 
-fn idl_type(path: String, out: Option<String>) -> Result<()> {
+fn idl_type(path: PathBuf, out: Option<PathBuf>) -> Result<()> {
     let idl = fs::read(path)?;
     let idl = convert_idl(&idl)?;
     let types = idl_ts(&idl)?;
@@ -2799,7 +2805,7 @@ fn idl_close_metadata(
 
 fn idl_create_buffer(
     cfg_override: &ConfigOverride,
-    filepath: String,
+    filepath: PathBuf,
     priority_fee: Option<u64>,
 ) -> Result<()> {
     let (cluster_url, wallet_path) = get_cluster_and_wallet(cfg_override)?;
@@ -2807,7 +2813,9 @@ fn idl_create_buffer(
         cluster_url,
         wallet_path,
         priority_fee,
-        metadata::FundedIdlSubcommand::CreateBuffer { filepath },
+        metadata::FundedIdlSubcommand::CreateBuffer {
+            filepath: filepath.to_str().expect("path should be utf8").to_string(),
+        },
     );
 
     if !command.status()?.success() {
@@ -4215,7 +4223,7 @@ fn clean(cfg_override: &ConfigOverride) -> Result<()> {
 fn deploy(
     cfg_override: &ConfigOverride,
     program_name: Option<String>,
-    program_keypair: Option<String>,
+    program_keypair: Option<PathBuf>,
     verifiable: bool,
     no_idl: bool,
     solana_args: Vec<String>,
@@ -4235,14 +4243,14 @@ fn deploy(
         println!("Upgrade authority: {keypair}");
 
         for program in cfg.get_programs(program_name)? {
-            let binary_path = program.binary_path(verifiable).display().to_string();
+            let binary_path = program.binary_path(verifiable);
 
             println!("Deploying program {:?}...", program.lib_name);
-            println!("Program path: {binary_path}...");
+            println!("Program path: {}...", binary_path.display());
 
-            let program_keypair_filepath = match &program_keypair {
+            let program_keypair_filepath = match program_keypair.as_ref() {
                 Some(path) => path.clone(),
-                None => program.keypair_file()?.path().display().to_string(),
+                None => program.keypair_file()?.path().clone(),
             };
 
             // Deploy using our native implementation
@@ -4271,7 +4279,7 @@ fn deploy(
 fn upgrade(
     cfg_override: &ConfigOverride,
     program_id: Pubkey,
-    program_filepath: String,
+    program_filepath: PathBuf,
     max_retries: u32,
     solana_args: Vec<String>,
 ) -> Result<()> {
@@ -4484,7 +4492,7 @@ fn config_get(cfg_override: &ConfigOverride) -> Result<()> {
 fn config_set(
     cfg_override: &ConfigOverride,
     url: Option<String>,
-    keypair: Option<String>,
+    keypair: Option<PathBuf>,
 ) -> Result<()> {
     // Find the Anchor.toml file
     let anchor_toml_path = match Config::discover(cfg_override)? {
@@ -4522,7 +4530,7 @@ fn config_set(
 
     // Update wallet path if provided
     if let Some(keypair_path) = keypair {
-        let expanded_path = shellexpand::tilde(&keypair_path).to_string();
+        let expanded_path = shellexpand::tilde(&keypair_path.to_string_lossy()).to_string();
 
         // Check if the wallet file exists
         if !Path::new(&expanded_path).exists() {
@@ -4985,9 +4993,8 @@ fn get_node_dns_option() -> Result<&'static str> {
 // a local filesystem path. Removing the workspace prefix handles most/all cases
 // of spaces in keypair/binary paths, but this should be fixed in the Solana CLI
 // and removed here.
-fn strip_workspace_prefix(absolute_path: String) -> String {
-    let workspace_prefix =
-        std::env::current_dir().unwrap().display().to_string() + std::path::MAIN_SEPARATOR_STR;
+fn strip_workspace_prefix(absolute_path: PathBuf) -> PathBuf {
+    let workspace_prefix = std::env::current_dir().unwrap();
     absolute_path
         .strip_prefix(&workspace_prefix)
         .unwrap_or(&absolute_path)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -709,7 +709,7 @@ pub enum IdlCommand {
         path: PathBuf,
         /// Output file for the IDL (stdout if not specified)
         #[clap(short, long)]
-        out: Option<String>,
+        out: Option<PathBuf>,
         /// Program id to initialize IDL for.
         /// If not provided, discovers program ID from IDL.
         #[clap(short, long)]
@@ -2746,7 +2746,7 @@ fn idl_fetch(
     Ok(())
 }
 
-fn idl_convert(path: PathBuf, out: Option<String>, program_id: Option<Pubkey>) -> Result<()> {
+fn idl_convert(path: PathBuf, out: Option<PathBuf>, program_id: Option<Pubkey>) -> Result<()> {
     let idl = fs::read(path)?;
 
     // Set the `metadata.address` field based on the given `program_id`
@@ -2767,7 +2767,7 @@ fn idl_convert(path: PathBuf, out: Option<String>, program_id: Option<Pubkey>) -
     let idl = convert_idl(&idl)?;
     let out = match out {
         None => OutFile::Stdout,
-        Some(out) => OutFile::File(PathBuf::from(out)),
+        Some(out) => OutFile::File(out),
     };
     write_idl(&idl, out)
 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -25,7 +25,7 @@ use {
     std::{
         fs::{self, File},
         io::Write,
-        path::Path,
+        path::{Path, PathBuf},
         sync::Arc,
         thread,
         time::Duration,
@@ -182,9 +182,9 @@ pub fn get_programs_from_workspace(
 #[allow(clippy::too_many_arguments)]
 pub fn process_deploy(
     cfg_override: &ConfigOverride,
-    program_filepath: Option<String>,
+    program_filepath: Option<PathBuf>,
     program_name: Option<String>,
-    program_keypair: Option<String>,
+    program_keypair: Option<PathBuf>,
     upgrade_authority: Option<String>,
     program_id: Option<Pubkey>,
     buffer: Option<Pubkey>,
@@ -274,7 +274,7 @@ pub fn process_deploy(
 fn deploy_workspace(
     cfg_override: &ConfigOverride,
     program_name: Option<String>,
-    program_keypair: Option<String>,
+    program_keypair: Option<PathBuf>,
     verifiable: bool,
     no_idl: bool,
     make_final: bool,
@@ -304,10 +304,7 @@ fn deploy_workspace(
             Some(path) => Some(path.clone()),
             None => {
                 // Try to find program keypair
-                let keypair_path = program
-                    .keypair_file()
-                    .ok()
-                    .map(|kp| kp.path().display().to_string());
+                let keypair_path = program.keypair_file().ok().map(|kp| kp.path().clone());
                 keypair_path
             }
         };
@@ -315,7 +312,7 @@ fn deploy_workspace(
         // Use the native program_deploy implementation
         program_deploy(
             cfg_override,
-            Some(binary_path.display().to_string()),
+            Some(binary_path),
             None, // program_name - not needed since we have filepath
             program_keypair_filepath,
             None, // upgrade_authority - uses wallet
@@ -475,9 +472,9 @@ fn get_payer_keypair(
 #[allow(clippy::too_many_arguments)]
 pub fn program_deploy(
     cfg_override: &ConfigOverride,
-    program_filepath: Option<String>,
+    program_filepath: Option<PathBuf>,
     program_name: Option<String>,
-    program_keypair: Option<String>,
+    program_keypair: Option<PathBuf>,
     upgrade_authority: Option<String>,
     program_id: Option<Pubkey>,
     buffer: Option<Pubkey>,
@@ -502,7 +499,7 @@ pub fn program_deploy(
 
         println!("Deploying program: {}", program.lib_name);
 
-        binary_path.display().to_string()
+        binary_path
     };
 
     // Augment solana_args with recommended defaults (priority fees, max sign attempts, buffer)
@@ -512,8 +509,13 @@ pub fn program_deploy(
     let priority_fee = parse_priority_fee_from_args(&solana_args);
 
     // Read program data
-    let program_data = fs::read(&program_filepath)
-        .map_err(|e| anyhow!("Failed to read program file {}: {}", program_filepath, e))?;
+    let program_data = fs::read(&program_filepath).map_err(|e| {
+        anyhow!(
+            "Failed to read program file {}: {}",
+            program_filepath.display(),
+            e
+        )
+    })?;
 
     // Determine program keypair
     let loaded_program_keypair = if let Some(keypair_path) = program_keypair {
@@ -521,7 +523,7 @@ pub fn program_deploy(
         Keypair::read_from_file(&keypair_path).map_err(|e| {
             anyhow!(
                 "Failed to read program keypair from {}: {}",
-                keypair_path,
+                keypair_path.display(),
                 e
             )
         })?
@@ -655,15 +657,17 @@ pub fn program_deploy(
             .ok_or_else(|| anyhow!("Invalid program filepath"))?;
 
         // Look for IDL file in target/idl/{program_name}.json
-        let idl_filepath = format!("target/idl/{}.json", program_name);
+        let idl_filepath: PathBuf = format!("target/idl/{}.json", program_name).into();
 
         if Path::new(&idl_filepath).exists() {
             // Read and update the IDL with the program address
-            let idl_content = fs::read_to_string(&idl_filepath)
-                .map_err(|e| anyhow!("Failed to read IDL file {}: {}", idl_filepath, e))?;
+            let idl_content = fs::read_to_string(&idl_filepath).map_err(|e| {
+                anyhow!("Failed to read IDL file {}: {}", idl_filepath.display(), e)
+            })?;
 
-            let mut idl: Idl = serde_json::from_str(&idl_content)
-                .map_err(|e| anyhow!("Failed to parse IDL file {}: {}", idl_filepath, e))?;
+            let mut idl: Idl = serde_json::from_str(&idl_content).map_err(|e| {
+                anyhow!("Failed to parse IDL file {}: {}", idl_filepath.display(), e)
+            })?;
 
             // Update the IDL with the program address
             idl.address = program_id.to_string();
@@ -671,8 +675,9 @@ pub fn program_deploy(
             // Write the updated IDL back to the file
             let idl_json = serde_json::to_string_pretty(&idl)
                 .map_err(|e| anyhow!("Failed to serialize IDL: {}", e))?;
-            fs::write(&idl_filepath, idl_json)
-                .map_err(|e| anyhow!("Failed to write IDL file {}: {}", idl_filepath, e))?;
+            fs::write(&idl_filepath, idl_json).map_err(|e| {
+                anyhow!("Failed to write IDL file {}: {}", idl_filepath.display(), e)
+            })?;
 
             // Wait for the program to be confirmed before initializing IDL to prevent
             // race condition where the program isn't yet available in validator cache
@@ -722,7 +727,7 @@ pub fn program_deploy(
         } else {
             println!(
                 "Warning: IDL file not found at {}, skipping IDL deployment",
-                idl_filepath
+                idl_filepath.display()
             );
         }
     }
@@ -964,7 +969,7 @@ fn upgrade_program(
 
 fn program_write_buffer(
     cfg_override: &ConfigOverride,
-    program_filepath: Option<String>,
+    program_filepath: Option<PathBuf>,
     program_name: Option<String>,
     _buffer: Option<String>,
     buffer_authority: Option<String>,
@@ -993,12 +998,17 @@ fn program_write_buffer(
 
         println!("Writing buffer for program: {}", program.lib_name);
 
-        binary_path.display().to_string()
+        binary_path
     };
 
     // Read program data
-    let program_data = fs::read(&program_filepath)
-        .map_err(|e| anyhow!("Failed to read program file {}: {}", program_filepath, e))?;
+    let program_data = fs::read(&program_filepath).map_err(|e| {
+        anyhow!(
+            "Failed to read program file {}: {}",
+            program_filepath.display(),
+            e
+        )
+    })?;
 
     // Determine buffer authority
     let buffer_authority_keypair = if let Some(auth_path) = buffer_authority {
@@ -1308,7 +1318,7 @@ fn program_show(
 pub fn program_upgrade(
     cfg_override: &ConfigOverride,
     program_id: Pubkey,
-    program_filepath: Option<String>,
+    program_filepath: Option<PathBuf>,
     program_name: Option<String>,
     buffer: Option<Pubkey>,
     upgrade_authority: Option<String>,
@@ -1368,11 +1378,16 @@ pub fn program_upgrade(
 
         println!("Upgrading program: {}", program.lib_name);
 
-        binary_path.display().to_string()
+        binary_path
     };
 
-    let program_data = fs::read(&program_filepath)
-        .map_err(|e| anyhow!("Failed to read program file {}: {}", program_filepath, e))?;
+    let program_data = fs::read(&program_filepath).map_err(|e| {
+        anyhow!(
+            "Failed to read program file {}: {}",
+            program_filepath.display(),
+            e
+        )
+    })?;
 
     // Retry loop for buffer creation and upgrade
     for retry in 0..(1 + max_retries) {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        config::ProgramWorkspace, create_files, override_or_create_files, Files, PackageManager,
-        VERSION,
+        config::ProgramWorkspace, create_files, override_or_create_files, AbsolutePath, Files,
+        PackageManager, VERSION,
     },
     anyhow::Result,
     clap::{Parser, ValueEnum},
@@ -21,7 +21,7 @@ use {
 const ANCHOR_MSRV: &str = "1.89.0";
 
 /// Program initialization template
-#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, AbsolutePath)]
 pub enum ProgramTemplate {
     /// Program with a single `lib.rs` file (not recommended for production)
     Single,
@@ -643,7 +643,7 @@ anchor.workspace.{} = new anchor.Program({}, provider);
 }
 
 /// Test initialization template
-#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum, AbsolutePath)]
 pub enum TestTemplate {
     /// Generate template for Mocha unit-test
     Mocha,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -62,7 +62,7 @@ pub use {
     anchor_attribute_event::{emit, event},
     anchor_attribute_program::{declare_program, instruction, program},
     anchor_derive_accounts::Accounts,
-    anchor_derive_serde::{__erase, AnchorDeserialize, AnchorSerialize},
+    anchor_derive_serde::{AnchorDeserialize, AnchorSerialize, __erase},
     anchor_derive_space::InitSpace,
     borsh::ser::BorshSerialize as AnchorSerialize,
     const_crypto::ed25519::derive_program_address,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -62,7 +62,7 @@ pub use {
     anchor_attribute_event::{emit, event},
     anchor_attribute_program::{declare_program, instruction, program},
     anchor_derive_accounts::Accounts,
-    anchor_derive_serde::{AnchorDeserialize, AnchorSerialize, __erase},
+    anchor_derive_serde::{__erase, AnchorDeserialize, AnchorSerialize},
     anchor_derive_space::InitSpace,
     borsh::ser::BorshSerialize as AnchorSerialize,
     const_crypto::ed25519::derive_program_address,

--- a/tests/anchor-cli-idl/tests/idl.ts
+++ b/tests/anchor-cli-idl/tests/idl.ts
@@ -76,4 +76,16 @@ describe("Test CLI IDL commands", () => {
     );
     assert.deepEqual(idlActual, idlExpected);
   });
+
+  it("Can initialize IDL account with relative path from subdirectory", async () => {
+    execSync(`anchor idl close ${programOne.programId}`, { stdio: "inherit" });
+
+    execSync(
+      `cd target/idl && anchor idl init --filepath idl_commands_one.json --allow-localnet ${programOne.programId}`,
+      { stdio: "inherit" }
+    );
+
+    const idl = await fetchIdl(programOne.programId, provider);
+    assert.deepEqual(idl, programOne.rawIdl);
+  });
 });

--- a/tests/anchor-cli-idl/tests/idl.ts
+++ b/tests/anchor-cli-idl/tests/idl.ts
@@ -20,7 +20,7 @@ describe("Test CLI IDL commands", () => {
   it("Can initialize IDL account", async () => {
     execSync(
       `anchor idl init --filepath target/idl/idl_commands_one.json --allow-localnet`,
-      { stdio: "inherit" },
+      { stdio: "inherit" }
     );
   });
 
@@ -38,7 +38,7 @@ describe("Test CLI IDL commands", () => {
     // Upgrade the IDL of program one to the IDL of program two to test upgrade
     execSync(
       `anchor idl upgrade --filepath target/idl/idl_commands_two.json --allow-localnet ${programOne.programId}`,
-      { stdio: "inherit" },
+      { stdio: "inherit" }
     );
     const idl = await fetchIdl(programOne.programId, provider);
     assert.deepEqual(idl, programTwo.rawIdl);
@@ -72,7 +72,7 @@ describe("Test CLI IDL commands", () => {
 
     const idlActual = await fetchIdl(programOne.programId);
     const idlExpected = JSON.parse(
-      fs.readFileSync("testLargeIdl.json", "utf8"),
+      fs.readFileSync("testLargeIdl.json", "utf8")
     );
     assert.deepEqual(idlActual, idlExpected);
   });

--- a/tests/anchor-cli-idl/tests/idl.ts
+++ b/tests/anchor-cli-idl/tests/idl.ts
@@ -76,4 +76,16 @@ describe("Test CLI IDL commands", () => {
     );
     assert.deepEqual(idlActual, idlExpected);
   });
+
+  it("Can initialize IDL account with relative path from subdirectory", async () => {
+    execSync(`anchor idl close ${programOne.programId}`, { stdio: "inherit" });
+
+    execSync(
+      `cd target/idl && anchor idl init --filepath idl_commands_one.json ${programOne.programId}`,
+      { stdio: "inherit" }
+    );
+
+    const idl = await anchor.Program.fetchIdl(programOne.programId, provider);
+    assert.deepEqual(idl, programOne.rawIdl);
+  });
 });

--- a/tests/anchor-cli-idl/tests/idl.ts
+++ b/tests/anchor-cli-idl/tests/idl.ts
@@ -20,7 +20,7 @@ describe("Test CLI IDL commands", () => {
   it("Can initialize IDL account", async () => {
     execSync(
       `anchor idl init --filepath target/idl/idl_commands_one.json --allow-localnet`,
-      { stdio: "inherit" }
+      { stdio: "inherit" },
     );
   });
 
@@ -38,7 +38,7 @@ describe("Test CLI IDL commands", () => {
     // Upgrade the IDL of program one to the IDL of program two to test upgrade
     execSync(
       `anchor idl upgrade --filepath target/idl/idl_commands_two.json --allow-localnet ${programOne.programId}`,
-      { stdio: "inherit" }
+      { stdio: "inherit" },
     );
     const idl = await fetchIdl(programOne.programId, provider);
     assert.deepEqual(idl, programTwo.rawIdl);
@@ -72,20 +72,8 @@ describe("Test CLI IDL commands", () => {
 
     const idlActual = await fetchIdl(programOne.programId);
     const idlExpected = JSON.parse(
-      fs.readFileSync("testLargeIdl.json", "utf8")
+      fs.readFileSync("testLargeIdl.json", "utf8"),
     );
     assert.deepEqual(idlActual, idlExpected);
-  });
-
-  it("Can initialize IDL account with relative path from subdirectory", async () => {
-    execSync(`anchor idl close ${programOne.programId}`, { stdio: "inherit" });
-
-    execSync(
-      `cd target/idl && anchor idl init --filepath idl_commands_one.json ${programOne.programId}`,
-      { stdio: "inherit" }
-    );
-
-    const idl = await anchor.Program.fetchIdl(programOne.programId, provider);
-    assert.deepEqual(idl, programOne.rawIdl);
   });
 });


### PR DESCRIPTION
Closes #2993

The root cause of the above issue is that we switch directories when running all commands, thus leaving relative paths incorrect.
This PR introduces a new trait (and corresponding derive macro) `AbsolutePath` for making paths in CLI arguments absolute. This is then used in `anchor_cli::entry` to prepare arguments for use.
As an additional cleanup, all path arguments have been converted to `PathBuf` (rather than `String`).