### PR TITLE
cli: Added litesvm test template and made it the default option on anchor init

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -369,13 +369,23 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: |
-          cd "$(mktemp -d)"
-          anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
-          cd hello-anchor-${{ matrix.template }}
-          sed -i "s|^anchor-lang = .*|anchor-lang = { path = \"$GITHUB_WORKSPACE/lang\" }|" programs/hello-anchor-${{ matrix.template }}/Cargo.toml
-          [[ "${{ matrix.template }}" == "rust" ]] && sed -i "s|^anchor-client = .*|anchor-client = { path = \"$GITHUB_WORKSPACE/client\" }|" tests/Cargo.toml || true
-          yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
+      - name: Init project
+        working-directory: /tmp
+        run: anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
+
+      - name: Point anchor-lang to workspace
+        working-directory: /tmp/hello-anchor-${{ matrix.template }}
+        run: cargo add anchor-lang --manifest-path programs/hello-anchor-${{ matrix.template }}/Cargo.toml --path "$GITHUB_WORKSPACE/lang"
+
+      - name: Point anchor-client to workspace
+        if: ${{ matrix.template == 'rust' }}
+        working-directory: /tmp/hello-anchor-${{ matrix.template }}
+        run: cargo add anchor-client --manifest-path tests/Cargo.toml --path "$GITHUB_WORKSPACE/client"
+
+      - name: Run generated project tests
+        working-directory: /tmp/hello-anchor-${{ matrix.template }}
+        run: yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
+
       - uses: ./.github/actions/git-diff/
 
   test-programs:

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -347,7 +347,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        template: [mocha, jest, rust, mollusk]
+        template: [mocha, jest, rust, mollusk, litesvm]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/
@@ -369,7 +369,12 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cd "$(mktemp -d)" && anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }} && cd hello-anchor-${{ matrix.template }} && yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
+      - run: |
+          cd "$(mktemp -d)"
+          anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
+          cd hello-anchor-${{ matrix.template }}
+          sed -i "s/^anchor-lang = .*/anchor-lang = { path = \"$GITHUB_WORKSPACE\/lang\" }/" programs/${{ matrix.template }}/Cargo.toml
+          yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
       - uses: ./.github/actions/git-diff/
 
   test-programs:

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -374,6 +374,7 @@ jobs:
           anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
           cd hello-anchor-${{ matrix.template }}
           sed -i "s|^anchor-lang = .*|anchor-lang = { path = \"$GITHUB_WORKSPACE/lang\" }|" programs/hello-anchor-${{ matrix.template }}/Cargo.toml
+          [[ "${{ matrix.template }}" == "rust" ]] && sed -i "s|^anchor-client = .*|anchor-client = { path = \"$GITHUB_WORKSPACE/client\" }|" tests/Cargo.toml || true
           yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
       - uses: ./.github/actions/git-diff/
 

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -373,7 +373,7 @@ jobs:
           cd "$(mktemp -d)"
           anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
           cd hello-anchor-${{ matrix.template }}
-          sed -i "s/^anchor-lang = .*/anchor-lang = { path = \"$GITHUB_WORKSPACE\/lang\" }/" programs/${{ matrix.template }}/Cargo.toml
+          sed -i "s|^anchor-lang = .*|anchor-lang = { path = \"$GITHUB_WORKSPACE/lang\" }|" programs/${{ matrix.template }}/Cargo.toml
           yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
       - uses: ./.github/actions/git-diff/
 

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -373,7 +373,7 @@ jobs:
           cd "$(mktemp -d)"
           anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
           cd hello-anchor-${{ matrix.template }}
