### PR TITLE
idl: Make `serde_json` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Fix constant nested string generation in `declare_program!` ([#4158](https://github.com/solana-foundation/anchor/pull/4158)).
 - idl: Fix `local_file` method not found for `proc_macro2::Span` error ([#4187](https://github.com/solana-foundation/anchor/pull/4187)).
 - lang: Relax duplicate mutable account constraint to only check types that serialize on exit (`Account`, `LazyAccount`, `InterfaceAccount`, `Migration`) ([#4202](https://github.com/solana-foundation/anchor/pull/4202)).
+- idl: Make `serde_json` optional ([#4296](https://github.com/solana-foundation/anchor/pull/4296)).
 
 ### Breaking
 

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -12,18 +12,18 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-build = ["regex"]
-convert = ["heck", "sha2"]
+build = ["regex", "serde_json"]
+convert = ["heck", "serde_json", "sha2"]
 
 [dependencies]
 anchor-lang-idl-spec = { path = "./spec", version = "0.1.0" }
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", optional = true }
 
 # `convert` feature only
 heck = { version = "0.3", optional = true }
 
 # `build` feature only
 regex = { version = "1", optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 sha2 = { version = "0.10", optional = true }

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -12,8 +12,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-build = ["regex", "serde_json"]
-convert = ["heck", "serde_json", "sha2"]
+build = ["dep:regex", "dep:serde_json"]
+convert = ["dep:heck", "dep:serde_json", "dep:sha2"]
 
 [dependencies]
 anchor-lang-idl-spec = { path = "./spec", version = "0.1.0" }


### PR DESCRIPTION
### Problem

The `serde_json` dependency is not necessary for the default features of the IDL crate.

### Summary of changes

Make the `serde_json` dependency optional and enable it for the `build` and `convert` features.

**Note:** `anyhow` and `serde` also don't seem necessary, but the spec crate, which is exported as `types` from the main IDL crate, uses them, meaning it's functionally useless to make them optional in the main crate.