### PR TITLE
idl-spec: avoid panics on malformed defined type generics

### DIFF
--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -386,14 +386,10 @@ impl FromStr for IdlType {
 
                 // Defined
                 let (name, generics) = if let Some(i) = s.find('<') {
-                    let name = s
-                        .get(..i)
-                        .ok_or_else(|| anyhow!("Invalid defined type '{s}': missing name"))?
-                        .to_owned();
+                    // `i` comes from `s.find('<')`, so it is always a valid UTF-8 boundary.
+                    let name = s[..i].to_owned();
 
-                    let generics_str = s
-                        .get(i + 1..)
-                        .ok_or_else(|| anyhow!("Invalid defined type '{s}': missing generics"))?
+                    let generics_str = s[i + 1..]
                         .strip_suffix('>')
                         .ok_or_else(|| anyhow!("Invalid defined type '{s}': missing closing '>'"))?;
 
@@ -551,5 +547,10 @@ mod tests {
     fn malformed_defined_empty_generics_returns_err() {
         // Previously this would panic due to `.strip_suffix('>').unwrap()` (and/or parse weirdly).
         assert!(IdlType::from_str("MyStruct<>").is_err());
+    }
+
+    #[test]
+    fn malformed_defined_trailing_comma_returns_err() {
+        assert!(IdlType::from_str("MyStruct<Pubkey,>").is_err());
     }
 }

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -489,6 +489,11 @@ mod tests {
     }
 
     #[test]
+    fn malformed_multidimensional_array_missing_closing_bracket_returns_err() {
+        assert!(IdlType::from_str("[[u8; 16]; 32").is_err());
+    }
+
+    #[test]
     fn generic_array() {
         assert_eq!(
             IdlType::from_str("[u64; T]").unwrap(),
@@ -552,5 +557,11 @@ mod tests {
     #[test]
     fn malformed_defined_trailing_comma_returns_err() {
         assert!(IdlType::from_str("MyStruct<Pubkey,>").is_err());
+    }
+
+    #[test]
+    fn malformed_defined_nested_missing_closing_angles_returns_err() {
+        // Ensure recursive parsing of generic arguments propagates syntax errors from nested generics.
+        assert!(IdlType::from_str("MyStruct<Option<Pubkey>").is_err());
     }
 }


### PR DESCRIPTION
This PR hardens `anchor-lang-idl-spec`'s `IdlType::from_str` parsing for **defined types with generics**.

## Issue
Malformed type strings like `MyStruct<Pubkey` (missing closing `>`) would trigger a panic due to `unwrap()` usage in the generic parsing branch.

## Fix
- Replace `unwrap()` calls with structured `anyhow::Error` returns.
- Add tests to ensure malformed inputs return `Err` (and do not panic).

## Verification
`cargo test -p anchor-lang-idl-spec`

Write-up: https://rentry.co/anchor-idl-defined-generics-dos-2