### PR TITLE
Minor release process tweaks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,7 +122,7 @@ jobs:
   publish-dockerhub:
     name: Publish Docker image to Dockerhub
     runs-on: ubuntu-latest
-    needs: verify-tag
+    needs: [verify-tag, publish-crates]
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     permissions:
       contents: read

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -345,6 +345,8 @@ jobs:
     needs: setup-anchor-cli
     name: Test Anchor Init
     runs-on: ubuntu-latest
+    # Release PRs bump the version, but the version is obviously not available yet making this test always fail in those scenarios
+    if: "!startsWith(github.head_ref, 'release/')"
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
The docker image actually depends on publish-crates as it installs some of the packages from crates.io, therefore we have to wait for the crates to be published before building the image or otherwise we may sometimes have to retry the CI job depending if we reach cargo install in the image before publish-crates finishes.

This also skips `Test Anchor Init` job when doing the release process PR. From a quick look, because `anchor init` writes its own package.json, the concrete versions there take priority over the `yarn link @anchor-lang/core` that is run afterward, and because the release PR is only about to bump the versions, obviously this will always fail. I guess we could monkeypatch the package.json in these scenarios to the local copies, but considering we already ignore the test failures here this is probably a cleaner solution without writing more release process -specific logic into tests (and can be "properly" fixed on later?).