### PR TITLE
Move to CI-based release process

### DIFF
--- a/.github/scripts/publish-npmjs.sh
+++ b/.github/scripts/publish-npmjs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+publish() {
+  local dir="$1"
+  pushd "$dir" >/dev/null
+
+  local name version
+  name="$(node -p "require('./package.json').name")"
+  version="$(node -p "require('./package.json').version")"
+
+  # We still build the package even if we don't publish it, as yarn workspace will
+  # use the local version of each package, and if it's unbuilt then any subsequent
+  # build will error out due to missing files.
+  yarn --frozen-lockfile
+  local dirname
+  dirname="$(basename "$dir")"
+  if [[ "$dirname" == spl-* ]]; then
+    yarn build:npm
+  else
+    yarn build
+  fi
+
+  if npm view "${name}@${version}" version >/dev/null 2>&1; then
+    echo "The package $dir is already up to date, skipping"
+    popd >/dev/null
+    return 0
+  fi
+
+  local publish_args=()
+  # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
+  if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+    publish_args+=(--tag next)
+  fi
+
+  if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    echo "Publishing $dir (${name}@${version}) as a dry-run"
+    npm publish "${publish_args[@]}" --dry-run
+  else
+    echo "Publishing $dir (${name}@${version})"
+    npm publish "${publish_args[@]}" --provenance --access public
+  fi
+
+  popd >/dev/null
+}
+
+base="ts/packages"
+
+publish "$base/borsh"
+publish "$base/anchor-errors"
+publish "$base/anchor"
+#publish "$base/spl-associated-token-account"
+#publish "$base/spl-binary-option"
+#publish "$base/spl-binary-oracle-pair"
+#publish "$base/spl-feature-proposal"
+#publish "$base/spl-governance"
+#publish "$base/spl-memo"
+#publish "$base/spl-name-service"
+#publish "$base/spl-record"
+#publish "$base/spl-stake-pool"
+#publish "$base/spl-stateless-asks"
+publish "$base/spl-token"
+#publish "$base/spl-token-lending"
+#publish "$base/spl-token-swap"

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -1,0 +1,86 @@
+name: Build CLI
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "If true, use 'dry-run' as the version string instead of the tag"
+        required: true
+        type: boolean
+      dist:
+        description: "Directory name for distribution artifacts (e.g. dist-v1.2.3 or dist-dry-run)"
+        required: true
+        type: string
+
+jobs:
+  build-cli:
+    name: Build binaries${{ inputs.dry_run && ' (dry-run)' || '' }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+
+          - target: x86_64-apple-darwin
+            os: macos-latest
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
+      - name: Build release binary
+        run: cargo build --package trixter-osec-anchor-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Prepare
+        id: prepare
+        shell: bash
+        run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            version="dry-run"
+          else
+            version=$(echo $GITHUB_REF_NAME | cut -dv -f2)
+          fi
+          ext=""
+          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
+
+          mkdir ${{ inputs.dist }}
+          mv "target/${{ matrix.target }}/release/anchor$ext" ${{ inputs.dist }}/anchor-$version-${{ matrix.target }}$ext
+
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: ${{ inputs.dist }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}
+          path: ${{ inputs.dist }}
+          overwrite: true
+          retention-days: 1

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -1,0 +1,122 @@
+name: Publish Crates
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "If true, build crates instead of publishing them (packaging validation only)"
+        required: true
+        type: boolean
+
+jobs:
+  publish-crates:
+    name: Publish crates${{ inputs.dry_run && ' (dry-run)' || '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Authenticate with crates.io
+        id: auth
+        if: ${{ !inputs.dry_run }}
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ !inputs.dry_run && steps.auth.outputs.token || '' }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
+            )"
+            version="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
+            )"
+
+            if cargo search "$name" --limit 1 | grep -q "$version"; then
+              echo "The crate $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Publishing $1 (${name}@${version}) as a dry-run"
+              # We cannot directly dry-run the publish process as all of the dependencies must be published
+              # to crates.io for the dry-run (even with --no-verify) to succeed. Therefore, we'll just see if
+              # packaging works.
+              cargo build --locked --release
+            else
+              echo "Publishing $1 (${name}@${version})"
+              cargo publish --locked
+
+              echo "Waiting for crates.io index to update"
+              sleep 25
+            fi
+
+            popd >/dev/null
+          }
+
+          publish idl/spec
+          publish idl
+          publish lang/syn
+          publish lang/derive/accounts
+          publish lang/derive/serde
+          publish lang/derive/space
+          publish lang/attribute/access-control
+          publish lang/attribute/account
+          publish lang/attribute/constant
+          publish lang/attribute/error
+          publish lang/attribute/program
+          publish lang/attribute/event
+          publish lang
+          publish spl
+          publish client
+          publish cli
+
+      - name: Check for crate artifacts
+        id: crate-artifacts
+        if: ${{ !inputs.dry_run }}
+        run: |
+          shopt -s nullglob
+          files=(target/package/*.crate)
+          if [ ${#files[@]} -gt 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            cd target/package
+            sha256sum *.crate > SHA256SUMS
+            echo "--- Crate checksums ---"
+            cat SHA256SUMS
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attest crate checksum manifest
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        if: ${{ !inputs.dry_run && steps.crate-artifacts.outputs.found == 'true' }}
+        with:
+          subject-path: target/package/SHA256SUMS
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !inputs.dry_run && steps.crate-artifacts.outputs.found == 'true' }}
+        with:
+          if-no-files-found: ignore
+          name: published-crates
+          path: |
+            target/package/*.crate
+            target/package/SHA256SUMS

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -9,14 +9,37 @@ on:
         type: boolean
 
 jobs:
+  publish-crates-dry-run:
+    name: Publish crates (dry-run)
+    if: ${{ inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Publish crates
+        run: |
+          set -xeuo pipefail
+
+          echo "Publishing all workspace packages as a dry-run"
+          cargo publish --workspace --locked --dry-run
+
   publish-crates:
-    name: Publish crates${{ inputs.dry_run && ' (dry-run)' || '' }}
+    name: Publish crates
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
       attestations: write
       artifact-metadata: write
+    environment:
+      name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -26,69 +49,16 @@ jobs:
 
       - name: Authenticate with crates.io
         id: auth
-        if: ${{ !inputs.dry_run }}
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
 
       - name: Publish crates
         env:
-          CARGO_REGISTRY_TOKEN: ${{ !inputs.dry_run && steps.auth.outputs.token || '' }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -xeuo pipefail
 
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
-
-            local name version
-            name="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
-            )"
-            version="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
-            )"
-
-            if cargo search "$name" --limit 1 | grep -q "$version"; then
-              echo "The crate $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            if [[ "$DRY_RUN" == "true" ]]; then
-              echo "Publishing $1 (${name}@${version}) as a dry-run"
-              # We cannot directly dry-run the publish process as all of the dependencies must be published
-              # to crates.io for the dry-run (even with --no-verify) to succeed. Therefore, we'll just see if
-              # packaging works.
-              cargo build --locked --release
-            else
-              echo "Publishing $1 (${name}@${version})"
-              cargo publish --locked
-
-              echo "Waiting for crates.io index to update"
-              sleep 25
-            fi
-
-            popd >/dev/null
-          }
-
-          publish idl/spec
-          publish idl
-          publish lang/syn
-          publish lang/derive/accounts
-          publish lang/derive/serde
-          publish lang/derive/space
-          publish lang/attribute/access-control
-          publish lang/attribute/account
-          publish lang/attribute/constant
-          publish lang/attribute/error
-          publish lang/attribute/program
-          publish lang/attribute/event
-          publish lang
-          publish spl
-          publish client
-          publish cli
+          echo "Publishing all workspace packages"
+          cargo publish --workspace --locked
 
       - name: Check for crate artifacts
         id: crate-artifacts

--- a/.github/workflows/publish-npmjs.yaml
+++ b/.github/workflows/publish-npmjs.yaml
@@ -1,0 +1,95 @@
+name: Publish npmjs
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "If true, use --dry-run instead of actually publishing"
+        required: true
+        type: boolean
+
+jobs:
+  publish-npmjs:
+    name: Publish npmjs packages${{ inputs.dry_run && ' (dry-run)' || '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - name: Publish npmjs packages
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(node -p "require('./package.json').name")"
+            version="$(node -p "require('./package.json').version")"
+
+            # We still build the package even if we don't publish it, as yarn workspace will
+            # use the local version of each package, and if it's unbuilt then any subsequent
+            # build will error out due to missing files.
+            yarn --frozen-lockfile
+            local dirname="$(basename $dir)"
+            if [[ "$dirname" == spl-* ]]; then
+              yarn build:npm
+            else
+              yarn build
+            fi
+
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "The package $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            local publish_args=()
+            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+              publish_args+=(--tag next)
+            fi
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Publishing $dir (${name}@${version}) as a dry-run"
+              npm publish "${publish_args[@]}" --dry-run
+            else
+              echo "Publishing $dir (${name}@${version})"
+              npm publish "${publish_args[@]}" --provenance --access public
+            fi
+
+            popd >/dev/null
+          }
+
+          base="ts/packages"
+
+          publish "$base/borsh"
+          publish "$base/anchor-errors"
+          publish "$base/anchor"
+          publish "$base/spl-associated-token-account"
+          publish "$base/spl-binary-option"
+          publish "$base/spl-binary-oracle-pair"
+          publish "$base/spl-feature-proposal"
+          publish "$base/spl-governance"
+          publish "$base/spl-memo"
+          publish "$base/spl-name-service"
+          publish "$base/spl-record"
+          publish "$base/spl-stake-pool"
+          publish "$base/spl-stateless-asks"
+          publish "$base/spl-token"
+          publish "$base/spl-token-lending"
+          publish "$base/spl-token-swap"

--- a/.github/workflows/publish-npmjs.yaml
+++ b/.github/workflows/publish-npmjs.yaml
@@ -9,11 +9,11 @@ on:
         type: boolean
 
 jobs:
-  publish-npmjs:
-    name: Publish npmjs packages${{ inputs.dry_run && ' (dry-run)' || '' }}
+  publish-npmjs-dry-run:
+    name: Publish npmjs packages (dry-run)
+    if: ${{ inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,67 +29,31 @@ jobs:
 
       - name: Publish npmjs packages
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -xeuo pipefail
+          DRY_RUN: "true"
+        run: bash .github/scripts/publish-npmjs.sh
 
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
+  publish-npmjs:
+    name: Publish npmjs packages
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-            local name version
-            name="$(node -p "require('./package.json').name")"
-            version="$(node -p "require('./package.json').version")"
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-            # We still build the package even if we don't publish it, as yarn workspace will
-            # use the local version of each package, and if it's unbuilt then any subsequent
-            # build will error out due to missing files.
-            yarn --frozen-lockfile
-            local dirname="$(basename $dir)"
-            if [[ "$dirname" == spl-* ]]; then
-              yarn build:npm
-            else
-              yarn build
-            fi
+      - name: Enable corepack (yarn)
+        run: corepack enable
 
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "The package $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            local publish_args=()
-            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
-            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
-              publish_args+=(--tag next)
-            fi
-
-            if [[ "$DRY_RUN" == "true" ]]; then
-              echo "Publishing $dir (${name}@${version}) as a dry-run"
-              npm publish "${publish_args[@]}" --dry-run
-            else
-              echo "Publishing $dir (${name}@${version})"
-              npm publish "${publish_args[@]}" --provenance --access public
-            fi
-
-            popd >/dev/null
-          }
-
-          base="ts/packages"
-
-          publish "$base/borsh"
-          publish "$base/anchor-errors"
-          publish "$base/anchor"
-          publish "$base/spl-associated-token-account"
-          publish "$base/spl-binary-option"
-          publish "$base/spl-binary-oracle-pair"
-          publish "$base/spl-feature-proposal"
-          publish "$base/spl-governance"
-          publish "$base/spl-memo"
-          publish "$base/spl-name-service"
-          publish "$base/spl-record"
-          publish "$base/spl-stake-pool"
-          publish "$base/spl-stateless-asks"
-          publish "$base/spl-token"
-          publish "$base/spl-token-lending"
-          publish "$base/spl-token-swap"
+      - name: Publish npmjs packages
+        env:
+          DRY_RUN: "false"
+        run: bash .github/scripts/publish-npmjs.sh

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,0 +1,226 @@
+name: Release Dry-run
+
+# To avoid finding out mid-tag that certain parts of the release do not build, we have `release.yaml` and
+# `release-pr.yaml` workflows. Both of these files should be kept up to date (with `release-pr.yaml` excluding
+# any publishing/attestation steps), especially if the build steps etc. are updated.
+
+on:
+  pull_request:
+    branches:
+      - master
+
+    paths:
+      - VERSION
+      - ./github/workflows/release-pr.yaml
+
+  workflow_dispatch:
+
+env:
+  DIST: dist-dry-run
+
+jobs:
+  publish-crates-dryrun:
+    name: Publish crates (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Publish crates (dry-run)
+        run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
+            )"
+            version="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
+            )"
+
+            if cargo search "$name" --limit 1 | grep -q "$version"; then
+              echo "The crate $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            echo "Publishing $1 (${name}@${version}) as a dry-run"
+            # We cannot directly dry-run the publish process as all of the dependencies must be published
+            # to crates.io for the dry-run (even with --no-verify) to succeed. Therefore, we'll just see if
+            # packaging works.
+            cargo build --locked --release
+
+            popd >/dev/null
+          }
+
+          publish idl/spec
+          publish idl
+          publish lang/syn
+          publish lang/derive/accounts
+          publish lang/derive/serde
+          publish lang/derive/space
+          publish lang/attribute/access-control
+          publish lang/attribute/account
+          publish lang/attribute/constant
+          publish lang/attribute/error
+          publish lang/attribute/program
+          publish lang/attribute/event
+          publish lang
+          publish spl
+          publish client
+          publish cli
+
+  publish-npmjs-dryrun:
+    name: Publish npmjs packages (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(node -p "require('./package.json').name")"
+            version="$(node -p "require('./package.json').version")"
+
+            # We still build the package even if we don't publish it, as yarn workspace will
+            # use the local version of each package, and if it's unbuilt then any subsequent
+            # build will error out due to missing files.
+            yarn --frozen-lockfile
+            local dirname="$(basename $dir)"
+            if [[ "$dirname" == spl-* ]]; then
+              yarn build:npm
+            else
+              yarn build
+            fi
+
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "The package $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            local publish_args=()
+            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+              publish_args+=(--tag next)
+            fi
+
+            echo "Publishing $dir (${name}@${version}) as a dry-run"
+            npm publish "${publish_args[@]}" --dry-run
+
+            popd >/dev/null
+          }
+
+          base="ts/packages"
+
+          publish "$base/borsh"
+          publish "$base/anchor-errors"
+          publish "$base/anchor"
+          publish "$base/spl-associated-token-account"
+          publish "$base/spl-binary-option"
+          publish "$base/spl-binary-oracle-pair"
+          publish "$base/spl-feature-proposal"
+          publish "$base/spl-governance"
+          publish "$base/spl-memo"
+          publish "$base/spl-name-service"
+          publish "$base/spl-record"
+          publish "$base/spl-stake-pool"
+          publish "$base/spl-stateless-asks"
+          publish "$base/spl-token"
+          publish "$base/spl-token-lending"
+          publish "$base/spl-token-swap"
+
+  # We skip checking if the Docker image builds for now as it depends on the version tag already existing,
+  # though as we already have the `build-cli-dryrun` step below there should be rarely any reason for the
+  # image build to ever fail anyway.
+
+  build-cli-dryrun:
+    name: Build binaries (dry-run)
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+
+          - target: x86_64-apple-darwin
+            os: macos-latest
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
+      - name: Build release binary
+        run: cargo build --package trixter-osec-anchor-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Prepare
+        id: prepare
+        shell: bash
+        run: |
+          version="dry-run"
+          ext=""
+          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
+
+          mkdir $DIST
+          mv "target/${{ matrix.target }}/release/anchor$ext" $DIST/anchor-$version-${{ matrix.target }}$ext
+
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      # As we upload the artifacts, we should generate the build attestation just in case
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: ${{ env.DIST }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}
+          path: ${{ env.DIST }}
+          overwrite: true
+          retention-days: 1

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,9 +1,5 @@
 name: Release Dry-run
 
-# To avoid finding out mid-tag that certain parts of the release do not build, we have `release.yaml` and
-# `release-pr.yaml` workflows. Both of these files should be kept up to date (with `release-pr.yaml` excluding
-# any publishing/attestation steps), especially if the build steps etc. are updated.
-
 on:
   pull_request:
     branches:
@@ -11,7 +7,10 @@ on:
 
     paths:
       - VERSION
-      - ./github/workflows/release-pr.yaml
+      - github/workflows/release-pr.yaml
+      - github/workflows/build-cli.yaml
+      - github/workflows/publish-crates.yaml
+      - github/workflows/publish-npmjs.yaml
 
   workflow_dispatch:
 
@@ -21,136 +20,15 @@ env:
 jobs:
   publish-crates-dryrun:
     name: Publish crates (dry-run)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-
-      - name: Publish crates (dry-run)
-        run: |
-          set -xeuo pipefail
-
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
-
-            local name version
-            name="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
-            )"
-            version="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
-            )"
-
-            if cargo search "$name" --limit 1 | grep -q "$version"; then
-              echo "The crate $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            echo "Publishing $1 (${name}@${version}) as a dry-run"
-            # We cannot directly dry-run the publish process as all of the dependencies must be published
-            # to crates.io for the dry-run (even with --no-verify) to succeed. Therefore, we'll just see if
-            # packaging works.
-            cargo build --locked --release
-
-            popd >/dev/null
-          }
-
-          publish idl/spec
-          publish idl
-          publish lang/syn
-          publish lang/derive/accounts
-          publish lang/derive/serde
-          publish lang/derive/space
-          publish lang/attribute/access-control
-          publish lang/attribute/account
-          publish lang/attribute/constant
-          publish lang/attribute/error
-          publish lang/attribute/program
-          publish lang/attribute/event
-          publish lang
-          publish spl
-          publish client
-          publish cli
+    uses: ./.github/workflows/publish-crates.yaml
+    with:
+      dry_run: true
 
   publish-npmjs-dryrun:
     name: Publish npmjs packages (dry-run)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Enable corepack (yarn)
-        run: corepack enable
-
-      - run: |
-          set -xeuo pipefail
-
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
-
-            local name version
-            name="$(node -p "require('./package.json').name")"
-            version="$(node -p "require('./package.json').version")"
-
-            # We still build the package even if we don't publish it, as yarn workspace will
-            # use the local version of each package, and if it's unbuilt then any subsequent
-            # build will error out due to missing files.
-            yarn --frozen-lockfile
-            local dirname="$(basename $dir)"
-            if [[ "$dirname" == spl-* ]]; then
-              yarn build:npm
-            else
-              yarn build
-            fi
-
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "The package $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            local publish_args=()
-            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
-            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
-              publish_args+=(--tag next)
-            fi
-
-            echo "Publishing $dir (${name}@${version}) as a dry-run"
-            npm publish "${publish_args[@]}" --dry-run
-
-            popd >/dev/null
-          }
-
-          base="ts/packages"
-
-          publish "$base/borsh"
-          publish "$base/anchor-errors"
-          publish "$base/anchor"
-          publish "$base/spl-associated-token-account"
-          publish "$base/spl-binary-option"
-          publish "$base/spl-binary-oracle-pair"
-          publish "$base/spl-feature-proposal"
-          publish "$base/spl-governance"
-          publish "$base/spl-memo"
-          publish "$base/spl-name-service"
-          publish "$base/spl-record"
-          publish "$base/spl-stake-pool"
-          publish "$base/spl-stateless-asks"
-          publish "$base/spl-token"
-          publish "$base/spl-token-lending"
-          publish "$base/spl-token-swap"
+    uses: ./.github/workflows/publish-npmjs.yaml
+    with:
+      dry_run: true
 
   # We skip checking if the Docker image builds for now as it depends on the version tag already existing,
   # though as we already have the `build-cli-dryrun` step below there should be rarely any reason for the
@@ -158,69 +36,7 @@ jobs:
 
   build-cli-dryrun:
     name: Build binaries (dry-run)
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-
-    strategy:
-      matrix:
-        target:
-          - aarch64-apple-darwin
-          - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-
-          - target: x86_64-apple-darwin
-            os: macos-latest
-
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
-
-      - name: Build release binary
-        run: cargo build --package trixter-osec-anchor-cli --release --locked --target ${{ matrix.target }}
-
-      - name: Prepare
-        id: prepare
-        shell: bash
-        run: |
-          version="dry-run"
-          ext=""
-          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
-
-          mkdir $DIST
-          mv "target/${{ matrix.target }}/release/anchor$ext" $DIST/anchor-$version-${{ matrix.target }}$ext
-
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      # As we upload the artifacts, we should generate the build attestation just in case
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
-        with:
-          subject-path: ${{ env.DIST }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}
-          path: ${{ env.DIST }}
-          overwrite: true
-          retention-days: 1
+    uses: ./.github/workflows/build-cli.yaml
+    with:
+      dry_run: true
+      dist: dist-dry-run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,363 @@
 name: Release
 
+# To avoid finding out mid-tag that certain parts of the release do not build, we have `release.yaml` and
+# `release-pr.yaml` workflows. Both of these files should be kept up to date (with `release-pr.yaml` excluding
+# any publishing/attestation steps), especially if the build steps etc. are updated.
+
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
-  pull_request:
-    branches:
-      - master
-    paths:
-      - VERSION
-      - ./github/workflows/release.yaml
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 env:
   DIST: dist-${{ github.ref_name }}
 
 jobs:
-  build:
-    name: Build
+  verify-tag:
+    name: Verify tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: release
+    # inspired by Caddy's release process: https://github.com/caddyserver/caddy/blob/987375297862d9cd0a3fa33cfb199c25e504ad1b/.github/workflows/release.yml#L29C1-L143C54
+    outputs:
+      verification_passed: ${{ steps.verify.outputs.passed }}
+      tag_version: ${{ steps.info.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Force fetch upstream tags
+        run: git fetch --tags --force
+
+      - name: Get tag info
+        id: info
+        run: |
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version_tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Validate commits and tag signatures
+        id: verify
+        env:
+          RELEASE_MANAGERS: ${{ vars.RELEASE_MANAGERS }}
+        run: |
+          if [ -z "${RELEASE_MANAGERS}" ]; then
+            echo "RELEASE_MANAGERS variable is not set"
+            echo "passed=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          IFS=',' read -ra rms <<< "${RELEASE_MANAGERS}"
+          for u in "${rms[@]}"; do
+            curl -fsSL "https://github.com/${u}.gpg" | gpg --batch --import >/dev/null
+          done
+
+          echo "Verifying the tag: ${{ steps.info.outputs.version_tag }}"
+          if ! git verify-tag -v "${{ steps.info.outputs.version_tag }}" 2>&1; then
+            echo "❌ Tag verification failed!"
+            echo "passed=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          # Run it again to capture the output
+          git verify-tag -v "${{ steps.info.outputs.version_tag }}" 2>&1 | tee /tmp/verify-output.txt;
+
+          # SSH verification output typically includes the key fingerprint
+          # Use GNU grep with Perl regex for cleaner extraction (Linux environment)
+          KEY_SHA256=$(grep -oP "SHA256:[\"']?\K[A-Za-z0-9+/=]+(?=[\"']?)" /tmp/verify-output.txt | head -1 || echo "")
+
+          if [ -z "$KEY_SHA256" ]; then
+            # Try alternative pattern with "key" prefix
+            KEY_SHA256=$(grep -oP "key SHA256:[\"']?\K[A-Za-z0-9+/=]+(?=[\"']?)" /tmp/verify-output.txt | head -1 || echo "")
+          fi
+
+          if [ -z "$KEY_SHA256" ]; then
+            # Fallback: extract any base64-like string (40+ chars)
+            KEY_SHA256=$(grep -oP '[A-Za-z0-9+/]{40,}=?' /tmp/verify-output.txt | head -1 || echo "")
+          fi
+
+          if [ -z "$KEY_SHA256" ]; then
+            echo "Somehow could not extract SSH key fingerprint from git verify-tag output"
+            echo "passed=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          echo "✅ Tag verification succeeded!"
+          echo "passed=true" >> $GITHUB_OUTPUT
+          echo "key_id=$KEY_SHA256" >> $GITHUB_OUTPUT
+
+      - name: Summary
+        run: |
+          echo "## Tag Verification Summary 🔐" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** ${{ steps.info.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${{ steps.info.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Signature:** ✅ Verified" >> $GITHUB_STEP_SUMMARY
+          echo "- **Signed by:** ${{ steps.verify.outputs.key_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Proceeding with release build..." >> $GITHUB_STEP_SUMMARY
+
+  publish-crates:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    needs: verify-tag
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
+            )"
+            version="$(
+              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
+                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
+            )"
+
+            if cargo search "$name" --limit 1 | grep -q "$version"; then
+              echo "The crate $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            echo "Publishing $1 (${name}@${version})"
+            cargo publish --locked
+
+            echo "Waiting for crates.io index to update"
+            sleep 25
+
+            popd >/dev/null
+          }
+
+          publish idl/spec
+          publish idl
+          publish lang/syn
+          publish lang/derive/accounts
+          publish lang/derive/serde
+          publish lang/derive/space
+          publish lang/attribute/access-control
+          publish lang/attribute/account
+          publish lang/attribute/constant
+          publish lang/attribute/error
+          publish lang/attribute/program
+          publish lang/attribute/event
+          publish lang
+          publish spl
+          publish client
+          publish cli
+
+      - name: Check for crate artifacts
+        id: crate-artifacts
+        run: |
+          shopt -s nullglob
+          files=(target/package/*.crate)
+          if [ ${#files[@]} -gt 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            cd target/package
+            sha256sum *.crate > SHA256SUMS
+            echo "--- Crate checksums ---"
+            cat SHA256SUMS
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attest crate checksum manifest
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        if: steps.crate-artifacts.outputs.found == 'true'
+        with:
+          subject-path: target/package/SHA256SUMS
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: steps.crate-artifacts.outputs.found == 'true'
+        with:
+          if-no-files-found: ignore
+          name: published-crates
+          path: |
+            target/package/*.crate
+            target/package/SHA256SUMS
+
+  publish-npmjs:
+    name: Publish npmjs packages
+    runs-on: ubuntu-latest
+    needs: verify-tag
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - run: |
+          set -xeuo pipefail
+
+          publish() {
+            local dir="$1"
+            pushd "$dir" >/dev/null
+
+            local name version
+            name="$(node -p "require('./package.json').name")"
+            version="$(node -p "require('./package.json').version")"
+
+            # We still build the package even if we don't publish it, as yarn workspace will
+            # use the local version of each package, and if it's unbuilt then any subsequent
+            # build will error out due to missing files.
+            yarn --frozen-lockfile
+            local dirname="$(basename $dir)"
+            if [[ "$dirname" == spl-* ]]; then
+              yarn build:npm
+            else
+              yarn build
+            fi
+
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "The package $1 is already up to date, skipping"
+              popd >/dev/null
+              return 0
+            fi
+
+            local publish_args=()
+            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+              publish_args+=(--tag next)
+            fi
+
+            echo "Publishing $dir (${name}@${version})"
+            npm publish "${publish_args[@]}" --provenance --access public
+
+            popd >/dev/null
+          }
+
+          base="ts/packages"
+
+          publish "$base/borsh"
+          publish "$base/anchor-errors"
+          publish "$base/anchor"
+          publish "$base/spl-associated-token-account"
+          publish "$base/spl-binary-option"
+          publish "$base/spl-binary-oracle-pair"
+          publish "$base/spl-feature-proposal"
+          publish "$base/spl-governance"
+          publish "$base/spl-memo"
+          publish "$base/spl-name-service"
+          publish "$base/spl-record"
+          publish "$base/spl-stake-pool"
+          publish "$base/spl-stateless-asks"
+          publish "$base/spl-token"
+          publish "$base/spl-token-lending"
+          publish "$base/spl-token-swap"
+
+  publish-dockerhub:
+    name: Publish Docker image to Dockerhub
+    runs-on: ubuntu-latest
+    needs: verify-tag
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    environment:
+      name: release
+    env:
+      IMAGE_NAME: solanafoundation/anchor
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: docker/build
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SOLANA_CLI=v2.3.0
+            ANCHOR_CLI=${{ github.ref_name }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        id: attest
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false # provenance: mode=max above already pushes it to Dockerhub
+
+  build-cli:
+    name: Build binaries
+    needs: verify-tag
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     strategy:
       matrix:
         target:
@@ -40,9 +379,9 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -52,10 +391,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
       - name: Build release binary
-        run: cargo build --package anchor-cli --release --locked --target ${{ matrix.target }}
+        run: cargo build --package trixter-osec-anchor-cli --release --locked --target ${{ matrix.target }}
 
       - name: Prepare
-        if: startsWith(github.ref, 'refs/tags/')
         id: prepare
         shell: bash
         run: |
@@ -68,26 +406,73 @@ jobs:
 
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: ${{ env.DIST }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}
           path: ${{ env.DIST }}
           overwrite: true
           retention-days: 1
 
-  upload:
+  upload-cli:
     name: Upload binaries to release
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [build]
     runs-on: ubuntu-latest
+    needs: [verify-tag, build-cli]
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: ${{ env.DIST }}
 
       - name: Upload
         shell: bash
-        run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release upload $GITHUB_REF_NAME $DIST/*/* --clobber
+        run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* --title "$GITHUB_REF_NAME"
+
+  publish-cli:
+    name: Publish CLI onto npmjs
+    runs-on: ubuntu-latest
+    needs: [verify-tag, build-cli]
+    if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: ${{ env.DIST }}
+
+      - run: |
+          set -xeuo pipefail
+
+          cp $DIST/anchor-*-x86_64-unknown-linux-gnu/anchor-*-x86_64-unknown-linux-gnu cli/npm-package/anchor
+          cd cli/npm-package/
+          chmod +x anchor
+
+          version="$(node -p "require('./package.json').version")"
+          publish_args=()
+          # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            publish_args+=(--tag next)
+          fi
+
+          echo "Publishing CLI"
+          npm publish "${publish_args[@]}" --provenance --access public

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,8 +108,6 @@ jobs:
     uses: ./.github/workflows/publish-crates.yaml
     with:
       dry_run: false
-    environment:
-      name: release
     secrets: inherit
 
   publish-npmjs:
@@ -119,8 +117,6 @@ jobs:
     uses: ./.github/workflows/publish-npmjs.yaml
     with:
       dry_run: false
-    environment:
-      name: release
     secrets: inherit
 
   publish-dockerhub:
@@ -199,6 +195,7 @@ jobs:
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
+          pattern: anchor-*
           path: ${{ env.DIST }}
 
       - name: Upload
@@ -229,6 +226,7 @@ jobs:
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
+          pattern: anchor-*
           path: ${{ env.DIST }}
 
       - run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,5 @@
 name: Release
 
-# To avoid finding out mid-tag that certain parts of the release do not build, we have `release.yaml` and
-# `release-pr.yaml` workflows. Both of these files should be kept up to date (with `release-pr.yaml` excluding
-# any publishing/attestation steps), especially if the build steps etc. are updated.
-
 on:
   push:
     tags:
@@ -107,189 +103,25 @@ jobs:
 
   publish-crates:
     name: Publish crates
-    runs-on: ubuntu-latest
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-      artifact-metadata: write
+    uses: ./.github/workflows/publish-crates.yaml
+    with:
+      dry_run: false
     environment:
       name: release
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-
-      - name: Authenticate with crates.io
-        id: auth
-        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
-
-      - name: Publish crates
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: |
-          set -xeuo pipefail
-
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
-
-            local name version
-            name="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .name'
-            )"
-            version="$(
-              cargo metadata --no-deps --format-version 1 --manifest-path Cargo.toml \
-                | jq -r --arg mp "$PWD/Cargo.toml" '.packages[] | select(.manifest_path == $mp) | .version'
-            )"
-
-            if cargo search "$name" --limit 1 | grep -q "$version"; then
-              echo "The crate $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            echo "Publishing $1 (${name}@${version})"
-            cargo publish --locked
-
-            echo "Waiting for crates.io index to update"
-            sleep 25
-
-            popd >/dev/null
-          }
-
-          publish idl/spec
-          publish idl
-          publish lang/syn
-          publish lang/derive/accounts
-          publish lang/derive/serde
-          publish lang/derive/space
-          publish lang/attribute/access-control
-          publish lang/attribute/account
-          publish lang/attribute/constant
-          publish lang/attribute/error
-          publish lang/attribute/program
-          publish lang/attribute/event
-          publish lang
-          publish spl
-          publish client
-          publish cli
-
-      - name: Check for crate artifacts
-        id: crate-artifacts
-        run: |
-          shopt -s nullglob
-          files=(target/package/*.crate)
-          if [ ${#files[@]} -gt 0 ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            cd target/package
-            sha256sum *.crate > SHA256SUMS
-            echo "--- Crate checksums ---"
-            cat SHA256SUMS
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Attest crate checksum manifest
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
-        if: steps.crate-artifacts.outputs.found == 'true'
-        with:
-          subject-path: target/package/SHA256SUMS
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: steps.crate-artifacts.outputs.found == 'true'
-        with:
-          if-no-files-found: ignore
-          name: published-crates
-          path: |
-            target/package/*.crate
-            target/package/SHA256SUMS
+    secrets: inherit
 
   publish-npmjs:
     name: Publish npmjs packages
-    runs-on: ubuntu-latest
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
-    permissions:
-      id-token: write
-      contents: read
+    uses: ./.github/workflows/publish-npmjs.yaml
+    with:
+      dry_run: false
     environment:
       name: release
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
-
-      - name: Enable corepack (yarn)
-        run: corepack enable
-
-      - run: |
-          set -xeuo pipefail
-
-          publish() {
-            local dir="$1"
-            pushd "$dir" >/dev/null
-
-            local name version
-            name="$(node -p "require('./package.json').name")"
-            version="$(node -p "require('./package.json').version")"
-
-            # We still build the package even if we don't publish it, as yarn workspace will
-            # use the local version of each package, and if it's unbuilt then any subsequent
-            # build will error out due to missing files.
-            yarn --frozen-lockfile
-            local dirname="$(basename $dir)"
-            if [[ "$dirname" == spl-* ]]; then
-              yarn build:npm
-            else
-              yarn build
-            fi
-
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "The package $1 is already up to date, skipping"
-              popd >/dev/null
-              return 0
-            fi
-
-            local publish_args=()
-            # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
-            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
-              publish_args+=(--tag next)
-            fi
-
-            echo "Publishing $dir (${name}@${version})"
-            npm publish "${publish_args[@]}" --provenance --access public
-
-            popd >/dev/null
-          }
-
-          base="ts/packages"
-
-          publish "$base/borsh"
-          publish "$base/anchor-errors"
-          publish "$base/anchor"
-          publish "$base/spl-associated-token-account"
-          publish "$base/spl-binary-option"
-          publish "$base/spl-binary-oracle-pair"
-          publish "$base/spl-feature-proposal"
-          publish "$base/spl-governance"
-          publish "$base/spl-memo"
-          publish "$base/spl-name-service"
-          publish "$base/spl-record"
-          publish "$base/spl-stake-pool"
-          publish "$base/spl-stateless-asks"
-          publish "$base/spl-token"
-          publish "$base/spl-token-lending"
-          publish "$base/spl-token-swap"
+    secrets: inherit
 
   publish-dockerhub:
     name: Publish Docker image to Dockerhub
@@ -352,71 +184,10 @@ jobs:
     name: Build binaries
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-
-    strategy:
-      matrix:
-        target:
-          - aarch64-apple-darwin
-          - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-
-          - target: x86_64-apple-darwin
-            os: macos-latest
-
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
-
-      - name: Build release binary
-        run: cargo build --package trixter-osec-anchor-cli --release --locked --target ${{ matrix.target }}
-
-      - name: Prepare
-        id: prepare
-        shell: bash
-        run: |
-          version=$(echo $GITHUB_REF_NAME | cut -dv -f2)
-          ext=""
-          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
-
-          mkdir $DIST
-          mv "target/${{ matrix.target }}/release/anchor$ext" $DIST/anchor-$version-${{ matrix.target }}$ext
-
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
-        with:
-          subject-path: ${{ env.DIST }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}
-          path: ${{ env.DIST }}
-          overwrite: true
-          retention-days: 1
+    uses: ./.github/workflows/build-cli.yaml
+    with:
+      dry_run: false
+      dist: dist-${{ github.ref_name }}
 
   upload-cli:
     name: Upload binaries to release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ members = [
 exclude = ["tests/cfo/deps/openbook-dex", "tests/swap/deps/openbook-dex"]
 resolver = "2"
 
+[workspace.package]
+version = "0.32.1"
+
 [workspace.dependencies]
 solana-account = "3.0.0"
 solana-account-decoder = "3.0.0"

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "avm"
-version = "0.32.1"
+version.workspace = true
+publish = false
 edition = "2021"
 
 [[bin]]

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -10,6 +10,11 @@ fi
 old_version=$(cat VERSION)
 version=$1
 
+if [[ "$version" == v* ]]; then
+    echo "The version number must not contain the v[...] prefix"
+    exit 1
+fi
+
 echo "Bumping versions to $version"
 
 # GNU/BSD compat
@@ -24,6 +29,9 @@ allow_globs=":**/Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program
 git grep -l $old_version -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$old_version/$version/g"
+
+# Regenerate lock file so that the release process running in CI matches the expected versions
+cargo generate-lockfile
 
 # Separately handle docs because blindly replacing the old version with the new
 # might break certain examples/links

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -25,7 +25,7 @@ case "$(uname)" in
 esac
 
 # Only replace version with the following globs
-allow_globs=":**/Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
+allow_globs="Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
 git grep -l $old_version -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$old_version/$version/g"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -30,8 +30,8 @@ git grep -l $old_version -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$old_version/$version/g"
 
-# Regenerate lock file so that the release process running in CI matches the expected versions
-cargo generate-lockfile
+# Update lock file to use the new versions
+cargo update $(cargo metadata --format-version 1 --no-deps | jq '.packages.[].name' -r)
 
 # Separately handle docs because blindly replacing the old version with the new
 # might break certain examples/links

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-cli"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 edition = "2021"
 repository = "https://github.com/coral-xyz/anchor"

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -102,8 +102,11 @@ pub fn check_deps(cfg: &WithPath<Config>) -> Result<()> {
             // Assume incompatible if parsing fails
             return false;
         };
-        let workspace_toml =
-            cargo_toml::Manifest::from_str(include_str!("../../Cargo.toml")).unwrap();
+        let workspace_toml = cargo_toml::Manifest::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/Cargo.toml"
+        )))
+        .unwrap();
         let version = workspace_toml
             .workspace
             .as_ref()

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-client"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-lang-idl"
 version = "0.1.2"
