### PR TITLE
fix(syn): use AST-based bytemuck serialization detection

### DIFF
--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -41,3 +41,7 @@ serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 syn = { workspace = true, features = ["full", "extra-traits", "parsing"] }
 thiserror = "1"
+
+[[test]]
+name = "idl_attributes"
+required-features = ["idl-build"]

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -203,19 +203,43 @@ where
         _ => quote! { vec![] },
     };
 
-    let serialization = get_attr_str("derive", attrs)
-        .and_then(|derive| {
-            if derive.contains("bytemuck") {
-                if derive.to_lowercase().contains("unsafe") {
-                    Some(quote! { #idl::IdlSerialization::BytemuckUnsafe })
-                } else {
-                    Some(quote! { #idl::IdlSerialization::Bytemuck })
+    // Track both safe and unsafe bytemuck derives from the same derive list.
+    let mut saw_bytemuck_pod = false;
+    let mut saw_bytemuck_unsafe = false;
+    for attr in attrs {
+        if !attr.path().is_ident("derive") {
+            continue;
+        }
+
+        let _ = attr.parse_nested_meta(|meta| {
+            let has_bytemuck_segment = meta.path.segments.iter().any(|s| s.ident == "bytemuck");
+
+            if has_bytemuck_segment {
+                let has_unsafe_segment = meta
+                    .path
+                    .segments
+                    .iter()
+                    .any(|s| s.ident.to_string().to_ascii_lowercase().contains("unsafe"));
+
+                let is_pod = meta.path.segments.last().is_some_and(|s| s.ident == "Pod");
+
+                if has_unsafe_segment {
+                    saw_bytemuck_unsafe = true;
+                } else if is_pod {
+                    saw_bytemuck_pod = true;
                 }
-            } else {
-                None
             }
-        })
-        .unwrap_or_else(|| quote! { #idl::IdlSerialization::default() });
+            Ok(())
+        });
+    }
+
+    let serialization = if saw_bytemuck_unsafe {
+        quote! { #idl::IdlSerialization::BytemuckUnsafe }
+    } else if saw_bytemuck_pod {
+        quote! { #idl::IdlSerialization::Bytemuck }
+    } else {
+        quote! { #idl::IdlSerialization::default() }
+    };
 
     let repr = get_attr_str("repr", attrs)
         .map(|repr| {

--- a/lang/syn/tests/idl_attributes.rs
+++ b/lang/syn/tests/idl_attributes.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "idl-build")]
+
+use {
+    anchor_syn::idl::impl_idl_build_struct,
+    syn::{parse_quote, ItemStruct},
+};
+
+fn check_serialization(item: ItemStruct, expected: &str) {
+    let stream = impl_idl_build_struct(&item);
+    let output = stream.to_string();
+    assert!(
+        output.contains(expected),
+        "Output did not contain expected serialization: '{}'. Got: '{}'",
+        expected,
+        output
+    );
+}
+
+#[test]
+fn test_bytemuck_unsafe_qualified() {
+    check_serialization(
+        parse_quote! {
+            #[derive(bytemuck::Unsafe)]
+            struct Foo {}
+        },
+        "IdlSerialization :: BytemuckUnsafe",
+    );
+}
+
+#[test]
+fn test_bytemuck_safe() {
+    check_serialization(
+        parse_quote! {
+            #[derive(bytemuck::Pod)]
+            struct Foo {}
+        },
+        "IdlSerialization :: Bytemuck",
+    );
+}
+
+#[test]
+fn test_bytemuck_non_pod_ignored() {
+    check_serialization(
+        parse_quote! {
+            #[derive(bytemuck::AnyBitPattern)]
+            struct Foo {}
+        },
+        "IdlSerialization :: default",
+    );
+}
+
+#[test]
+fn test_false_positive_prevention() {
+    check_serialization(
+        parse_quote! {
+            #[derive(MyUnsafeMacro)]
+            struct Foo {}
+        },
+        "IdlSerialization :: default",
+    );
+}
+
+#[test]
+fn test_bytemuck_safe_then_unsafe() {
+    check_serialization(
+        parse_quote! {
+            #[derive(bytemuck::Pod, bytemuck::Unsafe)]
+            struct Foo {}
+        },
+        "IdlSerialization :: BytemuckUnsafe",
+    );
+}


### PR DESCRIPTION
Replace string-based bytemuck detection with AST parsing. Only `bytemuck::Pod` sets safe serialization; only `bytemuck::Unsafe` sets unsafe serialization. Unqualified and non-Pod derives are ignored to prevent false positives from unrelated crates.