### PR TITLE
lang: Don't make `anchor_lang` implicitly mandatory as an extra dependency when using `declare_program!` via `anchor_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Added a `check_program_id_mismatch` in build time to check if the program ID in the source code matches the program ID in the keypair file ([#4018](https://github.com/solana-foundation/anchor/pull/4018)). This check will be skipped during `anchor test`.
 - lang: Add instruction parser to `declare_program!` ([#4118](https://github.com/solana-foundation/anchor/pull/4118)).
 - ts: Export all IDL types from the root. Users can now update `dist/cjs/idl` imports to import directly from `@anchor-lang/core` ([#3948](https://github.com/solana-foundation/anchor/pull/3948)).
+- lang: Add `declare_program!` support with just `anchor_client` and not `anchor_lang` ([#4157](https://github.com/solana-foundation/anchor/pull/4157)).
 
 ### Fixes
 

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -24,6 +24,7 @@ impl Parse for DeclareProgram {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let name = input.parse()?;
         let idl = get_idl(&name).map_err(|e| syn::Error::new(name.span(), e))?;
+
         Ok(Self { name, idl })
     }
 }
@@ -74,6 +75,11 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
     quote! {
         #docs
         pub mod #name {
+            #[cfg(target_os = "solana")]
+            use ::anchor_lang;
+            #[cfg(not(target_os = "solana"))]
+            use super::anchor_lang;
+
             use anchor_lang::prelude::*;
             use accounts::*;
             use events::*;

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -74,9 +74,9 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
     quote! {
         #docs
         pub mod #name {
-            #[cfg(target_os = "solana")]
+            #[cfg(any(target_os = "solana", feature = "idl-build"))]
             use ::anchor_lang;
-            #[cfg(not(target_os = "solana"))]
+            #[cfg(all(not(target_os = "solana"), not(feature = "idl-build")))]
             use super::anchor_lang;
 
             use anchor_lang::prelude::*;

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -24,7 +24,6 @@ impl Parse for DeclareProgram {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let name = input.parse()?;
         let idl = get_idl(&name).map_err(|e| syn::Error::new(name.span(), e))?;
-
         Ok(Self { name, idl })
     }
 }

--- a/lang/attribute/program/src/declare_program/mods/errors.rs
+++ b/lang/attribute/program/src/declare_program/mods/errors.rs
@@ -15,6 +15,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
             /// Program error type definitions.
             #[cfg(not(feature = "idl-build"))]
             pub mod errors {
+                use super::*;
             }
         };
     }
@@ -23,6 +24,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
         /// Program error type definitions.
         #[cfg(not(feature = "idl-build"))]
         pub mod errors {
+            use super::*;
 
             #[anchor_lang::error_code(offset = 0)]
             pub enum ProgramError {

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -47,7 +47,7 @@ pub fn program(
 ///
 /// Both on-chain and off-chain usage is supported.
 ///
-/// **Note:** When using via `anchor_client`, you must have `anchor_lang` in scope:
+/// **Note:** When using in non-solana environments, for example via `anchor_client`, you must have `anchor_lang` in scope:
 /// ```ignore
 /// use anchor_client::anchor_lang;
 /// ```

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -47,11 +47,6 @@ pub fn program(
 ///
 /// Both on-chain and off-chain usage is supported.
 ///
-/// **Note:** When using in non-solana environments, for example via `anchor_client`, you must have `anchor_lang` in scope:
-/// ```ignore
-/// use anchor_client::anchor_lang;
-/// ```
-///
 /// Use `cargo doc --open` to see the generated modules and their documentation.
 ///
 /// # Note
@@ -62,6 +57,15 @@ pub fn program(
 /// A program should only be defined once. If you have multiple programs that depend on the same
 /// definition, you should consider creating a separate crate for the external program definition
 /// and reusing it in your programs.
+///
+/// # Off-chain usage
+///
+/// When using in off-chain environments, for example via `anchor_client`, you must have
+/// `anchor_lang` in scope:
+///
+/// ```ignore
+/// use anchor_client::anchor_lang;
+/// ```
 ///
 /// # Example
 ///

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -47,6 +47,11 @@ pub fn program(
 ///
 /// Both on-chain and off-chain usage is supported.
 ///
+/// **Note:** When using via `anchor_client`, you must have `anchor_lang` in scope:
+/// ```ignore
+/// use anchor_client::anchor_lang;
+/// ```
+///
 /// Use `cargo doc --open` to see the generated modules and their documentation.
 ///
 /// # Note

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -498,6 +498,8 @@ pub mod prelude {
         InitSpace, Key, Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos,
         ToAccountMetas,
     };
+    // Re-export the crate as anchor_lang for declare_program! macro
+    pub use crate as anchor_lang;
     pub use crate::solana_program::account_info::{next_account_info, AccountInfo};
     pub use crate::solana_program::instruction::AccountMeta;
     pub use crate::solana_program::program_error::ProgramError;


### PR DESCRIPTION
A lot of the time when we use `declare_program!` this happens on the client side in conjunction with `anchor_client`. Since `anchor_client` re-exports `anchor_lang`, we can just import it as `use anchor_client::anchor_lang::prelude::declare_program`. If we then try to compile though, it won't work, as `declare_program!` generates a bunch of code that expects `anchor_lang` to be in scope as an individual crate, which means we're then forced to add `anchor_lang` to our `Cargo.toml` anyway.

This 
- makes using `declare_program!` via the re-export of anchor_client pointless
- can lead to [confusion for devs not as familiar with anchor](https://solana.stackexchange.com/questions/23969/declare-program-fails-in-anchor-rust-client-with-unresolved-crate-anchor-lang/23971#23971)
- lead to issues with version mismatches between anchor_lang from anchor_client and the individual anchor_lang 
- has been bugging me for a while

`serde` has a similar problem, which they [solve by allowing you to specify the crate path](https://serde.rs/container-attrs.html#crate). This PR introduces an optional `crate` parameter which can be used in the same vein, i.e. `declare_program!(my_program, crate = anchor_client::anchor_lang)`. Optionality of this param means this change is non-breaking.