### PR TITLE
Improvements to release process

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,80 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to without the v[...] prefix (e.g. 1.0.0-rc.5)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      # This is not great, but as this does not happen in the actual release actions,
+      # the worst that could happen is that this sneaks something in the PR diff.
+      - name: Install Solana CLI
+        run: |
+          set -xeou pipefail
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      # This is not great, but as this does not happen in the actual release actions,
+      # the worst that could happen is that this sneaks something in the PR diff.
+      - name: Install Surfpool
+        run: |
+          curl -sL https://run.surfpool.run/ | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install cargo-release
+        run: cargo install cargo-release --version 1.1.1 --locked
+
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -xeou pipefail
+
+          # required for tests
+          solana-keygen new --no-bip39-passphrase
+          ./setup-tests.sh
+
+          ./bump-version.sh "$VERSION"
+
+      # I would love to automatically create a PR here, but GitHub does not allow triggering CI jobs
+      # on automatically created PRs to prevent recursion
+      - name: Create release branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -xeou pipefail
+
+          BRANCH="release/v$VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "v$VERSION"
+          git push --set-upstream origin "$BRANCH"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -22,12 +22,15 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install cargo-release
+        run: cargo install cargo-release --version 1.1.1 --locked
+
       - name: Publish crates
         run: |
           set -xeuo pipefail
 
-          echo "Publishing all workspace packages as a dry-run"
-          cargo publish --workspace --locked --dry-run
+          echo "Publishing crates as a dry-run"
+          cargo release publish --workspace --allow-branch "*" --no-confirm
 
   publish-crates:
     name: Publish crates
@@ -47,6 +50,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install cargo-release
+        run: cargo install cargo-release --version 1.1.1 --locked
+
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
@@ -57,8 +63,8 @@ jobs:
         run: |
           set -xeuo pipefail
 
-          echo "Publishing all workspace packages"
-          cargo publish --workspace --locked
+          echo "Publishing crates"
+          cargo release publish --workspace --allow-branch "*" --no-confirm --execute
 
       - name: Check for crate artifacts
         id: crate-artifacts

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -7,10 +7,10 @@ on:
 
     paths:
       - VERSION
-      - github/workflows/release-pr.yaml
-      - github/workflows/build-cli.yaml
-      - github/workflows/publish-crates.yaml
-      - github/workflows/publish-npmjs.yaml
+      - .github/workflows/release-pr.yaml
+      - .github/workflows/build-cli.yaml
+      - .github/workflows/publish-crates.yaml
+      - .github/workflows/publish-npmjs.yaml
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,6 +207,12 @@ jobs:
           # If version looks like vX.Y.Z-<something> (e.g. v1.0.0-rc.2), publish as a pre-release
           if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
             publish_args+=(--prerelease)
+
+            # avm's older versions do not filter out pre-releases, meaning that
+            # if we were to create a pre-release, this would change the default
+            # version installed for new users
+            echo "Skipping creating GitHub release for a pre-release."
+            exit 0
           fi
 
           GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* --title "$GITHUB_REF_NAME" "${publish_args[@]}"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 if [ $# -eq 0 ]; then
     echo "Usage $0 VERSION"
@@ -15,7 +15,12 @@ if [[ "$version" == v* ]]; then
     exit 1
 fi
 
-echo "Bumping versions to $version"
+is_prerelease=0
+if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+    is_prerelease=1
+fi
+
+echo "Bumping versions to $version (is_prerelease=$is_prerelease)"
 
 # GNU/BSD compat
 sedi=(-i)
@@ -24,31 +29,38 @@ case "$(uname)" in
   Darwin*) sedi=(-i "")
 esac
 
+# Bump all rust crates that have `publish` enabled
+cargo release version $version \
+    --workspace \
+    $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish == []) | "--exclude " + .name') \
+    --no-confirm \
+    --execute
+
 # Only replace version with the following globs
-allow_globs=":**/Cargo.toml Cargo.toml **/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
+allow_globs="**/Makefile client/src/lib.rs lang/attribute/program/src/lib.rs"
 git grep -l $old_version -- $allow_globs |
     xargs sed "${sedi[@]}" \
     -e "s/$old_version/$version/g"
 
