### PR TITLE
fix(lang): Ensure `repr(packed)` is visible to derives

### DIFF
--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -146,10 +146,13 @@ pub fn convert_idl_type_def_to_ts(
             .flatten()
             .unwrap_or_default();
 
+        // `ser_attr` must be expanded first, as it may produce `repr(packed)`
+        // This affects builtin derives so must be visible to them
+        // https://github.com/solana-foundation/anchor/issues/4072
         quote! {
+            #ser_attr
             #debug_attr
             #default_attr
-            #ser_attr
             #clone_attr
             #copy_attr
         }

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -114,6 +114,25 @@
       "args": []
     },
     {
+      "name": "test_compilation_packed_account",
+      "discriminator": [
+        56,
+        168,
+        153,
+        46,
+        46,
+        240,
+        131,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "packed_account"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "test_compilation_return_type",
       "discriminator": [
         174,
@@ -370,6 +389,19 @@
         50,
         42
       ]
+    },
+    {
+      "name": "PackedAccount",
+      "discriminator": [
+        87,
+        129,
+        238,
+        130,
+        11,
+        67,
+        95,
+        44
+      ]
     }
   ],
   "events": [
@@ -418,6 +450,37 @@
           {
             "name": "value",
             "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PackedAccount",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "rust",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "a",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "b",
+            "type": {
+              "array": [
+                "u16",
+                8
+              ]
+            }
           }
         ]
       }

--- a/tests/declare-program/programs/declare-program/tests/parsers.rs
+++ b/tests/declare-program/programs/declare-program/tests/parsers.rs
@@ -16,6 +16,30 @@ pub fn test_account_parser() {
     // Correct discriminator and valid data
     match Account::parse(&[DISC, &[1, 0, 0, 0]].concat()) {
         Ok(Account::MyAccount(my_account)) => assert_eq!(my_account.field, 1),
+        Ok(_) => panic!("Expected MyAccount account variant"),
+        Err(e) => panic!("Expected Ok result, got error: {:?}", e),
+    }
+
+    // Unsafe zero-copy account
+    let packed_account = external::accounts::PackedAccount {
+        a: [1; 8],
+        b: [2; 8],
+    };
+    const PACKED_DISC: &[u8] = external::accounts::PackedAccount::DISCRIMINATOR;
+    match Account::parse(
+        &[
+            PACKED_DISC,
+            anchor_lang::__private::bytemuck::bytes_of(&packed_account),
+        ]
+        .concat(),
+    ) {
+        Ok(Account::PackedAccount(packed_account)) => {
+            let a = packed_account.a;
+            let b = packed_account.b;
+            assert_eq!(a, [1; 8]);
+            assert_eq!(b, [2; 8]);
+        }
+        Ok(_) => panic!("Expected PackedAccount account variant"),
         Err(e) => panic!("Expected Ok result, got error: {:?}", e),
     }
 }

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -107,6 +107,13 @@ pub mod external {
         Ok(())
     }
 
+    // Compilation test for unsafe zero-copy accounts generated via `declare_program!`
+    pub fn test_compilation_packed_account(
+        _ctx: Context<TestCompilationPackedAccount>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     // Compilation test for an instruction with no accounts
     pub fn test_compilation_no_accounts(_ctx: Context<TestCompilationNoAccounts>) -> Result<()> {
         Ok(())
@@ -130,6 +137,11 @@ pub enum ExternalProgramError {
 #[derive(Accounts)]
 pub struct TestCompilation<'info> {
     pub signer: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct TestCompilationPackedAccount<'info> {
+    pub packed_account: AccountLoader<'info, PackedAccount>,
 }
 
 #[derive(Accounts)]
@@ -201,6 +213,14 @@ pub struct UpdateWithOptional<'info> {
 #[account]
 pub struct MyAccount {
     pub field: u32,
+}
+
+// Regression test for `declare_program!` codegen on `#[account(zero_copy(unsafe))]`
+// https://github.com/solana-foundation/anchor/issues/4072
+#[account(zero_copy(unsafe))]
+pub struct PackedAccount {
+    pub a: [u8; 8],
+    pub b: [u16; 8],
 }
 
 #[event]


### PR DESCRIPTION
Fixes #4072

Avoids a Rust ICE when using `declare_program`. This issue may exist elsewhere.

