### PR TITLE
lang: Rename `errors` and `ProgramError` of `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+- lang: Rename `errors` and `ProgramError` of `declare_program!` ([#4347](https://github.com/solana-foundation/anchor/pull/4347)).
+
 ## [1.0.0-rc.5] - 2026-03-20
 
 ### Features

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -11,7 +11,7 @@ use syn::parse::{Parse, ParseStream};
 use common::gen_docs;
 use mods::{
     accounts::gen_accounts_mod, client::gen_client_mod, constants::gen_constants_mod,
-    cpi::gen_cpi_mod, errors::gen_errors_mod, events::gen_events_mod, internal::gen_internal_mod,
+    cpi::gen_cpi_mod, error::gen_errors_mod, events::gen_events_mod, internal::gen_internal_mod,
     parsers::gen_parsers_mod, program::gen_program_mod, types::gen_types_mod,
 };
 

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -11,7 +11,7 @@ use syn::parse::{Parse, ParseStream};
 use common::gen_docs;
 use mods::{
     accounts::gen_accounts_mod, client::gen_client_mod, constants::gen_constants_mod,
-    cpi::gen_cpi_mod, error::gen_errors_mod, events::gen_events_mod, internal::gen_internal_mod,
+    cpi::gen_cpi_mod, error::gen_error_mod, events::gen_events_mod, internal::gen_internal_mod,
     parsers::gen_parsers_mod, program::gen_program_mod, types::gen_types_mod,
 };
 
@@ -61,7 +61,7 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
     let accounts_mod = gen_accounts_mod(idl);
     let events_mod = gen_events_mod(idl);
     let types_mod = gen_types_mod(idl);
-    let errors_mod = gen_errors_mod(idl);
+    let error_mod = gen_error_mod(idl);
 
     // Clients
     let cpi_mod = gen_cpi_mod(idl);
@@ -91,7 +91,7 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
             #accounts_mod
             #events_mod
             #types_mod
-            #errors_mod
+            #error_mod
 
             #cpi_mod
             #client_mod

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -2,7 +2,7 @@ use anchor_lang_idl::types::Idl;
 use heck::CamelCase;
 use quote::{format_ident, quote};
 
-pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
+pub fn gen_error_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let errors = idl.errors.iter().map(|e| {
         let name = format_ident!("{}", e.name);
         let code = e.code;

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -14,7 +14,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
         return quote! {
             /// Program error type definitions.
             #[cfg(not(feature = "idl-build"))]
-            pub mod errors {
+            pub mod error {
                 use super::*;
             }
         };
@@ -23,7 +23,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
     quote! {
         /// Program error type definitions.
         #[cfg(not(feature = "idl-build"))]
-        pub mod errors {
+        pub mod error {
             use super::*;
 
             #[anchor_lang::error_code(offset = 0)]

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -1,4 +1,5 @@
 use anchor_lang_idl::types::Idl;
+use heck::CamelCase;
 use quote::{format_ident, quote};
 
 pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
@@ -20,6 +21,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
         };
     }
 
+    let name = format_ident!("{}Error", idl.metadata.name.to_camel_case());
     quote! {
         /// Program error type definitions.
         #[cfg(not(feature = "idl-build"))]
@@ -27,7 +29,7 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
             use super::*;
 
             #[anchor_lang::error_code(offset = 0)]
-            pub enum ProgramError {
+            pub enum #name {
                 #(#errors)*
             }
         }

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -11,27 +11,25 @@ pub fn gen_errors_mod(idl: &Idl) -> proc_macro2::TokenStream {
         }
     });
 
-    if errors.len() == 0 {
-        return quote! {
-            /// Program error type definitions.
-            #[cfg(not(feature = "idl-build"))]
-            pub mod error {
-                use super::*;
+    let error = if errors.len() == 0 {
+        quote!()
+    } else {
+        let name = format_ident!("{}Error", idl.metadata.name.to_camel_case());
+        quote! {
+            #[anchor_lang::error_code(offset = 0)]
+            pub enum #name {
+                #(#errors)*
             }
-        };
-    }
+        }
+    };
 
-    let name = format_ident!("{}Error", idl.metadata.name.to_camel_case());
     quote! {
         /// Program error type definitions.
         #[cfg(not(feature = "idl-build"))]
         pub mod error {
             use super::*;
 
-            #[anchor_lang::error_code(offset = 0)]
-            pub enum #name {
-                #(#errors)*
-            }
+            #error
         }
     }
 }

--- a/lang/attribute/program/src/declare_program/mods/mod.rs
+++ b/lang/attribute/program/src/declare_program/mods/mod.rs
@@ -2,7 +2,7 @@ pub mod accounts;
 pub mod client;
 pub mod constants;
 pub mod cpi;
-pub mod errors;
+pub mod error;
 pub mod events;
 pub mod internal;
 pub mod parsers;

--- a/tests/declare-program/programs/declare-program/tests/parsers.rs
+++ b/tests/declare-program/programs/declare-program/tests/parsers.rs
@@ -305,8 +305,8 @@ pub fn test_instruction_parser() {
 #[test]
 #[cfg(not(feature = "idl-build"))]
 pub fn test_errors() {
-    use external::errors::ProgramError;
+    use external::error::ExternalError;
 
-    assert_eq!(ProgramError::MyNormalError as u32, 6000);
-    assert_eq!(ProgramError::MyErrorWithSpecialOffset as u32, 6500);
+    assert_eq!(ExternalError::MyNormalError as u32, 6000);
+    assert_eq!(ExternalError::MyErrorWithSpecialOffset as u32, 6500);
 }


### PR DESCRIPTION
### Problem

- [The `errors` module](https://github.com/solana-foundation/anchor/blob/04997515c73ad7f36ccf7a7701408178503f3afa/lang/attribute/program/src/declare_program/mods/errors.rs#L26) generated by `declare_program!` only has a single error definition but has a plural name
- [The `ProgramError` enum](https://github.com/solana-foundation/anchor/blob/04997515c73ad7f36ccf7a7701408178503f3afa/lang/attribute/program/src/declare_program/mods/errors.rs#L30) is ambiguous with [`solana-program`'s `ProgramError`](https://github.com/anza-xyz/solana-sdk/blob/17ca02da0b56f1af27c2172b2c7d85b99e21ec2a/program-error/src/lib.rs#L57) and requires either using full paths or renaming the imports with the `as` keyword when you work with multiple programs

### Summary of changes

- Rename `errors` to `error`
- Rename `ProgramError` to `<ProgramName>Error`
- Refactor to avoid having to duplicate the `error` module generation code