### PR TITLE
examples, tests: Set package `version`s to `0.1.0`

### DIFF
--- a/examples/tutorial/basic-0/package.json
+++ b/examples/tutorial/basic-0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-0",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/examples/tutorial/basic-1/package.json
+++ b/examples/tutorial/basic-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-1",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/examples/tutorial/basic-2/package.json
+++ b/examples/tutorial/basic-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-2",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/examples/tutorial/basic-3/package.json
+++ b/examples/tutorial/basic-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-3",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/examples/tutorial/basic-4/package.json
+++ b/examples/tutorial/basic-4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-4",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/examples/tutorial/basic-5/package.json
+++ b/examples/tutorial/basic-5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-5",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/anchor-cli-account/package.json
+++ b/tests/anchor-cli-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchor-cli-account",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/anchor-cli-idl/package.json
+++ b/tests/anchor-cli-idl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchor-cli-idl",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/auction-house/package.json
+++ b/tests/auction-house/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auction-house",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/bench/package.json
+++ b/tests/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bench",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/bpf-upgradeable-state/package.json
+++ b/tests/bpf-upgradeable-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpf-upgradeable-state",
-  "version": "0.24.0",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/cashiers-check/package.json
+++ b/tests/cashiers-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cashiers-check",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/cfo/package.json
+++ b/tests/cfo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfo",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/chat/package.json
+++ b/tests/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/composite/package.json
+++ b/tests/composite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composite",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/cpi-returns/package.json
+++ b/tests/cpi-returns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cpi-returns",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/custom-coder/package.json
+++ b/tests/custom-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-coder",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/custom-discriminator/package.json
+++ b/tests/custom-discriminator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-discriminator",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/custom-program/package.json
+++ b/tests/custom-program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-program",
-  "version": "0.31.1",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/declare-id/package.json
+++ b/tests/declare-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "declare-id",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/declare-program/package.json
+++ b/tests/declare-program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "declare-program",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/duplicate-mutable-accounts/package.json
+++ b/tests/duplicate-mutable-accounts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duplicate-mutable-accounts",
-  "version": "0.31.1",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/errors/package.json
+++ b/tests/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "errors",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/escrow/package.json
+++ b/tests/escrow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escrow",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/events/package.json
+++ b/tests/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "events",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/floats/package.json
+++ b/tests/floats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floats",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/idl/package.json
+++ b/tests/idl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idl",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/ido-pool/package.json
+++ b/tests/ido-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ido-pool",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/interface-account/package.json
+++ b/tests/interface-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interface-account",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/lazy-account/package.json
+++ b/tests/lazy-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazy-account",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/lockup/package.json
+++ b/tests/lockup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lockup",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/misc/package.json
+++ b/tests/misc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misc",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/multiple-suites-run-single/package.json
+++ b/tests/multiple-suites-run-single/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-suites-run-single",
-  "version": "0.24.2",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/multiple-suites/package.json
+++ b/tests/multiple-suites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiple-suites",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/multisig/package.json
+++ b/tests/multisig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multisig",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/optional/package.json
+++ b/tests/optional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optional",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/pda-derivation/package.json
+++ b/tests/pda-derivation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pda-derivation",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/pyth/package.json
+++ b/tests/pyth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyth",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/realloc/package.json
+++ b/tests/realloc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realloc",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/relations-derivation/package.json
+++ b/tests/relations-derivation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relations-derivation",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/spl/metadata/package.json
+++ b/tests/spl/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/spl/token-extensions/package.json
+++ b/tests/spl/token-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-extensions",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/spl/token-proxy/package.json
+++ b/tests/spl/token-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-proxy",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/spl/token-wrapper/package.json
+++ b/tests/spl/token-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-wrapper",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/spl/transfer-hook/package.json
+++ b/tests/spl/transfer-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transfer-hook",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/swap/package.json
+++ b/tests/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swap",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/system-accounts/package.json
+++ b/tests/system-accounts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-accounts",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/sysvars/package.json
+++ b/tests/sysvars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysvars",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/tictactoe/package.json
+++ b/tests/tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tictactoe",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/typescript/package.json
+++ b/tests/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-example",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/validator-clone/package.json
+++ b/tests/validator-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validator-clone",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {

--- a/tests/zero-copy/package.json
+++ b/tests/zero-copy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zero-copy",
-  "version": "1.0.0-rc.5",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/solana-foundation/anchor#readme",
   "bugs": {


### PR DESCRIPTION
### Problem

Both in [`examples`](https://github.com/solana-foundation/anchor/tree/62865c636aecc6974fc9cfebfc6cf08ca4f0bb72/examples) and in [`tests`](https://github.com/solana-foundation/anchor/tree/62865c636aecc6974fc9cfebfc6cf08ca4f0bb72/tests), `Cargo.toml`s specify versions as `0.1.0`:

https://github.com/solana-foundation/anchor/blob/62865c636aecc6974fc9cfebfc6cf08ca4f0bb72/examples/tutorial/basic-0/programs/basic-0/Cargo.toml#L3

 but `package.json`s specify the current Anchor version:

https://github.com/solana-foundation/anchor/blob/62865c636aecc6974fc9cfebfc6cf08ca4f0bb72/examples/tutorial/basic-0/package.json#L3

This adds unnecessary noise to the version bump PRs (e.g. https://github.com/solana-foundation/anchor/pull/4344).

### Summary of changes

Set all of the `version` fields of `package.json`s in `examples` and `tests` to `0.1.0`.

**Note:** Perhaps it would be better to use `0.0.0` to signal that these are not being versioned at all, but given pretty much all `Cargo.toml`s have `0.1.0`, doing it this way results in the least amount of changes. It's also easier to maintain this versioning because `0.1.0` is the default when you add a new Rust crate.