### PR TITLE
ci: Upgrade Solana version to `3.0.0`

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -10,7 +10,7 @@ runs:
         path: |
           ~/.cache/solana/
           ~/.local/share/solana/
-        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_VERSION }}-${{ env.SOLANG_VERSION }}
+        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_VERSION }}
     - uses: nick-fields/retry@v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -10,7 +10,7 @@ runs:
         path: |
           ~/.cache/solana/
           ~/.local/share/solana/
-        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION }}-${{ env.SOLANG_VERSION }}
+        key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_VERSION }}-${{ env.SOLANG_VERSION }}
     - uses: nick-fields/retry@v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:
@@ -19,7 +19,7 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_CLI_VERSION }}/install)"
+        command: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_VERSION }}/install)"
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: false
-      solana_cli_version: 3.0.0
+      solana_version: 3.0.0
       node_version: 20.18.0
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   no-caching-tests:
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: false
-      solana_cli_version: 2.3.0
+      solana_cli_version: 3.0.0
       node_version: 20.18.0
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -6,7 +6,7 @@ on:
       cache:
         required: true
         type: boolean
-      solana_cli_version:
+      solana_version:
         required: true
         type: string
       node_version:
@@ -23,7 +23,7 @@ on:
         type: string
 env:
   CACHE: ${{ inputs.cache }}
-  SOLANA_CLI_VERSION: ${{ inputs.solana_cli_version }}
+  SOLANA_VERSION: ${{ inputs.solana_version }}
   NODE_VERSION: ${{ inputs.node_version }}
   CARGO_PROFILE: ${{ inputs.cargo_profile }}
   ANCHOR_BINARY_NAME: ${{ inputs.anchor_binary_name }}
@@ -123,7 +123,7 @@ jobs:
         id: cache-basic-0
         with:
           path: ./examples/tutorial/basic-0/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/cache@v3
         if: ${{ env.CACHE != 'false' }}
@@ -131,7 +131,7 @@ jobs:
         id: cache-basic-1
         with:
           path: ./examples/tutorial/basic-1/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/cache@v3
         if: ${{ env.CACHE != 'false' }}
@@ -139,7 +139,7 @@ jobs:
         id: cache-basic-2
         with:
           path: ./examples/tutorial/basic-2/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/cache@v3
         if: ${{ env.CACHE != 'false' }}
@@ -147,7 +147,7 @@ jobs:
         id: cache-basic-3
         with:
           path: ./examples/tutorial/basic-3/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/cache@v3
         if: ${{ env.CACHE != 'false' }}
@@ -155,7 +155,7 @@ jobs:
         id: cache-basic-4
         with:
           path: ./examples/tutorial/basic-4/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-4/**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-4/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cd examples/tutorial && yarn workspaces run test
       - uses: ./.github/actions/git-diff/
@@ -239,7 +239,7 @@ jobs:
         id: cache-test-target
         with:
           path: client/example/target
-          key: cargo-${{ runner.os }}-client/example-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-client/example-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
       - run: cd client/example && ./run-test.sh
@@ -277,7 +277,7 @@ jobs:
         id: cache-test-target
         with:
           path: tests/bpf-upgradeable-state/target
-          key: cargo-${{ runner.os }}-tests/bpf-upgradeable-state-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-tests/bpf-upgradeable-state-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: surfpool start --ci --offline &
         name: start surfpool
@@ -505,7 +505,7 @@ jobs:
         id: cache-test-target
         with:
           path: ${{ matrix.node.path }}/target
-          key: cargo-${{ runner.os }}-${{ matrix.node.path }}-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ matrix.node.path }}-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: ${{ matrix.node.cmd }}
         name: ${{ matrix.node.path }} program test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   pull_request:
     branches:
       - master
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   tests:
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: true
-      solana_cli_version: 2.3.0
+      solana_cli_version: 3.0.0
       node_version: 20.18.0
       cargo_profile: debug
       anchor_binary_name: anchor-binary

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: true
-      solana_cli_version: 3.0.0
+      solana_version: 3.0.0
       node_version: 20.18.0
       cargo_profile: debug
       anchor_binary_name: anchor-binary

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -67,7 +67,7 @@
 //! This feature allows passing in a custom RPC client when creating program instances, which is
 //! useful for mocking RPC responses, e.g. via [`RpcClient::new_mock`].
 //!
-//! [`RpcClient::new_mock`]: https://docs.rs/solana-rpc-client/2.3.0/solana_rpc_client/rpc_client/struct.RpcClient.html#method.new_mock
+//! [`RpcClient::new_mock`]: https://docs.rs/solana-rpc-client/3.0.0/solana_rpc_client/rpc_client/struct.RpcClient.html#method.new_mock
 
 use anchor_lang::solana_program::program_error::ProgramError;
 use anchor_lang::solana_program::pubkey::Pubkey;

--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 active_version=$(solana -V | awk '{print $2}')
-if [ "$active_version" != "2.3.0" ]; then
-  agave-install init 2.3.0
+if [ "$active_version" != "3.0.0" ]; then
+  agave-install init 3.0.0
 fi
 
 git submodule update --init --recursive --depth 1


### PR DESCRIPTION
### Problem

CI is still downloading and using Solana v2.3.0 tools after the Solana v3 update PR (https://github.com/solana-foundation/anchor/pull/4031).

### Summary of changes

- Upgrade Solana tools version in CI to `3.0.0`
- Rename `solana_cli_version` to `solana_version` for clarity (especially now that Anchor doesn't directly use the `solana-cli` binary (https://github.com/solana-foundation/anchor/pull/4099))
- Get rid of the redundant leftover code about Solang in CI (`SOLANG_VERSION`)
- Update the setup script to also use the Solana `3.0.0` tools