### PR TITLE
idl: Exclude external accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Rename `utils` module of `declare_program!` to `parsers` ([#4151](https://github.com/solana-foundation/anchor/pull/4151)).
 - lang: Remove the `interface-instructions` feature and the `#[interface]` attribute ([#4156](https://github.com/solana-foundation/anchor/pull/4156)).
 - cli: Remove the `login` command ([#4182](https://github.com/solana-foundation/anchor/pull/4182)).
+- idl: Exclude external accounts ([#4197](https://github.com/solana-foundation/anchor/pull/4197)).
 
 ## [0.32.1] - 2025-10-09
 

--- a/tests/idl/idls/idl.json
+++ b/tests/idl/idls/idl.json
@@ -597,6 +597,9 @@
           ]
         },
         {
+          "name": "external"
+        },
+        {
           "name": "token_account"
         },
         {
@@ -1354,6 +1357,13 @@
             }
           }
         ]
+      }
+    },
+    {
+      "name": "MyAccount",
+      "type": {
+        "kind": "struct",
+        "fields": []
       }
     },
     {

--- a/tests/idl/programs/external/src/lib.rs
+++ b/tests/idl/programs/external/src/lib.rs
@@ -6,10 +6,18 @@ declare_id!("Externa1111111111111111111111111111111111111");
 pub mod external {
     use super::*;
 
-    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+    pub fn test_compilation(_ctx: Context<TestCompilation>) -> Result<()> {
         Ok(())
     }
 }
+
+#[derive(Accounts)]
+pub struct TestCompilation<'info> {
+    account: Account<'info, MyAccount>,
+}
+
+#[account]
+pub struct MyAccount {}
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct MyStruct {
@@ -22,10 +30,3 @@ pub enum MyEnum {
     Named { name: String },
     Tuple(String),
 }
-
-pub struct NonBorshStruct {
-    pub data: i32,
-}
-
-#[derive(Accounts)]
-pub struct Initialize {}

--- a/tests/idl/programs/idl/src/lib.rs
+++ b/tests/idl/programs/idl/src/lib.rs
@@ -541,6 +541,8 @@ pub struct TestCompilation<'info> {
 
     composite: Composite<'info>,
 
+    external: Account<'info, external::MyAccount>,
+
     token_account: Account<'info, token::TokenAccount>,
     mint_account: Account<'info, token::Mint>,
     token_interface_account: InterfaceAccount<'info, token_interface::TokenAccount>,

--- a/tests/idl/tests/idl.ts
+++ b/tests/idl/tests/idl.ts
@@ -2,6 +2,7 @@ import * as anchor from "@anchor-lang/core";
 import BN from "bn.js";
 import { assert } from "chai";
 
+import type { External } from "../target/types/external";
 import type { Idl } from "../target/types/idl";
 
 describe("IDL", () => {
@@ -547,7 +548,7 @@ describe("IDL", () => {
         program.idl.accounts.find((acc) => acc.name === "zcAccount")
       );
       const zcAccount = program.idl.types.find((ty) => ty.name === "zcAccount");
-      if (!zcAccount) throw new Error("Zero copy accout not found");
+      if (!zcAccount) throw new Error("`zcAccount` not found");
 
       assert.strictEqual(zcAccount.serialization, "bytemuck");
       assert.deepEqual(zcAccount.repr, { kind: "c" });
@@ -560,11 +561,26 @@ describe("IDL", () => {
       const zcUnsafeAccount = program.idl.types.find(
         (ty) => ty.name === "zcUnsafeAccount"
       );
-      if (!zcUnsafeAccount)
-        throw new Error("Unsafe zero copy accout not found");
+      if (!zcUnsafeAccount) throw new Error("`zcUnsafeAccount` not found");
 
       assert.strictEqual(zcUnsafeAccount.serialization, "bytemuckunsafe");
       assert.deepEqual(zcUnsafeAccount.repr, { kind: "rust", packed: true });
+    });
+
+    it("Does not include external accounts", () => {
+      const external: anchor.Program<External> = anchor.workspace.external;
+      assert.isDefined(
+        external.idl.accounts.find((acc) => acc.name === "myAccount")
+      );
+      assert.isDefined(
+        external.idl.types.find((ty) => ty.name === "myAccount")
+      );
+
+      assert.isUndefined(
+        // @ts-expect-error
+        program.idl.accounts.find((acc) => acc.name === "myAccount")
+      );
+      assert.isDefined(program.idl.types.find((ty) => ty.name === "myAccount"));
     });
 
     it("Includes constants marked with `#[constant]`", () => {


### PR DESCRIPTION
### Problem

Including external accounts in the IDL *can* cause unexpected behavior and errors such as:

- `Error: Ambiguous discriminators for accounts <A> and <B>` (https://github.com/solana-foundation/anchor/issues/3562)
- `Error: Conflicting accounts names are not allowed` (https://github.com/solana-foundation/anchor/issues/3500)

### Summary of changes

- Exclude external accounts from the `accounts` section while keeping their type definitions in the `types` section
- Add a test case that checks the exclusion of external accounts

Fixes https://github.com/solana-foundation/anchor/issues/3562