-          sed -i "s|^anchor-lang = .*|anchor-lang = { path = \"$GITHUB_WORKSPACE/lang\" }|" programs/${{ matrix.template }}/Cargo.toml
+          sed -i "s|^anchor-lang = .*|anchor-lang = { path = \"$GITHUB_WORKSPACE/lang\" }|" programs/hello-anchor-${{ matrix.template }}/Cargo.toml
           yarn link @anchor-lang/core && yarn && anchor test && yarn lint:fix
       - uses: ./.github/actions/git-diff/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Update `anchor init` to use the `multiple` program template by default ([#3958](https://github.com/solana-foundation/anchor/pull/3958)).
 - cli: Add `hooks` section to `Anchor.toml` for `{pre,post}-{build,test,deploy}` lifecycle hooks ([#3862](https://github.com/solana-foundation/anchor/pull/3862)).
 - lang: Add generic program validation support to `Program` type allowing `Program<'info>` for executable-only validation ([#3878](https://github.com/solana-foundation/anchor/pull/3878)).
+- cli: Added `litesvm` test template and made it the default option on `anchor init` ([#4316](https://github.com/solana-foundation/anchor/pull/4316))
 
 ### Fixes
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -100,7 +100,7 @@ pub enum Command {
         #[clap(value_enum, short, long, default_value = "multiple")]
         template: ProgramTemplate,
         /// Test template to use
-        #[clap(value_enum, long, default_value = "mocha")]
+        #[clap(value_enum, long, default_value = "litesvm")]
         test_template: TestTemplate,
         /// Initialize even if there are files
         #[clap(long, action)]
@@ -1407,11 +1407,7 @@ fn init(
     }
 
     // Build the program.
-    rust_template::create_program(
-        &project_name,
-        template,
-        TestTemplate::Mollusk == test_template,
-    )?;
+    rust_template::create_program(&project_name, template, Some(&test_template))?;
 
     // Build the migrations directory.
     let migrations_path = Path::new("migrations");
@@ -1513,7 +1509,7 @@ fn new(
                     fs::remove_dir_all(std::env::current_dir()?.join("programs").join(&name))?;
                 }
 
-                rust_template::create_program(&name, template, false)?;
+                rust_template::create_program(&name, template, None)?;
 
                 programs.insert(
                     name.clone(),

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -202,14 +202,17 @@ fn cargo_toml(name: &str, test_template: Option<&TestTemplate>) -> String {
         Some(TestTemplate::Mollusk) => {
             r#"
 [dev-dependencies]
-mollusk-svm = "~0.4"
+mollusk-svm = "~0.10"
 "#
         }
         Some(TestTemplate::Litesvm) => {
             r#"
 [dev-dependencies]
 litesvm = "0.10.0"
-solana-sdk = "3.0.0"
+solana-message = "3.0.0"
+solana-transaction = "3.0.0"
+solana-signer = "3.0.0"
+solana-keypair = "3.0.0"
 "#
         }
         _ => "",
@@ -774,6 +777,8 @@ rust-version = "{ANCHOR_MSRV}"
 [dependencies]
 anchor-client = "{VERSION}"
 {name} = {{ version = "0.1.0", path = "../programs/{name}" }}
+solana-keypair = "3.0.0"
+solana-pubkey = "3.0.0"
 "#
     )
 }
@@ -792,14 +797,12 @@ mod test_initialize;
         (
             src_path.join("test_initialize.rs"),
             format!(
-                r#"use std::str::FromStr;
-
-use anchor_client::{{
-    solana_sdk::{{
-        commitment_config::CommitmentConfig, pubkey::Pubkey, signature::read_keypair_file,
-    }},
+                r#"use anchor_client::{{
+    CommitmentConfig,
     Client, Cluster,
 }};
+use solana_keypair::{{read_keypair_file}};
+use solana_pubkey::Pubkey;
 
 #[test]
 fn test_initialize() {{
@@ -869,9 +872,10 @@ fn create_program_template_litesvm_test(name: &str, tests_path: &Path) -> Files 
 use {{
     anchor_lang::{{solana_program::instruction::Instruction, InstructionData, ToAccountMetas}},
     litesvm::LiteSVM,
-    solana_sdk::message::{{Message, VersionedMessage}},
-    solana_sdk::signature::{{Keypair, Signer}},
-    solana_sdk::transaction::VersionedTransaction,
+    solana_message::{{Message, VersionedMessage}},
+    solana_signer::Signer,
+    solana_keypair::Keypair,
+    solana_transaction::versioned::VersionedTransaction,
 }};
 
 #[test]

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -863,7 +863,7 @@ fn test_initialize() {{
     )]
 }
 
-/// Generate template for Mollusk Rust unit-test
+/// Generate template for LiteSVM Rust unit-test
 fn create_program_template_litesvm_test(name: &str, tests_path: &Path) -> Files {
     vec![(
         tests_path.join("test_initialize.rs"),

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -884,7 +884,7 @@ fn test_initialize() {{
     let payer = Keypair::new();
     let mut svm = LiteSVM::new();
     let bytes = include_bytes!("../../../target/deploy/{0}.so");
-    svm.add_program(program_id, bytes);
+    svm.add_program(program_id, bytes).unwrap();
     svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
     
     let instruction = Instruction::new_with_bytes(

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -29,14 +29,18 @@ pub enum ProgramTemplate {
 }
 
 /// Create a program from the given name and template.
-pub fn create_program(name: &str, template: ProgramTemplate, with_mollusk: bool) -> Result<()> {
+pub fn create_program(
+    name: &str,
+    template: ProgramTemplate,
+    test_template: Option<&TestTemplate>,
+) -> Result<()> {
     let program_path = Path::new("programs").join(name);
     let common_files = vec![
         ("Cargo.toml".into(), workspace_manifest().into()),
         ("rust-toolchain.toml".into(), rust_toolchain_toml()),
         (
             program_path.join("Cargo.toml"),
-            cargo_toml(name, with_mollusk),
+            cargo_toml(name, test_template),
         ),
         // Note: Xargo.toml is no longer needed for modern Solana builds using SBF
     ];
@@ -189,15 +193,26 @@ codegen-units = 1
 "#
 }
 
-fn cargo_toml(name: &str, with_mollusk: bool) -> String {
-    let test_sbf_feature = if with_mollusk { r#"test-sbf = []"# } else { "" };
-    let dev_dependencies = if with_mollusk {
-        r#"
+fn cargo_toml(name: &str, test_template: Option<&TestTemplate>) -> String {
+    let test_sbf_feature = match test_template {
+        Some(TestTemplate::Mollusk) => r#"test-sbf = []"#,
+        _ => "",
+    };
+    let dev_dependencies = match test_template {
+        Some(TestTemplate::Mollusk) => {
+            r#"
 [dev-dependencies]
 mollusk-svm = "~0.4"
 "#
-    } else {
-        ""
+        }
+        Some(TestTemplate::Litesvm) => {
+            r#"
+[dev-dependencies]
+litesvm = "0.10.0"
+solana-sdk = "3.0.0"
+"#
+        }
+        _ => "",
     };
 
     format!(
@@ -623,7 +638,6 @@ anchor.workspace.{} = new anchor.Program({}, provider);
 #[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum)]
 pub enum TestTemplate {
     /// Generate template for Mocha unit-test
-    #[default]
     Mocha,
     /// Generate template for Jest unit-test
     Jest,
@@ -631,6 +645,9 @@ pub enum TestTemplate {
     Rust,
     /// Generate template for Mollusk Rust unit-test
     Mollusk,
+    /// Generate template for LiteSVM rust unit-test
+    #[default]
+    Litesvm,
 }
 
 impl TestTemplate {
@@ -659,7 +676,7 @@ impl TestTemplate {
                     format!("{pkg_manager_exec_cmd} jest --preset ts-jest")
                 }
             }
-            Self::Rust => "cargo test".to_owned(),
+            Self::Rust | Self::Litesvm => "cargo test".to_owned(),
             Self::Mollusk => "cargo test-sbf".to_owned(),
         }
     }
@@ -722,6 +739,18 @@ impl TestTemplate {
 
                 let mut files = Vec::new();
                 files.extend(create_program_template_mollusk_test(
+                    project_name,
+                    tests_path,
+                ));
+                override_or_create_files(&files)?;
+            }
+
+            Self::Litesvm => {
+                let tests_path_str = format!("programs/{}/tests", &project_name);
+                let tests_path = Path::new(&tests_path_str);
+                fs::create_dir_all(tests_path)?;
+                let mut files = Vec::new();
+                files.extend(create_program_template_litesvm_test(
                     project_name,
                     tests_path,
                 ));
@@ -824,6 +853,48 @@ fn test_initialize() {{
     );
 
     mollusk.process_and_validate_instruction(&instruction, &[], &[Check::success()]);
+}}
+"#,
+            name.to_snake_case(),
+        ),
+    )]
+}
+
+/// Generate template for Mollusk Rust unit-test
+fn create_program_template_litesvm_test(name: &str, tests_path: &Path) -> Files {
+    vec![(
+        tests_path.join("test_initialize.rs"),
+        format!(
+            r#"
+use {{
+    anchor_lang::{{solana_program::instruction::Instruction, InstructionData, ToAccountMetas}},
+    litesvm::LiteSVM,
+    solana_sdk::message::{{Message, VersionedMessage}},
+    solana_sdk::signature::{{Keypair, Signer}},
+    solana_sdk::transaction::VersionedTransaction,
+}};
+
+#[test]
+fn test_initialize() {{
+    let program_id = {0}::id();
+    let payer = Keypair::new();
+    let mut svm = LiteSVM::new();
+    let bytes = include_bytes!("../../../target/deploy/{0}.so");
+    svm.add_program(program_id, bytes);
+    svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
+    
+    let instruction = Instruction::new_with_bytes(
+        program_id,
+        &{0}::instruction::Initialize {{}}.data(),
+        {0}::accounts::Initialize {{}}.to_account_metas(None),
+    );
+
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[instruction], Some(&payer.pubkey()), &blockhash);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[payer]).unwrap();
+
+    let res = svm.send_transaction(tx);
+    assert!(res.is_ok());
 }}
 "#,
             name.to_snake_case(),


### PR DESCRIPTION
- Fixed other templates and dependencies in preparation for `1.0.0`
- Changed `test-anchor-init` test to replace `anchor-lang` and `anchor-client` dependencies to the local crates for more meaningful tests rather than testing outdated templates