### PR TITLE
cli: Remove the `login` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Add `Migration<'info, From, To>` account type for schema migrations between account types ([#4060](https://github.com/solana-foundation/anchor/pull/4060)).
 - cli: Added a `check_program_id_mismatch` in build time to check if the program ID in the source code matches the program ID in the keypair file ([#4018](https://github.com/solana-foundation/anchor/pull/4018)). This check will be skipped during `anchor test`.
-- lang: lang: Add instruction parser to `declare_program!` ([#4118](https://github.com/solana-foundation/anchor/pull/4118)).
+- lang: Add instruction parser to `declare_program!` ([#4118](https://github.com/solana-foundation/anchor/pull/4118)).
 - ts: Export all IDL types from the root. Users can now update `dist/cjs/idl` imports to import directly from `@anchor-lang/core` ([#3948](https://github.com/solana-foundation/anchor/pull/3948)).
 
 ### Fixes
@@ -32,6 +32,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Remove program id arguments of `idl init` and `idl upgrade` commands ([#4130](https://github.com/solana-foundation/anchor/pull/4130)).
 - lang: Rename `utils` module of `declare_program!` to `parsers` ([#4151](https://github.com/solana-foundation/anchor/pull/4151)).
 - lang: Remove the `interface-instructions` feature and the `#[interface]` attribute ([#4156](https://github.com/solana-foundation/anchor/pull/4156)).
+- cli: Remove the `login` command ([#4182](https://github.com/solana-foundation/anchor/pull/4182)).
 
 ## [0.32.1] - 2025-10-09
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -321,11 +321,6 @@ pub enum Command {
         #[clap(required = false, last = true)]
         script_args: Vec<String>,
     },
-    /// Saves an api token from the registry locally.
-    Login {
-        /// API access token.
-        token: String,
-    },
     /// Program keypair commands.
     Keys {
         #[clap(subcommand)]
@@ -1281,7 +1276,6 @@ fn process_command(opts: Opts) -> Result<()> {
             script,
             script_args,
         } => run(&opts.cfg_override, script, script_args),
-        Command::Login { token } => login(&opts.cfg_override, token),
         Command::Keys { subcmd } => keys(&opts.cfg_override, subcmd),
         Command::Localnet {
             skip_build,
@@ -4610,22 +4604,6 @@ fn run(cfg_override: &ConfigOverride, script: String, script_args: Vec<String>) 
         }
         Ok(())
     })?
-}
-
-fn login(_cfg_override: &ConfigOverride, token: String) -> Result<()> {
-    let anchor_dir = Path::new(&*shellexpand::tilde("~"))
-        .join(".config")
-        .join("anchor");
-    if !anchor_dir.exists() {
-        fs::create_dir(&anchor_dir)?;
-    }
-
-    std::env::set_current_dir(&anchor_dir)?;
-
-    // Freely overwrite the entire file since it's not used for anything else.
-    let mut file = File::create("credentials")?;
-    file.write_all(rust_template::credentials(&token).as_bytes())?;
-    Ok(())
 }
 
 fn keys(cfg_override: &ConfigOverride, cmd: KeysCommand) -> Result<()> {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -253,14 +253,6 @@ pub fn get_or_create_program_id(name: &str) -> Pubkey {
         .pubkey()
 }
 
-pub fn credentials(token: &str) -> String {
-    format!(
-        r#"[registry]
-token = "{token}"
-"#
-    )
-}
-
 pub fn deploy_js_script_host(cluster_url: &str, script_path: &str) -> String {
     format!(
         r#"


### PR DESCRIPTION
### Problem

The `login` command has been obsolete for a long time since the infra is no longer maintained.

### Summary of changes

- Remove the `anchor login` command
- Remove the credentials template (was only used in the `login` command)