### PR TITLE
feat(avm): add pre-release support across all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- avm: Added flags and version labels to explicity handle pre-releases (`avm list --pre-release`, `avm update --pre-release` and `avm install latest-pre-release`). Fixed handling of new Cargo.toml version location. Fixed handling of pre-release version parsing. ([#4335](https://github.com/solana-foundation/anchor/pull/4335))
+- avm: Added flags and version labels to explicitly handle pre-releases (`avm list --pre-release`, `avm update --pre-release` and `avm install latest-pre-release`). ([#4335](https://github.com/solana-foundation/anchor/pull/4335))
 
 ### Fixes
+
+- avm: Fixed handling of new Cargo.toml version location. Fixed handling of pre-release version parsing. ([#4335](https://github.com/solana-foundation/anchor/pull/4335))
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- avm: Added flags and version labels to explicity handle pre-releases (`avm list --pre-release`, `avm update --pre-release` and `avm install latest-pre-release`). Fixed handling of new Cargo.toml version location. Fixed handling of pre-release version parsing. ([#4335](https://github.com/solana-foundation/anchor/pull/4335))
+
 ### Fixes
 
 ### Breaking

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -263,7 +263,10 @@ pub fn check_and_get_full_commit(commit: &str) -> Result<String> {
 fn fetch_raw(client: &reqwest::blocking::Client, url: &str) -> Result<Option<String>> {
     let response = client
         .get(url)
-        .header(USER_AGENT, "avm https://github.com/solana-foundation/anchor")
+        .header(
+            USER_AGENT,
+            "avm https://github.com/solana-foundation/anchor",
+        )
         .send()?;
     if response.status() == StatusCode::OK {
         Ok(Some(response.text()?))
@@ -601,7 +604,7 @@ pub fn fetch_versions(include_pre_release: bool) -> Result<Vec<Version>, Error> 
         #[serde(rename = "name", deserialize_with = "version_deserializer")]
         version: Version,
         draft: bool,
-        prerelease: bool
+        prerelease: bool,
     }
 
     fn version_deserializer<'de, D>(deserializer: D) -> Result<Version, D::Error>

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -222,8 +222,8 @@ pub enum InstallTarget {
 }
 
 /// Update to the latest version
-pub fn update() -> Result<()> {
-    let latest_version = get_latest_version()?;
+pub fn update(include_pre_release: bool) -> Result<()> {
+    let latest_version = get_latest_version(include_pre_release)?;
     install_version(InstallTarget::Version(latest_version), false, false, false)
 }
 
@@ -260,29 +260,57 @@ pub fn check_and_get_full_commit(commit: &str) -> Result<String> {
         .map_err(|err| anyhow!("Failed to parse the response to JSON: {err:?}"))
 }
 
-fn get_anchor_version_from_commit(commit: &str) -> Result<Version> {
-    // We read the version from cli/Cargo.toml since there is no simpler way to do so
-    let client = reqwest::blocking::Client::new();
+fn fetch_raw(client: &reqwest::blocking::Client, url: &str) -> Result<Option<String>> {
     let response = client
-        .get(format!(
-            "https://raw.githubusercontent.com/solana-foundation/anchor/{commit}/cli/Cargo.toml"
-        ))
-        .header(
-            USER_AGENT,
-            "avm https://github.com/solana-foundation/anchor",
-        )
+        .get(url)
+        .header(USER_AGENT, "avm https://github.com/solana-foundation/anchor")
         .send()?;
+    if response.status() == StatusCode::OK {
+        Ok(Some(response.text()?))
+    } else {
+        Ok(None)
+    }
+}
 
-    if response.status() != StatusCode::OK {
-        return Err(anyhow!(
-            "Could not find anchor-cli version for commit: {response:?}"
-        ));
+/// Append `commit` to the version's pre-release field, preserving any existing pre-release info.
+/// e.g. `1.0.0-rc.3` + `e1afcbf7...` → `1.0.0-rc.3.e1afcbf7...`
+///      `0.28.0`      + `e1afcbf7...` → `0.28.0-e1afcbf7...`
+fn append_commit(version: &mut Version, commit: &str) -> Result<()> {
+    let pre_str = if version.pre.is_empty() {
+        commit.to_string()
+    } else {
+        format!("{}-{commit}", version.pre)
     };
+    version.pre = Prerelease::new(&pre_str)?;
+    Ok(())
+}
 
-    let anchor_cli_cargo_toml = response.text()?;
-    let anchor_cli_manifest = Manifest::from_str(&anchor_cli_cargo_toml)?;
-    let mut version = anchor_cli_manifest.package().version().parse::<Version>()?;
-    version.pre = Prerelease::new(commit)?;
+fn get_anchor_version_from_commit(commit: &str) -> Result<Version> {
+    let client = reqwest::blocking::Client::new();
+    let base = format!("https://raw.githubusercontent.com/solana-foundation/anchor/{commit}");
+
+    // Newer versions (workspace layout): version lives in [workspace.package] of the root Cargo.toml.
+    if let Some(text) = fetch_raw(&client, &format!("{base}/Cargo.toml"))? {
+        if let Ok(manifest) = Manifest::from_str(&text) {
+            if let Some(version_str) = manifest
+                .workspace
+                .as_ref()
+                .and_then(|ws| ws.package.as_ref())
+                .and_then(|pkg| pkg.version.as_deref())
+            {
+                let mut version = version_str.parse::<Version>()?;
+                append_commit(&mut version, commit)?;
+                return Ok(version);
+            }
+        }
+    }
+
+    // Older versions: version lives in [package] of cli/Cargo.toml.
+    let text = fetch_raw(&client, &format!("{base}/cli/Cargo.toml"))?
+        .ok_or_else(|| anyhow!("Could not find anchor-cli version for commit {commit}"))?;
+    let manifest = Manifest::from_str(&text)?;
+    let mut version = manifest.package().version().parse::<Version>()?;
+    append_commit(&mut version, commit)?;
 
     Ok(version)
 }
@@ -567,12 +595,13 @@ pub fn read_anchorversion_file() -> Result<Version> {
 
 /// Retrieve a list of installable versions of anchor-cli using the GitHub API and tags on the Anchor
 /// repository.
-pub fn fetch_versions() -> Result<Vec<Version>, Error> {
+pub fn fetch_versions(include_pre_release: bool) -> Result<Vec<Version>, Error> {
     #[derive(Deserialize)]
     struct Release {
         #[serde(rename = "name", deserialize_with = "version_deserializer")]
         version: Version,
         draft: bool,
+        prerelease: bool
     }
 
     fn version_deserializer<'de, D>(deserializer: D) -> Result<Version, D::Error>
@@ -593,9 +622,9 @@ pub fn fetch_versions() -> Result<Vec<Version>, Error> {
 
     if response.status().is_success() {
         let releases: Vec<Release> = response.json()?;
-        let versions = releases
+        let versions: Vec<Version> = releases
             .into_iter()
-            .filter(|r| !r.draft)
+            .filter(|r| !r.draft && (include_pre_release || !r.prerelease))
             .map(|r| r.version)
             .collect();
         Ok(versions)
@@ -617,10 +646,10 @@ pub fn fetch_versions() -> Result<Vec<Version>, Error> {
 }
 
 /// Print available versions and flags indicating installed, current and latest
-pub fn list_versions() -> Result<()> {
+pub fn list_versions(include_pre_release: bool) -> Result<()> {
     let mut installed_versions = read_installed_versions()?;
 
-    let mut available_versions = fetch_versions()?;
+    let mut available_versions = fetch_versions(include_pre_release)?;
     available_versions.sort();
 
     let print_versions =
@@ -652,11 +681,13 @@ pub fn list_versions() -> Result<()> {
     Ok(())
 }
 
-pub fn get_latest_version() -> Result<Version> {
-    fetch_versions()?
+pub fn get_latest_version(include_pre_release: bool) -> Result<Version> {
+    let mut versions = fetch_versions(include_pre_release)?;
+    versions.sort();
+    versions
         .into_iter()
-        .next()
-        .ok_or_else(|| anyhow!("First version not found"))
+        .last()
+        .ok_or_else(|| anyhow!("No versions found"))
 }
 
 /// Read the installed anchor-cli versions by reading the binaries in the AVM_HOME/bin directory.
@@ -788,5 +819,25 @@ mod tests {
             check_and_get_full_commit("e1afcbf").unwrap(),
             "e1afcbf71e0f2e10fae14525934a6a68479167b9"
         )
+    }
+
+    #[test]
+    fn test_append_commit_stable_version() {
+        let mut version = Version::parse("0.28.0").unwrap();
+        append_commit(&mut version, "e1afcbf71e0f2e10fae14525934a6a68479167b9").unwrap();
+        assert_eq!(
+            version.to_string(),
+            "0.28.0-e1afcbf71e0f2e10fae14525934a6a68479167b9"
+        );
+    }
+
+    #[test]
+    fn test_append_commit_pre_release_version() {
+        let mut version = Version::parse("1.0.0-rc.3").unwrap();
+        append_commit(&mut version, "e1afcbf71e0f2e10fae14525934a6a68479167b9").unwrap();
+        assert_eq!(
+            version.to_string(),
+            "1.0.0-rc.3-e1afcbf71e0f2e10fae14525934a6a68479167b9"
+        );
     }
 }

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -218,12 +218,12 @@ mod tests {
 
     #[test]
     fn test_is_pre_release_commit_hash() {
-        assert!(is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9"));
+        assert!(!is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9"));
     }
 
     #[test]
     fn test_is_pre_release_short_commit() {
-        assert!(is_pre_release("e1afcbf"));
+        assert!(!is_pre_release("e1afcbf"));
     }
 
     // --- parse_install_target (no-network cases) ---

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -64,9 +64,7 @@ pub enum Commands {
 /// Returns true if `pre` is a semver pre-release tag (`rc.`, `beta.`, `alpha.`),
 /// false if it looks like a git commit hash.
 fn is_pre_release(pre: &str) -> bool {
-    pre.starts_with("rc.")
-        || pre.starts_with("beta.")
-        || pre.starts_with("alpha.")
+    pre.starts_with("rc.") || pre.starts_with("beta.") || pre.starts_with("alpha.")
 }
 
 fn parse_install_target(version_or_commit: &str) -> Result<InstallTarget, Error> {
@@ -100,7 +98,9 @@ fn resolve_use_version(version: Option<String>) -> Result<Option<Version>> {
     match version.as_deref() {
         Some("latest") => Ok(Some(avm::get_latest_version(false)?)),
         Some("latest-pre-release") => Ok(Some(avm::get_latest_version(true)?)),
-        Some(v) => Ok(Some(Version::parse(v).map_err(|e| anyhow!("Invalid version `{v}`: {e}"))?)),
+        Some(v) => Ok(Some(
+            Version::parse(v).map_err(|e| anyhow!("Invalid version `{v}`: {e}"))?,
+        )),
         None => Ok(None),
     }
 }
@@ -194,7 +194,6 @@ fn main() -> Result<()> {
     entry(opt)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,7 +218,10 @@ mod tests {
 
     #[test]
     fn test_is_pre_release_commit_hash() {
-        assert_eq!(false, is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9"));
+        assert_eq!(
+            false,
+            is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9")
+        );
     }
 
     #[test]
@@ -232,19 +234,25 @@ mod tests {
     #[test]
     fn test_parse_install_target_stable_version() {
         let result = parse_install_target("1.0.0").unwrap();
-        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0").unwrap()));
+        assert!(
+            matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0").unwrap())
+        );
     }
 
     #[test]
     fn test_parse_install_target_pre_release_version() {
         let result = parse_install_target("1.0.0-rc.3").unwrap();
-        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-rc.3").unwrap()));
+        assert!(
+            matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-rc.3").unwrap())
+        );
     }
 
     #[test]
     fn test_parse_install_target_alpha_version() {
         let result = parse_install_target("1.0.0-alpha.1").unwrap();
-        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-alpha.1").unwrap()));
+        assert!(
+            matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-alpha.1").unwrap())
+        );
     }
 
     #[test]
@@ -272,7 +280,9 @@ mod tests {
 
     #[test]
     fn test_resolve_use_version_specific_stable() {
-        let version = resolve_use_version(Some("1.0.0".to_string())).unwrap().unwrap();
+        let version = resolve_use_version(Some("1.0.0".to_string()))
+            .unwrap()
+            .unwrap();
         assert_eq!(version.major, 1);
         assert_eq!(version.minor, 0);
         assert_eq!(version.patch, 0);
@@ -281,7 +291,9 @@ mod tests {
 
     #[test]
     fn test_resolve_use_version_specific_pre_release() {
-        let version = resolve_use_version(Some("1.0.0-rc.3".to_string())).unwrap().unwrap();
+        let version = resolve_use_version(Some("1.0.0-rc.3".to_string()))
+            .unwrap()
+            .unwrap();
         assert_eq!(version.major, 1);
         assert_eq!(version.minor, 0);
         assert_eq!(version.patch, 0);
@@ -290,8 +302,13 @@ mod tests {
 
     #[test]
     fn test_resolve_use_version_latest_is_stable() {
-        let version = resolve_use_version(Some("latest".to_string())).unwrap().unwrap();
-        assert!(version.pre.is_empty(), "latest should resolve to a stable version, got {version}");
+        let version = resolve_use_version(Some("latest".to_string()))
+            .unwrap()
+            .unwrap();
+        assert!(
+            version.pre.is_empty(),
+            "latest should resolve to a stable version, got {version}"
+        );
     }
 
     #[test]

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -203,30 +203,27 @@ mod tests {
 
     #[test]
     fn test_is_pre_release_rc() {
-        assert_eq!(true, is_pre_release("rc.3"));
+        assert!(is_pre_release("rc.3"));
     }
 
     #[test]
     fn test_is_pre_release_beta() {
-        assert_eq!(true, is_pre_release("beta.1"));
+        assert!(is_pre_release("beta.1"));
     }
 
     #[test]
     fn test_is_pre_release_alpha() {
-        assert_eq!(true, is_pre_release("alpha.2"));
+        assert!(is_pre_release("alpha.2"));
     }
 
     #[test]
     fn test_is_pre_release_commit_hash() {
-        assert_eq!(
-            false,
-            is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9")
-        );
+        assert!(is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9"));
     }
 
     #[test]
     fn test_is_pre_release_short_commit() {
-        assert_eq!(false, is_pre_release("e1afcbf"));
+        assert!(is_pre_release("e1afcbf"));
     }
 
     // --- parse_install_target (no-network cases) ---

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -15,20 +15,20 @@ pub struct Cli {
 pub enum Commands {
     #[clap(about = "Use a specific version of Anchor")]
     Use {
-        #[clap(value_parser = parse_version, required = false)]
-        version: Option<Version>,
+        /// Version to use: `latest`, `latest-pre-release`, or a specific version e.g. `1.0.0`, `1.0.0-rc.3`
+        #[clap(required = false)]
+        version: Option<String>,
     },
     #[clap(about = "Install a version of Anchor", alias = "i")]
     Install {
-        /// Anchor version or commit, conflicts with `--path`
+        /// Anchor version, commit, `latest`, or `latest-pre-release`; conflicts with `--path`
         #[clap(required_unless_present = "path")]
         version_or_commit: Option<String>,
         /// Path to local anchor repo, conflicts with `version_or_commit`
         #[clap(long, conflicts_with = "version_or_commit")]
         path: Option<String>,
         #[clap(long)]
-        /// Flag to force installation even if the version
-        /// is already installed
+        /// Flag to force installation even if the version is already installed
         force: bool,
         #[clap(long)]
         /// Build from source code rather than downloading prebuilt binaries
@@ -39,13 +39,21 @@ pub enum Commands {
     },
     #[clap(about = "Uninstall a version of Anchor")]
     Uninstall {
-        #[clap(value_parser = parse_version)]
-        version: Version,
+        /// Version to uninstall, e.g. `1.0.0` or `1.0.0-rc.3`
+        version: String,
     },
     #[clap(about = "List available versions of Anchor", alias = "ls")]
-    List {},
+    List {
+        #[clap(long)]
+        /// Include pre-release versions in the list
+        pre_release: bool,
+    },
     #[clap(about = "Update to the latest Anchor version")]
-    Update {},
+    Update {
+        #[clap(long)]
+        /// Include pre-release versions when selecting the latest
+        pre_release: bool,
+    },
     #[clap(about = "Generate shell completions for AVM")]
     Completions {
         #[clap(value_enum)]
@@ -53,31 +61,56 @@ pub enum Commands {
     },
 }
 
-// If `latest` is passed use the latest available version.
-fn parse_version(version: &str) -> Result<Version, Error> {
-    if version == "latest" {
-        avm::get_latest_version()
-    } else {
-        Ok(Version::parse(version)?)
-    }
+/// Returns true if `pre` is a semver pre-release tag (`rc.`, `beta.`, `alpha.`),
+/// false if it looks like a git commit hash.
+fn is_pre_release(pre: &str) -> bool {
+    pre.starts_with("rc.")
+        || pre.starts_with("beta.")
+        || pre.starts_with("alpha.")
 }
 
 fn parse_install_target(version_or_commit: &str) -> Result<InstallTarget, Error> {
-    if let Ok(version) = parse_version(version_or_commit) {
+    match version_or_commit {
+        "latest" => return Ok(InstallTarget::Version(avm::get_latest_version(false)?)),
+        "latest-pre-release" => return Ok(InstallTarget::Version(avm::get_latest_version(true)?)),
+        _ => {}
+    }
+
+    if let Ok(version) = Version::parse(version_or_commit) {
         if version.pre.is_empty() {
             return Ok(InstallTarget::Version(version));
         }
-        // Allow for e.g. `avm install 0.28.0-6cf200493a307c01487c7b492b4893e0d6f6cb23`
+        // If the prerelease segment is a bare hex string it was written as a commit, e.g.
+        // `avm install 0.28.0-6cf200493a307c01487c7b492b4893e0d6f6cb23`.
+        // Otherwise it is a proper semver pre-release tag such as `rc.3` or `alpha.1`.
+        if is_pre_release(version.pre.as_str()) {
+            return Ok(InstallTarget::Version(version));
+        }
+        // Prerelease segment looks like a commit hash, e.g.
+        // `avm install 0.28.0-6cf200493a307c01487c7b492b4893e0d6f6cb23`
         return Ok(InstallTarget::Commit(version.pre.to_string()));
     }
+
     avm::check_and_get_full_commit(version_or_commit)
         .map(InstallTarget::Commit)
         .map_err(|e| anyhow!("Not a valid version or commit: {e}"))
 }
 
+fn resolve_use_version(version: Option<String>) -> Result<Option<Version>> {
+    match version.as_deref() {
+        Some("latest") => Ok(Some(avm::get_latest_version(false)?)),
+        Some("latest-pre-release") => Ok(Some(avm::get_latest_version(true)?)),
+        Some(v) => Ok(Some(Version::parse(v).map_err(|e| anyhow!("Invalid version `{v}`: {e}"))?)),
+        None => Ok(None),
+    }
+}
+
 pub fn entry(opts: Cli) -> Result<()> {
     match opts.command {
-        Commands::Use { version } => avm::use_version(version),
+        Commands::Use { version } => {
+            let resolved = resolve_use_version(version)?;
+            avm::use_version(resolved)
+        }
         Commands::Install {
             version_or_commit,
             path,
@@ -92,9 +125,13 @@ pub fn entry(opts: Cli) -> Result<()> {
             };
             avm::install_version(install_target, force, from_source, verify)
         }
-        Commands::Uninstall { version } => avm::uninstall_version(&version),
-        Commands::List {} => avm::list_versions(),
-        Commands::Update {} => avm::update(),
+        Commands::Uninstall { version } => {
+            let v = Version::parse(&version)
+                .map_err(|e| anyhow!("Invalid version `{version}`: {e}"))?;
+            avm::uninstall_version(&v)
+        }
+        Commands::List { pre_release } => avm::list_versions(pre_release),
+        Commands::Update { pre_release } => avm::update(pre_release),
         Commands::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "avm", &mut std::io::stdout());
             Ok(())
@@ -155,4 +192,110 @@ fn main() -> Result<()> {
 
     let opt = Cli::parse();
     entry(opt)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use avm::InstallTarget;
+
+    // --- is_pre_release ---
+
+    #[test]
+    fn test_is_pre_release_rc() {
+        assert_eq!(true, is_pre_release("rc.3"));
+    }
+
+    #[test]
+    fn test_is_pre_release_beta() {
+        assert_eq!(true, is_pre_release("beta.1"));
+    }
+
+    #[test]
+    fn test_is_pre_release_alpha() {
+        assert_eq!(true, is_pre_release("alpha.2"));
+    }
+
+    #[test]
+    fn test_is_pre_release_commit_hash() {
+        assert_eq!(false, is_pre_release("e1afcbf71e0f2e10fae14525934a6a68479167b9"));
+    }
+
+    #[test]
+    fn test_is_pre_release_short_commit() {
+        assert_eq!(false, is_pre_release("e1afcbf"));
+    }
+
+    // --- parse_install_target (no-network cases) ---
+
+    #[test]
+    fn test_parse_install_target_stable_version() {
+        let result = parse_install_target("1.0.0").unwrap();
+        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0").unwrap()));
+    }
+
+    #[test]
+    fn test_parse_install_target_pre_release_version() {
+        let result = parse_install_target("1.0.0-rc.3").unwrap();
+        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-rc.3").unwrap()));
+    }
+
+    #[test]
+    fn test_parse_install_target_alpha_version() {
+        let result = parse_install_target("1.0.0-alpha.1").unwrap();
+        assert!(matches!(result, InstallTarget::Version(v) if v == Version::parse("1.0.0-alpha.1").unwrap()));
+    }
+
+    #[test]
+    fn test_parse_install_target_commit_as_prerelease() {
+        // `avm install 0.28.0-<sha>` syntax — pre segment is a commit hash
+        let commit = "6cf200493a307c01487c7b492b4893e0d6f6cb23";
+        let result = parse_install_target(&format!("0.28.0-{commit}")).unwrap();
+        assert!(matches!(result, InstallTarget::Commit(c) if c == commit));
+    }
+
+    #[test]
+    fn test_parse_install_target_bare_commit_hash() {
+        // bare full commit SHA — resolved via GitHub API to the same hash
+        let commit = "e1afcbf71e0f2e10fae14525934a6a68479167b9";
+        let result = parse_install_target(commit).unwrap();
+        assert!(matches!(result, InstallTarget::Commit(c) if c == commit));
+    }
+
+    // --- resolve_use_version (no-network cases) ---
+
+    #[test]
+    fn test_resolve_use_version_none() {
+        assert!(resolve_use_version(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_resolve_use_version_specific_stable() {
+        let version = resolve_use_version(Some("1.0.0".to_string())).unwrap().unwrap();
+        assert_eq!(version.major, 1);
+        assert_eq!(version.minor, 0);
+        assert_eq!(version.patch, 0);
+        assert!(version.pre.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_use_version_specific_pre_release() {
+        let version = resolve_use_version(Some("1.0.0-rc.3".to_string())).unwrap().unwrap();
+        assert_eq!(version.major, 1);
+        assert_eq!(version.minor, 0);
+        assert_eq!(version.patch, 0);
+        assert_eq!(version.pre.as_str(), "rc.3");
+    }
+
+    #[test]
+    fn test_resolve_use_version_latest_is_stable() {
+        let version = resolve_use_version(Some("latest".to_string())).unwrap().unwrap();
+        assert!(version.pre.is_empty(), "latest should resolve to a stable version, got {version}");
+    }
+
+    #[test]
+    fn test_resolve_use_version_invalid() {
+        assert!(resolve_use_version(Some("not-a-version".to_string())).is_err());
+    }
 }


### PR DESCRIPTION
feat(avm): add pre-release support across all commands. fixes fetching newer versions

CLI changes:

- `avm use` and `avm install` accept `latest` (stable only) and `latest-pre-release` (includes rc/beta/alpha) as version keywords. Specific pre-release versions (e.g. `1.0.0-rc.3`) are accepted directly. 
- `avm list` and `avm update` gain a `--pre-release` flag. 
- `avm uninstall` accepts pre-release versions directly (e.g. `1.0.0-rc.3`). 

Version resolution fixes:

- `parse_install_target` now correctly distinguishes semver pre-release tags (rc.3, alpha.1, beta.2) from the commit-as-prerelease syntax (`0.28.0-<sha>`), fixing `avm install 1.0.0-rc.3` which previously tried to resolve `rc.3` as a git commit. 
- `get_latest_version` now sorts versions before selecting, rather than relying on GitHub API ordering. 

Commit-based installs:

`get_anchor_version_from_commit` now tries the workspace root Cargo.toml ([workspace.package].version) first for newer repo layouts, falling back to cli/Cargo.toml for older versions. 
`append_commit` preserves any existing pre-release identifier when appending the commit SHA (e.g. 1.0.0-rc.3 + sha → 1.0.0-rc.3-<sha> instead of 1.0.0-<sha>).