### PR TITLE
idl: Disallow multiple error definitions

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -385,7 +385,7 @@ jobs:
             path: tests/sysvars
           - cmd: cd tests/composite && anchor test --skip-lint
             path: tests/composite
-          - cmd: cd tests/errors && anchor test --skip-lint && npx tsc --noEmit
+          - cmd: cd tests/errors && ./test.sh && npx tsc --noEmit
             path: tests/errors
           - cmd: cd tests/spl/metadata && anchor test --skip-lint
             path: spl/metadata

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -192,9 +192,9 @@ fn build(
     }
 
     let mut address = String::new();
-    let mut events = vec![];
-    let mut error_codes = vec![];
     let mut constants = vec![];
+    let mut events = vec![];
+    let mut errors = None;
     let mut types = BTreeMap::new();
     let mut idl: Option<Idl> = None;
 
@@ -205,6 +205,9 @@ fn build(
                 "--- IDL begin address ---" => state = State::Address,
                 "--- IDL begin const ---" => state = State::Constants(vec![]),
                 "--- IDL begin event ---" => state = State::Events(vec![]),
+                "--- IDL begin errors ---" if errors.is_some() => {
+                    return Err(anyhow!("Multiple error definitions are not allowed."));
+                }
                 "--- IDL begin errors ---" => state = State::Errors(vec![]),
                 "--- IDL begin program ---" => state = State::Program(vec![]),
                 _ => {
@@ -215,7 +218,7 @@ fn build(
                             idl.address = mem::take(&mut address);
                             idl.constants = mem::take(&mut constants);
                             idl.events = mem::take(&mut events);
-                            idl.errors = mem::take(&mut error_codes);
+                            idl.errors = mem::take(&mut errors).unwrap_or_default();
                             idl.types = {
                                 let prog_ty = mem::take(&mut idl.types);
                                 let mut types = mem::take(&mut types);
@@ -260,7 +263,7 @@ fn build(
             }
             State::Errors(lines) => {
                 if line == "--- IDL end errors ---" {
-                    error_codes = serde_json::from_str(&lines.join("\n"))?;
+                    errors = Some(serde_json::from_str(&lines.join("\n"))?);
                     state = State::Pass;
                     continue;
                 }

--- a/tests/errors/Anchor.toml
+++ b/tests/errors/Anchor.toml
@@ -4,6 +4,7 @@ wallet = "~/.config/solana/id.json"
 
 [programs.localnet]
 errors = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+multiple-errors = "Mu1tip1eErrors11111111111111111111111111111"
 
 [scripts]
 test = "yarn run ts-mocha -t 1000000 tests/*.ts"

--- a/tests/errors/programs/multiple-errors/Cargo.toml
+++ b/tests/errors/programs/multiple-errors/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "multiple-errors"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "multiple_errors"
+
+[features]
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/errors/programs/multiple-errors/src/lib.rs
+++ b/tests/errors/programs/multiple-errors/src/lib.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Mu1tip1eErrors11111111111111111111111111111");
+
+#[program]
+pub mod multiple_errors {
+    use super::*;
+
+    pub fn test(_ctx: Context<Test>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Test {}
+
+#[error_code]
+pub enum FirstError {
+    First,
+}
+
+#[error_code]
+pub enum SecondError {
+    Second,
+}

--- a/tests/errors/test.sh
+++ b/tests/errors/test.sh
@@ -1,0 +1,3 @@
+# We don't want to build `multiple-errors` because it is expected to error
+anchor build -p errors --skip-lint
+anchor test --skip-build

--- a/tests/errors/tests/multiple-errors.ts
+++ b/tests/errors/tests/multiple-errors.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "child_process";
+
+describe("multiple-errors", () => {
+  it("Returns 'multiple errors' error on builds", () => {
+    const result = spawnSync("anchor", [
+      "idl",
+      "build",
+      "-p",
+      "multiple-errors",
+    ]);
+    if (result.status === 0) {
+      throw new Error("No error on build");
+    }
+
+    const output = result.output.toString();
+    if (!output.includes("Error: Multiple error definitions are not allowed")) {
+      throw new Error(`Unexpected error: "${output}"`);
+    }
+  });
+});

--- a/tests/errors/tsconfig.json
+++ b/tests/errors/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "target": "es6",
     "esModuleInterop": true,
-    "strict": true,
     "skipLibCheck": true
   }
 }

--- a/tests/errors/tsconfig.json
+++ b/tests/errors/tsconfig.json
@@ -1,11 +1,11 @@
 {
-    "compilerOptions": {
-        "types": ["mocha", "chai", "node"],
-        "typeRoots": ["./node_modules/@types"],
-        "lib": ["es2015"],
-        "module": "commonjs",
-        "target": "es6",
-        "esModuleInterop": true,
-        "skipLibCheck": true
-    }
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
### Problem

Having multiple error definitions is not supported, but you don't get any errors when you do have them. Instead, the compiler chooses one of the definitions and discards the rest.

### Summary of changes

Make having multiple error definitions a hard error during IDL generation.

### Progress

- [x] Add `multiple-errors` tests that checks for the desired behavior (error when there are multiple error definitions i.e. enums with `#[error_code]`) ([CI](https://github.com/solana-foundation/anchor/actions/runs/22874137846/job/66361765344?pr=4300#step:11:70)):

    ```
    1) multiple-errors
         Returns 'multiple errors' error on builds:
       Error: No error on build
    ```
- [x] Disallow multiple error definitions

Fixes https://github.com/solana-foundation/anchor/issues/3532