### PR TITLE
fix: enforce --frozen-lockfile for yarn install calls

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -83,6 +83,8 @@ sed "${sedi[@]}" -e \
     CHANGELOG.md
 
 # Update lock files
+# NOTE: Cannot use --frozen-lockfile here because package.json versions were just
+# bumped above, so the lockfile legitimately needs to be regenerated.
 pushd ts
 yarn
 popd

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -83,20 +83,20 @@ sed "${sedi[@]}" -e \
     CHANGELOG.md
 
 # Update lock files
-# NOTE: Cannot use --frozen-lockfile here because package.json versions were just
-# bumped above, so the lockfile legitimately needs to be regenerated.
+# Cannot use --frozen-lockfile: package.json versions were just bumped, so refresh the lockfiles.
+# Only workspace versions changed above; if lockfile diffs look like broad third-party churn, investigate before tagging.
 pushd ts
-yarn
+yarn install
 popd
 
 pushd tests
-yarn
+yarn install
 popd
 
 pushd examples
-yarn
+yarn install
 pushd tutorial
-yarn
+yarn install
 popd
 popd
 

--- a/ts/build-packages.sh
+++ b/ts/build-packages.sh
@@ -1,7 +1,7 @@
 cd packages;
 for D in */;
     do if [ "$D" = "anchor/" ]; then
-        cd $D && yarn && yarn build; cd ..;
+        cd $D && yarn --frozen-lockfile && yarn build; cd ..;
     else
         cd $D && yarn init:yarn; cd ..;
     fi

--- a/ts/packages/spl-associated-token-account/package.json
+++ b/ts/packages/spl-associated-token-account/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-binary-option/package.json
+++ b/ts/packages/spl-binary-option/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-binary-oracle-pair/package.json
+++ b/ts/packages/spl-binary-oracle-pair/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-feature-proposal/package.json
+++ b/ts/packages/spl-feature-proposal/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-governance/package.json
+++ b/ts/packages/spl-governance/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-memo/package.json
+++ b/ts/packages/spl-memo/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-name-service/package.json
+++ b/ts/packages/spl-name-service/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-record/package.json
+++ b/ts/packages/spl-record/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-stake-pool/package.json
+++ b/ts/packages/spl-stake-pool/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-stateless-asks/package.json
+++ b/ts/packages/spl-stateless-asks/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-token-lending/package.json
+++ b/ts/packages/spl-token-lending/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-token-swap/package.json
+++ b/ts/packages/spl-token-swap/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",

--- a/ts/packages/spl-token/package.json
+++ b/ts/packages/spl-token/package.json
@@ -16,7 +16,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
-    "init:yarn": "yarn && yarn lint:fix && yarn build:yarn",
+    "init:yarn": "yarn --frozen-lockfile && yarn lint:fix && yarn build:yarn",
     "init:npm": "npm i && npm run lint:fix && npm run build:npm",
     "build:yarn": "rimraf dist/ && yarn build:node && yarn build:browser",
     "build:npm": "rimraf dist/ && npm run build:node && npm run build:browser",


### PR DESCRIPTION
## Summary

Resolves #4216

Ensures `yarn` install commands use `--frozen-lockfile` to pin dependencies and avoid safety issues from compromised packages.

## Changes

### `ts/build-packages.sh`
- Added `--frozen-lockfile` to the `yarn` install call when building the `anchor` package.

### `.github/workflows/reusable-tests.yaml`
- Added `--frozen-lockfile` to the bare `yarn` install call in the `test-init` job (line 372). This was the only CI `yarn install` call missing the flag.

### `bump-version.sh`
- Added a comment documenting why `--frozen-lockfile` **cannot** be used in the lock file update section: the `package.json` versions were just bumped by the script, so the lockfile legitimately needs to be regenerated. The bare `yarn` calls here are intentional.