### PR TITLE
lang: Remove the `bs58` dependency from macro crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,6 @@ name = "anchor-attribute-account"
 version = "0.32.1"
 dependencies = [
  "anchor-syn",
- "bs58",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -184,7 +183,6 @@ dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "bs58",
  "heck 0.3.3",
  "proc-macro2",
  "quote",

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -18,7 +18,6 @@ event-cpi = []
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "0.32.1", features = ["hash"] }
-bs58 = "0.5"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -19,7 +19,6 @@ interface-instructions = ["anchor-syn/interface-instructions"]
 anchor-lang-idl = { path = "../../../idl", version = "0.1.2", features = ["convert"] }
 anchor-syn = { path = "../../syn", version = "0.32.1" }
 anyhow = "1"
-bs58 = "0.5"
 heck = "0.3"
 proc-macro2 = "1"
 quote = "1"

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -110,9 +110,7 @@ fn gen_program_docs(idl: &Idl) -> proc_macro2::TokenStream {
 }
 
 fn gen_id(idl: &Idl) -> proc_macro2::TokenStream {
-    let address_bytes = bs58::decode(&idl.address)
-        .into_vec()
-        .expect("Invalid `idl.address`");
+    let address = &idl.address;
     let doc = format!("Program ID of program `{}`.", idl.metadata.name);
 
     quote! {
@@ -124,7 +122,7 @@ fn gen_id(idl: &Idl) -> proc_macro2::TokenStream {
 
         /// The name is intentionally prefixed with `__` in order to reduce to possibility of name
         /// clashes with the crate's `ID`.
-        static __ID: Pubkey = Pubkey::new_from_array([#(#address_bytes,)*]);
-        const __ID_CONST : Pubkey = Pubkey::new_from_array([#(#address_bytes,)*]);
+        static __ID: Pubkey = Pubkey::from_str_const(#address);
+        const __ID_CONST : Pubkey = Pubkey::from_str_const(#address);
     }
 }

--- a/tests/auction-house/Cargo.lock
+++ b/tests/auction-house/Cargo.lock
@@ -74,7 +74,6 @@ name = "anchor-attribute-account"
 version = "0.32.1"
 dependencies = [
  "anchor-syn",
- "bs58",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -115,7 +114,6 @@ dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "bs58",
  "heck",
  "proc-macro2",
  "quote",

--- a/tests/spl/metadata/Cargo.lock
+++ b/tests/spl/metadata/Cargo.lock
@@ -74,7 +74,6 @@ name = "anchor-attribute-account"
 version = "0.32.1"
 dependencies = [
  "anchor-syn",
- "bs58",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -115,7 +114,6 @@ dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "bs58",
  "heck",
  "proc-macro2",
  "quote",


### PR DESCRIPTION
### Problem

We use `bs58` in some places to decode pubkey string literal inputs. This is no longer necessary since the [`Pubkey`](https://docs.rs/solana-pubkey/3.0.0/solana_pubkey/struct.Pubkey.html) type now supports this functionality with its [`from_str_const`](https://docs.rs/solana-pubkey/3.0.0/solana_pubkey/struct.Pubkey.html#method.from_str_const) method.

### Summary of changes

Use `Pubkey::from_str_const` and remove the `bs58` dependency from:
- `anchor-attribute-account`
- `anchor-attribute-program`