### PR TITLE
fix: bumping versions and pre-release github releases for RC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,16 @@ jobs:
 
       - name: Upload
         shell: bash
-        run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* --title "$GITHUB_REF_NAME"
+        run: |
+          set -euo pipefail
+
+          publish_args=()
+          # If version looks like vX.Y.Z-<something> (e.g. v1.0.0-rc.2), publish as a pre-release
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            publish_args+=(--prerelease)
+          fi
+
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* --title "$GITHUB_REF_NAME" "${publish_args[@]}"
 
   publish-cli:
     name: Publish CLI onto npmjs

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -25,7 +25,7 @@ case "$(uname)" in
 esac
 
 # Only replace version with the following globs
-allow_globs="Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
+allow_globs=":**/Cargo.toml Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
 git grep -l $old_version -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$old_version/$version/g"


### PR DESCRIPTION
The `bump-version.sh` script was swapped to update version in just the workspace `Cargo.toml`, but this doesn't actually work as some of the dependencies are still version pinned :( We'll want to switch to `cargo-release` to avoid some edge cases in general, though for now this should be sufficient enough for continuing with the release candidate release and I'll follow up with refactor to use `cargo-release` at a later point.

GitHub releases are also now marked automatically as a pre-release.