### PR TITLE
idl: Fix `local_file` method not found for `proc_macro2::Span` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix `declare_program!` messing up IDL errors generation ([#4126](https://github.com/solana-foundation/anchor/pull/4126)).
 - idl: Fix `address` constraint not resolving constants that have numbers in their identifiers ([#4144](https://github.com/solana-foundation/anchor/pull/4144)).
 - lang: Fix constant nested string generation in `declare_program!` ([#4158](https://github.com/solana-foundation/anchor/pull/4158)).
+- idl: Fix `local_file` method not found for `proc_macro2::Span` error ([#4182](https://github.com/solana-foundation/anchor/pull/4182)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix `declare_program!` messing up IDL errors generation ([#4126](https://github.com/solana-foundation/anchor/pull/4126)).
 - idl: Fix `address` constraint not resolving constants that have numbers in their identifiers ([#4144](https://github.com/solana-foundation/anchor/pull/4144)).
 - lang: Fix constant nested string generation in `declare_program!` ([#4158](https://github.com/solana-foundation/anchor/pull/4158)).
-- idl: Fix `local_file` method not found for `proc_macro2::Span` error ([#4182](https://github.com/solana-foundation/anchor/pull/4182)).
+- idl: Fix `local_file` method not found for `proc_macro2::Span` error ([#4187](https://github.com/solana-foundation/anchor/pull/4187)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -26,7 +26,8 @@ bs58 = "0.5"
 # `idl-build` feature only
 cargo_toml = { version = "0.19", optional = true }
 heck = "0.3"
-proc-macro2 = { version = "1", features = ["span-locations"] }
+# `Span::local_file` required by the `idl-build` feature was stabilized in `1.0.100`
+proc-macro2 = { version = "1.0.100", features = ["span-locations"] }
 quote = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
### Problem

Having [`proc-macro2`](https://github.com/dtolnay/proc-macro2) version lower than `1.0.100` results in:

```
error[E0599]: no method named `local_file` found for struct `proc_macro2::Span` in the current scope
   --> /anchor/lang/syn/src/idl/defined.rs:500:22
    |
499 |                   let source_path = proc_macro2::Span::call_site()
    |  ___________________________________-
500 | |                     .local_file()
    | |                     -^^^^^^^^^^ method not found in `proc_macro2::Span`
    | |_____________________|
    |
```

This is because `Span::.local_file` was only stabilized in `1.0.100` (https://github.com/dtolnay/proc-macro2/pull/518), meaning the stable compiler, which the IDL build now uses (https://github.com/solana-foundation/anchor/pull/3842), won't allow access to those methods if `proc-macro2` version is `<1.0.100`.

I noticed this while working on an older codebase, and then realized the same problem exists even in this repository:

https://github.com/solana-foundation/anchor/blob/a1af19348ac99b1de79b1b5c9c21177629b997a8/Cargo.lock#L3090-L3091

New projects don't have this problem since they generate new lock files, which is why the tests in CI are unaffected.

### Summary of changes

- Require at least `1.0.100` for the `proc-macro2` dependency
- Update the root `Cargo.lock` to use `proc-macro2 1.0.105` (latest)

Fixes https://github.com/solana-foundation/anchor/issues/4041