### PR TITLE
fix: write anchor expand output to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- cli: Write `anchor expand` output to stdout instead of a file ([#4269](https://github.com/solana-foundation/anchor/pull/4269)).
+
 ### Fixes
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,6 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "cargo_toml",
- "chrono",
  "clap 4.6.0",
  "clap_complete",
  "console 0.15.11",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,6 @@ anyhow = "1.0.32"
 base64 = "0.21"
 bincode = "1.3.3"
 cargo_toml = "0.19.2"
-chrono = "0.4.19"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 console = "0.15"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1721,9 +1721,6 @@ fn expand_program(
         .as_ref()
         .ok_or_else(|| anyhow!("Cargo config is missing a package"))?
         .name;
-    let program_expansions_path = expansions_path.join(package_name);
-    fs::create_dir_all(&program_expansions_path)?;
-
     let exit = std::process::Command::new("cargo")
         .arg("expand")
         .arg(target_dir_arg)
@@ -1737,16 +1734,11 @@ fn expand_program(
         std::process::exit(exit.status.code().unwrap_or(1));
     }
 
-    let version = cargo.version();
-    let time = chrono::Utc::now().to_string().replace(' ', "_");
-    let file_path = program_expansions_path.join(format!("{package_name}-{version}-{time}.rs"));
-    fs::write(&file_path, &exit.stdout).map_err(|e| anyhow::format_err!("{}", e))?;
-
-    println!(
-        "Expanded {} into file {}\n",
-        package_name,
-        file_path.to_string_lossy()
-    );
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    handle
+        .write_all(&exit.stdout)
+        .map_err(|e| anyhow::format_err!("{}", e))?;
     Ok(())
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1721,24 +1721,19 @@ fn expand_program(
         .as_ref()
         .ok_or_else(|| anyhow!("Cargo config is missing a package"))?
         .name;
-    let exit = std::process::Command::new("cargo")
+    let status = std::process::Command::new("cargo")
         .arg("expand")
         .arg(target_dir_arg)
         .arg(format!("--package={package_name}"))
         .args(cargo_args)
-        .stderr(Stdio::inherit())
-        .output()
+        .stdout(Stdio::inherit())
+        .status()
         .map_err(|e| anyhow::format_err!("{}", e))?;
-    if !exit.status.success() {
+    if !status.success() {
         eprintln!("'anchor expand' failed. Perhaps you have not installed 'cargo-expand'? https://github.com/dtolnay/cargo-expand#installation");
-        std::process::exit(exit.status.code().unwrap_or(1));
+        std::process::exit(status.code().unwrap_or(1));
     }
 
-    let stdout = std::io::stdout();
-    let mut handle = stdout.lock();
-    handle
-        .write_all(&exit.stdout)
-        .map_err(|e| anyhow::format_err!("{}", e))?;
     Ok(())
 }
 


### PR DESCRIPTION
\`anchor expand\` saves the macro-expanded source to a timestamped file
under \`.anchor/expanded-macros/\` and prints the path, which makes it
impossible to pipe the output into other tools.

This patch writes the expanded source directly to stdout so callers can
redirect it (\`> file.rs\`) or pipe it through formatters and pagers like
any other CLI tool.

The now-unused \`chrono\` dependency is also removed.

Closes #4267