### PR TITLE
fix(avm): clearer error when prebuilt release binary is missing

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -493,11 +493,16 @@ pub fn install_version(
                 "https://github.com/solana-foundation/anchor/releases/download/v{version}/anchor-{version}-{target}{ext}"
             ))
             .send()?;
-        if !res.status().is_success() {
-            return Err(anyhow!(
+        match res.status() {
+            StatusCode::NOT_FOUND => bail!(
+                "No prebuilt binary found for version `{version}` (HTTP 404). \
+                 Try `avm install {version} --from-source`."
+            ),
+            status if !status.is_success() => bail!(
                 "Failed to download the binary for version `{version}` (status code: {})",
                 res.status()
-            ));
+            ),
+            _ => (),
         }
 
         let bin_path = version_binary_path(&version);

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -495,8 +495,8 @@ pub fn install_version(
             .send()?;
         match res.status() {
             StatusCode::NOT_FOUND => bail!(
-                "No prebuilt binary found for version `{version}` (HTTP 404). \
-                 Try `avm install {version} --from-source`."
+                "No prebuilt binary found for version `{version}` (HTTP 404). Try `avm install \
+                 {version} --from-source`."
             ),
             status if !status.is_success() => bail!(
                 "Failed to download the binary for version `{version}` (status code: {})",


### PR DESCRIPTION
Fix avm install for <=0.30 by avoiding symlink collisions during source install and improving 404 messaging for missing binaries. Closes #4159.

fixed avm installs for older Anchor versions by installing from source into a temporary root and then moving the built binary into the versioned path, which avoids collisions with the anchor symlink, also improved error handling so missing prebuilt binaries return a clear 404 message and suggest --from-source, instead of a misleading “binary exists” failure.