### PR TITLE
fix: add --use-rpc flag to fix flaky bpf-upgradeable-state test

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -284,7 +284,7 @@ jobs:
       - run: cd tests/bpf-upgradeable-state && yarn --frozen-lockfile
       - run: cd tests/bpf-upgradeable-state
       - run: cd tests/bpf-upgradeable-state && anchor build --skip-lint --ignore-keys
-      - run: cd tests/bpf-upgradeable-state && solana program deploy --program-id program_with_different_programdata.json target/deploy/bpf_upgradeable_state.so
+      - run: cd tests/bpf-upgradeable-state && solana program deploy --program-id program_with_different_programdata.json --use-rpc target/deploy/bpf_upgradeable_state.so
       - run: cd tests/bpf-upgradeable-state && cp bpf_upgradeable_state-keypair.json target/deploy/bpf_upgradeable_state-keypair.json && anchor test --skip-local-validator --skip-build --skip-lint
       - run: cd tests/bpf-upgradeable-state && npx tsc --noEmit
       - uses: ./.github/actions/git-diff/

--- a/tests/interface-account/tests/interface-account.ts
+++ b/tests/interface-account/tests/interface-account.ts
@@ -1,4 +1,4 @@
-import * as anchor from "@coral-xyz/anchor";
+  import * as anchor from "@anchor-lang/core";
 import assert from "assert";
 
 import type { InterfaceAccount } from "../target/types/interface_account";

--- a/tests/interface-account/tests/interface-account.ts
+++ b/tests/interface-account/tests/interface-account.ts
@@ -1,4 +1,4 @@
-  import * as anchor from "@anchor-lang/core";
+import * as anchor from "@anchor-lang/core";
 import assert from "assert";
 
 import type { InterfaceAccount } from "../target/types/interface_account";

--- a/tests/package.json
+++ b/tests/package.json
@@ -56,7 +56,6 @@
     "signature-verification"
   ],
   "dependencies": {
-    "@anchor-lang/core": "^0.32.1",
     "@project-serum/common": "^0.0.1-beta.3",
     "@project-serum/serum": "^0.13.60",
     "@solana/spl-token": "^0.1.8",

--- a/tests/package.json
+++ b/tests/package.json
@@ -56,6 +56,7 @@
     "signature-verification"
   ],
   "dependencies": {
+    "@anchor-lang/core": "^0.32.1",
     "@project-serum/common": "^0.0.1-beta.3",
     "@project-serum/serum": "^0.13.60",
     "@solana/spl-token": "^0.1.8",


### PR DESCRIPTION
Added `--use-rpc` flag to solana program deploy command. The `--use-rpc` flag ensures consistent RPC behavior during program deployment, avoiding flaky failures that can occur when relying on local validator state.
Additionally, By adding the missing dependency and migrating from `@coral-xyz/anchor` to 
`@anchor-lang/core`, the workspace resolves correctly. 

Fixes #4134 