### PR TITLE
chore: Add mass format commit to git blame ignorelist

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+62865c636aecc6974fc9cfebfc6cf08ca4f0bb72


### PR DESCRIPTION
Following up on #4354; format-the-world PRs can make blame-ing difficult so add it to GH's ignorelist.