+publish = false
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 edition = "2021"

--- a/idl/spec/Cargo.toml
+++ b/idl/spec/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-lang-idl-spec"
 version = "0.1.0"
+publish = false
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 edition = "2021"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-lang"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 edition = "2021"

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-access-control"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-account"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-constant"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-error"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-event"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-attribute-program"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-derive-accounts"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-derive-serde"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-derive-space"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-syn"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/coral-xyz/anchor"
 license = "Apache-2.0"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anchor-spl"
-version = "0.32.1"
+version.workspace = true
+publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/ts/packages/anchor-errors/package.json
+++ b/ts/packages/anchor-errors/package.json
@@ -8,6 +8,10 @@
     ".": "./dist/index.js"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/solana-foundation/anchor.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "publishConfig": {
     "access": "public"

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -8,6 +8,10 @@
     ".": "./dist/index.js"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/solana-foundation/anchor.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/ts/packages/spl-associated-token-account/package.json
+++ b/ts/packages/spl-associated-token-account/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-binary-option/package.json
+++ b/ts/packages/spl-binary-option/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-binary-oracle-pair/package.json
+++ b/ts/packages/spl-binary-oracle-pair/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-feature-proposal/package.json
+++ b/ts/packages/spl-feature-proposal/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-governance/package.json
+++ b/ts/packages/spl-governance/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-memo/package.json
+++ b/ts/packages/spl-memo/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-name-service/package.json
+++ b/ts/packages/spl-name-service/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-record/package.json
+++ b/ts/packages/spl-record/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-stake-pool/package.json
+++ b/ts/packages/spl-stake-pool/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-stateless-asks/package.json
+++ b/ts/packages/spl-stateless-asks/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token-lending/package.json
+++ b/ts/packages/spl-token-lending/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token-swap/package.json
+++ b/ts/packages/spl-token-swap/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token/package.json
+++ b/ts/packages/spl-token/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coral-xyz/anchor.git"
+    "url": "https://github.com/solana-foundation/anchor.git"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Updates the existing release process to the proposed release process that is done fully in CI. In practice, the release process now consists of the following steps:
- Creating a branch with bumped versions using the existing `bump-version.sh` script
- Creating a pull request to `master` with those changes. This triggers dry-run of release process (or as close to it as we can be) to confirm that everything builds and is publishable
- The PR is merged, and a signed tag for that commit is created with release manager's GPG key to trigger the CI release process
- CI builds all npmjs and crates.io packages. It also builds the Docker image, the CLI binaries, releases the npmjs package with the CLI binaries, and creates a GitHub release with the binaries as well. Build attestation is used everywhere where possible

My understanding is that the typedocs are handled automatically by Vercel on merge to `master`, so it has been untouched in this PR, though let me know if this is not the case.

This has been tested against monkey-patched version pointing at my own packages for testing this with a subset of the packages, and hopefully the PR-specific release dry-run will catch any issues in advance as well. The verify-tag job has been verified with 1) non-signed tag (doesn't pass), 2) signed tag not belonging to any specific account (doesn't pass), 3) signed tag belonging to a release manager's account (passes).

