### PR TITLE
fix(avm):  Using a temporary installation dir on cargo install calls to prevent cargo erroring out due to existing `anchor` symlink in `.avm/bin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Fixes
 
 - lang: Fix incorrect deserialization for dynamically sized types when using `lazy-account` ([#4319](https://github.com/solana-foundation/anchor/pull/4319))
+- avm: Using a temporary installation dir on cargo install calls to prevent cargo erroring out due to existing `anchor` symlink in `.avm/bin` ([4343](https://github.com/solana-foundation/anchor/pull/4343))
 
 ### Breaking
 

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -52,6 +52,16 @@ pub fn get_bin_dir_path() -> PathBuf {
     AVM_HOME.join("bin")
 }
 
+/// Path to the temporary folder for cargo install
+pub fn get_tmp_install_dir_path() -> PathBuf {
+    AVM_HOME.join("tmp")
+}
+
+/// Path to the temporary bin folder of cargo install
+pub fn get_tmp_bin_dir_path() -> PathBuf {
+    AVM_HOME.join("tmp").join("bin")
+}
+
 /// Path to the binary for the given version
 pub fn version_binary_path(version: &Version) -> PathBuf {
     get_bin_dir_path().join(format!("anchor-{version}"))
@@ -367,7 +377,11 @@ pub fn install_version(
             "anchor-cli".into(),
             "--locked".into(),
             "--root".into(),
-            AVM_HOME.to_str().unwrap().into(),
+            // can't install directly to `.avm/` because additional symlinks were
+            // added to the .avm/bin folder that can cause cargo to error out during installs
+            // simply removing the creation of those links would not remove them from user machines
+            // and we don't want to remove them because they may have been created by the user
+            get_tmp_install_dir_path().to_str().unwrap().into(),
         ];
         match install_target {
             InstallTarget::Version(version) => {
@@ -440,7 +454,7 @@ pub fn install_version(
             ));
         }
 
-        let bin_dir = get_bin_dir_path();
+        let bin_dir = get_tmp_bin_dir_path();
         let bin_name = if cfg!(target_os = "windows") {
             "anchor.exe"
         } else {


### PR DESCRIPTION
## Problem

Installations of `avm` and `anchor` are expected to be under `~/.cargo/bin/`, avm works by creating a controlled directory of anchor installations under `.avm/bin/`. This location is also where `cargo install` installs the many versions, and to end the process  avm will rename the binary to append the version number.
To tie this all together, a symlink of `.cargo/bin/anchor` -> `.cargo/bin/avm` is expected, so that avm proxies to the right install.

The PR #3768 added the additional symlink of `.avm/bin/anchor` -> `.avm/bin/avm` which breaks the `cargo install` in some systems as the location ( `.avm/bin/anchor` ) already exists when trying to install a new version.

## Solution

This PR installs binaries in a temporary path before renaming and moving them to the expected `.avm/bin`