### PR TITLE
lang: Export `Owners` from `prelude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add instruction parser to `declare_program!` ([#4118](https://github.com/solana-foundation/anchor/pull/4118)).
 - ts: Export all IDL types from the root. Users can now update `dist/cjs/idl` imports to import directly from `@anchor-lang/core` ([#3948](https://github.com/solana-foundation/anchor/pull/3948)).
 - lang: Add `declare_program!` support with just `anchor_client` and not `anchor_lang` ([#4157](https://github.com/solana-foundation/anchor/pull/4157)).
+- lang: Export `Owners` from `prelude` ([#4189](https://github.com/solana-foundation/anchor/pull/4189)).
 
 ### Fixes
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -495,8 +495,8 @@ pub mod prelude {
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
         AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Discriminator, Id,
-        InitSpace, Key, Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos,
-        ToAccountMetas,
+        InitSpace, Key, Lamports, Owner, Owners, ProgramData, Result, Space, ToAccountInfo,
+        ToAccountInfos, ToAccountMetas,
     };
     // Re-export the crate as anchor_lang for declare_program! macro
     pub use crate as anchor_lang;


### PR DESCRIPTION
### Problem

[The `Owner` trait](https://github.com/solana-foundation/anchor/blob/755692a3d8140018097bbdf3adc82f7012b1bdd9/lang/src/lib.rs#L419) is exported from [`prelude`](https://github.com/solana-foundation/anchor/blob/755692a3d8140018097bbdf3adc82f7012b1bdd9/lang/src/lib.rs#L484) but [`Owners`](https://github.com/solana-foundation/anchor/blob/755692a3d8140018097bbdf3adc82f7012b1bdd9/lang/src/lib.rs#L424) is not.

### Summary of changes

Export the `Owners` trait from `prelude`.