### PR TITLE
feat(ts): add Bun test template

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1433,11 +1433,10 @@ fn init(
 
     let license = get_npm_init_license()?;
 
-    let jest = TestTemplate::Jest == test_template;
     if javascript {
         // Build javascript config
         let mut package_json = File::create("package.json")?;
-        package_json.write_all(rust_template::package_json(jest, license).as_bytes())?;
+        package_json.write_all(rust_template::js_package_json(&test_template, license).as_bytes())?;
 
         let mut deploy = File::create(migrations_path.join("deploy.js"))?;
         deploy.write_all(rust_template::deploy_script().as_bytes())?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1133,17 +1133,25 @@ fn process_command(opts: Opts) -> Result<()> {
             template,
             test_template,
             force,
-        } => init(
-            &opts.cfg_override,
-            name,
-            javascript,
-            no_install,
-            package_manager,
-            no_git,
-            template,
-            test_template,
-            force,
-        ),
+        } => {
+            // use Bun as a package manager when test template is Bun
+            let package_manager = match test_template {
+                TestTemplate::Bun => PackageManager::Bun,
+                _ => package_manager,
+            };
+
+            init(
+                &opts.cfg_override,
+                name,
+                javascript,
+                no_install,
+                package_manager,
+                no_git,
+                template,
+                test_template,
+                force,
+            )
+        }
         Command::New {
             name,
             template,
@@ -1439,7 +1447,8 @@ fn init(
         ts_config.write_all(rust_template::ts_config(&test_template).as_bytes())?;
 
         let mut ts_package_json = File::create("package.json")?;
-        ts_package_json.write_all(rust_template::ts_package_json(&test_template, license).as_bytes())?;
+        ts_package_json
+            .write_all(rust_template::ts_package_json(&test_template, license).as_bytes())?;
 
         let mut deploy = File::create(migrations_path.join("deploy.ts"))?;
         deploy.write_all(rust_template::ts_deploy_script().as_bytes())?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1436,10 +1436,10 @@ fn init(
     } else {
         // Build typescript config
         let mut ts_config = File::create("tsconfig.json")?;
-        ts_config.write_all(rust_template::ts_config(jest).as_bytes())?;
+        ts_config.write_all(rust_template::ts_config(&test_template).as_bytes())?;
 
         let mut ts_package_json = File::create("package.json")?;
-        ts_package_json.write_all(rust_template::ts_package_json(jest, license).as_bytes())?;
+        ts_package_json.write_all(rust_template::ts_package_json(&test_template, license).as_bytes())?;
 
         let mut deploy = File::create(migrations_path.join("deploy.ts"))?;
         deploy.write_all(rust_template::ts_deploy_script().as_bytes())?;

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -431,9 +431,9 @@ describe("{}", () => {{
     )
 }
 
-pub fn package_json(jest: bool, license: String) -> String {
-    if jest {
-        format!(
+pub fn js_package_json(test_template: &TestTemplate, license: String) -> String {
+    match test_template {
+        TestTemplate::Jest => format!(
             r#"{{
   "license": "{license}",
   "scripts": {{
@@ -449,9 +449,24 @@ pub fn package_json(jest: bool, license: String) -> String {
   }}
 }}
     "#
-        )
-    } else {
-        format!(
+        ),
+        TestTemplate::Bun => format!(
+            r#"{{
+  "license": "{license}",
+  "scripts": {{
+    "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+    "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+  }},
+  "dependencies": {{
+    "@anchor-lang/core": "^{VERSION}"
+  }},
+  "devDependencies": {{
+    "prettier": "^2.6.2"
+  }}
+}}
+"#
+        ),
+        _ => format!(
             r#"{{
   "license": "{license}",
   "scripts": {{
@@ -468,7 +483,7 @@ pub fn package_json(jest: bool, license: String) -> String {
   }}
 }}
 "#
-        )
+        ),
     }
 }
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -472,8 +472,8 @@ pub fn package_json(jest: bool, license: String) -> String {
     }
 }
 
-pub fn ts_package_json(test_runner: &TestTemplate, license: String) -> String {
-    match test_runner {
+pub fn ts_package_json(test_template: &TestTemplate, license: String) -> String {
+    match test_template {
         &TestTemplate::Jest => format!(
             r#"{{
   "license": "{license}",
@@ -595,8 +595,8 @@ describe("{}", () => {{
     )
 }
 
-pub fn ts_config(js_test_runner: &TestTemplate) -> &'static str {
-    match js_test_runner {
+pub fn ts_config(test_template: &TestTemplate) -> &'static str {
+    match test_template {
         TestTemplate::Jest => {
             r#"{
   "compilerOptions": {


### PR DESCRIPTION
Adds a `--test-template bun` option to `anchor init`

The package manager is replace by `bun` when the test template is set to `bun`.

**Note**

I had to prepend a `sleep 0.3` to `bun test` in `Anchor.toml`, otherwise `anchor test` fails with an error that the program is not deployed.

The minimum time required looks suspiciously close to a slot time.

This is obviously a race condition due to the speed of Bun, but I'm not sure about the ideal way to handle it. 