-# Update lock file to use the new versions
-cargo update $(cargo metadata --format-version 1 --no-deps | jq '.packages.[].name' -r)
-
-# Separately handle docs because blindly replacing the old version with the new
-# might break certain examples/links
-pushd docs/content/docs
-git grep -l $old_version -- "./*.md*" | \
-    xargs sed "${sedi[@]}" \
-    -e "s/\"$old_version\"/\"$version\"/g"
-allow_globs="installation.mdx quickstart/local.mdx references/verifiable-builds.mdx"
-git grep -l $old_version -- $allow_globs |
-    xargs sed "${sedi[@]}" \
-    -e "s/$old_version/$version/g"
-# Replace `solana_version` with the current version
-solana_version=$(solana --version | awk '{print $2;}')
-sed $sedi "s/solana_version.*\"/solana_version = \"$solana_version\"/g" references/anchor-toml.mdx
-# Keep release notes and changelog the same
-git restore updates
-popd
+# Avoid updating the docs for pre-release builds
+if [[ "$is_prerelease" -eq 0 ]]; then
+    # Separately handle docs because blindly replacing the old version with the new
+    # might break certain examples/links
+    pushd docs/content/docs
+    git grep -l $old_version -- "./*.md*" | \
+        xargs sed "${sedi[@]}" \
+        -e "s/\"$old_version\"/\"$version\"/g"
+    allow_globs="installation.mdx quickstart/local.mdx references/verifiable-builds.mdx"
+    git grep -l $old_version -- $allow_globs |
+        xargs sed "${sedi[@]}" \
+        -e "s/$old_version/$version/g"
+    # Replace `solana_version` with the current version
+    solana_version=$(solana --version | awk '{print $2;}')
+    sed $sedi "s/solana_version.*\"/solana_version = \"$solana_version\"/g" references/anchor-toml.mdx
+    # Keep release notes and changelog the same
+    git restore updates
+    popd
+fi
 
 # Potential for collisions in `package.json` files, handle those separately
 # Replace only matching "version": "x.xx.x" and "@anchor-lang/core": "x.xx.x"
@@ -63,12 +75,28 @@ sed "${sedi[@]}" -e \
     CHANGELOG.md
 
 # Update lock files
-pushd ts && yarn && popd
-pushd tests && yarn && popd
-pushd examples && yarn && pushd tutorial && yarn && popd && popd
+pushd ts
+yarn
+popd
 
-# Bump benchmark files
-pushd tests/bench && anchor run bump-version -- --anchor-version $version && popd
+pushd tests
+yarn
+popd
+
+pushd examples
+yarn
+pushd tutorial
+yarn
+popd
+popd
+
+# Avoid updating the benchmarks for pre-release builds
+if [[ "$is_prerelease" -eq 0 ]]; then
+    # Bump benchmark files
+    pushd tests/bench
+    anchor run bump-version -- --anchor-version $version
+    popd
+fi
 
 echo $version > VERSION
 

--- a/docs/content/docs/clients/rust.mdx
+++ b/docs/content/docs/clients/rust.mdx
@@ -262,8 +262,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anchor-client = { version = "1.0.0-rc.3", features = ["async"] }
-anchor-lang = "1.0.0-rc.3"
+anchor-client = { version = "0.32.1", features = ["async"] }
+anchor-lang = "0.32.1"
 anyhow = "1.0.93"
 tokio = { version = "1.0", features = ["full"] }
 ```

--- a/docs/content/docs/features/declare-program.mdx
+++ b/docs/content/docs/features/declare-program.mdx
@@ -680,8 +680,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anchor-client = { version = "1.0.0-rc.3", features = ["async"] }
-anchor-lang = "1.0.0-rc.3"
+anchor-client = { version = "0.32.1", features = ["async"] }
+anchor-lang = "0.32.1"
 anyhow = "1.0.93"
 tokio = { version = "1.0", features = ["full"] }
 ```

--- a/docs/content/docs/features/events.mdx
+++ b/docs/content/docs/features/events.mdx
@@ -152,7 +152,7 @@ program's `Cargo.toml`:
 
 ```toml title="Cargo.toml"
 [dependencies]
-anchor-lang = { version = "1.0.0-rc.3", features = ["event-cpi"] }
+anchor-lang = { version = "0.32.1", features = ["event-cpi"] }
 ```
 
 Example usage:

--- a/docs/content/docs/features/zero-copy.mdx
+++ b/docs/content/docs/features/zero-copy.mdx
@@ -62,7 +62,7 @@ zero-copy types.
 ```toml title="Cargo.toml"
 [dependencies]
 bytemuck = { version = "1.20.0", features = ["min_const_generics"] }
-anchor-lang = "1.0.0-rc.3"
+anchor-lang = "0.32.1"
 ```
 
 ### Define a Zero Copy Account

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -30,7 +30,7 @@ After installation, you should see output similar to the following:
 Installed Versions:
 Rust: rustc 1.85.0 (4d91de4e4 2025-02-17)
 Solana CLI: solana-cli 2.1.15 (src:53545685; feat:3271415109, client:Agave)
-Anchor CLI: anchor-cli 1.0.0-rc.3
+Anchor CLI: anchor-cli 0.32.1
 Node.js: v23.9.0
 Yarn: 1.22.1
 
@@ -355,8 +355,8 @@ Alternatively, you can install a specific version of Anchor CLI by specifying
 the version number:
 
 ```shell title="Terminal"
-avm install 1.0.0-rc.3
-avm use 1.0.0-rc.3
+avm install 0.32.1
+avm use 0.32.1
 ```
 
 <Callout type="info">
