### PR TITLE
lang: Fix unexpected account substitution in `InterfaceAccount`

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -472,6 +472,8 @@ jobs:
             path: tests/bench
           - cmd: cd tests/idl && ./test.sh
             path: tests/idl
+          - cmd: cd tests/interface-account && anchor test
+            path: tests/interface-account
           - cmd: cd tests/lazy-account && anchor test --skip-lint
             path: tests/lazy-account
           - cmd: cd tests/test-instruction-validation && ./test.sh

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -240,9 +240,10 @@ impl<'a, T: AccountSerialize + AccountDeserialize + CheckOwner + Clone> Interfac
         T::check_owner(info.owner)?;
 
         // Re-deserialize fresh data into the inner account.
-        let mut data: &[u8] = &info.try_borrow_data()?;
-        let new_val = T::try_deserialize(&mut data)?;
-        self.account.set_inner(new_val);
+        self.account.set_inner({
+            let mut data: &[u8] = &info.try_borrow_data()?;
+            T::try_deserialize(&mut data)?
+        });
         Ok(())
     }
 }

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -1,14 +1,14 @@
 //! Account container that checks ownership on deserialization.
 
 use crate::accounts::account::Account;
-use crate::error::{Error, ErrorCode};
+use crate::error::ErrorCode;
 use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::instruction::AccountMeta;
 use crate::solana_program::pubkey::Pubkey;
 use crate::solana_program::system_program;
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, CheckOwner, Key,
-    Owners, Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    Owners, Result, ToAccountInfos, ToAccountMetas,
 };
 use std::collections::BTreeSet;
 use std::fmt;

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -236,7 +236,7 @@ impl<'a, T: AccountSerialize + AccountDeserialize + CheckOwner + Clone> Interfac
     ///
     /// This method also validates that the account is owned by one of the expected programs.
     pub fn reload(&mut self) -> Result<()> {
-        let info = self.account.to_account_info();
+        let info: &AccountInfo = self.account.as_ref();
         T::check_owner(info.owner)?;
 
         // Re-deserialize fresh data into the inner account.

--- a/tests/interface-account/Anchor.toml
+++ b/tests/interface-account/Anchor.toml
@@ -1,0 +1,11 @@
+[programs.localnet]
+interface_account = "interfaceAccount111111111111111111111111111"
+new = "New1111111111111111111111111111111111111111"
+old = "oLd1111111111111111111111111111111111111111"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/interface-account/Cargo.toml
+++ b/tests/interface-account/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tests/interface-account/package.json
+++ b/tests/interface-account/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "interface-account",
+  "version": "0.32.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  }
+}

--- a/tests/interface-account/programs/interface-account/Cargo.toml
+++ b/tests/interface-account/programs/interface-account/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "interface-account"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "interface_account"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+new = { path = "../new", features = ["cpi"] }
+old = { path = "../old", features = ["cpi"] }

--- a/tests/interface-account/programs/interface-account/src/lib.rs
+++ b/tests/interface-account/programs/interface-account/src/lib.rs
@@ -1,0 +1,52 @@
+#![allow(warnings)]
+
+use anchor_lang::prelude::*;
+
+declare_id!("interfaceAccount111111111111111111111111111");
+
+#[program]
+pub mod interface_account {
+    use super::*;
+
+    pub fn test(ctx: Context<Test>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Test<'info> {
+    pub expected_account: InterfaceAccount<'info, interface::ExpectedAccount>,
+}
+
+mod interface {
+    #[derive(Clone)]
+    pub struct ExpectedAccount(new::ExpectedAccount);
+
+    impl anchor_lang::AccountDeserialize for ExpectedAccount {
+        fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+            new::ExpectedAccount::try_deserialize(buf).map(Self)
+        }
+
+        fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+            new::ExpectedAccount::try_deserialize_unchecked(buf).map(Self)
+        }
+    }
+
+    impl anchor_lang::AccountSerialize for ExpectedAccount {}
+
+    impl anchor_lang::Owners for ExpectedAccount {
+        fn owners() -> &'static [anchor_lang::prelude::Pubkey] {
+            &[old::ID_CONST, new::ID_CONST]
+        }
+    }
+
+    #[cfg(feature = "idl-build")]
+    mod idl_impls {
+        use super::ExpectedAccount;
+
+        impl anchor_lang::IdlBuild for ExpectedAccount {}
+        impl anchor_lang::Discriminator for ExpectedAccount {
+            const DISCRIMINATOR: &'static [u8] = &[];
+        }
+    }
+}

