### PR TITLE
ci: Re-enable `zero-copy` tests

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -428,12 +428,8 @@ jobs:
             path: tests/typescript
           - cmd: cd tests/duplicate-mutable-accounts && anchor test --skip-lint
             path: tests/duplicate-mutable-accounts
-          # zero-copy tests cause `/usr/bin/ld: final link failed: No space left on device`
-          # on GitHub runners. It is likely caused by `cargo test-sbf` since all other tests
-          # don't have this problem.
-          # TODO: Find a fix.
-          # - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
-          #   path: tests/zero-copy
+          - cmd: cd tests/zero-copy && anchor test --skip-lint && cd programs/zero-copy && cargo test-sbf
+            path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat
           - cmd: cd tests/ido-pool && anchor test --skip-lint

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -22,4 +22,5 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 
 [dev-dependencies]
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
-solana-program-test = "2"
+solana-program-test = "*"
+solana-sdk = "*"

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -22,5 +22,5 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 
 [dev-dependencies]
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
-solana-program-test = "*"
-solana-sdk = "*"
+solana-program-test = "3.1"
+solana-sdk = "3.0"

--- a/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
+++ b/tests/zero-copy/programs/zero-copy/tests/compute_unit_test.rs
@@ -1,19 +1,12 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    anchor_client::{
-        anchor_lang::Discriminator,
-        solana_account::Account,
-        solana_sdk::{
-            commitment_config::CommitmentConfig,
-            pubkey::Pubkey,
-            signature::Keypair,
-            transaction::Transaction,
-        },
-        solana_signer::Signer,
-        Client, Cluster,
-    },
+    anchor_client::{anchor_lang::Discriminator, Client, Cluster},
     solana_program_test::{tokio, ProgramTest},
+    solana_sdk::{
+        account::Account, pubkey::Pubkey, signature::Keypair, signer::Signer,
+        transaction::Transaction,
+    },
     std::rc::Rc,
 };
 
@@ -40,13 +33,9 @@ async fn update_foo() {
     let mut pt = ProgramTest::new("zero_copy", zero_copy::id(), None);
     pt.add_account(foo_pubkey, foo_account);
     pt.set_compute_max_units(4157);
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+    let (banks_client, payer, recent_blockhash) = pt.start().await;
 
-    let client = Client::new_with_options(
-        Cluster::Debug,
-        Rc::new(Keypair::new()),
-        CommitmentConfig::processed(),
-    );
+    let client = Client::new(Cluster::Debug, Rc::new(Keypair::new()));
     let program = client.program(zero_copy::id()).unwrap();
     let update_ix = program
         .request()
@@ -56,7 +45,6 @@ async fn update_foo() {
         })
         .args(zero_copy::instruction::UpdateFoo { data: 1u64 })
         .instructions()
-        .unwrap()
         .pop()
         .unwrap();
 

--- a/tests/zero-copy/programs/zero-cpi/src/lib.rs
+++ b/tests/zero-copy/programs/zero-cpi/src/lib.rs
@@ -14,7 +14,7 @@ pub mod zero_cpi {
             bar: ctx.accounts.bar.to_account_info(),
             foo: ctx.accounts.foo.to_account_info(),
         };
-        let cpi_ctx = CpiContext::new(cpi_accounts);
+        let cpi_ctx = CpiContext::new(ctx.accounts.zero_copy_program.key(), cpi_accounts);
         zero_copy::cpi::update_bar(cpi_ctx, data)?;
         Ok(())
     }


### PR DESCRIPTION
### Problem

[`zero-copy` tests](https://github.com/solana-foundation/anchor/tree/2cb7ababa7dba3ac269fd2e60cfa06793ad2b989/tests/zero-copy) were disabled in https://github.com/solana-foundation/anchor/pull/2843 because GitHub runners were running out of memory:

```
/usr/bin/ld: final link failed: No space left on device
```

### Summary of changes

- Re-eneable the `zero-copy` tests in CI
- Fix the `cargo-build-sbf` tests