### PR TITLE
tests: Fix `errors`

### DIFF
--- a/tests/errors/test.sh
+++ b/tests/errors/test.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 # We don't want to build `multiple-errors` because it is expected to error
 anchor build -p errors --skip-lint --ignore-keys
 anchor test --skip-build

--- a/tests/errors/test.sh
+++ b/tests/errors/test.sh
@@ -1,3 +1,3 @@
 # We don't want to build `multiple-errors` because it is expected to error
-anchor build -p errors --skip-lint
+anchor build -p errors --skip-lint --ignore-keys
 anchor test --skip-build


### PR DESCRIPTION
### Problem

`tests/errors` is broken after https://github.com/solana-foundation/anchor/pull/4300 ([CI](https://github.com/solana-foundation/anchor/actions/runs/23022003917/job/66860965407)):

```
Error: Program ID mismatch detected for program 'errors':
  Keypair file has: HGBegzzQSBRRxvmQntoLrVREVgE7qH11TiSQ76Z67cYZ
  Source code has:  Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS

Please run 'anchor keys sync' to update the program ID in your source code or use the '--ignore-keys' flag to skip this check.
```

I didn't notice it locally because I had configured my `build` command to always pass in the `--ignore-keys` flag.

[CI runs of the PR](https://github.com/solana-foundation/anchor/actions/runs/22874881272/job/66661046951) also didn't catch it because the `target` directory was cached.

I didn't `set -e` because I thought it was such a simple 2-line script, but I guess no script is too simple for sane defaults.

### Summary of changes

- Fix `tests/errors` by passing in the `--ignore-keys` flag
- Use better `bash` defaults (`set -euo pipefail`)