--- a/tests/interface-account/programs/new/Cargo.toml
+++ b/tests/interface-account/programs/new/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "new"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/interface-account/programs/new/src/lib.rs
+++ b/tests/interface-account/programs/new/src/lib.rs
@@ -1,0 +1,47 @@
+#![allow(warnings)]
+
+use anchor_lang::prelude::*;
+
+declare_id!("New1111111111111111111111111111111111111111");
+
+#[program]
+pub mod new {
+    use super::*;
+
+    pub fn init(ctx: Context<Init>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn init_another(ctx: Context<InitAnother>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Init<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(init, payer = authority, space = 40)]
+    pub expected_account: Account<'info, ExpectedAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct InitAnother<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(init, payer = authority, space = 72)]
+    pub another_account: Account<'info, AnotherAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct ExpectedAccount {
+    pub data: Pubkey,
+}
+
+#[account]
+pub struct AnotherAccount {
+    pub a: Pubkey,
+    pub b: Pubkey,
+}

--- a/tests/interface-account/programs/old/Cargo.toml
+++ b/tests/interface-account/programs/old/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "old"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/interface-account/programs/old/src/lib.rs
+++ b/tests/interface-account/programs/old/src/lib.rs
@@ -1,0 +1,28 @@
+#![allow(warnings)]
+
+use anchor_lang::prelude::*;
+
+declare_id!("oLd1111111111111111111111111111111111111111");
+
+#[program]
+pub mod old {
+    use super::*;
+
+    pub fn init(ctx: Context<Init>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Init<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(init, payer = authority, space = 40)]
+    pub expected_account: Account<'info, ExpectedAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct ExpectedAccount {
+    pub data: Pubkey,
+}

--- a/tests/interface-account/tests/interface-account.ts
+++ b/tests/interface-account/tests/interface-account.ts
@@ -1,0 +1,90 @@
+import * as anchor from "@coral-xyz/anchor";
+import assert from "assert";
+
+import type { InterfaceAccount } from "../target/types/interface_account";
+import type { New } from "../target/types/new";
+import type { Old } from "../target/types/old";
+
+describe("interface-account", () => {
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const program: anchor.Program<InterfaceAccount> =
+    anchor.workspace.interfaceAccount;
+  const oldProgram: anchor.Program<Old> = anchor.workspace.old;
+  const newProgram: anchor.Program<New> = anchor.workspace.new;
+
+  const oldExpectedAccount = anchor.web3.Keypair.generate();
+  const newExpectedAccount = anchor.web3.Keypair.generate();
+  const anotherAccount = anchor.web3.Keypair.generate();
+
+  // Initialize accounts
+  before(async () => {
+    // Initialize the expected account of the old program
+    await oldProgram.methods
+      .init()
+      .accounts({ expectedAccount: oldExpectedAccount.publicKey })
+      .signers([oldExpectedAccount])
+      .rpc();
+
+    // Initialize the expected account of the new program
+    await newProgram.methods
+      .init()
+      .accounts({ expectedAccount: newExpectedAccount.publicKey })
+      .signers([newExpectedAccount])
+      .rpc();
+
+    // Initialize another account of the new program
+    await newProgram.methods
+      .initAnother()
+      .accounts({ anotherAccount: anotherAccount.publicKey })
+      .signers([anotherAccount])
+      .rpc();
+  });
+
+  it("Allows old exptected accounts", async () => {
+    await program.methods
+      .test()
+      .accounts({ expectedAccount: oldExpectedAccount.publicKey })
+      .rpc();
+  });
+
+  it("Allows new exptected accounts", async () => {
+    await program.methods
+      .test()
+      .accounts({ expectedAccount: newExpectedAccount.publicKey })
+      .rpc();
+  });
+
+  it("Doesn't allow accounts owned by other programs", async () => {
+    try {
+      await program.methods
+        .test()
+        .accounts({ expectedAccount: program.provider.wallet!.publicKey })
+        .rpc();
+
+      assert.fail("Allowed unexpected account substitution!");
+    } catch (e) {
+      assert(e instanceof anchor.AnchorError);
+      assert.strictEqual(
+        e.error.errorCode.number,
+        anchor.LangErrorCode.AccountOwnedByWrongProgram
+      );
+    }
+  });
+
+  it("Doesn't allow unexpected accounts owned by the expected programs", async () => {
+    try {
+      await program.methods
+        .test()
+        .accounts({ expectedAccount: anotherAccount.publicKey })
+        .rpc();
+
+      assert.fail("Allowed unexpected account substitution!");
+    } catch (e) {
+      assert(e instanceof anchor.AnchorError);
+      assert.strictEqual(
+        e.error.errorCode.number,
+        anchor.LangErrorCode.AccountDiscriminatorMismatch
+      );
+    }
+  });
+});

--- a/tests/interface-account/tsconfig.json
+++ b/tests/interface-account/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -25,7 +25,7 @@
     "floats",
     "idl",
     "ido-pool",
-    "interface",
+    "interface-account",
     "lazy-account",
     "lockup",
     "misc",


### PR DESCRIPTION
### Problem

[`InterfaceAccount`](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/accounts/interface_account.rs#L161) allows account substitution between unexpected types.

### PoC

Passing `AnotherAccount` to an account typed as `InterfaceAccount<ExpectedAccount>`:

- [Program](https://github.com/acheroncrypto/anchor/blob/37d18580bac0d07c856f06321068814921e6ade5/tests/interface-account/programs/interface-account/src/lib.rs#L16-L19)
- [Test](https://github.com/acheroncrypto/anchor/blob/37d18580bac0d07c856f06321068814921e6ade5/tests/interface-account/tests/interface-account.ts#L74-L89)

### Details

The PR titled "feat(account): Check Owner on Reload" [#3837](https://github.com/solana-foundation/anchor/pull/3837) changed `InterfaceAccount::try_from` from:

https://github.com/solana-foundation/anchor/blob/2da41204735c944686a39bd18a50a0ff173425bb/lang/src/accounts/account.rs#L303-L313

to:

https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/accounts/interface_account.rs#L243-L252

The author assumes `InterfaceAccount` is only intended to work with programs that "do not have Anchor discriminators". However, similar to `Account`, the `InterfaceAccount` implementation does **not** actually make any assumptions about discriminators. As its name suggests, it's for accounts that share the same interface between different programs; or in other words, it's the same as the `Account` type, but instead of checking only a single owner via [the `Owner` trait](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/lib.rs#L441), it allows multiple owners via [the `Owners` trait](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/lib.rs#L446).

Similar to the `Account` type, `InterfaceAccount`'s documentation even has a section called [Using `InterfaceAccount` with non-anchor programs](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/accounts/interface_account.rs#L83) that starts with:

https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/accounts/interface_account.rs#L85

which in itself should be enough to suggest that `InterfaceAccount` can also be used with Anchor program accounts, or generally, accounts that have discriminators.

The same erroneous understanding also resulted in changing the `reload` method of `AccountInterface` from:

https://github.com/solana-foundation/anchor/blob/2da41204735c944686a39bd18a50a0ff173425bb/lang/src/accounts/interface_account.rs#L188

which used `Account::reload` with checked account deserialization ([`AccountDeserialize::try_deserialize`](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/lib.rs#L368)):

https://github.com/solana-foundation/anchor/blob/2da41204735c944686a39bd18a50a0ff173425bb/lang/src/accounts/account.rs#L271

to an implementation that uses unchecked account deserialization ([`AccountDeserialize::try_deserialize_unchecked`](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/lib.rs#L375)):

https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/accounts/interface_account.rs#L206

The misconception might have arisen from the fact that `InterfaceAccount` was initially added (in [#2386](https://github.com/solana-foundation/anchor/pull/2386)) in order to make handling SPL Token and SPL Token 2022 accounts easier. However, its implementation is fully generic, just like the `Account` type. In fact, in its implementation PR, [the first commit](https://github.com/solana-foundation/anchor/pull/2386/commits/11bf4b43ffbf2beaf1b7c4efda86cc3fe9817c48) is titled 'Add "interface" and "interface account" concept', and it does not even touch `anchor-spl`.

The reason why `anchor-spl` types such as [`token::Mint`](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/spl/src/token.rs#L475) and [`token_interface::Mint`](https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/spl/src/token_interface.rs#L44) only implement `try_deserialize_unchecked` is because `try_deserialize` defaults to `try_deserialize_unchecked` (in this case they are all checked in reality):

https://github.com/solana-foundation/anchor/blob/3a799e2d32bd708f0b280c60baecac76418248b1/lang/src/lib.rs#L361-L370

This means changing `try_deserialize` to `try_deserialize_unchecked` here in the best case has no benefits (same impl), and in the worst case allows bypassing account checks.

### Summary of changes

- Add tests that test the basic security checks of `InterfaceAccount`, including unexpected account substitution
- Fix `InterfaceAccount::try_from` (revert to how it was before)
- Fix `InterfaceAccount::reload` (use checked account deserialization)
- Allow multiple owners in `InterfaceAccount::reload` (see https://github.com/solana-foundation/anchor/pull/4139#issuecomment-3694350783)