### PR TITLE
idl: Fix `address` constraint not resolving constants that have numbers in their identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Fix defined types with unsupported fields not producing an error ([#4088](https://github.com/solana-foundation/anchor/pull/4088)).
 - lang: Fix using non-instruction composite accounts multiple times with `declare_program!` ([#4113](https://github.com/solana-foundation/anchor/pull/4113)).
 - lang: Fix `declare_program!` messing up IDL errors generation ([#4126](https://github.com/solana-foundation/anchor/pull/4126)).
+- idl: Fix `address` constraint not resolving constants that have numbers in their identifiers ([#4144](https://github.com/solana-foundation/anchor/pull/4144)).
 
 ### Breaking
 

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -175,7 +175,7 @@ fn get_address(acc: &Field) -> TokenStream {
                         .ident
                         .to_string()
                         .chars()
-                        .all(|c| c.is_uppercase() || c == '_'),
+                        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'),
                     // Allow `const fn`s (assume any stand-alone function call without an argument)
                     // e.g. `crate::id()`
                     syn::Expr::Call(expr) => expr.args.is_empty(),

--- a/tests/relations-derivation/programs/relations-derivation/src/lib.rs
+++ b/tests/relations-derivation/programs/relations-derivation/src/lib.rs
@@ -65,12 +65,17 @@ pub struct TestRelation<'info> {
     nested: Nested<'info>,
 }
 
+// Test https://github.com/solana-foundation/anchor/issues/4143
+pub const ADDRESS_WITH_NUMBER_V2: Pubkey = pubkey!("D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf");
+
 #[derive(Accounts)]
 pub struct TestAddress<'info> {
     // Included wit the `address` field in IDL
     // It's actually `static` but it doesn't matter for our purposes
     #[account(address = crate::ID)]
     constant: UncheckedAccount<'info>,
+    #[account(address = ADDRESS_WITH_NUMBER_V2)]
+    const_with_number: UncheckedAccount<'info>,
     #[account(address = crate::id())]
     const_fn: UncheckedAccount<'info>,
 

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -45,8 +45,11 @@ describe("typescript", () => {
     const ix = program.idl.instructions.find(
       (ix) => ix.name === "testAddress"
     )!;
+
     expect(ix.accounts.find((acc) => acc.name === "constant")!.address).to.not
       .be.undefined;
+    expect(ix.accounts.find((acc) => acc.name === "constWithNumber")!.address)
+      .to.not.be.undefined;
     expect(ix.accounts.find((acc) => acc.name === "constFn")!.address).to.not.be
       .undefined;
   });


### PR DESCRIPTION
### Problem

As explained in https://github.com/solana-foundation/anchor/issues/4143, the IDL generation does not resolve `address` constraint if a constant identifier has a number in its name.

### Summary of changes

- Fix `address` constraint not resolving constants that have numbers in their identifiers by allowing digits (via [`char::is_ascii_digit`](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_digit)).
- Change the [`char::is_uppercase`](https://doc.rust-lang.org/std/primitive.char.html#method.is_uppercase) check to [`char::is_ascii_uppercase`](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_uppercase) for consistency (non-ASCII methods such as [`char::is_numeric`](https://doc.rust-lang.org/std/primitive.char.html#method.is_numeric) allow all sorts of characters other than the expected `0-9`).
- Add a test that uses `address = ADDRESS_WITH_NUMBER_V2`

Fixes https://github.com/solana-foundation/anchor/issues/4143