### PR TITLE
lang: Fix `declare_program!` messing up IDL errors generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - idl: Fix defined types with unsupported fields not producing an error ([#4088](https://github.com/solana-foundation/anchor/pull/4088)).
 - lang: Fix using non-instruction composite accounts multiple times with `declare_program!` ([#4113](https://github.com/solana-foundation/anchor/pull/4113)).
+- lang: Fix `declare_program!` messing up IDL errors generation ([#4126](https://github.com/solana-foundation/anchor/pull/4126)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/mods/errors.rs
+++ b/lang/attribute/program/src/declare_program/mods/errors.rs
@@ -12,6 +12,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
     if errors.len() == 0 {
         return quote! {
             /// Program error type definitions.
+            #[cfg(not(feature = "idl-build"))]
             pub mod errors {
             }
         };
@@ -19,6 +20,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
 
     quote! {
         /// Program error type definitions.
+        #[cfg(not(feature = "idl-build"))]
         pub mod errors {
 
             #[anchor_lang::error_code]

--- a/tests/declare-program/tests/declare-program.ts
+++ b/tests/declare-program/tests/declare-program.ts
@@ -58,4 +58,12 @@ describe("declare-program", () => {
   it("Can use instruction utils", async () => {
     await program.methods.instructionUtils().rpc();
   });
+
+  it("Produces correct IDL", () => {
+    // The program itself doesn't have an error definition, therefore its IDL
+    // also shouldn't have the `errors` field.
+    //
+    // https://github.com/solana-foundation/anchor/pull/3757#discussion_r2424695717
+    if (program.idl.errors) throw new Error("The IDL should not have `errors`");
+  });
 });


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/solana-foundation/anchor/pull/3757#discussion_r2424695717, the `errors` module generated by `declare_program!` makes the `errors` field of IDLs inconsistent at best and incorrect at worst.

### Summary of changes

- Fix `declare_program!` messing up IDL errors generation by skipping the generation of the `errors` module during IDL generation
- Add a test case that makes sure programs that don't have error definitions don't end up having `errors` field in their IDL because of `declare_program!` usage

**Note:** There is no good reason for the `errors` module to exist for Solana program builds, as it might result in getting stack-related error logs during build (see https://github.com/solana-foundation/anchor/pull/4109), but that problem is outside the scope of this PR (will handle in a subsequent PR).