The diff also contains `repository.url` in `package.json` being renamed, which is needed for npmjs build attestation to pass as it verifies that the repository URL matches the CI's repository.

### Manual changes required before merging this PR
- [ ] Create a new environment named `release`
  - [x] Setup variable `DOCKERHUB_USERNAME` and secret `DOCKERHUB_TOKEN` for `solanafoundation/anchor` (unfortunately, Dockerhub does not allow OIDC)
  - [x] Setup `RELEASE_MANAGERS` variable, which is comma separated list of GitHub usernames that are allowed to push releases. This is used to pull their GitHub GPG key and verify that the tag is signed with their key before proceeding with the release process.
- [x] Create a GitHub team in the organization, e.g. `anchor-release-managers` with all of the release managers in it
- [ ] In the repository settings, create the following rulesets:
  - [ ] New tag ruleset: `Only release managers can create tags`, with `Restrict creations` for all tags. The `anchor-release-managers` team should be added to the bypass list.
  - [x] New tag ruleset: `Restrict tag management`, with `Restrict updates`, `Restrict deletions`, `Block force pushes` for all tags.
- [x] Each release manager should have a GPG key configured in their GitHub account, preferably stored on e.g. Yubikey.
- [x] For the following npmjs packages, add a trusted publisher with this repository, workflow name of `release.yaml`, and environment name of `release`:
  - [x] `@anchor-lang/borsh`
  - [x] `@anchor-lang/spl-token`
  - [x] `@anchor-lang/core`
  - [x] `@anchor-lang/errors`
  - [x] `@anchor-lang/spl-associated-token` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-binary-option` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-binary-oracle-pair` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-feature-proposal` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-governance` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-memo` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-name-service` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-record` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-stake-pool` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-stateless-asks` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-token-lending` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
  - [x] `@anchor-lang/spl-token-swap` (this is not published though, if the plan is to keep publishing it an empty repository could be published to claim the name and setup trusted publishing)
- [x] For the following crates.io crates, add a trusted publisher with this repository, workflow name of `release.yaml`, and environment name of `release`:
  - [x] `anchor-syn`
  - [x] `anchor-spl`
  - [x] `anchor-lang`
  - [x] `anchor-derive-space`
  - [x] `anchor-derive-serde`
  - [x] `anchor-derive-accounts`
  - [x] `anchor-client`
  - [x] `anchor-cli`
  - [x] `anchor-attribute-state`
  - [x] `anchor-attribute-program`
  - [x] `anchor-attribute-event`
  - [x] `anchor-attribute-error`
  - [x] `anchor-attribute-constant`
  - [x] `anchor-attribute-account`
  - [x] `anchor-attribute-access-control`

Eventually, we would also want to restrict `Publishing access` in npmjs to `Require two-factor authentication and disallow tokens (recommended)` and `Require trusted publishing for all new versions` in crates.io, though for now this is not strictly necessary as we want to confirm the release process works before that.