### PR TITLE
Optimize enums with all unit variants and empty arrays with `Lazy`

### DIFF
--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -196,6 +196,15 @@ mod tests {
             len!(MyEnum::Unnamed(1, 2))
         );
         assert!(!MyEnum::SIZED);
+
+        #[derive(AnchorSerialize, AnchorDeserialize)]
+        enum UnitEnum {
+            A,
+            B,
+        }
+        assert_eq!(UnitEnum::size_of(&[0]), len!(UnitEnum::A));
+        assert_eq!(UnitEnum::size_of(&[1]), len!(UnitEnum::B));
+        assert!(UnitEnum::SIZED);
     }
 
     #[test]

--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -64,7 +64,7 @@ impl_sized!(f64);
 impl_sized!(Pubkey);
 
 impl<T: Lazy, const N: usize> Lazy for [T; N] {
-    const SIZED: bool = T::SIZED;
+    const SIZED: bool = N == 0 || T::SIZED;
 
     #[inline(always)]
     fn size_of(buf: &[u8]) -> usize {


### PR DESCRIPTION
Best reviewed commit-by-commit. Fixes some generics-related issues in the lazy derive, as well as making the `SIZED` counter more accurate to allow a few more fast-paths.
Finally, enables many lang features for unit/doc/integration tests in CI.