### PR TITLE
Include `init_if_needed` Accounts in Duplicate Mutable Account Checks

### DIFF
--- a/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
+++ b/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
@@ -75,6 +75,10 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                 })
             }
             // Direct fields that are mut, not dup, and not pure init (init_if_needed is included).
+            // Pure-init accounts are always freshly created so they cannot collide
+            // with an existing mutable account. `init_if_needed` accounts, however,
+            // may already be initialized and therefore must participate in the
+            // duplicate-mutable-account check.
             AccountField::Field(f)
                 if f.constraints.is_mutable()
                     && !f.constraints.is_dup()

--- a/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
+++ b/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
@@ -74,11 +74,11 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     keys.extend(self.#field_name.duplicate_mutable_account_keys());
                 })
             }
-            // Direct fields that are mut, not dup, and not init.
+            // Direct fields that are mut, not dup, and not pure init (init_if_needed is included).
             AccountField::Field(f)
                 if f.constraints.is_mutable()
                     && !f.constraints.is_dup()
-                    && f.constraints.init.is_none() =>
+                    && !f.constraints.is_pure_init() =>
             {
                 // Only types that serialize on exit (not Signer, Program, etc.).
                 match &f.ty {

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -333,7 +333,7 @@ fn generate_duplicate_mutable_checks(accs: &AccountsStruct) -> proc_macro2::Toke
             AccountField::Field(f)
                 if f.constraints.is_mutable()
                     && !f.constraints.is_dup()
-                    && f.constraints.init.is_none() =>
+                    && !f.constraints.is_pure_init() =>
             {
                 match &f.ty {
                     // Only include types that serialize on exit

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -749,6 +749,17 @@ impl ConstraintGroup {
         self.dup.is_some()
     }
 
+    /// Returns `true` when the field has `#[account(init, ...)]` but **not**
+    /// `#[account(init_if_needed, ...)]`.
+    ///
+    /// Pure-init accounts are always freshly created so they cannot collide
+    /// with an existing mutable account.  `init_if_needed` accounts, however,
+    /// may already be initialized and therefore must participate in the
+    /// duplicate-mutable-account check.
+    pub fn is_pure_init(&self) -> bool {
+        matches!(&self.init, Some(c) if !c.if_needed)
+    }
+
     pub fn is_signer(&self) -> bool {
         self.signer.is_some()
     }

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -751,11 +751,6 @@ impl ConstraintGroup {
 
     /// Returns `true` when the field has `#[account(init, ...)]` but **not**
     /// `#[account(init_if_needed, ...)]`.
-    ///
-    /// Pure-init accounts are always freshly created so they cannot collide
-    /// with an existing mutable account.  `init_if_needed` accounts, however,
-    /// may already be initialized and therefore must participate in the
-    /// duplicate-mutable-account check.
     pub fn is_pure_init(&self) -> bool {
         matches!(&self.init, Some(c) if !c.if_needed)
     }

--- a/tests/duplicate-mutable-accounts/programs/duplicate-mutable-accounts/Cargo.toml
+++ b/tests/duplicate-mutable-accounts/programs/duplicate-mutable-accounts/Cargo.toml
@@ -14,4 +14,4 @@ cpi = ["no-entrypoint"]
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-anchor-lang = { path = "../../../../lang" }
+anchor-lang = { path = "../../../../lang", features = ["init-if-needed"] }


### PR DESCRIPTION
- `init_if_needed` accounts may already be initialized and therefore must participate in the duplicate-mutable-account check.