### PR TITLE
Document that zero discriminators are unsupported

### DIFF
--- a/docs/content/docs/footguns.mdx
+++ b/docs/content/docs/footguns.mdx
@@ -1,0 +1,16 @@
+---
+title: Footguns
+description:
+  Common footguns in Anchor that can lead to issues.
+---
+
+## Zeroed Discriminators
+
+Anchor supports overriding discriminators with custom values (for accounts, events and instructions).
+All-zero discriminators are only supported in events and instructions. In the case of accounts, e.g:
+```rust
+#[account(discriminator = [0, 0, 0])]
+#[account(discriminator = 0)]
+#[account(discriminator = ZERO_CONSTANT)]
+```
+are illegal. The [`zero` constraint](/docs/references/account-constraints#accountzero) may be used instead.

--- a/docs/content/docs/footguns.mdx
+++ b/docs/content/docs/footguns.mdx
@@ -7,10 +7,12 @@ description:
 ## Zeroed Discriminators
 
 Anchor supports overriding discriminators with custom values (for accounts, events and instructions).
+
 All-zero discriminators are only supported in events and instructions. In the case of accounts, e.g:
 ```rust
 #[account(discriminator = [0, 0, 0])]
 #[account(discriminator = 0)]
 #[account(discriminator = ZERO_CONSTANT)]
 ```
-are illegal. The [`zero` constraint](/docs/references/account-constraints#accountzero) may be used instead.
+they are explicitly not supported, as all-zero discriminators are indistinguishable from
+newly allocated accounts and can expose your code to security and usability issues.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -11,6 +11,7 @@
     "clients",
     "testing",
     "features",
+    "footguns",
 
     "---SPL Tokens---",
     "tokens",

--- a/docs/content/docs/references/account-constraints.mdx
+++ b/docs/content/docs/references/account-constraints.mdx
@@ -233,7 +233,7 @@ Examples: [Github](https://github.com/solana-developers/anchor-examples/tree/mai
 ### `#[account(realloc)]`
 
 Description: Used to realloc program account space at the beginning of an
-instruction.  
+instruction.
 Examples: [Github](https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/realloc)
 |
 [Solpg](https://beta.solpg.io/https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/realloc)
@@ -244,6 +244,20 @@ Examples: [Github](https://github.com/solana-developers/anchor-examples/tree/mai
     realloc::payer = <target>,
     realloc::zero = <bool>
 )]
+```
+
+### `#[account(discriminator = discrim)]`
+
+Description: Used to override the discriminator for an account. All constant expressions are supported,
+but [all-zero](/docs/footguns#zeroed-discriminators) discriminators are not.
+
+In versions of Anchor before 1.0, program-owned accounts with zeroed discriminators (for example, by manually
+initializing an `AccountInfo`, or as preparation for `#[zero]` initialization) can be taken over via IDL instructions.
+
+```rust title="attribute"
+#[account(discriminator = 12)]
+#[account(discriminator = [1, 2, 3, 4])]
+#[account(discriminator = MY_CONST_DISCRIMINATOR)]
 ```
 
 ## SPL Constraints
@@ -271,7 +285,7 @@ Examples: [Github](https://github.com/solana-developers/anchor-examples/tree/mai
 
 ### `#[account(mint::*)]`
 
-Description: Create or validate mint accounts with specified parameters.  
+Description: Create or validate mint accounts with specified parameters.
 Examples: [Github](https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/mint)
 |
 [Solpg](https://beta.solpg.io/https://github.com/solana-developers/anchor-examples/tree/main/account-constraints/mint)

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -370,12 +370,14 @@ impl FromStr for IdlType {
                                 array_from_str(&nested_inner[1..])
                             }
                             None => {
-                                let (raw_type, raw_length) = inner
-                                    .rsplit_once(';')
-                                    .ok_or_else(|| anyhow!(
-                                        "Invalid array syntax: expected '[type; length]', found '[{}]'",
-                                        inner
-                                    ))?;
+                                let (raw_type, raw_length) =
+                                    inner.rsplit_once(';').ok_or_else(|| {
+                                        anyhow!(
+                                            "Invalid array syntax: expected '[type; length]', \
+                                             found '[{}]'",
+                                            inner
+                                        )
+                                    })?;
 
                                 let raw_type = raw_type.trim();
                                 if raw_type.is_empty() {

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -113,26 +113,24 @@ pub fn account(
     let account_name_str = account_name.to_string();
     let (impl_gen, type_gen, where_clause) = account_strct.generics.split_for_impl();
 
+    fn is_zero_lit(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::Lit(syn::ExprLit { lit: syn::Lit::Int(val), .. })
+                if val.base10_parse::<u128>().is_ok_and(|v| v == 0)
+        )
+    }
+
     fn is_zeroed_discriminator(mut discr: &Expr) -> bool {
         // Peel references
         while let Expr::Reference(syn::ExprReference { expr, .. }) = discr {
             discr = expr;
         }
         match discr {
-            Expr::Lit(syn::ExprLit {
-                lit: syn::Lit::Int(val),
-                ..
-            }) => val.base10_parse::<u128>().is_ok_and(|v| v == 0),
-            Expr::Array(arr) => arr.elems.iter().all(|expr| {
-                let Expr::Lit(syn::ExprLit {
-                    lit: syn::Lit::Int(val),
-                    ..
-                }) = expr
-                else {
-                    return false;
-                };
-                val.base10_parse::<u128>().is_ok_and(|v| v == 0)
-            }),
+            Expr::Lit(_) => is_zero_lit(discr),
+            Expr::Array(arr) => arr.elems.iter().all(is_zero_lit),
+            // [0; N] — repeat expression
+            Expr::Repeat(rep) => is_zero_lit(&rep.expr),
             _ => false,
         }
     }

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -2,13 +2,14 @@ extern crate proc_macro;
 
 use {
     anchor_syn::{codegen::program::common::gen_discriminator, Overrides},
-    quote::{quote, ToTokens},
+    quote::{quote, quote_spanned, ToTokens},
     syn::{
         parenthesized,
         parse::{Parse, ParseStream},
         parse_macro_input,
+        spanned::Spanned,
         token::{Comma, Paren},
-        Ident, LitStr,
+        Expr, Ident, LitStr,
     },
 };
 
@@ -54,6 +55,8 @@ mod lazy;
 ///     - `discriminator = b"hi"`
 ///     - `discriminator = MY_DISC`
 ///     - `discriminator = get_disc(...)`
+///
+/// All-zeroed discriminators are not supported.
 ///
 /// # Zero Copy Deserialization
 ///
@@ -110,10 +113,43 @@ pub fn account(
     let account_name_str = account_name.to_string();
     let (impl_gen, type_gen, where_clause) = account_strct.generics.split_for_impl();
 
-    let discriminator = args
-        .overrides
-        .and_then(|ov| ov.discriminator)
-        .unwrap_or_else(|| {
+    fn is_zeroed_discriminator(mut discr: &Expr) -> bool {
+        // Peel references
+        while let Expr::Reference(syn::ExprReference { expr, .. }) = discr {
+            discr = expr;
+        }
+        match discr {
+            Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Int(val),
+                ..
+            }) => val.base10_parse::<u128>().is_ok_and(|v| v == 0),
+            Expr::Array(arr) => arr.elems.iter().all(|expr| {
+                let Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Int(val),
+                    ..
+                }) = expr
+                else {
+                    return false;
+                };
+                val.base10_parse::<u128>().is_ok_and(|v| v == 0)
+            }),
+            _ => false,
+        }
+    }
+
+    let discriminator = match args.overrides.and_then(|ov| ov.discriminator) {
+        Some(discrim) => {
+            let zero_err = is_zeroed_discriminator(&discrim).then(||
+                quote_spanned! {discrim.span() => compile_error!("all-zero discriminators are not supported");}
+            );
+            quote! {
+                {
+                    #zero_err
+                    #discrim
+                }
+            }
+        }
+        None => {
             // Namespace the discriminator to prevent collisions.
             let namespace = if namespace.is_empty() {
                 "account"
@@ -122,7 +158,9 @@ pub fn account(
             };
 
             gen_discriminator(namespace, account_name)
-        });
+        }
+    };
+
     let disc = if account_strct.generics.lt_token.is_some() {
         quote! { #account_name::#type_gen::DISCRIMINATOR }
     } else {

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -4,7 +4,7 @@ extern crate proc_macro;
 use anchor_syn::parser::accounts::event_cpi::{add_event_cpi_accounts, EventAuthority};
 use {
     anchor_syn::{codegen::program::common::gen_discriminator, Overrides},
-    quote::quote,
+    quote::{quote, ToTokens},
     syn::parse_macro_input,
 };
 
@@ -41,6 +41,7 @@ pub fn event(
 
     let discriminator = args
         .discriminator
+        .map(|d| d.to_token_stream())
         .unwrap_or_else(|| gen_discriminator("event", event_name));
 
     let ret = quote! {

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -1,7 +1,7 @@
 use {
     crate::{codegen::program::common::*, parser, Program},
     heck::CamelCase,
-    quote::{quote, quote_spanned},
+    quote::{quote, quote_spanned, ToTokens},
 };
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
@@ -34,13 +34,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let impls = {
                 let discriminator = match ix.overrides.as_ref() {
                     Some(overrides) if overrides.discriminator.is_some() => {
-                        #[allow(
-                            clippy::unwrap_used,
-                            reason = "discriminator is Some, guarded by the if-let \
-                                      Some(overrides) and discriminator.is_some() check"
-                        )]
-                        let d = overrides.discriminator.as_ref().unwrap().to_owned();
-                        d
+                        overrides.discriminator.to_token_stream()
                     }
                     _ => gen_discriminator(SIGHASH_GLOBAL_NAMESPACE, name),
                 };

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -20,11 +20,12 @@ use {
     syn::{
         ext::IdentExt,
         parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult},
+        parse_quote,
         punctuated::Punctuated,
         spanned::Spanned,
         token::Comma,
-        Attribute, Expr, Generics, Ident, ItemEnum, ItemFn, ItemMod, ItemStruct, Lit, LitInt,
-        PatType, Token, Type, TypePath,
+        Attribute, Expr, ExprLit, Generics, Ident, ItemEnum, ItemFn, ItemMod, ItemStruct, Lit,
+        LitInt, PatType, Token, Type, TypePath,
     },
 };
 
@@ -74,7 +75,8 @@ pub struct Ix {
 #[derive(Debug, Default)]
 pub struct Overrides {
     /// Override the default 8-byte discriminator
-    pub discriminator: Option<TokenStream>,
+    // `Box` is used to avoid large memory use in the common case as `Expr` is a large type
+    pub discriminator: Option<Box<Expr>>,
 }
 
 impl Parse for Overrides {
@@ -84,14 +86,21 @@ impl Parse for Overrides {
         for arg in args {
             match arg.name.to_string().as_str() {
                 "discriminator" => {
-                    let value = match &arg.value {
+                    let value = match arg.value {
                         // Allow `discriminator = 42`
-                        Expr::Lit(lit) if matches!(lit.lit, Lit::Int(_)) => quote! { &[#lit] },
+                        Expr::Lit(ExprLit {
+                            lit: lit @ Lit::Int(_),
+                            ..
+                        }) => {
+                            parse_quote!(&[#lit])
+                        }
                         // Allow `discriminator = [0, 1, 2, 3]`
-                        Expr::Array(arr) => quote! { &#arr },
-                        expr => expr.to_token_stream(),
+                        Expr::Array(arr) => {
+                            parse_quote!(&#arr)
+                        }
+                        expr => expr,
                     };
-                    attr.discriminator.replace(value)
+                    attr.discriminator.replace(Box::new(value))
                 }
                 name => {
                     return Err(ParseError::new(


### PR DESCRIPTION
The first commit documents the unsupported nature of all-zero discriminators in several places, introducing a new `footguns` docs section.

The second commit produces a compile error if all-zero discriminators are used (on a best-effort basis). This check does exist already at the IDL building phase, but this is a hardening/UX improvement by emitting a nicer error:
```rs
error: all-zero discriminators are not supported
 --> src/lib.rs:3:27
  |
3 | #[account(discriminator = 0)]
  |                           ^
```
@chen-robert 