### PR TITLE
idl: Remove the conflicting account names check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Remove the `interface-instructions` feature and the `#[interface]` attribute ([#4156](https://github.com/solana-foundation/anchor/pull/4156)).
 - cli: Remove the `login` command ([#4182](https://github.com/solana-foundation/anchor/pull/4182)).
 - idl: Exclude external accounts ([#4197](https://github.com/solana-foundation/anchor/pull/4197)).
+- idl: Remove the conflicting account names check ([#4294](https://github.com/solana-foundation/anchor/pull/4294)).
 
 ## [0.32.1] - 2025-10-09
 

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -339,19 +339,6 @@ fn sort(mut idl: Idl) -> Idl {
 
 /// Verify IDL is valid.
 fn verify(idl: &Idl) -> Result<()> {
-    // Check full path accounts
-    if let Some(account) = idl
-        .accounts
-        .iter()
-        .find(|account| account.name.contains("::"))
-    {
-        return Err(anyhow!(
-            "Conflicting accounts names are not allowed.\nProgram: `{}`\nAccount: `{}`",
-            idl.metadata.name,
-            account.name
-        ));
-    }
-
     // Check empty discriminators
     macro_rules! check_empty_discriminators {
         ($field:ident) => {


### PR DESCRIPTION
### Problem

The conflicting account name check was added because:

- Account discriminators were fully dependent on account names
- Supporting full path types required significant effort, but the demand wasn't there

The former is no longer valid after the custom discriminator support (https://github.com/solana-foundation/anchor/issues/3097), and the latter can be implemented without breaking changes later.

### Summary of changes

Allow full path account names (e.g. `program::module::Account`) while generating the IDL by removing the conflicting account names check.