### PR TITLE
cli: Remove the `registry` section of `Anchor.toml`

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -320,7 +320,6 @@ impl<T> std::ops::DerefMut for WithPath<T> {
 pub struct Config {
     pub toolchain: ToolchainConfig,
     pub features: FeaturesConfig,
-    pub registry: RegistryConfig,
     pub provider: ProviderConfig,
     pub programs: ProgramsConfig,
     pub scripts: ScriptsConfig,
@@ -622,7 +621,6 @@ struct _Config {
     toolchain: Option<ToolchainConfig>,
     features: Option<FeaturesConfig>,
     programs: Option<BTreeMap<String, BTreeMap<String, serde_json::Value>>>,
-    registry: Option<RegistryConfig>,
     provider: Provider,
     workspace: Option<WorkspaceConfig>,
     scripts: Option<ScriptsConfig>,
@@ -716,7 +714,6 @@ impl fmt::Display for Config {
         let cfg = _Config {
             toolchain: Some(self.toolchain.clone()),
             features: Some(self.features.clone()),
-            registry: Some(self.registry.clone()),
             provider: Provider {
                 cluster: self.provider.cluster.clone(),
                 wallet: self.provider.wallet.stringify_with_tilde(),
@@ -747,7 +744,6 @@ impl FromStr for Config {
         Ok(Config {
             toolchain: cfg.toolchain.unwrap_or_default(),
             features: cfg.features.unwrap_or_default(),
-            registry: cfg.registry.unwrap_or_default(),
             provider: ProviderConfig {
                 cluster: cfg.provider.cluster,
                 wallet: shellexpand::tilde(&cfg.provider.wallet).parse()?,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -403,19 +403,6 @@ impl Default for FeaturesConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RegistryConfig {
-    pub url: String,
-}
-
-impl Default for RegistryConfig {
-    fn default() -> Self {
-        Self {
-            url: "https://api.apr.dev".to_string(),
-        }
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct ProviderConfig {
     pub cluster: Cluster,

--- a/docs/content/docs/quickstart/local.mdx
+++ b/docs/content/docs/quickstart/local.mdx
@@ -285,9 +285,6 @@ skip-lint = false
 [programs.localnet]
 my_program = "3ynNB373Q3VAzKp7m4x238po36hjAGFXFJB4ybN2iTyg"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/custom-discriminator/Anchor.toml
+++ b/tests/custom-discriminator/Anchor.toml
@@ -9,9 +9,6 @@ skip-lint = false
 ambiguous-discriminator = "AmbiguousDiscriminator111111111111111111111"
 custom_discriminator = "CustomDiscriminator111111111111111111111111"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/safety-checks/Anchor.toml
+++ b/tests/safety-checks/Anchor.toml
@@ -8,9 +8,6 @@ skip-lint = false
 account_info = "99YPYSHjNekPHmMB7yrTxZCV2k2pRMKEqwwcqE62NqdA"
 unchecked_account = "4es8ojkX4URUyar2pbuLXQ4WoFtUizb5EupfaEgHjYQF"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/test-instruction-validation/fail-args-count/Anchor.toml
+++ b/tests/test-instruction-validation/fail-args-count/Anchor.toml
@@ -7,9 +7,6 @@ skip-lint = false
 [programs.localnet]
 test_instruction_validation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/test-instruction-validation/fail-type/Anchor.toml
+++ b/tests/test-instruction-validation/fail-type/Anchor.toml
@@ -7,9 +7,6 @@ skip-lint = false
 [programs.localnet]
 test_instruction_validation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/test-instruction-validation/pass-args-count/Anchor.toml
+++ b/tests/test-instruction-validation/pass-args-count/Anchor.toml
@@ -7,9 +7,6 @@ skip-lint = false
 [programs.localnet]
 test_instruction_validation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/test-instruction-validation/pass-type/Anchor.toml
+++ b/tests/test-instruction-validation/pass-type/Anchor.toml
@@ -7,9 +7,6 @@ skip-lint = false
 [programs.localnet]
 test_instruction_validation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"


### PR DESCRIPTION
### Problem

The `registry` section has been redundant for quite some time. It also adds unnecessary clutter to the default initialization config:

```toml
[registry]
url = "https://api.apr.dev"
```

### Summary of changes

Remove the `registry` section of `Anchor.toml`.