### PR TITLE
lang: improve anchor-debug panic message for non-writable Account

### DIFF
--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -421,7 +421,10 @@ impl<T: AccountSerialize + AccountDeserialize + Clone> DerefMut for Account<'_, 
         #[cfg(feature = "anchor-debug")]
         if !self.info.is_writable {
             crate::solana_program::msg!("The given Account is not mutable");
-            panic!();
+            panic!(
+                "anchor-debug: attempted to mutably deref a non-writable Account (key={})",
+                self.info.key
+            );
         }
         &mut self.account
     }


### PR DESCRIPTION
When `anchor-debug` is enabled, `Account<T>::deref_mut` currently panics on non-writable accounts with no panic message, making diagnosis harder.

This PR keeps behavior the same (still panics under anchor-debug), but includes the offending account key in the panic message to speed up debugging.