### PR TITLE
Add `rustfmt` configuration

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -54,7 +54,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build
-      - run: cargo +nightly fmt -- --check
+      - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt && cargo +nightly fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
       # FIXME: Enable `idl-build`
       - run: cargo test --workspace --exclude avm --features allow-missing-optionals,anchor-debug,derive,event-cpi,init-if-needed,lazy-account

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -54,7 +54,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build
-      - run: cargo fmt -- --check
+      - run: cargo +nightly fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
       # FIXME: Enable `idl-build`
       - run: cargo test --workspace --exclude avm --features allow-missing-optionals,anchor-debug,derive,event-cpi,init-if-needed,lazy-account

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -1,15 +1,18 @@
-use anyhow::{anyhow, bail, Context, Error, Result};
-use cargo_toml::Manifest;
-use chrono::{TimeZone, Utc};
-use reqwest::header::USER_AGENT;
-use reqwest::StatusCode;
-use semver::{Prerelease, Version};
-use serde::{de, Deserialize};
-use std::fs;
-use std::io::{BufRead, Write};
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::sync::LazyLock;
+use {
+    anyhow::{anyhow, bail, Context, Error, Result},
+    cargo_toml::Manifest,
+    chrono::{TimeZone, Utc},
+    reqwest::{header::USER_AGENT, StatusCode},
+    semver::{Prerelease, Version},
+    serde::{de, Deserialize},
+    std::{
+        fs,
+        io::{BufRead, Write},
+        path::PathBuf,
+        process::{Command, Stdio},
+        sync::LazyLock,
+    },
+};
 
 /// Checked at most once per hour.
 const UPDATE_CHECK_INTERVAL_SECS: i64 = 60 * 60;
@@ -165,7 +168,8 @@ pub fn ensure_paths() {
                     if !linked {
                         if let Err(e) = fs::copy(&target, &anchor_in_cargo) {
                             eprintln!(
-                                "Failed to place `anchor` in {}: {}.\nAdd {} to your PATH or create a symlink manually.",
+                                "Failed to place `anchor` in {}: {}.\nAdd {} to your PATH or \
+                                 create a symlink manually.",
                                 cargo_bin.display(),
                                 e,
                                 bin_dir.display()
@@ -800,8 +804,8 @@ pub fn check_avm_version_and_warn() {
         UpdateCacheState::Success(ts, latest) if now - ts < UPDATE_CHECK_INTERVAL_SECS => {
             if latest > current {
                 eprintln!(
-                    "A new version of avm is available: {latest} (you have {current}). \
-                     Run `avm self-update` to upgrade."
+                    "A new version of avm is available: {latest} (you have {current}). Run `avm \
+                     self-update` to upgrade."
                 );
             }
         }
@@ -816,8 +820,8 @@ pub fn check_avm_version_and_warn() {
                 write_update_cache_success(&latest);
                 if latest > current {
                     eprintln!(
-                        "A new version of avm is available: {latest} (you have {current}). \
-                             Run `avm self-update` to upgrade."
+                        "A new version of avm is available: {latest} (you have {current}). Run \
+                         `avm self-update` to upgrade."
                     );
                 }
             }
@@ -879,11 +883,11 @@ pub fn self_update(include_pre_release: bool, bleeding_edge: bool) -> Result<()>
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
-    use semver::Version;
-    use std::fs;
-    use std::io::Write;
-    use std::path::Path;
+    use {
+        crate::*,
+        semver::Version,
+        std::{fs, io::Write, path::Path},
+    };
 
     #[test]
     fn test_ensure_paths() {

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -1,8 +1,10 @@
-use anyhow::{anyhow, Error, Result};
-use avm::InstallTarget;
-use clap::{CommandFactory, Parser, Subcommand};
-use semver::Version;
-use std::ffi::OsStr;
+use {
+    anyhow::{anyhow, Error, Result},
+    avm::InstallTarget,
+    clap::{CommandFactory, Parser, Subcommand},
+    semver::Version,
+    std::ffi::OsStr,
+};
 
 #[derive(Parser)]
 #[clap(name = "avm", about = "Anchor version manager", version)]
@@ -216,8 +218,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use avm::InstallTarget;
+    use {super::*, avm::InstallTarget};
 
     // --- is_pre_release ---
 

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,13 +1,12 @@
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use solana_commitment_config::CommitmentConfig;
-use solana_pubkey::Pubkey;
-use solana_rpc_client::rpc_client::RpcClient;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
-use crate::config::{Config, ConfigOverride};
+use {
+    crate::config::{Config, ConfigOverride},
+    anyhow::{anyhow, Result},
+    clap::Parser,
+    solana_commitment_config::CommitmentConfig,
+    solana_pubkey::Pubkey,
+    solana_rpc_client::rpc_client::RpcClient,
+    std::{fs::File, io::Write, path::PathBuf},
+};
 
 #[derive(Debug, Parser)]
 pub struct ShowAccountCommand {

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,6 +1,4 @@
-use anchor_cli::Opts;
-use anyhow::Result;
-use clap::Parser;
+use {anchor_cli::Opts, anyhow::Result, clap::Parser};
 
 fn main() -> Result<()> {
     anchor_cli::entry(Opts::parse())

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,11 +1,11 @@
-use std::{fs, path::Path};
-
-use anyhow::{anyhow, Result};
-use semver::{Version, VersionReq};
-
-use crate::{
-    config::{Config, Manifest, PackageManager, WithPath},
-    VERSION,
+use {
+    crate::{
+        config::{Config, Manifest, PackageManager, WithPath},
+        VERSION,
+    },
+    anyhow::{anyhow, Result},
+    semver::{Version, VersionReq},
+    std::{fs, path::Path},
 };
 
 /// Check whether `overflow-checks` codegen option is enabled.
@@ -18,10 +18,8 @@ pub fn check_overflow(cargo_toml_path: impl AsRef<Path>) -> Result<bool> {
         .as_ref()
         .and_then(|profile| profile.overflow_checks)
         .ok_or(anyhow!(
-            "`overflow-checks` is not enabled. To enable, add:\n\n\
-    [profile.release]\n\
-    overflow-checks = true\n\n\
-    in workspace root Cargo.toml",
+            "`overflow-checks` is not enabled. To enable, \
+             add:\n\n[profile.release]\noverflow-checks = true\n\nin workspace root Cargo.toml",
         ))
 }
 
@@ -48,11 +46,8 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
     if let Some(ver) = mismatched_lang_version {
         eprintln!(
             "WARNING: `anchor-lang` version({ver}) and the current CLI version({cli_version}) \
-                 don't match.\n\n\t\
-                 This can lead to unwanted behavior. To use the same CLI version, add:\n\n\t\
-                 [toolchain]\n\t\
-                 anchor_version = \"{ver}\"\n\n\t\
-                 to Anchor.toml\n"
+             don't match.\n\n\tThis can lead to unwanted behavior. To use the same CLI version, \
+             add:\n\n\t[toolchain]\n\tanchor_version = \"{ver}\"\n\n\tto Anchor.toml\n"
         );
     }
 
@@ -78,10 +73,9 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
         };
 
         eprintln!(
-            "WARNING: `@anchor-lang/core` version({ver}) and the current CLI version\
-                ({cli_version}) don't match.\n\n\t\
-                This can lead to unwanted behavior. To fix, upgrade the package by running:\n\n\t\
-                {update_cmd} @anchor-lang/core@{cli_version}\n"
+            "WARNING: `@anchor-lang/core` version({ver}) and the current CLI \
+             version({cli_version}) don't match.\n\n\tThis can lead to unwanted behavior. To fix, \
+             upgrade the package by running:\n\n\t{update_cmd} @anchor-lang/core@{cli_version}\n"
         );
     }
 
@@ -135,11 +129,10 @@ pub fn check_deps(cfg: &WithPath<Config>) -> Result<()> {
         })
         .for_each(|man| {
             eprintln!(
-                "WARNING: Adding `solana-program` as a separate dependency might cause conflicts.\n\
-                To solve, remove the `solana-program` dependency and use the exported crate from \
-                `anchor-lang`.\n\
-                `use solana_program` becomes `use anchor_lang::solana_program`.\n\
-                Program name: `{}`\n",
+                "WARNING: Adding `solana-program` as a separate dependency might cause \
+                 conflicts.\nTo solve, remove the `solana-program` dependency and use the \
+                 exported crate from `anchor-lang`.\n`use solana_program` becomes `use \
+                 anchor_lang::solana_program`.\nProgram name: `{}`\n",
                 man.package().name()
             )
         });
@@ -187,12 +180,10 @@ in `{manifest_path:?}`."#
         .filter(|(_, dep)| dep.req_features().contains(&"idl-build".into()))
         .for_each(|(name, _)| {
             eprintln!(
-                "WARNING: `idl-build` feature of crate `{name}` is enabled by default. \
-                    This is not the intended usage.\n\n\t\
-                    To solve, do not enable the `idl-build` feature and include crates that have \
-                    `idl-build` feature in the `idl-build` feature list:\n\n\t\
-                    [features]\n\t\
-                    idl-build = [\"{name}/idl-build\", ...]\n"
+                "WARNING: `idl-build` feature of crate `{name}` is enabled by default. This is \
+                 not the intended usage.\n\n\tTo solve, do not enable the `idl-build` feature and \
+                 include crates that have `idl-build` feature in the `idl-build` feature \
+                 list:\n\n\t[features]\n\tidl-build = [\"{name}/idl-build\", ...]\n"
             )
         });
 
@@ -205,11 +196,10 @@ in `{manifest_path:?}`."#
         .unwrap_or_default()
         .then(|| {
             eprintln!(
-                "WARNING: `idl-build` feature of `anchor-spl` is not enabled. \
-                This is likely to result in cryptic compile errors.\n\n\t\
-                To solve, add `anchor-spl/idl-build` to the `idl-build` feature list:\n\n\t\
-                [features]\n\t\
-                idl-build = [\"anchor-spl/idl-build\", ...]\n"
+                "WARNING: `idl-build` feature of `anchor-spl` is not enabled. This is likely to \
+                 result in cryptic compile errors.\n\n\tTo solve, add `anchor-spl/idl-build` to \
+                 the `idl-build` feature list:\n\n\t[features]\n\tidl-build = \
+                 [\"anchor-spl/idl-build\", ...]\n"
             )
         });
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,32 +1,37 @@
-use crate::{get_keypair, is_hidden, keys_sync, DEFAULT_RPC_PORT};
-use anchor_client::Cluster;
-use anchor_lang_idl::types::Idl;
-use anyhow::{anyhow, bail, Context, Error, Result};
-use clap::{Parser, ValueEnum};
-use dirs::home_dir;
-use heck::ToSnakeCase;
-use reqwest::Url;
-use serde::de::{self, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use solana_cli_config::{Config as SolanaConfig, CONFIG_FILE};
-use solana_clock::Slot;
-use solana_commitment_config::CommitmentLevel;
-use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
-use solana_signer::Signer;
-use std::collections::{BTreeMap, HashMap};
-use std::convert::TryFrom;
-use std::fs::{self, File};
-use std::io::prelude::*;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::path::Path;
-use std::path::PathBuf;
-use std::process::Command;
-use std::str::FromStr;
-use std::{fmt, io};
-use walkdir::WalkDir;
+use {
+    crate::{get_keypair, is_hidden, keys_sync, DEFAULT_RPC_PORT},
+    anchor_client::Cluster,
+    anchor_lang_idl::types::Idl,
+    anyhow::{anyhow, bail, Context, Error, Result},
+    clap::{Parser, ValueEnum},
+    dirs::home_dir,
+    heck::ToSnakeCase,
+    reqwest::Url,
+    serde::{
+        de::{self, MapAccess, Visitor},
+        ser::SerializeMap,
+        Deserialize, Deserializer, Serialize, Serializer,
+    },
+    solana_cli_config::{Config as SolanaConfig, CONFIG_FILE},
+    solana_clock::Slot,
+    solana_commitment_config::CommitmentLevel,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    std::{
+        collections::{BTreeMap, HashMap},
+        convert::TryFrom,
+        fmt,
+        fs::{self, File},
+        io::{self, prelude::*},
+        marker::PhantomData,
+        ops::Deref,
+        path::{Path, PathBuf},
+        process::Command,
+        str::FromStr,
+    },
+    walkdir::WalkDir,
+};
 
 pub const SURFPOOL_HOST: &str = "127.0.0.1";
 /// Wrapper around CommitmentLevel to support case-insensitive parsing
@@ -1034,7 +1039,8 @@ fn canonicalize_filepath_from_origin(
     let result = fs::canonicalize(&file_path)
         .with_context(|| {
             format!(
-                "Error reading (possibly relative) path: {}. If relative, this is the path that was used as the current path: {}",
+                "Error reading (possibly relative) path: {}. If relative, this is the path that \
+                 was used as the current path: {}",
                 &file_path.as_ref().display(),
                 &origin.as_ref().display()
             )

--- a/cli/src/keygen.rs
+++ b/cli/src/keygen.rs
@@ -1,20 +1,20 @@
-use std::{
-    fs,
-    io::{self, Write},
-    path::Path,
+use {
+    crate::{config::ConfigOverride, get_keypair, KeygenCommand},
+    anyhow::{anyhow, bail, Result},
+    bip39::{Language, Mnemonic, MnemonicType, Seed},
+    console::{Key, Term},
+    dirs::home_dir,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_signer::{EncodableKey, Signer},
+    solana_transaction::Message,
+    std::{
+        fs,
+        io::{self, Write},
+        path::Path,
+    },
 };
-
-use anyhow::{anyhow, bail, Result};
-use bip39::{Language, Mnemonic, MnemonicType, Seed};
-use console::{Key, Term};
-use dirs::home_dir;
-use solana_instruction::{AccountMeta, Instruction};
-use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
-use solana_signer::{EncodableKey, Signer};
-use solana_transaction::Message;
-
-use crate::{config::ConfigOverride, get_keypair, KeygenCommand};
 
 /// Secure password input with asterisk visual feedback
 /// - show_spaces: if true, spaces are visible (for seed phrases); if false, all characters are asterisks (for passphrases)
@@ -351,8 +351,10 @@ fn keygen_verify(pubkey: Pubkey, keypair_path: Option<String>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tempfile::{tempdir, TempDir};
+    use {
+        super::*,
+        tempfile::{tempdir, TempDir},
+    };
 
     fn tmp_outfile_path(out_dir: &TempDir, name: &str) -> String {
         let path = out_dir.path().join(name);
@@ -433,7 +435,8 @@ mod tests {
     #[test]
     fn test_keypair_from_seed_consistency() {
         // Test that the same seed phrase produces the same keypair
-        let test_phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let test_phrase = "abandon abandon abandon abandon abandon abandon abandon abandon \
+                           abandon abandon abandon about";
 
         let mnemonic = Mnemonic::from_phrase(test_phrase, Language::English).unwrap();
         let seed1 = Seed::new(&mnemonic, "");

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,46 +1,52 @@
-use crate::config::{
-    get_default_ledger_path, BootstrapMode, BuildConfig, Config, ConfigOverride, HookType,
-    Manifest, PackageManager, ProgramDeployment, ProgramWorkspace, ScriptsConfig,
-    SurfnetInfoResponse, SurfpoolConfig, TestValidator, ValidatorType, WithPath, SHUTDOWN_WAIT,
-    STARTUP_WAIT, SURFPOOL_HOST,
+use {
+    crate::config::{
+        get_default_ledger_path, BootstrapMode, BuildConfig, Config, ConfigOverride, HookType,
+        Manifest, PackageManager, ProgramDeployment, ProgramWorkspace, ScriptsConfig,
+        SurfnetInfoResponse, SurfpoolConfig, TestValidator, ValidatorType, WithPath, SHUTDOWN_WAIT,
+        STARTUP_WAIT, SURFPOOL_HOST,
+    },
+    anchor_client::Cluster,
+    anchor_lang::{
+        prelude::UpgradeableLoaderState, solana_program::bpf_loader_upgradeable, AnchorDeserialize,
+    },
+    anchor_lang_idl::{
+        convert::convert_idl,
+        types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy},
+    },
+    anyhow::{anyhow, bail, Context, Result},
+    checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow},
+    clap::{CommandFactory, Parser},
+    dirs::home_dir,
+    heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToSnakeCase},
+    regex::{Regex, RegexBuilder},
+    rust_template::{ProgramTemplate, TestTemplate},
+    semver::{Version, VersionReq},
+    serde_json::{json, Map, Value as JsonValue},
+    solana_cli_config::Config as SolanaCliConfig,
+    solana_commitment_config::CommitmentConfig,
+    solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_instruction::Instruction,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_pubsub_client::pubsub_client::{PubsubClient, PubsubClientSubscription},
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::{
+        config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
+        request::RpcRequest,
+        response::{Response as RpcResponse, RpcLogsResponse},
+    },
+    solana_signer::{EncodableKey, Signer},
+    std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        ffi::OsString,
+        fs::{self, File},
+        io::prelude::*,
+        path::{Path, PathBuf},
+        process::{Child, Stdio},
+        string::ToString,
+        sync::LazyLock,
+    },
 };
-use anchor_client::Cluster;
-use anchor_lang::prelude::UpgradeableLoaderState;
-use anchor_lang::solana_program::bpf_loader_upgradeable;
-use anchor_lang::AnchorDeserialize;
-use anchor_lang_idl::convert::convert_idl;
-use anchor_lang_idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy};
-use anyhow::{anyhow, bail, Context, Result};
-use checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow};
-use clap::{CommandFactory, Parser};
-use dirs::home_dir;
-use heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToSnakeCase};
-use regex::{Regex, RegexBuilder};
-use rust_template::{ProgramTemplate, TestTemplate};
-use semver::{Version, VersionReq};
-use serde_json::{json, Map, Value as JsonValue};
-use solana_cli_config::Config as SolanaCliConfig;
-use solana_commitment_config::CommitmentConfig;
-use solana_compute_budget_interface::ComputeBudgetInstruction;
-use solana_instruction::Instruction;
-use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
-use solana_pubsub_client::pubsub_client::{PubsubClient, PubsubClientSubscription};
-use solana_rpc_client::rpc_client::RpcClient;
-use solana_rpc_client_api::config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter};
-use solana_rpc_client_api::request::RpcRequest;
-use solana_rpc_client_api::response::{Response as RpcResponse, RpcLogsResponse};
-use solana_signer::{EncodableKey, Signer};
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::ffi::OsString;
-use std::fs::{self, File};
-use std::io::prelude::*;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Stdio};
-use std::string::ToString;
-use std::sync::LazyLock;
 
 mod account;
 mod checks;
@@ -1022,8 +1028,8 @@ fn override_toolchain(cfg_override: &ConfigOverride) -> Result<RestoreToolchainC
                         }
                     })),
                     false => eprintln!(
-                        "Failed to override `solana` version to {solana_version}, \
-                        using {current_version} instead"
+                        "Failed to override `solana` version to {solana_version}, using \
+                         {current_version} instead"
                     ),
                 }
             }
@@ -1517,8 +1523,8 @@ fn install_solana_skill() {
         }
         _ => {
             eprintln!(
-                "Warning: Failed to install Solana dev skill. \
-                 Install manually with:\n  npx skills add {SKILL_REPO}"
+                "Warning: Failed to install Solana dev skill. Install manually with:\n  npx \
+                 skills add {SKILL_REPO}"
             );
         }
     }
