### PR TITLE
fix(token2022): Wrong Owner Pubkey in CPI Guard Enable and Disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- spl: Fix wrong owner pubkey in CPI Guard enable/disable ([#4322](https://github.com/solana-foundation/anchor/pull/4322)).
 - spl: Add missing auth account to `group_pointer_update` ([#4324](https://github.com/solana-foundation/anchor/pull/4324)).
 - lang: Make idl build time way faster by caching `CrateContext` ([#4325](https://github.com/solana-foundation/anchor/pull/4325)).
 

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -13,7 +13,7 @@ pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info
     let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(
         ctx.accounts.token_program_id.key,
         ctx.accounts.account.key,
-        ctx.accounts.account.owner,
+        ctx.accounts.owner.key,
         &[],
     )?;
     anchor_lang::solana_program::program::invoke_signed(
@@ -32,7 +32,7 @@ pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'inf
     let ix = spl_token_2022::extension::cpi_guard::instruction::disable_cpi_guard(
         ctx.accounts.token_program_id.key,
         ctx.accounts.account.key,
-        ctx.accounts.account.owner,
+        ctx.accounts.owner.key,
         &[],
     )?;
 

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -220,3 +220,41 @@ pub fn update_group_pointer_handler(
     let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
     token_2022_extensions::group_pointer::group_pointer_update(cpi_ctx, new_group_address)
 }
+
+#[derive(Accounts)]
+pub struct EnableCpiGuard<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    /// CHECK: token account with CPI Guard extension
+    pub token_account: UncheckedAccount<'info>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+pub fn enable_cpi_guard_handler(ctx: Context<EnableCpiGuard>) -> Result<()> {
+    let cpi_accounts = token_2022_extensions::cpi_guard::CpiGuard {
+        token_program_id: ctx.accounts.token_program.to_account_info(),
+        account: ctx.accounts.token_account.to_account_info(),
+        owner: ctx.accounts.authority.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
+    token_2022_extensions::cpi_guard::cpi_guard_enable(cpi_ctx)
+}
+
+#[derive(Accounts)]
+pub struct DisableCpiGuard<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    /// CHECK: token account with CPI Guard extension
+    pub token_account: UncheckedAccount<'info>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+pub fn disable_cpi_guard_handler(ctx: Context<DisableCpiGuard>) -> Result<()> {
+    let cpi_accounts = token_2022_extensions::cpi_guard::CpiGuard {
+        token_program_id: ctx.accounts.token_program.to_account_info(),
+        account: ctx.accounts.token_account.to_account_info(),
+        owner: ctx.accounts.authority.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
+    token_2022_extensions::cpi_guard::cpi_guard_disable(cpi_ctx)
+}

--- a/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
@@ -42,4 +42,12 @@ pub mod token_extensions {
     ) -> Result<()> {
         instructions::update_group_pointer_handler(ctx, new_group_address)
     }
+
+    pub fn enable_cpi_guard(ctx: Context<EnableCpiGuard>) -> Result<()> {
+        instructions::enable_cpi_guard_handler(ctx)
+    }
+
+    pub fn disable_cpi_guard(ctx: Context<DisableCpiGuard>) -> Result<()> {
+        instructions::disable_cpi_guard_handler(ctx)
+    }
 }

--- a/tests/spl/token-extensions/tests/token-extensions.ts
+++ b/tests/spl/token-extensions/tests/token-extensions.ts
@@ -1,8 +1,20 @@
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
-import { PublicKey, Keypair } from "@solana/web3.js";
+import {
+  PublicKey,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
 import { TokenExtensions } from "../target/types/token_extensions";
 import { ASSOCIATED_PROGRAM_ID } from "@anchor-lang/core/dist/cjs/utils/token";
+import {
+  createInitializeAccountInstruction,
+  createMint,
+  ExtensionType,
+  getAccountLen,
+} from "@solana/spl-token";
 import { it } from "node:test";
 
 const TOKEN_2022_PROGRAM_ID = new anchor.web3.PublicKey(
@@ -118,6 +130,85 @@ describe("token extensions", () => {
         .accountsStrict({
           authority: payer.publicKey,
           mint: groupPointerMint.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer])
+        .rpc();
+    });
+  });
+
+  describe("cpi_guard", () => {
+    let cpiGuardMint: PublicKey;
+    let enableAccount = Keypair.generate();
+    let disableAccount = Keypair.generate();
+
+    async function createCpiGuardTokenAccount(
+      tokenAccountKeypair: Keypair
+    ): Promise<void> {
+      const accountLen = getAccountLen([ExtensionType.CpiGuard]);
+      const lamports =
+        await provider.connection.getMinimumBalanceForRentExemption(accountLen);
+
+      const tx = new Transaction().add(
+        SystemProgram.createAccount({
+          fromPubkey: payer.publicKey,
+          newAccountPubkey: tokenAccountKeypair.publicKey,
+          space: accountLen,
+          lamports,
+          programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeAccountInstruction(
+          tokenAccountKeypair.publicKey,
+          cpiGuardMint,
+          payer.publicKey,
+          TOKEN_2022_PROGRAM_ID
+        )
+      );
+
+      await sendAndConfirmTransaction(
+        provider.connection,
+        tx,
+        [payer, tokenAccountKeypair],
+        { commitment: "confirmed" }
+      );
+    }
+
+    it("Create mint and token accounts with CPI Guard extension", async () => {
+      cpiGuardMint = await createMint(
+        provider.connection,
+        payer,
+        payer.publicKey,
+        null,
+        9,
+        Keypair.generate(),
+        { commitment: "confirmed" },
+        TOKEN_2022_PROGRAM_ID
+      );
+
+      await createCpiGuardTokenAccount(enableAccount);
+      await createCpiGuardTokenAccount(disableAccount);
+    });
+
+    it("Enable CPI Guard via CPI succeeds", async () => {
+      await program.methods
+        .enableCpiGuard()
+        .accountsStrict({
+          authority: payer.publicKey,
+          tokenAccount: enableAccount.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer])
+        .rpc();
+    });
+
+    it("Disable CPI Guard via CPI succeeds", async () => {
+      // Uses a separate account where guard is not active,
+      // since an active CPI Guard blocks disable via CPI
+      await program.methods
+        .disableCpiGuard()
+        .accountsStrict({
+          authority: payer.publicKey,
+          tokenAccount: disableAccount.publicKey,
           tokenProgram: TOKEN_2022_PROGRAM_ID,
         })
         .signers([payer])


### PR DESCRIPTION
This PR resolves #4321 by passing in `ctx.accounts.owner.key` to `cpi_guard_enable` and `cpi_guard_disable`, aligning with the correct pattern already used in `memo_transfer.rs`