### PR TITLE
lang: Add instruction parser to `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 - cli: Added a `check_program_id_mismatch` in build time to check if the program ID in the source code matches the program ID in the keypair file ([#4018](https://github.com/solana-foundation/anchor/pull/4018)). This check will be skipped during `anchor test`.
+- lang: lang: Add instruction parser to `declare_program!` ([#4118](https://github.com/solana-foundation/anchor/pull/4118)).
 
 ### Fixes
 

--- a/tests/declare-program/tests/declare-program.ts
+++ b/tests/declare-program/tests/declare-program.ts
@@ -54,4 +54,8 @@ describe("declare-program", () => {
   it("Can use event utils", async () => {
     await program.methods.eventUtils().rpc();
   });
+
+  it("Can use instruction utils", async () => {
+    await program.methods.instructionUtils().rpc();
+  });
 });


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/solana-foundation/anchor/issues/2538#issuecomment-1604642998, there is no simple way to parse program instructions using Anchor Rust crates.

### Summary of changes

- Add instruction parser (`utils::Instruction`) to `declare_program!`
- Refactor to avoid repetition with the internal accounts
- Add tests that use the new parser

### Details

This is similar to the other parsers in the `utils` module ([`Account`](https://github.com/solana-foundation/anchor/pull/3091) and [`Event`](https://github.com/solana-foundation/anchor/pull/2897)):

```rs
/// An enum that includes all instructions of the declared program.
pub enum Instruction {
    MyInstruction { accounts: client::accounts::MyInstruction, args: client::args::MyInstruction },
    // ...
}
```

However, rather than having a `try_from_bytes` method like the other parsers, the instruction parser has:

```rs
impl Instruction {
    pub fn try_from_solana_instruction(ix: &solana_instruction::Instruction) -> Result<Self> {
        // ...
    }
}
```

The parser checks:

- The program ID
- There is no missing account(s)
- All accounts have the correct signer and writable attributes
- The instruction data can be deserialized

It does **not** check whether:

- There are more accounts than expected
- The account addresses match the ones that could be derived using the resolution fields such as `address` and `pda`

---

Currently the parser tests are done inside a program because there was a problem in CI (runners getting OOM) when I added a test crate inside [the `declare-program` tests](https://github.com/solana-foundation/anchor/tree/48aba30646fb7ac4400a33a7ae679fc790d796ea/tests/declare-program) last year.

We'll most likely omit the parsers in program builds because they log useless errors during build (https://github.com/solana-foundation/anchor/pull/4109#pullrequestreview-3540272729):

```
Error: Function _ZN129_$LT$declare_program..amm_v3..utils..Instruction$u20$as$u20$core..convert..TryFrom$LT$$RF$solana_instruction..Instruction$GT$$GT$8try_from17h875276608bc7e93aE Stack offset of 5632 exceeded max offset of 4096 by 1536 bytes, please minimize large stack variables. Estimated function frame size: 6848 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```

If the author of https://github.com/solana-foundation/anchor/pull/4109 is not willing to update the PR, I'll make a separate PR for this.

---

<details><summary>Composite accounts rant</summary><p>

Composite accounts make everything harder to work with; the non-instruction composite accounts issues (, https://github.com/solana-foundation/anchor/issues/3349) also exist here, so a refactor was need to reuse the solution from https://github.com/solana-foundation/anchor/pull/4113.

The refactor includes changing instructions to instruction accounts ([`IdlInstructionAccounts`](https://github.com/solana-foundation/anchor/blob/48aba30646fb7ac4400a33a7ae679fc790d796ea/idl/spec/src/lib.rs#L98)) because:

- We only need the `name` and `accounts` fields of [`IdlInstruction`](https://github.com/solana-foundation/anchor/blob/48aba30646fb7ac4400a33a7ae679fc790d796ea/idl/spec/src/lib.rs#L60)
- Creating instructions for non-instruction composite accounts sounds and looks incorrect

This change made it hard to name the variables in the code because everything ended up being some variation of instruction accounts.

Composite accounts also require creating recursive functions everywhere to handle them properly, which further complicates the implementation.
</p></details>

---

Being able to convert `Vec<AccountMeta>` to accounts structs (https://github.com/solana-foundation/anchor/issues/2538) would have helped here, but the implementation (https://github.com/solana-foundation/anchor/pull/2540) ended up increasing the complexity quite a bit. I think it's better to keep the program codegen as simple as possible, especially now that this functionality can be implemented in `declare_program!`.

The issue did not receive any traction, and given this PR allows parsing instructions in a simple way, I think it's safe to close https://github.com/solana-foundation/anchor/issues/2538.