@@ -2170,22 +2176,19 @@ fn docker_build_bpf(
         .args([
             "exec",
             "--env",
-            "PATH=/root/.local/share/solana/install/active_release/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "PATH=/root/.local/share/solana/install/active_release/bin:/root/.cargo/bin:/usr/\
+             local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         ])
-        .args(env_vars
-            .iter()
-            .map(|x| ["--env", x.as_str()])
-            .collect::<Vec<[&str; 2]>>()
-            .concat())
-        .args([
-            container_name,
-            "cargo",
-        ])
+        .args(
+            env_vars
+                .iter()
+                .map(|x| ["--env", x.as_str()])
+                .collect::<Vec<[&str; 2]>>()
+                .concat(),
+        )
+        .args([container_name, "cargo"])
         .args(BUILD_SUBCOMMAND)
-        .args([
-            "--manifest-path",
-            &manifest_path.display().to_string(),
-        ])
+        .args(["--manifest-path", &manifest_path.display().to_string()])
         .args(cargo_args)
         .stdout(match stdout {
             None => Stdio::inherit(),
@@ -2905,7 +2908,12 @@ fn account(
     let idl = idl_filepath.map_or_else(
         || {
             Config::discover(cfg_override)?
-                .ok_or_else(|| anyhow!("The 'anchor account' command requires an Anchor workspace with Anchor.toml for IDL type generation."))?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "The 'anchor account' command requires an Anchor workspace with \
+                         Anchor.toml for IDL type generation."
+                    )
+                })?
                 .read_all_programs()
                 .expect("Workspace must contain atleast one program.")
                 .into_iter()
@@ -3514,7 +3522,8 @@ fn validator_flags(
                         create_client(url)
                     } else {
                         return Err(anyhow!(
-                            "Validator url for Solana's JSON RPC should be provided in order to clone accounts from it"
+                            "Validator url for Solana's JSON RPC should be provided in order to \
+                             clone accounts from it"
                         ));
                     };
 
@@ -3933,8 +3942,9 @@ fn start_surfpool_validator(
 
     if count >= ms_wait {
         eprintln!(
-            "Unable to get latest blockhash. Surfpool validator does not look started. \
-            Check .surfpool/logs/ directory for errors. Consider increasing [surfpool.startup_wait] in Anchor.toml."
+            "Unable to get latest blockhash. Surfpool validator does not look started. Check \
+             .surfpool/logs/ directory for errors. Consider increasing [surfpool.startup_wait] in \
+             Anchor.toml."
         );
         validator_handle.kill()?;
         std::process::exit(1);
@@ -4042,8 +4052,9 @@ fn start_solana_test_validator(
     }
     if count >= ms_wait {
         eprintln!(
-            "Unable to get latest blockhash. Test validator does not look started. \
-            Check {test_ledger_log_filename:?} for errors. Consider increasing [test.startup_wait] in Anchor.toml."
+            "Unable to get latest blockhash. Test validator does not look started. Check \
+             {test_ledger_log_filename:?} for errors. Consider increasing [test.startup_wait] in \
+             Anchor.toml."
         );
         validator_handle.kill()?;
         std::process::exit(1);
@@ -4336,7 +4347,10 @@ fn set_workspace_dir_or_exit() {
 
             let cargo_toml_path = current_dir.join("Cargo.toml");
             if !cargo_toml_path.exists() {
-                println!("Not in a Solana workspace. This command requires either Anchor.toml or a Cargo workspace with Solana programs.");
+                println!(
+                    "Not in a Solana workspace. This command requires either Anchor.toml or a \
+                     Cargo workspace with Solana programs."
+                );
                 std::process::exit(1);
             }
 
@@ -4347,7 +4361,10 @@ fn set_workspace_dir_or_exit() {
                     // (already in the right place)
                 }
                 _ => {
-                    println!("Not in a Solana workspace. This command requires either Anchor.toml or a Cargo workspace with Solana programs.");
+                    println!(
+                        "Not in a Solana workspace. This command requires either Anchor.toml or a \
+                         Cargo workspace with Solana programs."
+                    );
                     std::process::exit(1);
                 }
             }
@@ -4360,7 +4377,10 @@ fn set_workspace_dir_or_exit() {
                 }
                 Some(parent) => {
                     if std::env::set_current_dir(parent).is_err() {
-                        println!("Not in a Solana workspace. This command requires either Anchor.toml or a Cargo workspace with Solana programs.");
+                        println!(
+                            "Not in a Solana workspace. This command requires either Anchor.toml \
+                             or a Cargo workspace with Solana programs."
+                        );
                         std::process::exit(1);
                     }
                 }
@@ -4669,7 +4689,10 @@ fn keys_sync(cfg_override: &ConfigOverride, program_name: Option<String>) -> Res
                     }
 
                     if deployment.address.to_string() != actual_program_id {
-                        println!("Found incorrect program id declaration in Anchor.toml for the program `{name}`");
+                        println!(
+                            "Found incorrect program id declaration in Anchor.toml for the \
+                             program `{name}`"
+                        );
 
                         // Update the program id
                         deployment.address = Pubkey::try_from(actual_program_id.as_str()).unwrap();
@@ -4721,10 +4744,9 @@ fn check_program_id_mismatch(cfg: &WithPath<Config>, program_name: Option<String
             if let Some(program_id_match) = incorrect_program_id {
                 let declared_id = program_id_match.as_str();
                 return Err(anyhow!(
-                    "Program ID mismatch detected for program '{}':\n  \
-                    Keypair file has: {}\n  \
-                    Source code has:  {}\n\n\
-                    Please run 'anchor keys sync' to update the program ID in your source code or use the '--ignore-keys' flag to skip this check.",
+                    "Program ID mismatch detected for program '{}':\n  Keypair file has: {}\n  \
+                     Source code has:  {}\n\nPlease run 'anchor keys sync' to update the program \
+                     ID in your source code or use the '--ignore-keys' flag to skip this check.",
                     program.lib_name,
                     actual_program_id,
                     declared_id

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1,34 +1,35 @@
-use anchor_lang_idl::types::Idl;
-use anyhow::{anyhow, bail, Result};
-use solana_client::send_and_confirm_transactions_in_parallel::{
-    send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
-};
-use solana_commitment_config::CommitmentConfig;
-use solana_keypair::Keypair;
-use solana_loader_v3_interface::{
-    instruction as loader_v3_instruction, state::UpgradeableLoaderState,
-};
-use solana_message::{Hash, Message};
-use solana_packet::PACKET_DATA_SIZE;
-use solana_pubkey::Pubkey;
-use solana_rpc_client::rpc_client::RpcClient;
-use solana_rpc_client_api::config::RpcSendTransactionConfig;
-use solana_sdk_ids::bpf_loader_upgradeable as bpf_loader_upgradeable_id;
-use solana_signature::Signature;
-use solana_signer::{EncodableKey, Signer};
-use solana_transaction::Transaction;
-use std::{
-    fs::{self, File},
-    io::Write,
-    path::Path,
-    sync::Arc,
-    thread,
-    time::Duration,
-};
-
-use crate::{
-    config::{Config, Manifest, Program, WithPath},
-    ConfigOverride, ProgramCommand,
+use {
+    crate::{
+        config::{Config, Manifest, Program, WithPath},
+        ConfigOverride, ProgramCommand,
+    },
+    anchor_lang_idl::types::Idl,
+    anyhow::{anyhow, bail, Result},
+    solana_client::send_and_confirm_transactions_in_parallel::{
+        send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
+    },
+    solana_commitment_config::CommitmentConfig,
+    solana_keypair::Keypair,
+    solana_loader_v3_interface::{
+        instruction as loader_v3_instruction, state::UpgradeableLoaderState,
+    },
+    solana_message::{Hash, Message},
+    solana_packet::PACKET_DATA_SIZE,
+    solana_pubkey::Pubkey,
+    solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client_api::config::RpcSendTransactionConfig,
+    solana_sdk_ids::bpf_loader_upgradeable as bpf_loader_upgradeable_id,
+    solana_signature::Signature,
+    solana_signer::{EncodableKey, Signer},
+    solana_transaction::Transaction,
+    std::{
+        fs::{self, File},
+        io::Write,
+        path::Path,
+        sync::Arc,
+        thread,
+        time::Duration,
+    },
 };
 
 /// Parse priority fee from solana args
@@ -160,12 +161,16 @@ pub fn get_programs_from_workspace(
     if programs.is_empty() {
         if let Some(name) = program_name {
             return Err(anyhow!(
-                "Program '{}' not found. Make sure you're in a Solana workspace (Anchor or non-Anchor) with programs in the programs/ directory, or provide a program filepath.",
+                "Program '{}' not found. Make sure you're in a Solana workspace (Anchor or \
+                 non-Anchor) with programs in the programs/ directory, or provide a program \
+                 filepath.",
                 name
             ));
         } else {
             return Err(anyhow!(
-                "No Solana programs found. Make sure you're in a Solana workspace (Anchor or non-Anchor) with programs in the programs/ directory, or provide a program filepath."
+                "No Solana programs found. Make sure you're in a Solana workspace (Anchor or \
+                 non-Anchor) with programs in the programs/ directory, or provide a program \
+                 filepath."
             ));
         }
     }
@@ -214,22 +219,26 @@ pub fn process_deploy(
         // Validate that single-program options aren't used
         if program_id.is_some() {
             return Err(anyhow!(
-                "Cannot specify --program-id when deploying multiple programs. Use --program-name to deploy a specific program."
+                "Cannot specify --program-id when deploying multiple programs. Use --program-name \
+                 to deploy a specific program."
             ));
         }
         if buffer.is_some() {
             return Err(anyhow!(
-                "Cannot specify --buffer when deploying multiple programs. Use --program-name to deploy a specific program."
+                "Cannot specify --buffer when deploying multiple programs. Use --program-name to \
+                 deploy a specific program."
             ));
         }
         if upgrade_authority.is_some() {
             return Err(anyhow!(
-                "Cannot specify --upgrade-authority when deploying multiple programs. Use --program-name to deploy a specific program."
+                "Cannot specify --upgrade-authority when deploying multiple programs. Use \
+                 --program-name to deploy a specific program."
             ));
         }
         if max_len.is_some() {
             return Err(anyhow!(
-                "Cannot specify --max-len when deploying multiple programs. Use --program-name to deploy a specific program."
+                "Cannot specify --max-len when deploying multiple programs. Use --program-name to \
+                 deploy a specific program."
             ));
         }
 
@@ -530,8 +539,8 @@ pub fn program_deploy(
         let keypair_path = format!("target/deploy/{}-keypair.json", program_name);
         Keypair::read_from_file(&keypair_path).map_err(|e| {
             anyhow!(
-                "Failed to read program keypair from {}: {}. \
-                Use --program-keypair to specify a custom location.",
+                "Failed to read program keypair from {}: {}. Use --program-keypair to specify a \
+                 custom location.",
                 keypair_path,
                 e
             )
@@ -1086,16 +1095,17 @@ fn program_set_upgrade_authority(
         }
         Ok(UpgradeableLoaderState::ProgramData { .. }) => {
             return Err(anyhow!(
-                "Error: {} is a ProgramData account, not a Program account.\n\n\
-                To set the upgrade authority, you must provide the Program ID, not the ProgramData address.\n\
-                Use 'anchor program show {}' to find the associated Program ID.",
+                "Error: {} is a ProgramData account, not a Program account.\n\nTo set the upgrade \
+                 authority, you must provide the Program ID, not the ProgramData address.\nUse \
+                 'anchor program show {}' to find the associated Program ID.",
                 program_id,
                 program_id
             ));
         }
         Ok(UpgradeableLoaderState::Buffer { .. }) => {
             return Err(anyhow!(
-                "{} is a Buffer account, not a Program account. Use set-buffer-authority for buffers.",
+                "{} is a Buffer account, not a Program account. Use set-buffer-authority for \
+                 buffers.",
                 program_id
             ));
         }
@@ -1135,8 +1145,8 @@ fn program_set_upgrade_authority(
         if let Some(pubkey) = new_upgrade_authority {
             if pubkey != keypair.pubkey() {
                 return Err(anyhow!(
-                    "New upgrade authority pubkey mismatch: --new-upgrade-authority ({}) \
-                    doesn't match --new-upgrade-authority-signer keypair ({})",
+                    "New upgrade authority pubkey mismatch: --new-upgrade-authority ({}) doesn't \
+                     match --new-upgrade-authority-signer keypair ({})",
                     pubkey,
                     keypair.pubkey()
                 ));
@@ -1155,9 +1165,10 @@ fn program_set_upgrade_authority(
         } else {
             // By default, require the signer for safety
             return Err(anyhow!(
-                "New upgrade authority signer is required for safety.\n\
-                Please provide --new-upgrade-authority-signer <KEYPAIR_FILE> (recommended),\n\
-                or use --skip-new-upgrade-authority-signer-check if you're confident the pubkey is correct."
+                "New upgrade authority signer is required for safety.\nPlease provide \
+                 --new-upgrade-authority-signer <KEYPAIR_FILE> (recommended),\nor use \
+                 --skip-new-upgrade-authority-signer-check if you're confident the pubkey is \
+                 correct."
             ));
         }
     } else {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,19 +1,21 @@
-use crate::{
-    config::ProgramWorkspace, create_files, override_or_create_files, Files, PackageManager,
-    VERSION,
-};
-use anyhow::Result;
-use clap::{Parser, ValueEnum};
-use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase};
-use solana_keypair::{read_keypair_file, write_keypair_file, Keypair};
-use solana_pubkey::Pubkey;
-use solana_signer::Signer;
-use std::{
-    fmt::Write as _,
-    fs::{self, File},
-    io::Write as _,
-    path::Path,
-    process::Stdio,
+use {
+    crate::{
+        config::ProgramWorkspace, create_files, override_or_create_files, Files, PackageManager,
+        VERSION,
+    },
+    anyhow::Result,
+    clap::{Parser, ValueEnum},
+    heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase},
+    solana_keypair::{read_keypair_file, write_keypair_file, Keypair},
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    std::{
+        fmt::Write as _,
+        fs::{self, File},
+        io::Write as _,
+        path::Path,
+        process::Stdio,
+    },
 };
 
 const ANCHOR_MSRV: &str = "1.89.0";
@@ -47,7 +49,10 @@ pub fn create_program(
 
     let template_files = match template {
         ProgramTemplate::Single => {
-            println!("Note: Using single-file template. For better code organization and maintainability, consider using --template multiple (default).");
+            println!(
+                "Note: Using single-file template. For better code organization and \
+                 maintainability, consider using --template multiple (default)."
+            );
             create_program_template_single(name, &program_path)
         }
         ProgramTemplate::Multiple => create_program_template_multiple(name, &program_path),

--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -1,21 +1,22 @@
-use crate::{
-    ClientError, Config, EventContext, EventUnsubscriber, Program, ProgramAccountsIterator,
-    RequestBuilder,
-};
-use anchor_lang::{prelude::Pubkey, AccountDeserialize, Discriminator};
-use solana_commitment_config::CommitmentConfig;
-use solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
 #[cfg(not(feature = "mock"))]
 use solana_rpc_client::rpc_client::RpcClient;
-use solana_rpc_client_api::{config::RpcSendTransactionConfig, filter::RpcFilterType};
-use solana_signature::Signature;
-use solana_signer::Signer;
-use solana_transaction::Transaction;
-
-use std::{marker::PhantomData, ops::Deref};
-use tokio::{
-    runtime::{Builder, Handle},
-    sync::OnceCell,
+use {
+    crate::{
+        ClientError, Config, EventContext, EventUnsubscriber, Program, ProgramAccountsIterator,
+        RequestBuilder,
+    },
+    anchor_lang::{prelude::Pubkey, AccountDeserialize, Discriminator},
+    solana_commitment_config::CommitmentConfig,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient,
+    solana_rpc_client_api::{config::RpcSendTransactionConfig, filter::RpcFilterType},
+    solana_signature::Signature,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+    std::{marker::PhantomData, ops::Deref},
+    tokio::{
+        runtime::{Builder, Handle},
+        sync::OnceCell,
+    },
 };
 
 impl EventUnsubscriber<'_> {

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -1,7 +1,9 @@
-use anyhow::{anyhow, Result};
-use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-use url::Url;
+use {
+    anyhow::{anyhow, Result},
+    serde::{Deserialize, Serialize},
+    std::str::FromStr,
+    url::Url,
+};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Cluster {
@@ -31,22 +33,25 @@ impl FromStr for Cluster {
 
                 let mut ws_url = Url::parse(http_url)?;
                 if let Some(port) = ws_url.port() {
-                    ws_url.set_port(Some(port + 1))
+                    ws_url
+                        .set_port(Some(port + 1))
                         .map_err(|_| anyhow!("Unable to set port"))?;
                 }
                 if ws_url.scheme() == "https" {
-                    ws_url.set_scheme("wss")
+                    ws_url
+                        .set_scheme("wss")
                         .map_err(|_| anyhow!("Unable to set scheme"))?;
                 } else {
-                    ws_url.set_scheme("ws")
+                    ws_url
+                        .set_scheme("ws")
                         .map_err(|_| anyhow!("Unable to set scheme"))?;
                 }
-
 
                 Ok(Cluster::Custom(http_url.to_string(), ws_url.to_string()))
             }
             _ => Err(anyhow::Error::msg(
-                "Cluster must be one of [localnet, testnet, mainnet, devnet] or be an http or https url\n",
+                "Cluster must be one of [localnet, testnet, mainnet, devnet] or be an http or \
+                 https url\n",
             )),
         }
     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -64,53 +64,54 @@
 //!
 //! [`RpcClient::new_mock`]: https://docs.rs/solana-rpc-client/3.0.0/solana_rpc_client/rpc_client/struct.RpcClient.html#method.new_mock
 
-use anchor_lang::solana_program::program_error::ProgramError;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
-use futures::{Future, StreamExt};
-use regex::Regex;
-use solana_account_decoder::{UiAccount, UiAccountEncoding};
-use solana_instruction::AccountMeta;
-use solana_pubsub_client::nonblocking::pubsub_client::PubsubClient;
-use solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
-use solana_rpc_client_api::{
-    config::{
-        RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcTransactionLogsConfig,
-        RpcTransactionLogsFilter,
-    },
-    filter::Memcmp,
-    response::{Response as RpcResponse, RpcLogsResponse},
-};
-use solana_signature::Signature;
-use std::iter::Map;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::vec::IntoIter;
-use thiserror::Error;
-use tokio::sync::OnceCell;
-use tokio::{
-    runtime::Handle,
-    sync::mpsc::{unbounded_channel, UnboundedReceiver},
-    task::JoinHandle,
-};
-
-pub use anchor_lang;
-pub use cluster::Cluster;
 #[cfg(feature = "async")]
 pub use nonblocking::ThreadSafeSigner;
-pub use solana_account_decoder;
-pub use solana_commitment_config::CommitmentConfig;
-pub use solana_instruction::Instruction;
-pub use solana_program::hash::Hash;
-pub use solana_pubsub_client::nonblocking::pubsub_client::PubsubClientError;
-pub use solana_rpc_client_api::{
-    client_error::Error as SolanaClientError, config::RpcSendTransactionConfig,
-    filter::RpcFilterType,
+pub use {
+    anchor_lang,
+    cluster::Cluster,
+    solana_account_decoder,
+    solana_commitment_config::CommitmentConfig,
+    solana_instruction::Instruction,
+    solana_program::hash::Hash,
+    solana_pubsub_client::nonblocking::pubsub_client::PubsubClientError,
+    solana_rpc_client_api::{
+        client_error::Error as SolanaClientError, config::RpcSendTransactionConfig,
+        filter::RpcFilterType,
+    },
+    solana_signer::{Signer, SignerError},
+    solana_transaction::Transaction,
 };
-pub use solana_signer::{Signer, SignerError};
-pub use solana_transaction::Transaction;
+use {
+    anchor_lang::{
+        solana_program::{program_error::ProgramError, pubkey::Pubkey},
+        AccountDeserialize, Discriminator, InstructionData, ToAccountMetas,
+    },
+    futures::{Future, StreamExt},
+    regex::Regex,
+    solana_account_decoder::{UiAccount, UiAccountEncoding},
+    solana_instruction::AccountMeta,
+    solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient,
+    solana_rpc_client_api::{
+        config::{
+            RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcTransactionLogsConfig,
+            RpcTransactionLogsFilter,
+        },
+        filter::Memcmp,
+        response::{Response as RpcResponse, RpcLogsResponse},
+    },
+    solana_signature::Signature,
+    std::{iter::Map, marker::PhantomData, ops::Deref, pin::Pin, sync::Arc, vec::IntoIter},
+    thiserror::Error,
+    tokio::{
+        runtime::Handle,
+        sync::{
+            mpsc::{unbounded_channel, UnboundedReceiver},
+            OnceCell,
+        },
+        task::JoinHandle,
+    },
+};
 
 mod cluster;
 
@@ -374,9 +375,10 @@ pub fn handle_program_log<T: anchor_lang::Event + anchor_lang::AnchorDeserialize
     self_program_str: &str,
     l: &str,
 ) -> Result<(Option<T>, Option<String>, bool), ClientError> {
-    use anchor_lang::__private::base64;
-    use base64::engine::general_purpose::STANDARD;
-    use base64::Engine;
+    use {
+        anchor_lang::__private::base64,
+        base64::{engine::general_purpose::STANDARD, Engine},
+    };
 
     // Log emitted from the current program.
     if let Some(log) = l
@@ -732,14 +734,15 @@ fn parse_logs_response<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
 
 #[cfg(test)]
 mod tests {
-    use futures::{SinkExt, StreamExt};
-    use solana_rpc_client_api::response::RpcResponseContext;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use tokio_tungstenite::tungstenite::Message;
-
     // Creating a mock struct that implements `anchor_lang::events`
     // for type inference in `test_logs`
-    use anchor_lang::prelude::*;
+    use {
+        anchor_lang::prelude::*,
+        futures::{SinkExt, StreamExt},
+        solana_rpc_client_api::response::RpcResponseContext,
+        std::sync::atomic::{AtomicU64, Ordering},
+        tokio_tungstenite::tungstenite::Message,
+    };
     #[derive(Debug, Clone, Copy)]
     #[event]
     pub struct MockEvent {}
@@ -776,81 +779,95 @@ mod tests {
     fn test_parse_logs_response() -> Result<()> {
         // Mock logs received within an `RpcResponse`. These are based on a Jupiter transaction.
         let logs = vec![
-          "Program VeryCoolProgram invoke [1]", // Outer instruction #1 starts
-          "Program log: Instruction: VeryCoolEvent",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 664387 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program VeryCoolProgram consumed 42417 of 700000 compute units",
-          "Program VeryCoolProgram success", // Outer instruction #1 ends
-          "Program EvenCoolerProgram invoke [1]", // Outer instruction #2 starts
-          "Program log: Instruction: EvenCoolerEvent",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-          "Program log: Instruction: TransferChecked",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6200 of 630919 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt invoke [2]",
-          "Program log: Instruction: Swap",
-          "Program log: INVARIANT: SWAP",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 539321 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 531933 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt consumed 84670 of 610768 compute units",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt success",
-          "Program EvenCoolerProgram invoke [2]",
-          "Program EvenCoolerProgram consumed 2021 of 523272 compute units",
-          "Program EvenCoolerProgram success",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt invoke [2]",
-          "Program log: Instruction: Swap",
-          "Program log: INVARIANT: SWAP",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 418618 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 411230 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt consumed 102212 of 507607 compute units",
-          "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt success",
-          "Program EvenCoolerProgram invoke [2]",
-          "Program EvenCoolerProgram consumed 2021 of 402569 compute units",
-          "Program EvenCoolerProgram success",
-          "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP invoke [2]",
-          "Program log: Instruction: Swap",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 371140 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: MintTo",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4492 of 341800 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
-          "Program log: Instruction: Transfer",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 334370 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP consumed 57610 of 386812 compute units",
-          "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP success",
-          "Program EvenCoolerProgram invoke [2]",
-          "Program EvenCoolerProgram consumed 2021 of 326438 compute units",
-          "Program EvenCoolerProgram success",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-          "Program log: Instruction: TransferChecked",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6173 of 319725 compute units",
-          "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-          "Program EvenCoolerProgram consumed 345969 of 657583 compute units",
-          "Program EvenCoolerProgram success", // Outer instruction #2 ends
-          "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-          "Program ComputeBudget111111111111111111111111111111 success",
-          "Program ComputeBudget111111111111111111111111111111 invoke [1]",
-          "Program ComputeBudget111111111111111111111111111111 success"];
+            "Program VeryCoolProgram invoke [1]", // Outer instruction #1 starts
+            "Program log: Instruction: VeryCoolEvent",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 664387 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program VeryCoolProgram consumed 42417 of 700000 compute units",
+            "Program VeryCoolProgram success", // Outer instruction #1 ends
+            "Program EvenCoolerProgram invoke [1]", // Outer instruction #2 starts
+            "Program log: Instruction: EvenCoolerEvent",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6200 of 630919 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt invoke [2]",
+            "Program log: Instruction: Swap",
+            "Program log: INVARIANT: SWAP",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 539321 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 531933 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt consumed 84670 of 610768 \
+             compute units",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt success",
+            "Program EvenCoolerProgram invoke [2]",
+            "Program EvenCoolerProgram consumed 2021 of 523272 compute units",
+            "Program EvenCoolerProgram success",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt invoke [2]",
+            "Program log: Instruction: Swap",
+            "Program log: INVARIANT: SWAP",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 418618 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 411230 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt consumed 102212 of 507607 \
+             compute units",
+            "Program HyaB3W9q6XdA5xwpU4XnSZV94htfmbmqJXZcEbRaJutt success",
+            "Program EvenCoolerProgram invoke [2]",
+            "Program EvenCoolerProgram consumed 2021 of 402569 compute units",
+            "Program EvenCoolerProgram success",
+            "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP invoke [2]",
+            "Program log: Instruction: Swap",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4736 of 371140 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: MintTo",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4492 of 341800 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+            "Program log: Instruction: Transfer",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 334370 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP consumed 57610 of 386812 \
+             compute units",
+            "Program 9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP success",
+            "Program EvenCoolerProgram invoke [2]",
+            "Program EvenCoolerProgram consumed 2021 of 326438 compute units",
+            "Program EvenCoolerProgram success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6173 of 319725 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program EvenCoolerProgram consumed 345969 of 657583 compute units",
+            "Program EvenCoolerProgram success", // Outer instruction #2 ends
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+            "Program ComputeBudget111111111111111111111111111111 invoke [1]",
+            "Program ComputeBudget111111111111111111111111111111 success",
+        ];
 
         // Converting to Vec<String> as expected in `RpcLogsResponse`
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();
@@ -881,9 +898,10 @@ mod tests {
             "Program fake111111111111111111111111111111111111112 invoke [1]",
             "Program log: i logged success",
             "Program log: i logged success",
-            "Program fake111111111111111111111111111111111111112 consumed 1411 of 200000 compute units",
-            "Program fake111111111111111111111111111111111111112 success"
-          ];
+            "Program fake111111111111111111111111111111111111112 consumed 1411 of 200000 compute \
+             units",
+            "Program fake111111111111111111111111111111111111112 success",
+        ];
 
         // Converting to Vec<String> as expected in `RpcLogsResponse`
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();

--- a/client/src/nonblocking.rs
+++ b/client/src/nonblocking.rs
@@ -1,16 +1,18 @@
-use crate::{
-    AsSigner, ClientError, Config, EventContext, EventUnsubscriber, Program,
-    ProgramAccountsIterator, RequestBuilder,
+use {
+    crate::{
+        AsSigner, ClientError, Config, EventContext, EventUnsubscriber, Program,
+        ProgramAccountsIterator, RequestBuilder,
+    },
+    anchor_lang::{prelude::Pubkey, AccountDeserialize, Discriminator},
+    solana_commitment_config::CommitmentConfig,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient,
+    solana_rpc_client_api::{config::RpcSendTransactionConfig, filter::RpcFilterType},
+    solana_signature::Signature,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+    std::{marker::PhantomData, ops::Deref, sync::Arc},
+    tokio::sync::OnceCell,
 };
-use anchor_lang::{prelude::Pubkey, AccountDeserialize, Discriminator};
-use solana_commitment_config::CommitmentConfig;
-use solana_rpc_client::nonblocking::rpc_client::RpcClient as AsyncRpcClient;
-use solana_rpc_client_api::{config::RpcSendTransactionConfig, filter::RpcFilterType};
-use solana_signature::Signature;
-use solana_signer::Signer;
-use solana_transaction::Transaction;
-use std::{marker::PhantomData, ops::Deref, sync::Arc};
-use tokio::sync::OnceCell;
 
 impl<'a> EventUnsubscriber<'a> {
     /// Unsubscribe gracefully.

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -1,7 +1,8 @@
-use std::str::FromStr;
-
-use anyhow::anyhow;
-use serde::{Deserialize, Serialize};
+use {
+    anyhow::anyhow,
+    serde::{Deserialize, Serialize},
+    std::str::FromStr,
+};
 
 /// IDL specification Semantic Version
 pub const IDL_SPEC: &str = env!("CARGO_PKG_VERSION");

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -1,15 +1,15 @@
-use std::{
-    collections::BTreeMap,
-    env, mem,
-    path::{Path, PathBuf},
-    process::{Command, Stdio},
+use {
+    crate::types::{Idl, IdlEvent, IdlTypeDef},
+    anyhow::{anyhow, Result},
+    regex::Regex,
+    serde::Deserialize,
+    std::{
+        collections::BTreeMap,
+        env, mem,
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+    },
 };
-
-use anyhow::{anyhow, Result};
-use regex::Regex;
-use serde::Deserialize;
-
-use crate::types::{Idl, IdlEvent, IdlTypeDef};
 
 /// A trait that types must implement in order to include the type in the IDL definition.
 ///

--- a/idl/src/convert.rs
+++ b/idl/src/convert.rs
@@ -1,6 +1,7 @@
-use anyhow::{anyhow, Result};
-
-use crate::types::Idl;
+use {
+    crate::types::Idl,
+    anyhow::{anyhow, Result},
+};
 
 /// Create an [`Idl`] value with additional support for older specs based on the
 /// `idl.metadata.spec` field.
@@ -29,10 +30,12 @@ pub fn convert_idl(idl: &[u8]) -> Result<Idl> {
 
 /// Legacy IDL spec (pre Anchor v0.30)
 mod legacy {
-    use crate::types as t;
-    use anyhow::{anyhow, Result};
-    use heck::SnakeCase;
-    use serde::{Deserialize, Serialize};
+    use {
+        crate::types as t,
+        anyhow::{anyhow, Result},
+        heck::SnakeCase,
+        serde::{Deserialize, Serialize},
+    };
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     pub struct Idl {

--- a/idl/src/lib.rs
+++ b/idl/src/lib.rs
@@ -7,6 +7,5 @@ pub mod build;
 pub mod convert;
 
 pub use anchor_lang_idl_spec as types;
-
 #[cfg(feature = "build")]
 pub use serde_json;

--- a/lang/attribute/access-control/src/lib.rs
+++ b/lang/attribute/access-control/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate proc_macro;
 
-use quote::quote;
-use syn::parse_macro_input;
+use {quote::quote, syn::parse_macro_input};
 
 /// Executes the given access control method before running the decorated
 /// instruction handler. Any method in scope of the attribute can be invoked

--- a/lang/attribute/account/src/id.rs
+++ b/lang/attribute/account/src/id.rs
@@ -8,10 +8,12 @@
 
 extern crate proc_macro;
 
-use quote::{quote, ToTokens};
-use syn::{
-    parse::{Parse, ParseStream, Result},
-    Expr, LitStr,
+use {
+    quote::{quote, ToTokens},
+    syn::{
+        parse::{Parse, ParseStream, Result},
+        Expr, LitStr,
+    },
 };
 
 fn parse_id(

--- a/lang/attribute/account/src/lazy.rs
+++ b/lang/attribute/account/src/lazy.rs
@@ -1,5 +1,7 @@
-use proc_macro2::{Literal, TokenStream};
-use quote::{format_ident, quote, ToTokens};
+use {
+    proc_macro2::{Literal, TokenStream},
+    quote::{format_ident, quote, ToTokens},
+};
 
 pub fn gen_lazy(strct: &syn::ItemStruct) -> syn::Result<TokenStream> {
     let ident = &strct.ident;

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -1,13 +1,15 @@
 extern crate proc_macro;
 
-use anchor_syn::{codegen::program::common::gen_discriminator, Overrides};
-use quote::{quote, ToTokens};
-use syn::{
-    parenthesized,
-    parse::{Parse, ParseStream},
-    parse_macro_input,
-    token::{Comma, Paren},
-    Ident, LitStr,
+use {
+    anchor_syn::{codegen::program::common::gen_discriminator, Overrides},
+    quote::{quote, ToTokens},
+    syn::{
+        parenthesized,
+        parse::{Parse, ParseStream},
+        parse_macro_input,
+        token::{Comma, Paren},
+        Ident, LitStr,
+    },
 };
 
 mod id;

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -1,12 +1,15 @@
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
-use quote::quote;
-
-use anchor_syn::codegen;
-use anchor_syn::parser::error::{self as error_parser, ErrorInput};
-use anchor_syn::ErrorArgs;
-use syn::{parse_macro_input, Expr};
+use {
+    anchor_syn::{
+        codegen,
+        parser::error::{self as error_parser, ErrorInput},
+        ErrorArgs,
+    },
+    proc_macro::TokenStream,
+    quote::quote,
+    syn::{parse_macro_input, Expr},
+};
 
 /// Generates `Error` and `type Result<T> = Result<T, Error>` types to be
 /// used as return types from Anchor instruction handlers. Importantly, the

--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -2,9 +2,11 @@ extern crate proc_macro;
 
 #[cfg(feature = "event-cpi")]
 use anchor_syn::parser::accounts::event_cpi::{add_event_cpi_accounts, EventAuthority};
-use anchor_syn::{codegen::program::common::gen_discriminator, Overrides};
-use quote::quote;
-use syn::parse_macro_input;
+use {
+    anchor_syn::{codegen::program::common::gen_discriminator, Overrides},
+    quote::quote,
+    syn::parse_macro_input,
+};
 
 /// The event attribute allows a struct to be used with
 /// [emit!](./macro.emit.html) so that programs can log significant events in

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -1,10 +1,12 @@
-use anchor_lang_idl::types::{
-    Idl, IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlInstructionAccountItem,
-    IdlInstructionAccounts, IdlRepr, IdlSerialization, IdlType, IdlTypeDef, IdlTypeDefGeneric,
-    IdlTypeDefTy,
+use {
+    anchor_lang_idl::types::{
+        Idl, IdlArrayLen, IdlDefinedFields, IdlField, IdlGenericArg, IdlInstructionAccountItem,
+        IdlInstructionAccounts, IdlRepr, IdlSerialization, IdlType, IdlTypeDef, IdlTypeDefGeneric,
+        IdlTypeDefTy,
+    },
+    proc_macro2::Literal,
+    quote::{format_ident, quote},
 };
-use proc_macro2::Literal;
-use quote::{format_ident, quote};
 
 /// This function should ideally return the absolute path to the declared program's id but because
 /// `proc_macro2::Span::call_site().source_file().path()` is behind an unstable feature flag, we

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -1,18 +1,18 @@
 mod common;
 mod mods;
 
-use std::{env, fs, path::PathBuf};
-
-use anchor_lang_idl::{convert::convert_idl, types::Idl};
-use anyhow::anyhow;
-use quote::{quote, ToTokens};
-use syn::parse::{Parse, ParseStream};
-
-use common::gen_docs;
-use mods::{
-    accounts::gen_accounts_mod, client::gen_client_mod, constants::gen_constants_mod,
-    cpi::gen_cpi_mod, error::gen_error_mod, events::gen_events_mod, internal::gen_internal_mod,
-    parsers::gen_parsers_mod, program::gen_program_mod, types::gen_types_mod,
+use {
+    anchor_lang_idl::{convert::convert_idl, types::Idl},
+    anyhow::anyhow,
+    common::gen_docs,
+    mods::{
+        accounts::gen_accounts_mod, client::gen_client_mod, constants::gen_constants_mod,
+        cpi::gen_cpi_mod, error::gen_error_mod, events::gen_events_mod, internal::gen_internal_mod,
+        parsers::gen_parsers_mod, program::gen_program_mod, types::gen_types_mod,
+    },
+    quote::{quote, ToTokens},
+    std::{env, fs, path::PathBuf},
+    syn::parse::{Parse, ParseStream},
 };
 
 pub struct DeclareProgram {

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -1,7 +1,8 @@
-use anchor_lang_idl::types::{Idl, IdlSerialization};
-use quote::{format_ident, quote};
-
-use super::common::{convert_idl_type_def_to_ts, gen_discriminator, get_canonical_program_id};
+use {
+    super::common::{convert_idl_type_def_to_ts, gen_discriminator, get_canonical_program_id},
+    anchor_lang_idl::types::{Idl, IdlSerialization},
+    quote::{format_ident, quote},
+};
 
 pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let accounts = idl.accounts.iter().map(|acc| {

--- a/lang/attribute/program/src/declare_program/mods/client.rs
+++ b/lang/attribute/program/src/declare_program/mods/client.rs
@@ -1,7 +1,4 @@
-use anchor_lang_idl::types::Idl;
-use quote::quote;
-
-use super::common::gen_accounts_common;
+use {super::common::gen_accounts_common, anchor_lang_idl::types::Idl, quote::quote};
 
 pub fn gen_client_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let client_args_mod = gen_client_args_mod();

--- a/lang/attribute/program/src/declare_program/mods/constants.rs
+++ b/lang/attribute/program/src/declare_program/mods/constants.rs
@@ -1,7 +1,8 @@
-use anchor_lang_idl::types::{Idl, IdlType};
-use quote::{format_ident, quote, ToTokens};
-
-use super::common::{convert_idl_type_to_str, gen_docs};
+use {
+    super::common::{convert_idl_type_to_str, gen_docs},
+    anchor_lang_idl::types::{Idl, IdlType},
+    quote::{format_ident, quote, ToTokens},
+};
 
 pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let constants = idl.constants.iter().map(|c| {

--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -1,8 +1,9 @@
-use anchor_lang_idl::types::Idl;
-use heck::CamelCase;
-use quote::{format_ident, quote};
-
-use super::common::{convert_idl_type_to_syn_type, gen_accounts_common};
+use {
+    super::common::{convert_idl_type_to_syn_type, gen_accounts_common},
+    anchor_lang_idl::types::Idl,
+    heck::CamelCase,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_cpi_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let cpi_instructions = gen_cpi_instructions(idl);

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -1,6 +1,8 @@
-use anchor_lang_idl::types::Idl;
-use heck::CamelCase;
-use quote::{format_ident, quote};
+use {
+    anchor_lang_idl::types::Idl,
+    heck::CamelCase,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_error_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let errors = idl.errors.iter().map(|e| {

--- a/lang/attribute/program/src/declare_program/mods/events.rs
+++ b/lang/attribute/program/src/declare_program/mods/events.rs
@@ -1,7 +1,8 @@
-use anchor_lang_idl::types::Idl;
-use quote::{format_ident, quote};
-
-use super::common::{convert_idl_type_def_to_ts, gen_discriminator};
+use {
+    super::common::{convert_idl_type_def_to_ts, gen_discriminator},
+    anchor_lang_idl::types::Idl,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_events_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let events = idl.events.iter().map(|ev| {

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -1,15 +1,16 @@
-use anchor_lang_idl::types::{Idl, IdlInstructionAccountItem};
-use anchor_syn::{
-    codegen::accounts::{__client_accounts, __cpi_client_accounts},
-    parser::accounts,
-    AccountsStruct,
-};
-use heck::CamelCase;
-use quote::{format_ident, quote};
-
-use super::common::{
-    convert_idl_type_to_syn_type, gen_discriminator, get_all_instruction_accounts,
-    get_canonical_program_id,
+use {
+    super::common::{
+        convert_idl_type_to_syn_type, gen_discriminator, get_all_instruction_accounts,
+        get_canonical_program_id,
+    },
+    anchor_lang_idl::types::{Idl, IdlInstructionAccountItem},
+    anchor_syn::{
+        codegen::accounts::{__client_accounts, __cpi_client_accounts},
+        parser::accounts,
+        AccountsStruct,
+    },
+    heck::CamelCase,
+    quote::{format_ident, quote},
 };
 
 pub fn gen_internal_mod(idl: &Idl) -> proc_macro2::TokenStream {

--- a/lang/attribute/program/src/declare_program/mods/parsers.rs
+++ b/lang/attribute/program/src/declare_program/mods/parsers.rs
@@ -1,8 +1,9 @@
-use anchor_lang_idl::types::{Idl, IdlInstructionAccountItem, IdlInstructionAccounts};
-use heck::CamelCase;
-use quote::{format_ident, quote};
-
-use super::common::{get_all_instruction_accounts, get_canonical_program_id};
+use {
+    super::common::{get_all_instruction_accounts, get_canonical_program_id},
+    anchor_lang_idl::types::{Idl, IdlInstructionAccountItem, IdlInstructionAccounts},
+    heck::CamelCase,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_parsers_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let account = gen_account(idl);

--- a/lang/attribute/program/src/declare_program/mods/program.rs
+++ b/lang/attribute/program/src/declare_program/mods/program.rs
@@ -1,7 +1,8 @@
-use heck::CamelCase;
-use quote::{format_ident, quote};
-
-use super::common::get_canonical_program_id;
+use {
+    super::common::get_canonical_program_id,
+    heck::CamelCase,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_program_mod(program_name: &str) -> proc_macro2::TokenStream {
     let name = format_ident!("{}", program_name.to_camel_case());

--- a/lang/attribute/program/src/declare_program/mods/types.rs
+++ b/lang/attribute/program/src/declare_program/mods/types.rs
@@ -1,7 +1,4 @@
-use anchor_lang_idl::types::Idl;
-use quote::quote;
-
-use super::common::convert_idl_type_def_to_ts;
+use {super::common::convert_idl_type_def_to_ts, anchor_lang_idl::types::Idl, quote::quote};
 
 pub fn gen_types_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let types = idl

--- a/lang/attribute/program/src/lib.rs
+++ b/lang/attribute/program/src/lib.rs
@@ -2,9 +2,7 @@ extern crate proc_macro;
 
 mod declare_program;
 
-use declare_program::DeclareProgram;
-use quote::ToTokens;
-use syn::parse_macro_input;
+use {declare_program::DeclareProgram, quote::ToTokens, syn::parse_macro_input};
 
 /// The `#[program]` attribute defines the module containing all instruction
 /// handlers defining all entries into a Solana program.

--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
-use quote::ToTokens;
-use syn::parse_macro_input;
+use {proc_macro::TokenStream, quote::ToTokens, syn::parse_macro_input};
 
 /// Implements an [`Accounts`](./trait.Accounts.html) deserializer on the given
 /// struct. Can provide further functionality through the use of attributes.

--- a/lang/derive/serde/src/lazy.rs
+++ b/lang/derive/serde/src/lazy.rs
@@ -1,6 +1,8 @@
-use proc_macro2::Literal;
-use quote::{format_ident, quote, ToTokens};
-use syn::{parse_quote, spanned::Spanned, Fields, Item};
+use {
+    proc_macro2::Literal,
+    quote::{format_ident, quote, ToTokens},
+    syn::{parse_quote, spanned::Spanned, Fields, Item},
+};
 
 pub fn gen_lazy(input: proc_macro::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
     let item = syn::parse::<Item>(input)?;

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -7,11 +7,13 @@ extern crate proc_macro;
 #[cfg(feature = "lazy-account")]
 mod lazy;
 
-use proc_macro::TokenStream;
-use proc_macro2::{Span, TokenStream as TokenStream2};
-use proc_macro_crate::FoundCrate;
-use quote::quote;
-use syn::Ident;
+use {
+    proc_macro::TokenStream,
+    proc_macro2::{Span, TokenStream as TokenStream2},
+    proc_macro_crate::FoundCrate,
+    quote::quote,
+    syn::Ident,
+};
 
 fn gen_borsh_serialize(input: TokenStream) -> TokenStream2 {
     let input = TokenStream2::from(input);
@@ -31,9 +33,7 @@ pub fn anchor_serialize(input: TokenStream) -> TokenStream {
 
     #[cfg(feature = "idl-build")]
     {
-        use anchor_syn::idl::*;
-        use quote::quote;
-        use syn::Item;
+        use {anchor_syn::idl::*, quote::quote, syn::Item};
 
         let idl_build_impl = match syn::parse(input).unwrap() {
             Item::Struct(item) => impl_idl_build_struct(&item),

--- a/lang/derive/space/src/lib.rs
+++ b/lang/derive/space/src/lib.rs
@@ -1,11 +1,13 @@
-use std::collections::VecDeque;
-
-use proc_macro::TokenStream;
-use proc_macro2::{Ident, TokenStream as TokenStream2, TokenTree};
-use quote::{quote, quote_spanned, ToTokens};
-use syn::{
-    parse::ParseStream, parse2, parse_macro_input, punctuated::Punctuated, token::Comma, Attribute,
-    DeriveInput, Field, Fields, GenericArgument, LitInt, PathArguments, Type, TypeArray,
+use {
+    proc_macro::TokenStream,
+    proc_macro2::{Ident, TokenStream as TokenStream2, TokenTree},
+    quote::{quote, quote_spanned, ToTokens},
+    std::collections::VecDeque,
+    syn::{
+        parse::ParseStream, parse2, parse_macro_input, punctuated::Punctuated, token::Comma,
+        Attribute, DeriveInput, Field, Fields, GenericArgument, LitInt, PathArguments, Type,
+        TypeArray,
+    },
 };
 
 /// Implements a [`Space`](./trait.Space.html) trait on the given

--- a/lang/src/account_meta.rs
+++ b/lang/src/account_meta.rs
@@ -1,5 +1,4 @@
-use crate::ToAccountMetas;
-use solana_instruction::AccountMeta;
+use {crate::ToAccountMetas, solana_instruction::AccountMeta};
 
 impl ToAccountMetas for AccountMeta {
     fn to_account_metas(&self, _is_signer: Option<bool>) -> Vec<AccountMeta> {

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -1,18 +1,21 @@
 //! Account container that checks ownership on deserialization.
 
-use crate::bpf_writer::BpfWriter;
-use crate::error::{Error, ErrorCode};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::solana_program::system_program;
-use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Owner,
-    Result, ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        bpf_writer::BpfWriter,
+        error::{Error, ErrorCode},
+        solana_program::{
+            account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
+        },
+        AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Owner,
+        Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::{
+        collections::BTreeSet,
+        fmt,
+        ops::{Deref, DerefMut},
+    },
 };
-use std::collections::BTreeSet;
-use std::fmt;
-use std::ops::{Deref, DerefMut};
 
 /// Wrapper around [`AccountInfo`] that verifies program ownership
 /// and deserializes underlying data into a Rust type.

--- a/lang/src/accounts/account_info.rs
+++ b/lang/src/accounts/account_info.rs
@@ -2,12 +2,14 @@
 //! [Unchecked Account](crate::accounts::unchecked_account::UncheckedAccount)
 //! should be used instead.
 
-use crate::error::ErrorCode;
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
-use std::collections::BTreeSet;
+use {
+    crate::{
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::collections::BTreeSet,
+};
 
 impl<'info, B> Accounts<'info, B> for AccountInfo<'info> {
     fn try_accounts(

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -1,21 +1,23 @@
 //! Type facilitating on demand zero copy deserialization.
 
-use crate::bpf_writer::BpfWriter;
-use crate::error::{Error, ErrorCode};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{
-    Accounts, AccountsClose, AccountsExit, Key, Owner, Result, ToAccountInfos, ToAccountMetas,
-    ZeroCopy,
+use {
+    crate::{
+        bpf_writer::BpfWriter,
+        error::{Error, ErrorCode},
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsClose, AccountsExit, Key, Owner, Result, ToAccountInfos, ToAccountMetas,
+        ZeroCopy,
+    },
+    std::{
+        cell::{Ref, RefMut},
+        collections::BTreeSet,
+        fmt,
+        io::Write,
+        marker::PhantomData,
+        mem,
+        ops::DerefMut,
+    },
 };
-use std::cell::{Ref, RefMut};
-use std::collections::BTreeSet;
-use std::fmt;
-use std::io::Write;
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::DerefMut;
 
 /// Type facilitating on demand zero copy deserialization.
 ///

--- a/lang/src/accounts/boxed.rs
+++ b/lang/src/accounts/boxed.rs
@@ -13,12 +13,13 @@
 //! }
 //! ```
 
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas};
-use std::collections::BTreeSet;
-use std::ops::Deref;
+use {
+    crate::{
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::{collections::BTreeSet, ops::Deref},
+};
 
 impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Box<T> {
     fn try_accounts(

--- a/lang/src/accounts/interface.rs
+++ b/lang/src/accounts/interface.rs
@@ -1,16 +1,15 @@
 //! Type validating that the account is one of a set of given Programs
 
-use crate::accounts::program::Program;
-use crate::error::{Error, ErrorCode};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{
-    AccountDeserialize, Accounts, AccountsExit, CheckId, Key, Result, ToAccountInfos,
-    ToAccountMetas,
+use {
+    crate::{
+        accounts::program::Program,
+        error::{Error, ErrorCode},
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        AccountDeserialize, Accounts, AccountsExit, CheckId, Key, Result, ToAccountInfos,
+        ToAccountMetas,
+    },
+    std::{collections::BTreeSet, ops::Deref},
 };
-use std::collections::BTreeSet;
-use std::ops::Deref;
 
 /// Type validating that the account is one of a set of given Programs
 ///

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -1,18 +1,21 @@
 //! Account container that checks ownership on deserialization.
 
-use crate::accounts::account::Account;
-use crate::error::ErrorCode;
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::solana_program::system_program;
-use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, CheckOwner, Key,
-    Owners, Result, ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        accounts::account::Account,
+        error::ErrorCode,
+        solana_program::{
+            account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
+        },
+        AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, CheckOwner,
+        Key, Owners, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::{
+        collections::BTreeSet,
+        fmt,
+        ops::{Deref, DerefMut},
+    },
 };
-use std::collections::BTreeSet;
-use std::fmt;
-use std::ops::{Deref, DerefMut};
 
 /// Wrapper around [`AccountInfo`]
 /// that verifies program ownership and deserializes underlying data into a Rust type.

--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -1,11 +1,12 @@
 //! Like [`Account`](crate::Account), but deserializes on-demand.
 
-use std::{cell::RefCell, collections::BTreeSet, fmt, mem::MaybeUninit, rc::Rc};
-
-use crate::{
-    error::{Error, ErrorCode},
-    AccountInfo, AccountMeta, AccountSerialize, Accounts, AccountsClose, Discriminator, Key, Owner,
-    Pubkey, Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        error::{Error, ErrorCode},
+        AccountInfo, AccountMeta, AccountSerialize, Accounts, AccountsClose, Discriminator, Key,
+        Owner, Pubkey, Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    },
+    std::{cell::RefCell, collections::BTreeSet, fmt, mem::MaybeUninit, rc::Rc},
 };
 
 /// Deserialize account data lazily (on-demand).

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -1,17 +1,20 @@
 //! Account container for migrating from one account type to another.
 
-use crate::bpf_writer::BpfWriter;
-use crate::error::{Error, ErrorCode};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::solana_program::system_program;
-use crate::{
-    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Owner, Result,
-    ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        bpf_writer::BpfWriter,
+        error::{Error, ErrorCode},
+        solana_program::{
+            account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
+        },
+        AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Owner, Result,
+        ToAccountInfos, ToAccountMetas,
+    },
+    std::{
+        collections::BTreeSet,
+        ops::{Deref, DerefMut},
+    },
 };
-use std::collections::BTreeSet;
-use std::ops::{Deref, DerefMut};
 
 /// Internal representation of the migration state.
 #[derive(Debug)]
@@ -470,8 +473,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{AnchorDeserialize, AnchorSerialize, Discriminator};
+    use {
+        super::*,
+        crate::{AnchorDeserialize, AnchorSerialize, Discriminator},
+    };
 
     const TEST_DISCRIMINATOR_V1: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     const TEST_DISCRIMINATOR_V2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];

--- a/lang/src/accounts/option.rs
+++ b/lang/src/accounts/option.rs
@@ -8,14 +8,13 @@
 //! }
 //! ```
 
-use std::collections::BTreeSet;
-
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-
-use crate::{
-    error::ErrorCode, Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::collections::BTreeSet,
 };
 
 impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Option<T> {

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -1,17 +1,19 @@
 //! Type validating that the account is the given Program
 
-use crate::error::{Error, ErrorCode};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{
-    AccountDeserialize, Accounts, AccountsExit, Id, Key, Result, ToAccountInfos, ToAccountMetas,
+use {
+    crate::{
+        error::{Error, ErrorCode},
+        solana_program::{
+            account_info::AccountInfo,
+            bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+            instruction::AccountMeta,
+            pubkey::Pubkey,
+        },
+        AccountDeserialize, Accounts, AccountsExit, Id, Key, Result, ToAccountInfos,
+        ToAccountMetas,
+    },
+    std::{collections::BTreeSet, fmt, marker::PhantomData, ops::Deref},
 };
-use std::collections::BTreeSet;
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 /// Type validating that the account is the given Program
 ///

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -1,11 +1,12 @@
 //! Type validating that the account signed the transaction
-use crate::error::ErrorCode;
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
-use std::collections::BTreeSet;
-use std::ops::Deref;
+use {
+    crate::{
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::{collections::BTreeSet, ops::Deref},
+};
 
 /// Type validating that the account signed the transaction. No other ownership
 /// or type checks are done. If this is used, one should not try to access the

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -1,9 +1,9 @@
 //! Type validating that the account is owned by the system program
 
-use crate::error::ErrorCode;
-use crate::solana_program::system_program;
-use crate::*;
-use std::ops::Deref;
+use {
+    crate::{error::ErrorCode, solana_program::system_program, *},
+    std::ops::Deref,
+};
 
 /// Type validating that the account is owned by the system program
 ///

--- a/lang/src/accounts/sysvar.rs
+++ b/lang/src/accounts/sysvar.rs
@@ -1,14 +1,18 @@
 //! Type validating that the account is a sysvar and deserializing it
 
-use crate::error::ErrorCode;
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
-use solana_sysvar::{Sysvar as SolanaSysvar, SysvarSerialize as SolanaSysvarSerialize};
-use std::collections::BTreeSet;
-use std::fmt;
-use std::ops::{Deref, DerefMut};
+use {
+    crate::{
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas,
+    },
+    solana_sysvar::{Sysvar as SolanaSysvar, SysvarSerialize as SolanaSysvarSerialize},
+    std::{
+        collections::BTreeSet,
+        fmt,
+        ops::{Deref, DerefMut},
+    },
+};
 
 /// Type validating that the account is a sysvar and deserializing it.
 ///

--- a/lang/src/accounts/unchecked_account.rs
+++ b/lang/src/accounts/unchecked_account.rs
@@ -1,13 +1,14 @@
 //! Explicit wrapper for AccountInfo types to emphasize
 //! that no checks are performed
 
-use crate::error::ErrorCode;
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
-use std::collections::BTreeSet;
-use std::ops::Deref;
+use {
+    crate::{
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::{collections::BTreeSet, ops::Deref},
+};
 
 /// Explicit wrapper for AccountInfo types to emphasize
 /// that no checks are performed

--- a/lang/src/bpf_upgradeable_state.rs
+++ b/lang/src/bpf_upgradeable_state.rs
@@ -1,8 +1,10 @@
-use crate::error::ErrorCode;
-use crate::solana_program::{
-    bpf_loader_upgradeable::UpgradeableLoaderState, program_error::ProgramError, pubkey::Pubkey,
+use crate::{
+    error::ErrorCode,
+    solana_program::{
+        bpf_loader_upgradeable::UpgradeableLoaderState, program_error::ProgramError, pubkey::Pubkey,
+    },
+    AccountDeserialize, AccountSerialize, Owner, Result,
 };
-use crate::{AccountDeserialize, AccountSerialize, Owner, Result};
 
 #[derive(Clone)]
 pub struct ProgramData {

--- a/lang/src/bpf_writer.rs
+++ b/lang/src/bpf_writer.rs
@@ -1,6 +1,10 @@
-use crate::solana_program::program_memory::sol_memcpy;
-use std::cmp;
-use std::io::{self, Write};
+use {
+    crate::solana_program::program_memory::sol_memcpy,
+    std::{
+        cmp,
+        io::{self, Write},
+    },
+};
 
 #[derive(Debug, Default)]
 pub struct BpfWriter<T> {

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -1,7 +1,8 @@
-use crate::prelude::{Id, System};
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::system_program;
-use crate::Result;
+use crate::{
+    prelude::{Id, System},
+    solana_program::{account_info::AccountInfo, system_program},
+    Result,
+};
 
 pub(crate) fn close<'info>(
     info: &AccountInfo<'info>,

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -1,10 +1,12 @@
 //! Data structures that are used to provide non-argument inputs to program endpoints
 
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, Bumps, ToAccountInfos, ToAccountMetas};
-use std::fmt;
+use {
+    crate::{
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, Bumps, ToAccountInfos, ToAccountMetas,
+    },
+    std::fmt,
+};
 
 /// Provides non-argument inputs to the program.
 ///

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -1,8 +1,12 @@
-use crate::solana_program::{program_error::ProgramError, pubkey::Pubkey};
-use anchor_lang::error_code;
-use borsh::io::Error as BorshIoError;
-use std::fmt::{Debug, Display};
-use std::num::TryFromIntError;
+use {
+    crate::solana_program::{program_error::ProgramError, pubkey::Pubkey},
+    anchor_lang::error_code,
+    borsh::io::Error as BorshIoError,
+    std::{
+        fmt::{Debug, Display},
+        num::TryFromIntError,
+    },
+};
 
 /// The starting point for user defined error codes.
 pub const ERROR_CODE_OFFSET: u32 = 6000;
@@ -422,7 +426,8 @@ impl ProgramErrorWithOrigin {
             }
             Some(ErrorOrigin::Source(source)) => {
                 anchor_lang::solana_program::msg!(
-                    "ProgramError thrown in {}:{}. Error Code: {:?}. Error Number: {}. Error Message: {}.",
+                    "ProgramError thrown in {}:{}. Error Code: {:?}. Error Number: {}. Error \
+                     Message: {}.",
                     source.filename,
                     source.line,
                     self.program_error,
@@ -433,7 +438,8 @@ impl ProgramErrorWithOrigin {
             Some(ErrorOrigin::AccountName(account_name)) => {
                 // using sol_log because msg! wrongly interprets 5 inputs as u64
                 anchor_lang::solana_program::log::sol_log(&format!(
-                    "ProgramError caused by account: {}. Error Code: {:?}. Error Number: {}. Error Message: {}.",
+                    "ProgramError caused by account: {}. Error Code: {:?}. Error Number: {}. \
+                     Error Message: {}.",
                     account_name,
                     self.program_error,
                     u64::from(self.program_error.clone()),
@@ -509,7 +515,8 @@ impl AnchorError {
             }
             Some(ErrorOrigin::Source(source)) => {
                 anchor_lang::solana_program::msg!(
-                    "AnchorError thrown in {}:{}. Error Code: {}. Error Number: {}. Error Message: {}.",
+                    "AnchorError thrown in {}:{}. Error Code: {}. Error Number: {}. Error \
+                     Message: {}.",
                     source.filename,
                     source.line,
                     self.error_name,
@@ -519,11 +526,9 @@ impl AnchorError {
             }
             Some(ErrorOrigin::AccountName(account_name)) => {
                 anchor_lang::solana_program::log::sol_log(&format!(
-                    "AnchorError caused by account: {}. Error Code: {}. Error Number: {}. Error Message: {}.",
-                    account_name,
-                    self.error_name,
-                    self.error_code_number,
-                    self.error_msg
+                    "AnchorError caused by account: {}. Error Code: {}. Error Number: {}. Error \
+                     Message: {}.",
+                    account_name, self.error_name, self.error_code_number, self.error_msg
                 ));
             }
         }

--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -119,8 +119,7 @@ fn get_len(buf: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::AnchorSerialize;
+    use {super::*, crate::AnchorSerialize};
 
     macro_rules! len {
         ($val: expr) => {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -25,12 +25,14 @@
 
 extern crate self as anchor_lang;
 
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::program_error::ProgramError;
-use crate::solana_program::pubkey::Pubkey;
-use bytemuck::{Pod, Zeroable};
-use std::{collections::BTreeSet, fmt::Debug, io::Write};
+use {
+    crate::solana_program::{
+        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    bytemuck::{Pod, Zeroable},
+    std::{collections::BTreeSet, fmt::Debug, io::Write},
+};
 
 mod account_meta;
 pub mod accounts;
@@ -49,32 +51,33 @@ mod vec;
 #[cfg(feature = "lazy-account")]
 mod lazy;
 
-pub use crate::bpf_upgradeable_state::*;
-pub use anchor_attribute_access_control::access_control;
-pub use anchor_attribute_account::{account, declare_id, pubkey, zero_copy};
-pub use anchor_attribute_constant::constant;
-pub use anchor_attribute_error::*;
-pub use anchor_attribute_event::{emit, event};
-pub use anchor_attribute_program::{declare_program, instruction, program};
-pub use anchor_derive_accounts::Accounts;
-pub use anchor_derive_serde::{AnchorDeserialize, AnchorSerialize};
-pub use anchor_derive_space::InitSpace;
-pub use const_crypto::ed25519::derive_program_address;
-
-pub use anchor_derive_serde::__erase;
 /// Borsh is the default serialization format for instructions and accounts.
 pub use borsh::de::BorshDeserialize as AnchorDeserialize;
-pub use borsh::ser::BorshSerialize as AnchorSerialize;
+pub use {
+    crate::bpf_upgradeable_state::*,
+    anchor_attribute_access_control::access_control,
+    anchor_attribute_account::{account, declare_id, pubkey, zero_copy},
+    anchor_attribute_constant::constant,
+    anchor_attribute_error::*,
+    anchor_attribute_event::{emit, event},
+    anchor_attribute_program::{declare_program, instruction, program},
+    anchor_derive_accounts::Accounts,
+    anchor_derive_serde::{AnchorDeserialize, AnchorSerialize, __erase},
+    anchor_derive_space::InitSpace,
+    borsh::ser::BorshSerialize as AnchorSerialize,
+    const_crypto::ed25519::derive_program_address,
+};
 
 pub mod solana_program {
-    pub use solana_feature_gate_interface as feature;
-
     pub use {
-        solana_account_info as account_info, solana_clock as clock, solana_msg::msg,
-        solana_program_entrypoint as entrypoint, solana_program_entrypoint::entrypoint,
+        solana_account_info as account_info, solana_clock as clock,
+        solana_feature_gate_interface as feature,
+        solana_msg::msg,
+        solana_program_entrypoint::{self as entrypoint, entrypoint},
         solana_program_error as program_error, solana_program_memory as program_memory,
         solana_program_option as program_option, solana_program_pack as program_pack,
-        solana_pubkey as pubkey, solana_sdk_ids::system_program,
+        solana_pubkey as pubkey,
+        solana_sdk_ids::system_program,
         solana_system_interface::instruction as system_instruction,
     };
     pub mod instruction {
@@ -98,8 +101,10 @@ pub mod solana_program {
         pub use solana_sysvar::rent::*;
     }
     pub mod program {
-        pub use solana_cpi::*;
-        pub use solana_invoke::{invoke, invoke_signed, invoke_signed_unchecked, invoke_unchecked};
+        pub use {
+            solana_cpi::*,
+            solana_invoke::{invoke, invoke_signed, invoke_signed_unchecked, invoke_unchecked},
+        };
     }
 
     pub mod bpf_loader_upgradeable {
@@ -146,7 +151,6 @@ pub mod solana_program {
 
 #[cfg(feature = "event-cpi")]
 pub use anchor_attribute_event::{emit_cpi, event_cpi};
-
 #[cfg(feature = "idl-build")]
 pub use idl::IdlBuild;
 
@@ -490,63 +494,66 @@ impl Key for Pubkey {
 /// The prelude contains all commonly used components of the crate.
 /// All programs should include it via `anchor_lang::prelude::*;`.
 pub mod prelude {
-    pub use super::{
-        access_control, account, accounts::account::Account,
-        accounts::account_loader::AccountLoader, accounts::interface::Interface,
-        accounts::interface_account::InterfaceAccount, accounts::migration::Migration,
-        accounts::program::Program, accounts::signer::Signer,
-        accounts::system_account::SystemAccount, accounts::sysvar::Sysvar,
-        accounts::unchecked_account::UncheckedAccount, constant, context::Context,
-        context::CpiContext, declare_id, declare_program, emit, err, error, event, instruction,
-        program, pubkey, require, require_eq, require_gt, require_gte, require_keys_eq,
-        require_keys_neq, require_neq,
-        solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
-        system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
-        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Discriminator,
-        DuplicateMutableAccountKeys, Id, InitSpace, Key, Lamports, Owner, Owners, ProgramData,
-        Result, Space, ToAccountInfo, ToAccountInfos, ToAccountMetas,
-    };
-    // Re-export the crate as anchor_lang for declare_program! macro
-    pub use crate as anchor_lang;
-    pub use crate::solana_program::account_info::{next_account_info, AccountInfo};
-    pub use crate::solana_program::instruction::AccountMeta;
-    pub use crate::solana_program::program_error::ProgramError;
-    pub use crate::solana_program::pubkey::Pubkey;
-    pub use crate::solana_program::*;
-    pub use anchor_attribute_error::*;
-    pub use borsh;
-    pub use error::*;
-    pub use solana_clock::Clock;
-    pub use solana_instructions_sysvar::Instructions;
-    pub use solana_stake_interface::stake_history::StakeHistory;
-    pub use solana_sysvar::epoch_schedule::EpochSchedule;
-    pub use solana_sysvar::rent::Rent;
-    pub use solana_sysvar::rewards::Rewards;
-    pub use solana_sysvar::slot_hashes::SlotHashes;
-    pub use solana_sysvar::slot_history::SlotHistory;
-    pub use solana_sysvar::Sysvar as SolanaSysvar;
-    pub use thiserror;
-
-    #[cfg(feature = "event-cpi")]
-    pub use super::{emit_cpi, event_cpi};
-
-    #[cfg(feature = "idl-build")]
-    pub use super::idl::IdlBuild;
-
     #[cfg(feature = "lazy-account")]
     pub use super::accounts::lazy_account::LazyAccount;
+    #[cfg(feature = "idl-build")]
+    pub use super::idl::IdlBuild;
+    #[cfg(feature = "event-cpi")]
+    pub use super::{emit_cpi, event_cpi};
+    // Re-export the crate as anchor_lang for declare_program! macro
+    pub use crate as anchor_lang;
+    pub use {
+        super::{
+            access_control, account,
+            accounts::{
+                account::Account, account_loader::AccountLoader, interface::Interface,
+                interface_account::InterfaceAccount, migration::Migration, program::Program,
+                signer::Signer, system_account::SystemAccount, sysvar::Sysvar,
+                unchecked_account::UncheckedAccount,
+            },
+            constant,
+            context::{Context, CpiContext},
+            declare_id, declare_program, emit, err, error, event, instruction, program, pubkey,
+            require, require_eq, require_gt, require_gte, require_keys_eq, require_keys_neq,
+            require_neq,
+            solana_program::bpf_loader_upgradeable::UpgradeableLoaderState,
+            source,
+            system_program::System,
+            zero_copy, AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit,
+            AnchorDeserialize, AnchorSerialize, Discriminator, DuplicateMutableAccountKeys, Id,
+            InitSpace, Key, Lamports, Owner, Owners, ProgramData, Result, Space, ToAccountInfo,
+            ToAccountInfos, ToAccountMetas,
+        },
+        crate::solana_program::{
+            account_info::{next_account_info, AccountInfo},
+            instruction::AccountMeta,
+            program_error::ProgramError,
+            pubkey::Pubkey,
+            *,
+        },
+        anchor_attribute_error::*,
+        borsh,
+        error::*,
+        solana_clock::Clock,
+        solana_instructions_sysvar::Instructions,
+        solana_stake_interface::stake_history::StakeHistory,
+        solana_sysvar::{
+            epoch_schedule::EpochSchedule, rent::Rent, rewards::Rewards, slot_hashes::SlotHashes,
+            slot_history::SlotHistory, Sysvar as SolanaSysvar,
+        },
+        thiserror,
+    };
 }
 
 /// Internal module used by macros and unstable apis.
 #[doc(hidden)]
 pub mod __private {
-    pub use anchor_attribute_account::ZeroCopyAccessor;
-    pub use base64;
-    pub use bytemuck;
-
-    pub use crate::{bpf_writer::BpfWriter, common::is_closed};
-
     use crate::solana_program::pubkey::Pubkey;
+    pub use {
+        crate::{bpf_writer::BpfWriter, common::is_closed},
+        anchor_attribute_account::ZeroCopyAccessor,
+        base64, bytemuck,
+    };
 
     // Used to calculate the maximum between two expressions.
     // It is necessary for the calculation of the enum space.
@@ -581,7 +588,8 @@ pub mod __private {
     /// Used to enforce that instruction argument types match the `#[instruction(...)]` attribute types.
     #[doc(hidden)]
     #[diagnostic::on_unimplemented(
-        message = "instruction handler argument type `{Self}` does not match `#[instruction(...)]` attribute type `{T}`",
+        message = "instruction handler argument type `{Self}` does not match \
+                   `#[instruction(...)]` attribute type `{T}`",
         label = "expected `{T}` here based on `#[instruction(...)]` attribute, found `{Self}`",
         note = "ensure `#[instruction(..)]` argument types match those of the instruction handler"
     )]

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -62,7 +62,7 @@ pub use {
     anchor_attribute_event::{emit, event},
     anchor_attribute_program::{declare_program, instruction, program},
     anchor_derive_accounts::Accounts,
-    anchor_derive_serde::{AnchorDeserialize, AnchorSerialize, __erase},
+    anchor_derive_serde::{__erase, AnchorDeserialize, AnchorSerialize},
     anchor_derive_space::InitSpace,
     borsh::ser::BorshSerialize as AnchorSerialize,
     const_crypto::ed25519::derive_program_address,

--- a/lang/src/system_program.rs
+++ b/lang/src/system_program.rs
@@ -1,9 +1,7 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use crate::prelude::*;
-use crate::solana_program::pubkey::Pubkey;
-
 pub use crate::solana_program::system_program::ID;
+use crate::{prelude::*, solana_program::pubkey::Pubkey};
 
 #[derive(Debug, Clone)]
 pub struct System;

--- a/lang/src/vec.rs
+++ b/lang/src/vec.rs
@@ -1,10 +1,12 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use crate::solana_program::account_info::AccountInfo;
-use crate::solana_program::instruction::AccountMeta;
-use crate::solana_program::pubkey::Pubkey;
-use crate::{Accounts, Result, ToAccountInfos, ToAccountMetas};
-use std::collections::BTreeSet;
+use {
+    crate::{
+        solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+        Accounts, Result, ToAccountInfos, ToAccountMetas,
+    },
+    std::collections::BTreeSet,
+};
 
 impl<'info, T: ToAccountInfos<'info>> ToAccountInfos<'info> for Vec<T> {
     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
@@ -39,9 +41,7 @@ impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::solana_program::pubkey::Pubkey;
-
-    use super::*;
+    use {super::*, crate::solana_program::pubkey::Pubkey};
 
     #[derive(Accounts)]
     pub struct Test<'info> {

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -1,7 +1,9 @@
-use crate::{AccountField, AccountsStruct, Ty};
-use heck::SnakeCase;
-use quote::quote;
-use std::str::FromStr;
+use {
+    crate::{AccountField, AccountsStruct, Ty},
+    heck::SnakeCase,
+    quote::quote,
+    std::str::FromStr,
+};
 
 // Generates the private `__client_accounts` mod implementation, containing
 // a generated struct mapping 1-1 to the `Accounts` struct, except with

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -1,8 +1,9 @@
-use std::str::FromStr;
-
-use crate::{AccountField, AccountsStruct, Ty};
-use heck::SnakeCase;
-use quote::quote;
+use {
+    crate::{AccountField, AccountsStruct, Ty},
+    heck::SnakeCase,
+    quote::quote,
+    std::str::FromStr,
+};
 
 // Generates the private `__cpi_client_accounts` mod implementation, containing
 // a generated struct mapping 1-1 to the `Accounts` struct, except with

--- a/lang/syn/src/codegen/accounts/bumps.rs
+++ b/lang/syn/src/codegen/accounts/bumps.rs
@@ -1,10 +1,11 @@
-use crate::{
-    codegen::accounts::{generics, ParsedGenerics},
-    *,
+use {
+    super::constraints,
+    crate::{
+        codegen::accounts::{generics, ParsedGenerics},
+        *,
+    },
+    std::fmt::Display,
 };
-use std::fmt::Display;
-
-use super::constraints;
 
 pub fn generate_bumps_name<T: Display>(anchor_ident: &T) -> Ident {
     Ident::new(&format!("{anchor_ident}Bumps"), Span::call_site())

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1,7 +1,8 @@
-use quote::{format_ident, quote};
-use std::collections::HashSet;
-
-use crate::*;
+use {
+    crate::*,
+    quote::{format_ident, quote},
+    std::collections::HashSet,
+};
 
 pub fn generate(f: &Field, accs: &AccountsStruct) -> proc_macro2::TokenStream {
     let constraints = linearize(&f.constraints);

--- a/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
+++ b/lang/syn/src/codegen/accounts/duplicate_mutable_account_keys.rs
@@ -1,6 +1,10 @@
-use crate::codegen::accounts::{generics, ParsedGenerics};
-use crate::{AccountField, AccountsStruct};
-use quote::quote;
+use {
+    crate::{
+        codegen::accounts::{generics, ParsedGenerics},
+        AccountField, AccountsStruct,
+    },
+    quote::quote,
+};
 
 /// Generates the `DuplicateMutableAccountKeys` trait implementation for an Accounts struct.
 ///

--- a/lang/syn/src/codegen/accounts/exit.rs
+++ b/lang/syn/src/codegen/accounts/exit.rs
@@ -1,7 +1,11 @@
-use crate::accounts_codegen::constraints::OptionalCheckScope;
-use crate::codegen::accounts::{generics, ParsedGenerics};
-use crate::{AccountField, AccountsStruct, Ty};
-use quote::quote;
+use {
+    crate::{
+        accounts_codegen::constraints::OptionalCheckScope,
+        codegen::accounts::{generics, ParsedGenerics},
+        AccountField, AccountsStruct, Ty,
+    },
+    quote::quote,
+};
 
 // Generates the `Exit` trait implementation.
 pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -1,9 +1,12 @@
-use crate::AccountsStruct;
-use quote::quote;
-use std::iter;
-use syn::punctuated::Punctuated;
-use syn::{ConstParam, LifetimeDef, Token, TypeParam};
-use syn::{GenericParam, PredicateLifetime, WhereClause, WherePredicate};
+use {
+    crate::AccountsStruct,
+    quote::quote,
+    std::iter,
+    syn::{
+        punctuated::Punctuated, ConstParam, GenericParam, LifetimeDef, PredicateLifetime, Token,
+        TypeParam, WhereClause, WherePredicate,
+    },
+};
 
 pub mod __client_accounts;
 pub mod __cpi_client_accounts;

--- a/lang/syn/src/codegen/accounts/to_account_infos.rs
+++ b/lang/syn/src/codegen/accounts/to_account_infos.rs
@@ -1,6 +1,10 @@
-use crate::codegen::accounts::{generics, ParsedGenerics};
-use crate::{AccountField, AccountsStruct};
-use quote::quote;
+use {
+    crate::{
+        codegen::accounts::{generics, ParsedGenerics},
+        AccountField, AccountsStruct,
+    },
+    quote::quote,
+};
 
 // Generates the `ToAccountInfos` trait implementation.
 pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {

--- a/lang/syn/src/codegen/accounts/to_account_metas.rs
+++ b/lang/syn/src/codegen/accounts/to_account_metas.rs
@@ -1,5 +1,7 @@
-use crate::{AccountField, AccountsStruct};
-use quote::quote;
+use {
+    crate::{AccountField, AccountsStruct},
+    quote::quote,
+};
 
 // Generates the `ToAccountMetas` trait implementation.
 pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -1,7 +1,11 @@
-use crate::codegen::accounts::{bumps, constraints, generics, ParsedGenerics};
-use crate::{AccountField, AccountsStruct, Ty};
-use quote::{quote, quote_spanned};
-use syn::Expr;
+use {
+    crate::{
+        codegen::accounts::{bumps, constraints, generics, ParsedGenerics},
+        AccountField, AccountsStruct, Ty,
+    },
+    quote::{quote, quote_spanned},
+    syn::Expr,
+};
 
 // Generates the `Accounts` trait implementation.
 pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -1,5 +1,4 @@
-use crate::Error;
-use quote::quote;
+use {crate::Error, quote::quote};
 
 pub fn generate(error: Error) -> proc_macro2::TokenStream {
     let error_enum = &error.raw_enum;

--- a/lang/syn/src/codegen/program/accounts.rs
+++ b/lang/syn/src/codegen/program/accounts.rs
@@ -1,6 +1,4 @@
-use crate::Program;
-use heck::SnakeCase;
-use quote::quote;
+use {crate::Program, heck::SnakeCase, quote::quote};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let mut accounts = std::collections::HashMap::new();

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -1,7 +1,4 @@
-use crate::IxArg;
-use anyhow::Result;
-use heck::CamelCase;
-use quote::quote;
+use {crate::IxArg, anyhow::Result, heck::CamelCase, quote::quote};
 
 // Namespace for calculating instruction sighash signatures for any instruction
 // not affecting program state.

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -1,7 +1,11 @@
-use crate::codegen::program::common::{generate_ix_variant, generate_ix_variant_name};
-use crate::Program;
-use heck::SnakeCase;
-use quote::{quote, ToTokens};
+use {
+    crate::{
+        codegen::program::common::{generate_ix_variant, generate_ix_variant_name},
+        Program,
+    },
+    heck::SnakeCase,
+    quote::{quote, ToTokens},
+};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     // Generate cpi methods for global methods.

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -1,6 +1,4 @@
-use crate::Program;
-use heck::CamelCase;
-use quote::quote;
+use {crate::Program, heck::CamelCase, quote::quote};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     // Dispatch all global instructions.

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -1,6 +1,4 @@
-use crate::Program;
-use heck::CamelCase;
-use quote::quote;
+use {crate::Program, heck::CamelCase, quote::quote};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let name: proc_macro2::TokenStream = program.name.to_string().to_camel_case().parse().unwrap();

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -1,6 +1,7 @@
-use crate::codegen::program::common::*;
-use crate::Program;
-use quote::{quote, ToTokens};
+use {
+    crate::{codegen::program::common::*, Program},
+    quote::{quote, ToTokens},
+};
 
 // Generate non-inlined wrappers for each instruction handler, since Solana's
 // BPF max stack size can't handle reasonable sized dispatch trees without doing

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -1,8 +1,8 @@
-use crate::codegen::program::common::*;
-use crate::parser;
-use crate::Program;
-use heck::CamelCase;
-use quote::{quote, quote_spanned};
+use {
+    crate::{codegen::program::common::*, parser, Program},
+    heck::CamelCase,
+    quote::{quote, quote_spanned},
+};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let variants: Vec<proc_macro2::TokenStream> = program

--- a/lang/syn/src/codegen/program/mod.rs
+++ b/lang/syn/src/codegen/program/mod.rs
@@ -1,5 +1,4 @@
-use crate::Program;
-use quote::quote;
+use {crate::Program, quote::quote};
 
 mod accounts;
 pub mod common;

--- a/lang/syn/src/hash.rs
+++ b/lang/syn/src/hash.rs
@@ -1,10 +1,12 @@
 // Utility hashing module copied from `solana_program::program::hash`, since we
 // can't import solana_program for compile time hashing for some reason.
 
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use std::{fmt, mem, str::FromStr};
-use thiserror::Error;
+use {
+    serde::{Deserialize, Serialize},
+    sha2::{Digest, Sha256},
+    std::{fmt, mem, str::FromStr},
+    thiserror::Error,
+};
 
 pub const HASH_BYTES: usize = 32;
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -1,9 +1,10 @@
-use anyhow::{anyhow, Result};
-use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
-
-use super::common::{get_idl_module_path, get_no_docs};
-use crate::{AccountField, AccountsStruct, ConstraintSeedsGroup, Field, InitKind, Ty};
+use {
+    super::common::{get_idl_module_path, get_no_docs},
+    crate::{AccountField, AccountsStruct, ConstraintSeedsGroup, Field, InitKind, Ty},
+    anyhow::{anyhow, Result},
+    proc_macro2::TokenStream,
+    quote::{quote, ToTokens},
+};
 
 /// Generate the IDL build impl for the Accounts struct.
 pub fn gen_idl_build_impl_accounts_struct(accounts: &AccountsStruct) -> TokenStream {

--- a/lang/syn/src/idl/address.rs
+++ b/lang/syn/src/idl/address.rs
@@ -1,7 +1,4 @@
-use proc_macro2::TokenStream;
-use quote::quote;
-
-use super::common::gen_print_section;
+use {super::common::gen_print_section, proc_macro2::TokenStream, quote::quote};
 
 pub fn gen_idl_print_fn_address(address: String) -> TokenStream {
     let fn_body = gen_print_section("address", quote! { #address });

--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -1,8 +1,9 @@
-use std::path::{Path, PathBuf};
-
-use anyhow::{anyhow, Result};
-use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use {
+    anyhow::{anyhow, Result},
+    proc_macro2::TokenStream,
+    quote::{quote, ToTokens},
+    std::path::{Path, PathBuf},
+};
 
 pub fn find_path(name: &str, path: impl AsRef<Path>) -> Result<PathBuf> {
     let path = path.as_ref();

--- a/lang/syn/src/idl/constant.rs
+++ b/lang/syn/src/idl/constant.rs
@@ -1,12 +1,13 @@
-use heck::SnakeCase;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-
-use super::{
-    common::{gen_print_section, get_idl_module_path, get_no_docs},
-    defined::gen_idl_type,
+use {
+    super::{
+        common::{gen_print_section, get_idl_module_path, get_no_docs},
+        defined::gen_idl_type,
+    },
+    crate::parser::docs,
+    heck::SnakeCase,
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
 };
-use crate::parser::docs;
 
 pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
     let idl = get_idl_module_path();

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -1,9 +1,10 @@
-use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{spanned::Spanned, Result};
-
-use super::common::{get_idl_module_path, get_no_docs};
-use crate::parser::docs;
+use {
+    super::common::{get_idl_module_path, get_no_docs},
+    crate::parser::docs,
+    proc_macro2::TokenStream,
+    quote::quote,
+    syn::{spanned::Spanned, Result},
+};
 
 /// Generate `IdlBuild` impl for a struct.
 pub fn impl_idl_build_struct(item: &syn::ItemStruct) -> TokenStream {
@@ -491,9 +492,11 @@ pub fn gen_idl_type(
 
             // Handle type aliases and external types
             {
-                use super::{common::find_path, external::get_external_type};
-                use crate::parser::context::CrateContext;
-                use quote::ToTokens;
+                use {
+                    super::{common::find_path, external::get_external_type},
+                    crate::parser::context::CrateContext,
+                    quote::ToTokens,
+                };
 
                 // If no path was found, just return an empty path and let the find_path function handle it
                 let source_path = proc_macro2::Span::call_site()

--- a/lang/syn/src/idl/error.rs
+++ b/lang/syn/src/idl/error.rs
@@ -1,9 +1,10 @@
-use heck::SnakeCase;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-
-use super::common::{gen_print_section, get_idl_module_path};
-use crate::Error;
+use {
+    super::common::{gen_print_section, get_idl_module_path},
+    crate::Error,
+    heck::SnakeCase,
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
+};
 
 pub fn gen_idl_print_fn_error(error: &Error) -> TokenStream {
     let idl = get_idl_module_path();

--- a/lang/syn/src/idl/event.rs
+++ b/lang/syn/src/idl/event.rs
@@ -1,10 +1,11 @@
-use heck::SnakeCase;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-
-use super::{
-    common::{gen_print_section, get_idl_module_path, get_serde_json_module_path},
-    defined::gen_idl_type_def_struct,
+use {
+    super::{
+        common::{gen_print_section, get_idl_module_path, get_serde_json_module_path},
+        defined::gen_idl_type_def_struct,
+    },
+    heck::SnakeCase,
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
 };
 
 pub fn gen_idl_print_fn_event(event_struct: &syn::ItemStruct) -> TokenStream {

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -1,14 +1,14 @@
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
+use {
+    super::common::{find_path, get_program_path},
+    crate::parser::context::CrateContext,
+    anyhow::{anyhow, Result},
+    cargo_toml::Manifest,
+    quote::ToTokens,
+    std::{
+        env, fs,
+        path::{Path, PathBuf},
+    },
 };
-
-use anyhow::{anyhow, Result};
-use cargo_toml::Manifest;
-use quote::ToTokens;
-
-use super::common::{find_path, get_program_path};
-use crate::parser::context::CrateContext;
 
 pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<syn::Type>> {
     let use_path = get_uses(path.as_ref())?

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -10,10 +10,12 @@ mod event;
 mod external;
 mod program;
 
-pub use accounts::gen_idl_build_impl_accounts_struct;
-pub use address::gen_idl_print_fn_address;
-pub use constant::gen_idl_print_fn_constant;
-pub use defined::{impl_idl_build_enum, impl_idl_build_struct, impl_idl_build_union};
-pub use error::gen_idl_print_fn_error;
-pub use event::gen_idl_print_fn_event;
-pub use program::gen_idl_print_fn_program;
+pub use {
+    accounts::gen_idl_build_impl_accounts_struct,
+    address::gen_idl_print_fn_address,
+    constant::gen_idl_print_fn_constant,
+    defined::{impl_idl_build_enum, impl_idl_build_struct, impl_idl_build_union},
+    error::gen_idl_print_fn_error,
+    event::gen_idl_print_fn_event,
+    program::gen_idl_print_fn_program,
+};

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -1,16 +1,17 @@
-use anyhow::{anyhow, Result};
-use heck::CamelCase;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::spanned::Spanned;
-
-use super::{
-    common::{gen_print_section, get_idl_module_path, get_no_docs, get_program_path},
-    defined::gen_idl_type,
-};
-use crate::{
-    parser::{context::CrateContext, docs},
-    Program,
+use {
+    super::{
+        common::{gen_print_section, get_idl_module_path, get_no_docs, get_program_path},
+        defined::gen_idl_type,
+    },
+    crate::{
+        parser::{context::CrateContext, docs},
+        Program,
+    },
+    anyhow::{anyhow, Result},
+    heck::CamelCase,
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
+    syn::spanned::Spanned,
 };
 
 /// Generate the IDL build print function for the program module.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -11,25 +11,21 @@ pub mod hash;
 #[cfg(not(feature = "hash"))]
 pub(crate) mod hash;
 
-use codegen::accounts as accounts_codegen;
-use codegen::program as program_codegen;
-use parser::accounts as accounts_parser;
-use parser::program as program_parser;
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use quote::ToTokens;
-use std::collections::HashMap;
-use std::ops::Deref;
-use syn::ext::IdentExt;
-use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::token::Comma;
-use syn::Attribute;
-use syn::Lit;
-use syn::{
-    Expr, Generics, Ident, ItemEnum, ItemFn, ItemMod, ItemStruct, LitInt, PatType, Token, Type,
-    TypePath,
+use {
+    codegen::{accounts as accounts_codegen, program as program_codegen},
+    parser::{accounts as accounts_parser, program as program_parser},
+    proc_macro2::{Span, TokenStream},
+    quote::{quote, ToTokens},
+    std::{collections::HashMap, ops::Deref},
+    syn::{
+        ext::IdentExt,
+        parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult},
+        punctuated::Punctuated,
+        spanned::Spanned,
+        token::Comma,
+        Attribute, Expr, Generics, Ident, ItemEnum, ItemFn, ItemMod, ItemStruct, Lit, LitInt,
+        PatType, Token, Type, TypePath,
+    },
 };
 
 #[derive(Debug)]

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -1,6 +1,10 @@
-use crate::*;
-use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::{Expr, Ident, Token};
+use {
+    crate::*,
+    syn::{
+        parse::{Error as ParseError, Result as ParseResult},
+        Expr, Ident, Token,
+    },
+};
 
 pub fn parse(f: &syn::Field, f_ty: Option<&Ty>) -> ParseResult<ConstraintGroup> {
     let mut constraints = ConstraintGroupBuilder::new(f_ty);
@@ -407,7 +411,13 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                             zero: stream.parse()?,
                         },
                     )),
-                    _ => return Err(ParseError::new(ident.span(), "Invalid attribute. realloc::payer and realloc::zero are the only valid attributes")),
+                    _ => {
+                        return Err(ParseError::new(
+                            ident.span(),
+                            "Invalid attribute. realloc::payer and realloc::zero are the only \
+                             valid attributes",
+                        ))
+                    }
                 }
             }
         }
@@ -595,11 +605,10 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             if cfg!(not(feature = "init-if-needed")) && i.if_needed {
                 return Err(ParseError::new(
                     i.span(),
-                    "init_if_needed requires that anchor-lang be imported \
-                    with the init-if-needed cargo feature enabled. \
-                    Carefully read the init_if_needed docs before using this feature \
-                    to make sure you know how to protect yourself against \
-                    re-initialization attacks.",
+                    "init_if_needed requires that anchor-lang be imported with the init-if-needed \
+                     cargo feature enabled. Carefully read the init_if_needed docs before using \
+                     this feature to make sure you know how to protect yourself against \
+                     re-initialization attacks.",
                 ));
             }
 
@@ -639,7 +648,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                 if b.bump.is_some() {
                     return Err(ParseError::new(
                         b.span(),
-                        "bump targets should not be provided with init. Please use bump without a target."
+                        "bump targets should not be provided with init. Please use bump without a \
+                         target.",
                     ));
                 }
             }
@@ -838,20 +848,24 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                     .as_ref()
                     .map(|a| a.clone().into_inner().token_program),
             }),
-            (Some(mint), None, _) => return Err(ParseError::new(
-                mint.span(),
-                "authority must be provided to specify an associated token program derived address",
-            )),
+            (Some(mint), None, _) => {
+                return Err(ParseError::new(
+                    mint.span(),
+                    "authority must be provided to specify an associated token program derived \
+                     address",
+                ))
+            }
             (None, Some(auth), _) => {
                 return Err(ParseError::new(
                     auth.span(),
                     "mint must be provided to specify an associated token program derived address",
                 ))
-            },
+            }
             (None, None, Some(token_program)) => {
                 return Err(ParseError::new(
                     token_program.span(),
-                    "mint and authority must be provided to specify an associated token program derived address",
+                    "mint and authority must be provided to specify an associated token program \
+                     derived address",
                 ))
             }
             _ => None,
@@ -958,59 +972,87 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         };
 
         Ok(ConstraintGroup {
-            init: init.as_ref().map(|i| Ok(ConstraintInitGroup {
-                if_needed: i.if_needed,
-                seeds: seeds.clone(),
-                payer: into_inner!(payer.clone()).unwrap().target,
-                space: space.clone().map(|s| s.space.clone()),
-                kind: if let Some(tm) = &token_mint {
-                    InitKind::Token {
-                        mint: tm.clone().into_inner().mint,
-                        owner: match &token_authority {
-                            Some(a) => a.clone().into_inner().auth,
-                            None => return Err(ParseError::new(
-                                tm.span(),
-                                "authority must be provided to initialize a token program derived address"
-                            )),
+            init: init
+                .as_ref()
+                .map(|i| {
+                    Ok(ConstraintInitGroup {
+                        if_needed: i.if_needed,
+                        seeds: seeds.clone(),
+                        payer: into_inner!(payer.clone()).unwrap().target,
+                        space: space.clone().map(|s| s.space.clone()),
+                        kind: if let Some(tm) = &token_mint {
+                            InitKind::Token {
+                                mint: tm.clone().into_inner().mint,
+                                owner: match &token_authority {
+                                    Some(a) => a.clone().into_inner().auth,
+                                    None => {
+                                        return Err(ParseError::new(
+                                            tm.span(),
+                                            "authority must be provided to initialize a token \
+                                             program derived address",
+                                        ))
+                                    }
+                                },
+                                token_program: token_token_program
+                                    .map(|tp| tp.into_inner().token_program),
+                            }
+                        } else if let Some(at) = &associated_token {
+                            InitKind::AssociatedToken {
+                                mint: at.mint.clone(),
+                                owner: at.wallet.clone(),
+                                token_program: associated_token_token_program
+                                    .map(|tp| tp.into_inner().token_program),
+                            }
+                        } else if let Some(d) = &mint_decimals {
+                            InitKind::Mint {
+                                decimals: d.clone().into_inner().decimals,
+                                owner: match &mint_authority {
+                                    Some(a) => a.clone().into_inner().mint_auth,
+                                    None => {
+                                        return Err(ParseError::new(
+                                            d.span(),
+                                            "authority must be provided to initialize a mint \
+                                             program derived address",
+                                        ))
+                                    }
+                                },
+                                freeze_authority: mint_freeze_authority
+                                    .map(|fa| fa.into_inner().mint_freeze_auth),
+                                token_program: mint_token_program
+                                    .map(|tp| tp.into_inner().token_program),
+                                // extensions
+                                group_pointer_authority: extension_group_pointer_authority
+                                    .map(|gpa| gpa.into_inner().authority),
+                                group_pointer_group_address: extension_group_pointer_group_address
+                                    .map(|gpga| gpga.into_inner().group_address),
+                                group_member_pointer_authority:
+                                    extension_group_member_pointer_authority
+                                        .map(|gmpa| gmpa.into_inner().authority),
+                                group_member_pointer_member_address:
+                                    extension_group_member_pointer_member_address
+                                        .map(|gmpma| gmpma.into_inner().member_address),
+                                metadata_pointer_authority: extension_metadata_pointer_authority
+                                    .map(|mpa| mpa.into_inner().authority),
+                                metadata_pointer_metadata_address:
+                                    extension_metadata_pointer_metadata_address
+                                        .map(|mpma| mpma.into_inner().metadata_address),
+                                close_authority: extension_close_authority
+                                    .map(|ca| ca.into_inner().authority),
+                                permanent_delegate: extension_permanent_delegate
+                                    .map(|pd| pd.into_inner().permanent_delegate),
+                                transfer_hook_authority: extension_transfer_hook_authority
+                                    .map(|tha| tha.into_inner().authority),
+                                transfer_hook_program_id: extension_transfer_hook_program_id
+                                    .map(|thpid| thpid.into_inner().program_id),
+                            }
+                        } else {
+                            InitKind::Program {
+                                owner: owner.as_ref().map(|o| o.owner_address.clone()),
+                            }
                         },
-                        token_program: token_token_program.map(|tp| tp.into_inner().token_program),
-                    }
-                } else if let Some(at) = &associated_token {
-                    InitKind::AssociatedToken {
-                        mint: at.mint.clone(),
-                        owner: at.wallet.clone(),
-                        token_program: associated_token_token_program.map(|tp| tp.into_inner().token_program),
-                    }
-                } else if let Some(d) = &mint_decimals {
-                    InitKind::Mint {
-                        decimals: d.clone().into_inner().decimals,
-                        owner: match &mint_authority {
-                            Some(a) => a.clone().into_inner().mint_auth,
-                            None => return Err(ParseError::new(
-                                d.span(),
-                                "authority must be provided to initialize a mint program derived address"
-                            ))
-                        },
-                        freeze_authority: mint_freeze_authority.map(|fa| fa.into_inner().mint_freeze_auth),
-                        token_program: mint_token_program.map(|tp| tp.into_inner().token_program),
-                        // extensions
-                        group_pointer_authority: extension_group_pointer_authority.map(|gpa| gpa.into_inner().authority),
-                        group_pointer_group_address: extension_group_pointer_group_address.map(|gpga| gpga.into_inner().group_address),
-                        group_member_pointer_authority: extension_group_member_pointer_authority.map(|gmpa| gmpa.into_inner().authority),
-                        group_member_pointer_member_address: extension_group_member_pointer_member_address.map(|gmpma| gmpma.into_inner().member_address),
-                        metadata_pointer_authority: extension_metadata_pointer_authority.map(|mpa| mpa.into_inner().authority),
-                        metadata_pointer_metadata_address: extension_metadata_pointer_metadata_address.map(|mpma| mpma.into_inner().metadata_address),
-                        close_authority: extension_close_authority.map(|ca| ca.into_inner().authority),
-                        permanent_delegate: extension_permanent_delegate.map(|pd| pd.into_inner().permanent_delegate),
-                        transfer_hook_authority: extension_transfer_hook_authority.map(|tha| tha.into_inner().authority),
-                        transfer_hook_program_id: extension_transfer_hook_program_id.map(|thpid| thpid.into_inner().program_id),
-                    }
-                } else {
-                    InitKind::Program {
-                        owner: owner.as_ref().map(|o| o.owner_address.clone()),
-                    }
-                },
-            })).transpose()?,
+                    })
+                })
+                .transpose()?,
             realloc: realloc.as_ref().map(|r| ConstraintReallocGroup {
                 payer: into_inner!(realloc_payer).unwrap().target,
                 space: r.space.clone(),
@@ -1028,8 +1070,8 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             address: into_inner!(address),
             associated_token: if !is_init { associated_token } else { None },
             seeds,
-            token_account: if !is_init {token_account} else {None},
-            mint: if !is_init {mint} else {None},
+            token_account: if !is_init { token_account } else { None },
+            mint: if !is_init { mint } else { None },
             dup: into_inner!(dup),
         })
     }

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -2,10 +2,13 @@ pub mod constraints;
 #[cfg(feature = "event-cpi")]
 pub mod event_cpi;
 
-use crate::parser::docs;
-use crate::*;
-use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::Path;
+use {
+    crate::{parser::docs, *},
+    syn::{
+        parse::{Error as ParseError, Result as ParseResult},
+        Path,
+    },
+};
 
 pub fn parse(accounts_struct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {
     let instruction_api: Option<Punctuated<Expr, Comma>> = accounts_struct
@@ -97,11 +100,10 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         if matches!(field.ty, Ty::SystemAccount) {
             return Err(ParseError::new(
                 field.ident.span(),
-                "Cannot use `init` on a `SystemAccount`. \
-                    The `SystemAccount` type represents an already-existing account \
-                    owned by the system program and cannot be initialized. \
-                    If you need to create a new account, use a more specific account type \
-                    or `UncheckedAccount` and perform manual initialization instead.",
+                "Cannot use `init` on a `SystemAccount`. The `SystemAccount` type represents an \
+                 already-existing account owned by the system program and cannot be initialized. \
+                 If you need to create a new account, use a more specific account type or \
+                 `UncheckedAccount` and perform manual initialization instead.",
             ));
         }
     }
@@ -206,7 +208,8 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     }) {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "the mint constraint has to be an account field for token initializations (not a public key)",
+                            "the mint constraint has to be an account field for token \
+                             initializations (not a public key)",
                         ));
                     }
                 }
@@ -224,7 +227,8 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     }) {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "because of the init constraint, the mint has to be declared before the corresponding token account",
+                            "because of the init constraint, the mint has to be declared before \
+                             the corresponding token account",
                         ));
                     }
                 }
@@ -281,12 +285,14 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     if !associated_payer_field.constraints.is_mutable() {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "the realloc::payer specified for an realloc constraint must be mutable.",
+                            "the realloc::payer specified for an realloc constraint must be \
+                             mutable.",
                         ));
                     } else if associated_payer_field.is_optional && required_realloc {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "the realloc::payer specified for a required realloc constraint must be required.",
+                            "the realloc::payer specified for a required realloc constraint must \
+                             be required.",
                         ));
                     }
                 }
@@ -540,9 +546,12 @@ fn parse_program_account(path: &syn::Path) -> ParseResult<syn::TypePath> {
                 // Program<'info> - only lifetime, no type parameter
                 1 => {
                     // Create a special marker for unit type that gets handled later
-                    use syn::{Path, PathSegment, PathArguments};
+                    use syn::{Path, PathArguments, PathSegment};
                     let path_segment = PathSegment {
-                        ident: syn::Ident::new("__SolanaProgramUnitType", proc_macro2::Span::call_site()),
+                        ident: syn::Ident::new(
+                            "__SolanaProgramUnitType",
+                            proc_macro2::Span::call_site(),
+                        ),
                         arguments: PathArguments::None,
                     };
 
@@ -555,18 +564,17 @@ fn parse_program_account(path: &syn::Path) -> ParseResult<syn::TypePath> {
                     })
                 }
                 // Program<'info, T> - lifetime and type
-                2 => {
-                    match &args.args[1] {
-                        syn::GenericArgument::Type(syn::Type::Path(ty_path)) => Ok(ty_path.clone()),
-                        _ => Err(ParseError::new(
-                            args.args[1].span(),
-                            "second bracket argument must be a type",
-                        )),
-                    }
-                }
+                2 => match &args.args[1] {
+                    syn::GenericArgument::Type(syn::Type::Path(ty_path)) => Ok(ty_path.clone()),
+                    _ => Err(ParseError::new(
+                        args.args[1].span(),
+                        "second bracket argument must be a type",
+                    )),
+                },
                 _ => Err(ParseError::new(
                     args.args.span(),
-                    "Program must have either just a lifetime (Program<'info>) or a lifetime and type (Program<'info, T>)",
+                    "Program must have either just a lifetime (Program<'info>) or a lifetime and \
+                     type (Program<'info, T>)",
                 )),
             }
         }

--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -1,8 +1,14 @@
-use anyhow::{anyhow, Result};
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::{Ident, ImplItem, ImplItemConst, Type, TypePath};
+use {
+    anyhow::{anyhow, Result},
+    std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    },
+    syn::{
+        parse::{Error as ParseError, Result as ParseResult},
+        Ident, ImplItem, ImplItemConst, Type, TypePath,
+    },
+};
 
 /// Crate parse context
 ///

--- a/lang/syn/src/parser/error.rs
+++ b/lang/syn/src/parser/error.rs
@@ -1,6 +1,10 @@
-use crate::{Error, ErrorArgs, ErrorCode};
-use syn::parse::{Parse, Result as ParseResult};
-use syn::Expr;
+use {
+    crate::{Error, ErrorArgs, ErrorCode},
+    syn::{
+        parse::{Parse, Result as ParseResult},
+        Expr,
+    },
+};
 
 // Removes any internal #[msg] attributes, as they are inert.
 pub fn parse(error_enum: &mut syn::ItemEnum, args: Option<ErrorArgs>) -> Error {

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -1,9 +1,14 @@
-use crate::parser::docs;
-use crate::parser::program::ctx_accounts_ident;
-use crate::{FallbackFn, Ix, IxArg, IxReturn, Overrides};
-use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::spanned::Spanned;
-use syn::Attribute;
+use {
+    crate::{
+        parser::{docs, program::ctx_accounts_ident},
+        FallbackFn, Ix, IxArg, IxReturn, Overrides,
+    },
+    syn::{
+        parse::{Error as ParseError, Result as ParseResult},
+        spanned::Spanned,
+        Attribute,
+    },
+};
 
 // Parse all non-state ix handlers from the program mod definition.
 pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<FallbackFn>)> {

--- a/lang/syn/src/parser/program/mod.rs
+++ b/lang/syn/src/parser/program/mod.rs
@@ -1,7 +1,10 @@
-use crate::parser::docs;
-use crate::Program;
-use syn::parse::{Error as ParseError, Result as ParseResult};
-use syn::spanned::Spanned;
+use {
+    crate::{parser::docs, Program},
+    syn::{
+        parse::{Error as ParseError, Result as ParseResult},
+        spanned::Spanned,
+    },
+};
 
 mod instructions;
 

--- a/lang/tests/generics_test.rs
+++ b/lang/tests/generics_test.rs
@@ -3,10 +3,11 @@
 // Generic accounts are not supported with `Lazy`
 #![cfg(not(feature = "lazy-account"))]
 
-use anchor_lang::prelude::borsh::io::Write;
-use anchor_lang::prelude::*;
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_pubkey::Pubkey;
+use {
+    anchor_lang::prelude::{borsh::io::Write, *},
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_pubkey::Pubkey,
+};
 
 // Needed to declare accounts.
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

--- a/lang/tests/macros.rs
+++ b/lang/tests/macros.rs
@@ -1,6 +1,4 @@
-use core::str::FromStr;
-
-use anchor_lang::solana_program::pubkey::Pubkey;
+use {anchor_lang::solana_program::pubkey::Pubkey, core::str::FromStr};
 
 mod id {
     anchor_lang::declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+format_strings = true
+group_imports = "One"
+imports_granularity = "One"
+style_edition = "2021"

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -1,14 +1,14 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-
-pub use ::spl_associated_token_account_interface as spl_associated_token_account;
 pub use ::spl_associated_token_account_interface::{
+    self as spl_associated_token_account,
     address::{get_associated_token_address, get_associated_token_address_with_program_id},
     program::ID,
+};
+use anchor_lang::{
+    context::CpiContext,
+    solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+    Accounts, Result,
 };
 
 pub fn create<'info>(ctx: CpiContext<'_, '_, '_, 'info, Create<'info>>) -> Result<()> {

--- a/spl/src/memo.rs
+++ b/spl/src/memo.rs
@@ -1,9 +1,5 @@
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-
-pub use spl_memo_interface::instruction as spl_memo;
-pub use spl_memo_interface::v3::ID;
+use anchor_lang::{context::CpiContext, solana_program::pubkey::Pubkey, Accounts, Result};
+pub use spl_memo_interface::{instruction as spl_memo, v3::ID};
 
 pub fn build_memo<'info>(ctx: CpiContext<'_, '_, '_, 'info, BuildMemo>, memo: &[u8]) -> Result<()> {
     let ix = spl_memo::build_memo(

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -1,12 +1,13 @@
-use anchor_lang::context::CpiContext;
-use anchor_lang::error::ErrorCode;
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::{system_program, Accounts, Result, ToAccountInfos};
-use std::ops::Deref;
-
-pub use mpl_token_metadata;
-pub use mpl_token_metadata::ID;
+pub use mpl_token_metadata::{self, ID};
+use {
+    anchor_lang::{
+        context::CpiContext,
+        error::ErrorCode,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        system_program, Accounts, Result, ToAccountInfos,
+    },
+    std::ops::Deref,
+};
 
 pub fn approve_collection_authority<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, ApproveCollectionAuthority<'info>>,

--- a/spl/src/mint.rs
+++ b/spl/src/mint.rs
@@ -1,5 +1,4 @@
 use anchor_lang::declare_id;
-
 pub use srm::ID as SRM;
 mod srm {
     use super::*;

--- a/spl/src/stake.rs
+++ b/spl/src/stake.rs
@@ -1,15 +1,17 @@
-use anchor_lang::{
-    context::CpiContext,
-    solana_program::{account_info::AccountInfo, pubkey::Pubkey},
-    Accounts, Result,
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    borsh::BorshDeserialize,
+    solana_stake_interface::{
+        self as stake,
+        program::ID,
+        state::{StakeAuthorize, StakeStateV2},
+    },
+    std::ops::Deref,
 };
-use borsh::BorshDeserialize;
-use solana_stake_interface::{
-    self as stake,
-    program::ID,
-    state::{StakeAuthorize, StakeStateV2},
-};
-use std::ops::Deref;
 
 // CPI functions
 

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -1,14 +1,14 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::program_pack::Pack;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use std::ops::Deref;
-
-pub use spl_token::ID;
-pub use spl_token_interface as spl_token;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, program_pack::Pack, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    std::ops::Deref,
+};
+pub use {spl_token::ID, spl_token_interface as spl_token};
 
 pub fn transfer<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, Transfer<'info>>,

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -1,12 +1,11 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-
-pub use spl_token_2022::ID;
-pub use spl_token_2022_interface as spl_token_2022;
+use anchor_lang::{
+    context::CpiContext,
+    solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+    Accounts, Result,
+};
+pub use {spl_token_2022::ID, spl_token_2022_interface as spl_token_2022};
 
 #[deprecated(
     since = "0.28.0",

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(

--- a/spl/src/token_2022_extensions/default_account_state.rs
+++ b/spl/src/token_2022_extensions/default_account_state.rs
@@ -1,11 +1,14 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022::state::AccountState;
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022::state::AccountState,
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn default_account_state_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, DefaultAccountStateInitialize<'info>>,

--- a/spl/src/token_2022_extensions/group_member_pointer.rs
+++ b/spl/src/token_2022_extensions/group_member_pointer.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn group_member_pointer_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, GroupMemberPointerInitialize<'info>>,

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn group_pointer_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, GroupPointerInitialize<'info>>,

--- a/spl/src/token_2022_extensions/immutable_owner.rs
+++ b/spl/src/token_2022_extensions/immutable_owner.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn immutable_owner_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, ImmutableOwnerInitialize<'info>>,

--- a/spl/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl/src/token_2022_extensions/interest_bearing_mint.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn interest_bearing_mint_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, InterestBearingMintInitialize<'info>>,

--- a/spl/src/token_2022_extensions/memo_transfer.rs
+++ b/spl/src/token_2022_extensions/memo_transfer.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn memo_transfer_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, MemoTransfer<'info>>,

--- a/spl/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl/src/token_2022_extensions/metadata_pointer.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn metadata_pointer_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, MetadataPointerInitialize<'info>>,

--- a/spl/src/token_2022_extensions/mint_close_authority.rs
+++ b/spl/src/token_2022_extensions/mint_close_authority.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn mint_close_authority_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, MintCloseAuthorityInitialize<'info>>,

--- a/spl/src/token_2022_extensions/mod.rs
+++ b/spl/src/token_2022_extensions/mod.rs
@@ -16,21 +16,10 @@ pub mod token_metadata;
 pub mod transfer_fee;
 pub mod transfer_hook;
 
-pub use cpi_guard::*;
-pub use default_account_state::*;
-pub use group_member_pointer::*;
-pub use group_pointer::*;
-pub use immutable_owner::*;
-pub use interest_bearing_mint::*;
-pub use memo_transfer::*;
-pub use metadata_pointer::*;
-pub use mint_close_authority::*;
-pub use non_transferable::*;
-pub use permanent_delegate::*;
-pub use token_group::*;
-pub use token_metadata::*;
-pub use transfer_fee::*;
-pub use transfer_hook::*;
-
-pub use spl_pod;
-pub use spl_token_metadata_interface;
+pub use {
+    cpi_guard::*, default_account_state::*, group_member_pointer::*, group_pointer::*,
+    immutable_owner::*, interest_bearing_mint::*, memo_transfer::*, metadata_pointer::*,
+    mint_close_authority::*, non_transferable::*, permanent_delegate::*, spl_pod,
+    spl_token_metadata_interface, token_group::*, token_metadata::*, transfer_fee::*,
+    transfer_hook::*,
+};

--- a/spl/src/token_2022_extensions/non_transferable.rs
+++ b/spl/src/token_2022_extensions/non_transferable.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn non_transferable_mint_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, NonTransferableMintInitialize<'info>>,

--- a/spl/src/token_2022_extensions/permanent_delegate.rs
+++ b/spl/src/token_2022_extensions/permanent_delegate.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn permanent_delegate_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, PermanentDelegateInitialize<'info>>,

--- a/spl/src/token_2022_extensions/token_group.rs
+++ b/spl/src/token_2022_extensions/token_group.rs
@@ -1,9 +1,10 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
+use anchor_lang::{
+    context::CpiContext,
+    solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+    Accounts, Result,
+};
 
 pub fn token_group_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TokenGroupInitialize<'info>>,

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -1,12 +1,14 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-
-use spl_pod::optional_keys::OptionalNonZeroPubkey;
-use spl_token_metadata_interface::state::Field;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_metadata_interface::state::Field,
+};
 
 pub fn token_metadata_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TokenMetadataInitialize<'info>>,

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn transfer_fee_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TransferFeeInitialize<'info>>,

--- a/spl/src/token_2022_extensions/transfer_hook.rs
+++ b/spl/src/token_2022_extensions/transfer_hook.rs
@@ -1,10 +1,13 @@
 // Avoiding AccountInfo deprecated msg in anchor context
 #![allow(deprecated)]
-use anchor_lang::solana_program::account_info::AccountInfo;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::Result;
-use anchor_lang::{context::CpiContext, Accounts};
-use spl_token_2022_interface as spl_token_2022;
+use {
+    anchor_lang::{
+        context::CpiContext,
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey},
+        Accounts, Result,
+    },
+    spl_token_2022_interface as spl_token_2022,
+};
 
 pub fn transfer_hook_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TransferHookInitialize<'info>>,

--- a/spl/src/token_interface.rs
+++ b/spl/src/token_interface.rs
@@ -1,13 +1,16 @@
-use anchor_lang::__private::bytemuck::Pod;
-use anchor_lang::solana_program::program_pack::Pack;
-use anchor_lang::solana_program::pubkey::Pubkey;
-use spl_token_2022::extension::ExtensionType;
-use spl_token_2022::extension::{BaseStateWithExtensions, Extension, StateWithExtensions};
-use std::ops::Deref;
-
 pub use crate::token_2022::*;
 #[cfg(feature = "token_2022_extensions")]
 pub use crate::token_2022_extensions::*;
+use {
+    anchor_lang::{
+        __private::bytemuck::Pod,
+        solana_program::{program_pack::Pack, pubkey::Pubkey},
+    },
+    spl_token_2022::extension::{
+        BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensions,
+    },
+    std::ops::Deref,
+};
 
 static IDS: [Pubkey; 2] = [spl_token_interface::ID, spl_token_2022_interface::ID];
 


### PR DESCRIPTION
### Problem

The codebase has inconsistent imports and string formatting.

### Summary of changes

- Add `rustfmt.toml`, which is adapted from [Agave's `rustfmt.toml`](https://github.com/anza-xyz/agave/blob/aa807a8813f45888301086d79a0cd79f65ad2cce/rustfmt.toml) with the only differences being:

    - Reorder fields alphabetically
    - Set `style_edition` to `2021` (until we set crate editions to `2024`)

- Run `cargo +nightly fmt`
- Use the nightly compiler in CI when checking formatting (required for some of the configuration options):
    
    ```
    Warning: can't set `imports_granularity = One`, unstable features are only available in nightly channel.
    Warning: can't set `group_imports = One`, unstable features are only available in nightly channel.
    ```

**Note:** This configuration would not be my first choice, but I think having the same options as the upstream Agave/Solana crates is preferable, at least as a starting point.