### PR TITLE
Fix `size_of` calculations for dynamically sized types in `Lazy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- lang: Fix incorrect deserialization for dynamically sized types when using `lazy-account` ([#4319](https://github.com/solana-foundation/anchor/pull/4319))
+
 ### Breaking
 
 ## [1.0.0-rc.4] - 2026-03-19

--- a/lang/derive/serde/src/lazy.rs
+++ b/lang/derive/serde/src/lazy.rs
@@ -17,13 +17,15 @@ pub fn gen_lazy(input: proc_macro::TokenStream) -> syn::Result<proc_macro2::Toke
                 .fold(quote!(true), |acc, sized| quote! { #acc && #sized }),
         ),
         Item::Enum(enm) => {
+            // Each match arm checks the tag byte then shadows the `buf` variable with
+            // the remaining buffer. This allows `sum_fields` to operate on the correct buffer
             let arms = enm
                 .variants
                 .iter()
                 .map(|variant| sum_fields(&variant.fields))
                 .enumerate()
                 .map(|(i, size)| (Literal::usize_unsuffixed(i), size))
-                .map(|(i, size)| quote! { Some(#i) => { #size } });
+                .map(|(i, size)| quote! { Some((#i, buf)) => { #size } });
             let sized = enm
                 .variants
                 .iter()
@@ -32,7 +34,7 @@ pub fn gen_lazy(input: proc_macro::TokenStream) -> syn::Result<proc_macro2::Toke
                 &enm.ident,
                 &enm.generics,
                 quote! {
-                    1 + match buf.first() {
+                    1 + match buf.split_first() {
                         #(#arms,)*
                         _ => unreachable!(),
                     }

--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -226,4 +226,23 @@ mod tests {
         );
         assert!(!GenericStruct::<Vec<u8>>::SIZED);
     }
+
+    #[test]
+    fn enum_variable() {
+        // Test that the size of variably-sized types in an enum is calculated correctly
+        #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone)]
+        enum State {
+            User(Vec<u8>),
+            Other(u8),
+        }
+        const VEC_LEN: usize = 32;
+        let state = State::User(vec![1; VEC_LEN]);
+
+        let state_bytes = borsh::to_vec(&state).unwrap();
+        let actual_state_size = state_bytes.len();
+        let lazy_state_size = <State as Lazy>::size_of(&state_bytes);
+        assert_eq!(actual_state_size, lazy_state_size);
+        // enum tag + vec length field + vec contents
+        assert_eq!(lazy_state_size, 1 + LEN + VEC_LEN);
+    }
 }

--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -68,7 +68,11 @@ impl<T: Lazy, const N: usize> Lazy for [T; N] {
 
     #[inline(always)]
     fn size_of(buf: &[u8]) -> usize {
-        N * T::size_of(buf)
+        if Self::SIZED {
+            N * T::size_of(buf)
+        } else {
+            (0..N).fold(0, |acc, _| acc + T::size_of(&buf[acc..]))
+        }
     }
 }
 
@@ -244,5 +248,15 @@ mod tests {
         assert_eq!(actual_state_size, lazy_state_size);
         // enum tag + vec length field + vec contents
         assert_eq!(lazy_state_size, 1 + LEN + VEC_LEN);
+    }
+
+    #[test]
+    fn array_variable() {
+        // Test that the size of an array of variably sized types is calculated correctly
+        let messages: [Vec<u8>; 8] = std::array::from_fn(|i| vec![i as u8; i]);
+        let serialized = borsh::to_vec(&messages).unwrap();
+        let actual_size = serialized.len();
+        let lazy_size = <[Vec<u8>; 8] as Lazy>::size_of(&serialized);
+        assert_eq!(actual_size, lazy_size);
     }
 }


### PR DESCRIPTION
This PR addresses two issues with `Lazy` which resulted in miscalculations for dynamically sized types.

- Enums: Enums are encoded with a tag byte before the payload. The `size_of` calculation for the inner data was passed the full data including the tag byte, instead of the actual inner payload, resulting in potential size miscalculations
- Arrays: Previously, the size of the first element was calculated, then multiplied by the array length. This is incorrect, as an array of dynamically sized types (e.g. `[String; 5]`) have non-homogenous sizes. Correct this by calculating the size of each element

This can result in incorrect deserialisation, allowing malicious payloads to bypass security checks.