### PR TITLE
chore: Remove unused deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
-- cli: Remove program `arch` options ([#4195](https://github.com/solana-foundation/anchor/pull/4195)).
+- cli: Remove program `arch` options ([#4295](https://github.com/solana-foundation/anchor/pull/4295)).
 - lang: Disallow duplicate mutable accounts by default. But allows duplicate mutable accounts in instruction contexts using `dup` constraint ([#3946](https://github.com/solana-foundation/anchor/pull/3946)).
 - cli: Remove program id arguments of `idl init` and `idl upgrade` commands ([#4130](https://github.com/solana-foundation/anchor/pull/4130)).
 - lang: Rename `utils` module of `declare_program!` to `parsers` ([#4151](https://github.com/solana-foundation/anchor/pull/4151)).
@@ -73,6 +73,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Disallow multiple `#[error_code]` definitions in a single program ([#4300](https://github.com/solana-foundation/anchor/pull/4300)).
 - cli: Remove the `[registry]` section from `Anchor.toml` ([#4299](https://github.com/solana-foundation/anchor/pull/4299)).
 - client: Make sending a tx not panic and instead return an Error when signing fails ([#3865](https://github.com/solana-foundation/anchor/pull/3865)).
+- idl: Disallow multiple error definitions ([#4300](https://github.com/solana-foundation/anchor/pull/4300)).
 
 ## [0.32.1] - 2025-10-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,6 @@ dependencies = [
 name = "anchor-attribute-access-control"
 version = "0.32.1"
 dependencies = [
- "anchor-syn",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -237,7 +236,6 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction",
  "syn 1.0.109",
- "tar",
  "tempfile",
  "tiny-bip39",
  "toml 0.7.8",
@@ -367,7 +365,6 @@ name = "anchor-spl"
 version = "0.32.1"
 dependencies = [
  "anchor-lang",
- "base64ct",
  "borsh 1.5.7",
  "mpl-token-metadata",
  "solana-stake-interface",
@@ -1673,18 +1670,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "filetime"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "five8"
@@ -6418,17 +6403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7572,15 +7546,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 1.0.66",
  "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 1.0.109",
 ]
 
@@ -393,7 +392,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_json",
  "sha2",
  "syn 1.0.109",
  "thiserror 1.0.66",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,6 @@ solana-rpc-client.workspace = true
 solana-rpc-client-api.workspace = true
 solana-pubsub-client.workspace = true
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }
-tar = "0.4.35"
 tempfile = "3"
 tiny-bip39 = "2.0"
 toml = "0.7.6"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -14,7 +14,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 allow-missing-optionals = ["anchor-derive-accounts/allow-missing-optionals"]
 anchor-debug = [
-    "anchor-attribute-access-control/anchor-debug",
     "anchor-attribute-account/anchor-debug",
     "anchor-attribute-constant/anchor-debug",
     "anchor-attribute-error/anchor-debug",

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -11,10 +11,9 @@ edition = "2021"
 proc-macro = true
 
 [features]
-anchor-debug = ["anchor-syn/anchor-debug"]
+anchor-debug = []
 
 [dependencies]
-anchor-syn = { path = "../../syn", version = "0.32.1" }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -10,9 +10,6 @@ edition = "2021"
 [lib]
 proc-macro = true
 
-[features]
-anchor-debug = []
-
 [dependencies]
 proc-macro2 = "1"
 quote = "1"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -21,5 +21,4 @@ anyhow = "1"
 heck = "0.3"
 proc-macro2 = "1"
 quote = "1"
-serde_json = "1"
 syn = { version = "1", features = ["full"] }

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -30,7 +30,6 @@ heck = "0.3"
 proc-macro2 = { version = "1.0.100", features = ["span-locations"] }
 quote = "1"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 sha2 = "0.10"
 syn = { version = "1", features = ["full", "extra-traits", "parsing"] }
 thiserror = "1"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -18,7 +18,7 @@ devnet = []
 governance = []
 idl-build = ["anchor-lang/idl-build"]
 memo = ["spl-memo-interface"]
-metadata = ["mpl-token-metadata", "dep:solana-sysvar", "dep:base64ct"]
+metadata = ["mpl-token-metadata", "dep:solana-sysvar"]
 mint = []
 stake = ["dep:borsh", "dep:solana-stake-interface"]
 token = ["spl-token-interface"]
@@ -32,9 +32,6 @@ token_2022_extensions = [
 
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.32.1", features = ["derive"] }
-# FIXME(edition2024): Not used directly, but upstream crates resolve to this version,
-# which uses Edition 2024
-base64ct = { version = "<1.8.0", optional = true }
 borsh = { version = "1.5.7", optional = true }
 mpl-token-metadata = { version = "=5.1.2-alpha.1", optional = true }
 solana-stake-interface = { workspace = true, features = ["borsh"], optional = true }


### PR DESCRIPTION
### Problem

There are some leftover `serde_json` dependencies in our macro crates:

- https://github.com/solana-foundation/anchor/blob/70f7203a99eceb14134cfa8c7f618dbf3fdc279e/lang/syn/Cargo.toml#L33
- https://github.com/solana-foundation/anchor/blob/70f7203a99eceb14134cfa8c7f618dbf3fdc279e/lang/attribute/program/Cargo.toml#L24

### Summary of changes

Remove the unused `serde_json` dependencies.


----

### EDIT:

Further removed unused deps on `base64ct`, `tar` and an inter-workspace `anchor-syn` dep.