### PR TITLE
docs: update event_cpi account example

### DIFF
--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -216,7 +216,7 @@ pub fn emit_cpi(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// pub struct MyInstruction<'info> {
 ///    pub signer: Signer<'info>,
 ///    /// CHECK: Only the event authority can invoke self-CPI
-///    #[account(seeds = [b"__event_authority"], bump)]
+///    #[account(address = crate::EVENT_AUTHORITY_AND_BUMP.0)]
 ///    pub event_authority: UncheckedAccount<'info>,
 ///    /// CHECK: Self-CPI will fail if the program is not the current program
 ///    pub program: UncheckedAccount<'info>,


### PR DESCRIPTION
The example in the #[event_cpi] doc comment still showed a seeds+bump constraint for the event_authority PDA, while the current implementation uses an address constraint via crate::EVENT_AUTHORITY_AND_BUMP.0. This change updates the documentation example to match the actual generated accounts, so users see the correct constraint pattern when relying on #[event_cpi].