### PR TITLE
syn: Ignore `generic-array` deprecation warnings

### DIFF
--- a/lang/syn/src/hash.rs
+++ b/lang/syn/src/hash.rs
@@ -26,8 +26,10 @@ impl Hasher {
         }
     }
     pub fn result(self) -> Hash {
-        // At the time of this writing, the sha2 library is stuck on an old version
-        // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
+        // `generic-array ^0.14.8` logs deprecation warnings
+        //
+        // TODO: Remove once `sha2` (transitively) depends on `generic-array` v1.
+        #[allow(deprecated)]
         Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
     }
 }


### PR DESCRIPTION
### Problem

`generic-array 0.14.8` added deprecation warnings (https://github.com/fizyk20/generic-array/commit/d859e59b29412c8434563716e418884c6a9266b2):

```
warning: use of deprecated method `sha2::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
  --> /anchor/lang/syn/src/hash.rs:31:66
   |
31 |         Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
   |                                                                  ^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

It's a transitive dependency; we don't depend on it directly:

```
generic-array v0.14.9
├── block-buffer v0.10.4
│   ├── digest v0.10.7
│   │   ├── curve25519-dalek v4.1.3
│   │   │   ├── solana-address v2.0.0
│   │   │   │   ├── solana-account-info v3.1.0
│   │   │   │   │   ├── anchor-lang v0.32.1
...
```

This means we can't easily update it to v1 ourselves.

### Summary of changes

Disable the deprecation warnings coming from the `generic-array` crate.