### PR TITLE
fix(ts): remove stale @types/crypto-hash devDependency

### DIFF
--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -56,7 +56,6 @@
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/bn.js": "^4.11.6",
     "@types/bs58": "^4.0.1",
-    "@types/crypto-hash": "^1.1.2",
     "@types/jest": "^27.4.1",
     "@types/pako": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^4.6.0",

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1085,13 +1085,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/crypto-hash@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/crypto-hash/-/crypto-hash-1.1.2.tgz#5a993deb0e6ba7c42f86eaa65d9bf563378f4569"
-  integrity sha512-sOmi+4Go2XKodLV4+lfP+5QMQ+6ZYqRJhK8D/n6xsxIUvlerEulmU9S4Lo02pXCH3qPBeJXEy+g8ZERktDJLSg==
-  dependencies:
-    crypto-hash "*"
-
 "@types/estree@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
@@ -1917,11 +1910,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-hash@*:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-2.0.1.tgz#46c3732e65a078ea06b8b4ae686db41216f81213"
-  integrity sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ==
 
 cssom@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
## Summary

The `crypto-hash` package was removed in #3171 but its type definitions (`@types/crypto-hash`) were left behind as an orphaned devDependency in `ts/packages/anchor/package.json` and `ts/yarn.lock`.

This PR removes both entries.

Closes #4312

## Changes

- Remove `@types/crypto-hash` from `ts/packages/anchor/package.json` devDependencies
- Remove `@types/crypto-hash` and transitive `crypto-hash` entries from `ts/yarn.lock`