@@ -365,7 +365,7 @@ Don't forget to run the `avm use` command to declare which Anchor CLI version
 should be used on your system.
 
 - If you installed the `latest` version, run `avm use latest`.
-- If you installed the version `1.0.0-rc.3`, run `avm use 1.0.0-rc.3`.
+- If you installed the version `0.32.1`, run `avm use 0.32.1`.
 
 </Callout>
 
@@ -376,7 +376,7 @@ should be used on your system.
 Install a specific version of the Anchor CLI with the following command:
 
 ```shell title="Terminal"
-cargo install --git https://github.com/solana-foundation/anchor --tag v1.0.0-rc.3 anchor-cli
+cargo install --git https://github.com/solana-foundation/anchor --tag v0.32.1 anchor-cli
 ```
 
 </Tab>
@@ -391,7 +391,7 @@ anchor --version
 You should see output similar to the following:
 
 ```
-anchor-cli 1.0.0-rc.3
+anchor-cli 0.32.1
 ```
 
 <Callout type="warn">

--- a/docs/content/docs/quickstart/local.mdx
+++ b/docs/content/docs/quickstart/local.mdx
@@ -37,7 +37,7 @@ anchor --version
 Expected output:
 
 ```shell filename="Terminal"
-anchor-cli 1.0.0-rc.3
+anchor-cli 0.32.1
 ```
 
 ## Getting Started

--- a/docs/content/docs/references/anchor-toml.mdx
+++ b/docs/content/docs/references/anchor-toml.mdx
@@ -218,7 +218,7 @@ Override toolchain data in the workspace similar to
 
 ```toml
 [toolchain]
-anchor_version = "1.0.0-rc.3"    # `anchor-cli` version to use(requires `avm`)
+anchor_version = "0.32.1"    # `anchor-cli` version to use(requires `avm`)
 solana_version = "3.1.11"     # Solana version to use(applies to all Solana tools)
 package_manager = "yarn"     # JS package manager to use
 ```

--- a/docs/content/docs/references/verifiable-builds.mdx
+++ b/docs/content/docs/references/verifiable-builds.mdx
@@ -39,10 +39,10 @@ If the program has an IDL, it will also check the IDL deployed on chain matches.
 A docker image for each version of Anchor is published on
 [Docker Hub](https://hub.docker.com/r/solanafoundation/anchor). They are tagged
 in the form `solanafoundation/anchor:<version>`. For example, to get the image
-for Anchor `v1.0.0-rc.3` one can run
+for Anchor `v0.32.1` one can run
 
 ```shell
-docker pull solanafoundation/anchor:v1.0.0-rc.3
+docker pull solanafoundation/anchor:v0.32.1
 ```
 
 ## Removing an Image

--- a/docs/content/docs/tokens/basics/create-token-account.mdx
+++ b/docs/content/docs/tokens/basics/create-token-account.mdx
@@ -309,7 +309,7 @@ To use the `init_if_needed` constraint, enable the `init-if-needed` feature in
 
 ```toml title="Cargo.toml"
 [dependencies]
-anchor-lang = { version = "1.0.0-rc.3", features = ["init-if-needed"] }
+anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }
 ```
 
 ## Examples

--- a/docs/content/docs/tokens/index.mdx
+++ b/docs/content/docs/tokens/index.mdx
@@ -40,8 +40,8 @@ idl-build = [
 ]
 
 [dependencies]
-anchor-lang = "1.0.0-rc.3"
-anchor-spl = "1.0.0-rc.3"
+anchor-lang = "0.32.1"
+anchor-spl = "0.32.1"
 ```
 
 ### Core Modules

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -3,6 +3,7 @@ name = "anchor-spl"
 version.workspace = true
 publish = true
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
+repository = "https://github.com/solana-foundation/anchor"
 edition = "2021"
 license = "Apache-2.0"
 description = "CPI clients for SPL programs"


### PR DESCRIPTION
Based on the rc3 process, now the workflow is significantly simplified:
- instead of having to create branch locally and figure out how to run bump-version.sh without running into issues, you can now trigger a workflow `Prepare Release` with a version string, and a branch named `release/v[...]` will be automatically created with bump-version done
  - I would love to create the PR automatically as well, but GitHub does not run any of the workflows automatically if it's the one that created the PR to avoid infinite recursion. The workarounds here are GitHub app or PAT, but this seems slightly too dangerous for a workflow that's not restricted to the release environment (and would fail if we want to create the branch from a local fork)
- switch publishing crates to use `cargo-release`, as `cargo publish` does not allow you to retry publishes easily
- skip creating pre-release GitHub releases as avm would pull them by default on older installations of it
- benchmarks and docs are skipped in pre-releases as well per https://github.com/solana-foundation/anchor/pull/4329#pullrequestreview-3973677102
- revert back docs to use 0.32.1