### PR TITLE
cli: Remove program id arguments of `idl init` and `idl upgrade` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Breaking
 
 - lang: Disallow duplicate mutable accounts by default. But allows duplicate mutable accounts in instruction contexts using `dup` constraint ([#3946](https://github.com/solana-foundation/anchor/pull/3946)).
+- cli: Remove program id arguments of `idl init` and `idl upgrade` commands ([#4130](https://github.com/solana-foundation/anchor/pull/4130)).
 
 ## [0.32.1] - 2025-10-09
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -711,10 +711,10 @@ pub fn program_deploy(
 
                 if idl_account_exists {
                     // IDL account exists, upgrade it
-                    crate::idl_upgrade(cfg_override, program_id, idl_filepath, None)?;
+                    crate::idl_upgrade(cfg_override, idl_filepath, None)?;
                 } else {
                     // IDL account doesn't exist, create it
-                    crate::idl_init(cfg_override, program_id, idl_filepath, None, false)?;
+                    crate::idl_init(cfg_override, idl_filepath, None, false)?;
                 }
 
                 println!("✓ Idl account created: {}", idl_address);


### PR DESCRIPTION
### Problem

`idl init` and `idl upgrade` commands unnecessarily take in program id as their first argument when the IDL already stores this information.

The reason for this is historical, as the the legacy IDL spec did not have a required field about the program id.

### Summary of changes

Remove program id arguments from the `idl init` and `idl upgrade` commands and use `idl.address` to get the program id.

This change also makes it so that the commands verify that the thing that users are trying to upload is an actual IDL that conforms to the spec and not just a random file (this was the behavior before https://github.com/solana-foundation/anchor/pull/3798 😵)

**Note:** This PR intentionally does *not* update the docs until we have a release that includes this change to avoid confusion.