### PR TITLE
fix(token2022): Add Missing Auth Account to `invoke_signed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- spl: Add missing auth account to `group_pointer_update` ([#4324](https://github.com/solana-foundation/anchor/pull/4324)).
+
 ### Breaking
 
 ## [1.0.0] - 2026-04-02

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -47,7 +47,11 @@ pub fn group_pointer_update<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
+        &[
+            ctx.accounts.token_program_id,
+            ctx.accounts.mint,
+            ctx.accounts.authority,
+        ],
         ctx.signer_seeds,
     )
     .map_err(Into::into)

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -3,9 +3,9 @@ use anchor_lang::{prelude::*, solana_program::entrypoint::ProgramResult};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token_2022::spl_token_2022::extension::{
-        group_member_pointer::GroupMemberPointer, group_pointer::GroupPointer,
-        metadata_pointer::MetadataPointer, mint_close_authority::MintCloseAuthority,
-        permanent_delegate::PermanentDelegate, transfer_hook::TransferHook,
+        group_member_pointer::GroupMemberPointer, metadata_pointer::MetadataPointer,
+        mint_close_authority::MintCloseAuthority, permanent_delegate::PermanentDelegate,
+        transfer_hook::TransferHook,
     },
     token_2022_extensions,
     token_interface::{
@@ -217,6 +217,6 @@ pub fn update_group_pointer_handler(
         mint: ctx.accounts.mint.to_account_info(),
         authority: ctx.accounts.authority.to_account_info(),
     };
-    let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
+    let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
     token_2022_extensions::group_pointer::group_pointer_update(cpi_ctx, new_group_address)
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -3,10 +3,11 @@ use anchor_lang::{prelude::*, solana_program::entrypoint::ProgramResult};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token_2022::spl_token_2022::extension::{
-        group_member_pointer::GroupMemberPointer, metadata_pointer::MetadataPointer,
-        mint_close_authority::MintCloseAuthority, permanent_delegate::PermanentDelegate,
-        transfer_hook::TransferHook,
+        group_member_pointer::GroupMemberPointer, group_pointer::GroupPointer,
+        metadata_pointer::MetadataPointer, mint_close_authority::MintCloseAuthority,
+        permanent_delegate::PermanentDelegate, transfer_hook::TransferHook,
     },
+    token_2022_extensions,
     token_interface::{
         get_mint_extension_data, spl_token_metadata_interface::state::TokenMetadata,
         token_metadata_initialize, Mint, Token2022, TokenAccount, TokenMetadataInitialize,
@@ -177,4 +178,45 @@ pub struct CheckMintExtensionConstraints<'info> {
         extensions::permanent_delegate::delegate = authority,
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
+}
+
+#[derive(Accounts)]
+pub struct CreateGroupPointerMint<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub authority: Signer<'info>,
+    #[account(
+        init,
+        signer,
+        payer = payer,
+        mint::token_program = token_program,
+        mint::decimals = 0,
+        mint::authority = authority,
+        extensions::group_pointer::authority = authority,
+        extensions::group_pointer::group_address = mint,
+    )]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateGroupPointer<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+pub fn update_group_pointer_handler(
+    ctx: Context<UpdateGroupPointer>,
+    new_group_address: Option<Pubkey>,
+) -> Result<()> {
+    let cpi_accounts = token_2022_extensions::group_pointer::GroupPointerUpdate {
+        token_program_id: ctx.accounts.token_program.to_account_info(),
+        mint: ctx.accounts.mint.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
+    token_2022_extensions::group_pointer::group_pointer_update(cpi_ctx, new_group_address)
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
@@ -29,4 +29,17 @@ pub mod token_extensions {
     ) -> Result<()> {
         Ok(())
     }
+
+    pub fn create_group_pointer_mint(
+        _ctx: Context<CreateGroupPointerMint>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn update_group_pointer(
+        ctx: Context<UpdateGroupPointer>,
+        new_group_address: Option<Pubkey>,
+    ) -> Result<()> {
+        instructions::update_group_pointer_handler(ctx, new_group_address)
+    }
 }

--- a/tests/spl/token-extensions/tests/token-extensions.ts
+++ b/tests/spl/token-extensions/tests/token-extensions.ts
@@ -81,4 +81,47 @@ describe("token extensions", () => {
       .signers([payer])
       .rpc();
   });
+
+  describe("group_pointer_update", () => {
+    let groupPointerMint = new Keypair();
+
+    it("Create mint with group pointer extension", async () => {
+      await program.methods
+        .createGroupPointerMint()
+        .accountsStrict({
+          payer: payer.publicKey,
+          authority: payer.publicKey,
+          mint: groupPointerMint.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer, groupPointerMint])
+        .rpc();
+    });
+
+    it("Update group pointer via CPI succeeds", async () => {
+      const newGroupAddress = Keypair.generate().publicKey;
+      await program.methods
+        .updateGroupPointer(newGroupAddress)
+        .accountsStrict({
+          authority: payer.publicKey,
+          mint: groupPointerMint.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer])
+        .rpc();
+    });
+
+    it("Update group pointer to None via CPI succeeds", async () => {
+      await program.methods
+        .updateGroupPointer(null)
+        .accountsStrict({
+          authority: payer.publicKey,
+          mint: groupPointerMint.publicKey,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer])
+        .rpc();
+    });
+  });
 });


### PR DESCRIPTION
This PR resolves #4323 by adding the missing `ctx.accounts.authority` to the `invoke_signed` accounts slice in `group_pointer_update`, aligning with the correct pattern already used in `group_member_pointer_update`