### PR TITLE
ts: Fix incorrect Anchor dependency version requirements

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -45,9 +45,9 @@ popd
 # Potential for collisions in `package.json` files, handle those separately
 # Replace only matching "version": "x.xx.x" and "@coral-xyz/anchor": "x.xx.x"
 git grep -l $old_version -- "**/package.json" | \
-    xargs sed "${sedi[@]}" \
-    -e "s/@coral-xyz\/anchor\": \"$old_version\"/@coral-xyz\/anchor\": \"$version\"/g" \
-    -e "s/\"version\": \"$old_version\"/\"version\": \"$version\"/g"
+    xargs sed -E "${sedi[@]}" \
+    -e "s/\"version\": \"$old_version\"/\"version\": \"$version\"/g" \
+    -e "s/@coral-xyz\/(.*)\": \"(.*)$old_version\"/@coral-xyz\/\1\": \"\2$version\"/g"
 
 # Insert version number into CHANGELOG
 sed "${sedi[@]}" -e \

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -33,8 +33,8 @@
     "test": "jest tests --detectOpenHandles"
   },
   "dependencies": {
-    "@coral-xyz/anchor-errors": "^0.31.1",
-    "@coral-xyz/borsh": "^0.31.1",
+    "@coral-xyz/anchor-errors": "^0.32.1",
+    "@coral-xyz/borsh": "^0.32.1",
     "@noble/hashes": "^1.3.1",
     "@solana/web3.js": "^1.69.0",
     "bn.js": "^5.1.2",


### PR DESCRIPTION
### Problem

v0.32 TS packages depend on older versions of `anchor-errors` and `borsh` packages:

https://github.com/solana-foundation/anchor/blob/b51210bef47b8d95718bdbc122196877f5fe200c/ts/packages/anchor/package.json#L36-L37

This is not that big of an issue right now since JS is quite relaxed when it comes to dependencies, but it could eventually lead to incompatibilities between the packages.

### Summary of changes

- Fix incorrect Anchor dependency version requirements of the main Anchor TS package
- Fix `bump-version` script not updating the version requirements of other Anchor packages that have the same versioning as the main package