### PR TITLE
lang: Fix constant nested string generation in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix using non-instruction composite accounts multiple times with `declare_program!` ([#4113](https://github.com/solana-foundation/anchor/pull/4113)).
 - lang: Fix `declare_program!` messing up IDL errors generation ([#4126](https://github.com/solana-foundation/anchor/pull/4126)).
 - idl: Fix `address` constraint not resolving constants that have numbers in their identifiers ([#4144](https://github.com/solana-foundation/anchor/pull/4144)).
+- lang: Fix constant nested string generation in `declare_program!` ([#4158](https://github.com/solana-foundation/anchor/pull/4158)).
 
 ### Breaking
 

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -383,12 +383,142 @@
   ],
   "constants": [
     {
-      "name": "MASTER_SEED",
-      "docs": [
-        "Master seed slice"
-      ],
+      "name": "ARRAY",
+      "type": {
+        "array": [
+          "u8",
+          4
+        ]
+      },
+      "value": "[1, 2, 3, 4]"
+    },
+    {
+      "name": "BOOL",
+      "type": "bool",
+      "value": "false"
+    },
+    {
+      "name": "BYTES",
       "type": "bytes",
-      "value": "[109, 97, 115, 116, 101, 114]"
+      "value": "[97, 98, 99]"
+    },
+    {
+      "name": "I128",
+      "type": "i128",
+      "value": "16"
+    },
+    {
+      "name": "I16",
+      "type": "i16",
+      "value": "2"
+    },
+    {
+      "name": "I32",
+      "type": "i32",
+      "value": "4"
+    },
+    {
+      "name": "I64",
+      "type": "i64",
+      "value": "8"
+    },
+    {
+      "name": "I8",
+      "type": "i8",
+      "value": "1"
+    },
+    {
+      "name": "NESTED_OPTION_ARRAY",
+      "type": {
+        "option": {
+          "option": {
+            "array": [
+              "u8",
+              4
+            ]
+          }
+        }
+      },
+      "value": "Some(Some([1, 2, 3, 4]))"
+    },
+    {
+      "name": "NESTED_OPTION_BOOL",
+      "type": {
+        "option": {
+          "option": "bool"
+        }
+      },
+      "value": "Some(Some(false))"
+    },
+    {
+      "name": "NESTED_OPTION_STRING",
+      "type": {
+        "option": {
+          "option": "string"
+        }
+      },
+      "value": "Some(Some(\"abc\"))"
+    },
+    {
+      "name": "OPTION_ARRAY",
+      "type": {
+        "option": {
+          "array": [
+            "u8",
+            4
+          ]
+        }
+      },
+      "value": "Some([1, 2, 3, 4])"
+    },
+    {
+      "name": "OPTION_BOOL",
+      "type": {
+        "option": "bool"
+      },
+      "value": "Some(false)"
+    },
+    {
+      "name": "OPTION_STRING",
+      "type": {
+        "option": "string"
+      },
+      "value": "Some(\"abc\")"
+    },
+    {
+      "name": "PUBKEY",
+      "type": "pubkey",
+      "value": "SomeAdress111111111111111111111111111111111"
+    },
+    {
+      "name": "STRING",
+      "type": "string",
+      "value": "\"abc\""
+    },
+    {
+      "name": "U128",
+      "type": "u128",
+      "value": "16"
+    },
+    {
+      "name": "U16",
+      "type": "u16",
+      "value": "2"
+    },
+    {
+      "name": "U32",
+      "type": "u32",
+      "value": "4"
+    },
+    {
+      "name": "U64",
+      "type": "u64",
+      "value": "8"
+    },
+    {
+      "name": "U8",
+      "type": "u8",
+      "value": "1"
     }
   ]
 }

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -4,9 +4,48 @@ use anchor_lang::prelude::*;
 
 declare_id!("Externa111111111111111111111111111111111111");
 
-/// Master seed slice
 #[constant]
-pub const MASTER_SEED: &[u8] = b"master";
+pub const BOOL: bool = false;
+#[constant]
+pub const U8: u8 = 1;
+#[constant]
+pub const U16: u16 = 2;
+#[constant]
+pub const U32: u32 = 4;
+#[constant]
+pub const U64: u64 = 8;
+#[constant]
+pub const U128: u128 = 16;
+#[constant]
+pub const I8: i8 = 1;
+#[constant]
+pub const I16: i16 = 2;
+#[constant]
+pub const I32: i32 = 4;
+#[constant]
+pub const I64: i64 = 8;
+#[constant]
+pub const I128: i128 = 16;
+#[constant]
+pub const BYTES: &[u8] = b"abc";
+#[constant]
+pub const STRING: &str = "abc";
+#[constant]
+pub const PUBKEY: Pubkey = Pubkey::from_str_const("SomeAdress111111111111111111111111111111111");
+#[constant]
+pub const ARRAY: [u8; 4] = [1, 2, 3, 4];
+#[constant]
+pub const OPTION_BOOL: Option<bool> = Some(BOOL);
+#[constant]
+pub const NESTED_OPTION_BOOL: Option<Option<bool>> = Some(OPTION_BOOL);
+#[constant]
+pub const OPTION_STRING: Option<&str> = Some(STRING);
+#[constant]
+pub const NESTED_OPTION_STRING: Option<Option<&str>> = Some(OPTION_STRING);
+#[constant]
+pub const OPTION_ARRAY: Option<[u8; 4]> = Some(ARRAY);
+#[constant]
+pub const NESTED_OPTION_ARRAY: Option<Option<[u8; 4]>> = Some(OPTION_ARRAY);
 
 #[program]
 pub mod external {


### PR DESCRIPTION
### Problem

Having an optional string as a constant:

```rs
#[constant]
pub const OPTION_STRING: Option<&str> = Some("anchor");
```

results in a compile error when that program is used with `declare_program!`:

```
error[E0308]: mismatched types
 --> programs/declare-program/src/lib.rs:5:1
  |
5 | declare_program!(external);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
  | |
  | expected `String`, found `&str`
  | arguments to this enum variant are incorrect
```

The generated `constants` module includes:

```rs
pub const OPTION_STRING: Option<String> = Some("anchor");
```

The problem: we only convert `IdlType::String` to `&str`:

https://github.com/solana-foundation/anchor/blob/c557ad703ac385503a5831fc0c9e42637f7bb59d/lang/attribute/program/src/declare_program/mods/constants.rs#L15

and don't do anything for complex types that could contain `IdlType::String` like `IdlType::Option`:

https://github.com/solana-foundation/anchor/blob/c557ad703ac385503a5831fc0c9e42637f7bb59d/lang/attribute/program/src/declare_program/mods/constants.rs#L23

### Summary of changes

- Change `IdlType::Bytes` and `IdlType::String` conversion based on whether the current context is constant or not:

    ```rs
    IdlType::Bytes => if is_const { "&[u8]" } else { "Vec<u8>" }.into(),
    IdlType::String => if is_const { "&str" } else { "String" }.into(),
    ```
- Add more constants to the `declare-program` tests

**Note:** The types that require modifications to get their constant values (currently `IdlType::Bytes` and `IdlType::Pubkey`) still have problems when they are used in nested types. This problem is out of scope of this PR because fixing it properly might require changing how we store constant values in the IDL during generation.