### PR TITLE
lang: Make `common::close` accept references

### DIFF
--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -8,7 +8,7 @@ use crate::solana_program::pubkey::Pubkey;
 use crate::solana_program::system_program;
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Owner,
-    Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    Result, ToAccountInfos, ToAccountMetas,
 };
 use std::collections::BTreeSet;
 use std::fmt;
@@ -371,7 +371,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsClose<'inf
     for Account<'info, T>
 {
     fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()> {
-        crate::common::close(self.to_account_info(), sol_destination)
+        crate::common::close(self.as_ref(), sol_destination.as_ref())
     }
 }
 

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -6,8 +6,8 @@ use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::instruction::AccountMeta;
 use crate::solana_program::pubkey::Pubkey;
 use crate::{
-    Accounts, AccountsClose, AccountsExit, Key, Owner, Result, ToAccountInfo, ToAccountInfos,
-    ToAccountMetas, ZeroCopy,
+    Accounts, AccountsClose, AccountsExit, Key, Owner, Result, ToAccountInfos, ToAccountMetas,
+    ZeroCopy,
 };
 use std::cell::{Ref, RefMut};
 use std::collections::BTreeSet;
@@ -256,7 +256,7 @@ impl<'info, T: ZeroCopy + Owner> AccountsExit<'info> for AccountLoader<'info, T>
 
 impl<'info, T: ZeroCopy + Owner> AccountsClose<'info> for AccountLoader<'info, T> {
     fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()> {
-        crate::common::close(self.to_account_info(), sol_destination)
+        crate::common::close(self.as_ref(), sol_destination.as_ref())
     }
 }
 

--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -292,7 +292,7 @@ where
     T: AccountSerialize + Discriminator + Owner + Clone,
 {
     fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()> {
-        crate::common::close(self.to_account_info(), sol_destination)
+        crate::common::close(self.as_ref(), sol_destination.as_ref())
     }
 }
 

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -3,7 +3,7 @@ use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::system_program;
 use crate::Result;
 
-pub fn close<'info>(info: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> Result<()> {
+pub fn close<'info>(info: &AccountInfo<'info>, sol_destination: &AccountInfo<'info>) -> Result<()> {
     // Transfer tokens from the account to the sol_destination.
     let dest_starting_lamports = sol_destination.lamports();
     **sol_destination.lamports.borrow_mut() =

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -3,7 +3,10 @@ use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::system_program;
 use crate::Result;
 
-pub(crate) fn close<'info>(info: &AccountInfo<'info>, sol_destination: &AccountInfo<'info>) -> Result<()> {
+pub(crate) fn close<'info>(
+    info: &AccountInfo<'info>,
+    sol_destination: &AccountInfo<'info>,
+) -> Result<()> {
     // Transfer tokens from the account to the sol_destination.
     let dest_starting_lamports = sol_destination.lamports();
     **sol_destination.lamports.borrow_mut() =

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -3,7 +3,7 @@ use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::system_program;
 use crate::Result;
 
-pub fn close<'info>(info: &AccountInfo<'info>, sol_destination: &AccountInfo<'info>) -> Result<()> {
+pub(crate) fn close<'info>(info: &AccountInfo<'info>, sol_destination: &AccountInfo<'info>) -> Result<()> {
     // Transfer tokens from the account to the sol_destination.
     let dest_starting_lamports = sol_destination.lamports();
     **sol_destination.lamports.borrow_mut() =


### PR DESCRIPTION
### Problem

The account close helper function we have unnecessarily require owned values:

https://github.com/solana-foundation/anchor/blob/d7ace7a47d9720386d5ddc1690f358e2d1d33ff5/lang/src/common.rs#L6

### Summary of changes

- Change `common::close` to take in reference values
- Update the account wrapper types to pass values by reference in their `AccountsClose` impls

**Note:** This is not a breaking change because the `common::close` function is not exported from the crate. It might be worth to also change the `AccountsClose::close`'s signature, but since that'll be a breaking change, it's better to handle that in a separate PR.