### PR TITLE
chore: Increase verbosity of generate_create_account to avoid shadowing the evil solana ergonomic

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -628,13 +628,14 @@ fn generate_constraint_init_group(
 
             let token_account_space = generate_get_token_account_space(mint);
 
-            let create_account = generate_create_account(
-                field,
-                quote! {#token_account_space},
-                quote! {&#token_program.key()},
-                quote! {#payer},
-                seeds_with_bump,
-            );
+            let create_account_or_fund_allocate_assign =
+                generate_create_account_or_fund_allocate_assign(
+                    field,
+                    quote! {#token_account_space},
+                    quote! {&#token_program.key()},
+                    quote! {#payer},
+                    seeds_with_bump,
+                );
 
             quote! {
                 // Define the bump and pda variable.
@@ -649,7 +650,7 @@ fn generate_constraint_init_group(
                         #payer_optional_check
 
                         // Create the account with the system program.
-                        #create_account
+                        #create_account_or_fund_allocate_assign
 
                         // Initialize the token account.
                         let cpi_program_id = #token_program.key();
@@ -954,13 +955,14 @@ fn generate_constraint_init_group(
                 None => quote! { Option::<anchor_lang::prelude::Pubkey>::None },
             };
 
-            let create_account = generate_create_account(
-                field,
-                mint_space,
-                quote! {&#token_program.key()},
-                quote! {#payer},
-                seeds_with_bump,
-            );
+            let create_account_or_fund_allocate_assign =
+                generate_create_account_or_fund_allocate_assign(
+                    field,
+                    mint_space,
+                    quote! {&#token_program.key()},
+                    quote! {#payer},
+                    seeds_with_bump,
+                );
 
             quote! {
                 // Define the bump and pda variable.
@@ -976,7 +978,7 @@ fn generate_constraint_init_group(
                         #payer_optional_check
 
                         // Create the account with the system program.
-                        #create_account
+                        #create_account_or_fund_allocate_assign
 
                         let cpi_program_id = #token_program.key();
 
@@ -1100,13 +1102,14 @@ fn generate_constraint_init_group(
             };
 
             // CPI to the system program to create the account.
-            let create_account = generate_create_account(
-                field,
-                quote! {space},
-                owner.clone(),
-                quote! {#payer},
-                seeds_with_bump,
-            );
+            let create_account_or_fund_allocate_assign =
+                generate_create_account_or_fund_allocate_assign(
+                    field,
+                    quote! {space},
+                    owner.clone(),
+                    quote! {#payer},
+                    seeds_with_bump,
+                );
 
             // Put it all together.
             quote! {
@@ -1129,7 +1132,7 @@ fn generate_constraint_init_group(
                         #payer_optional_check
 
                         // CPI to the system program to create.
-                        #create_account
+                        #create_account_or_fund_allocate_assign
 
                         // Convert from account info to account context wrapper type.
                         #from_account_info_unchecked
@@ -1665,14 +1668,15 @@ fn generate_get_token_account_space(mint: &Expr) -> proc_macro2::TokenStream {
     }
 }
 
-// Generated code to create an account with system program with the
+// Generated code to create an account or fund, allocate, and
+// assign using the system program with the
 // given `space` amount of data, owned by `owner`.
 //
 // `seeds_with_nonce` should be given for creating PDAs. Otherwise it's an
 // empty stream.
 //
 // This should only be run within scopes where `system_program` is not Optional
-fn generate_create_account(
+fn generate_create_account_or_fund_allocate_assign(
     field: &Ident,
     space: proc_macro2::TokenStream,
     owner: proc_macro2::TokenStream,
@@ -1682,12 +1686,10 @@ fn generate_create_account(
     // Field, payer, and system program are already validated to not be an Option at this point
     quote! {
         // If the account being initialized already has lamports, then
-        // return them all back to the payer so that the account has
-        // zero lamports when the system program's create instruction
-        // is eventually called.
+        // fund the required lamports for rent exemption, allocate and assign
         let __current_lamports = #field.lamports();
         if __current_lamports == 0 {
-            // Create the token account with right amount of lamports and space, and the correct owner.
+            // Create the account with right amount of lamports and space, and the correct owner.
             let space = #space;
             let lamports = __anchor_rent.minimum_balance(space);
             let cpi_accounts = anchor_lang::system_program::CreateAccount {
@@ -1711,13 +1713,13 @@ fn generate_create_account(
                 let cpi_context = anchor_lang::context::CpiContext::new(system_program.key(), cpi_accounts);
                 anchor_lang::system_program::transfer(cpi_context, required_lamports)?;
             }
-            // Allocate space.
+
             let cpi_accounts = anchor_lang::system_program::Allocate {
                 account_to_allocate: #field.to_account_info()
             };
             let cpi_context = anchor_lang::context::CpiContext::new(system_program.key(), cpi_accounts);
             anchor_lang::system_program::allocate(cpi_context.with_signer(&[#seeds_with_nonce]), #space as u64)?;
-            // Assign to the spl token program.
+
             let cpi_accounts = anchor_lang::system_program::Assign {
                 account_to_assign: #field.to_account_info()
             };


### PR DESCRIPTION
Avoid reusing the term `create_account` as this is a system program instruction but the generated code does the full dance to avoid impaling itself into the thorny solana ergonomics.

Also remove token or spl-program mentions since this function is used for non token businesses.