### PR TITLE
client: Remove the `solana-account-decoder` crate export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 ### Fixes
+
 - client: Fix deadlock when having multiple websocket listeners ([#4250](https://github.com/solana-foundation/anchor/pull/4250)).
 
 ### Breaking
 
 - lang: Rename `errors` and `ProgramError` of `declare_program!` ([#4347](https://github.com/solana-foundation/anchor/pull/4347)).
+- client: Remove the `solana-account-decoder` crate export ([#4373](https://github.com/solana-foundation/anchor/pull/4373)).
 
 ## [1.0.0-rc.5] - 2026-03-20
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -69,7 +69,6 @@ pub use nonblocking::ThreadSafeSigner;
 pub use {
     anchor_lang,
     cluster::Cluster,
-    solana_account_decoder,
     solana_commitment_config::CommitmentConfig,
     solana_instruction::Instruction,
     solana_program::hash::Hash,


### PR DESCRIPTION
### Problem

`solana-account-decoder` is not being used in public API, but it's being exported:

https://github.com/solana-foundation/anchor/blob/df3f11f22d6bac495ccde898109ba1abbb6b24e9/client/src/lib.rs#L69-L72

This was added to make version management convenient (https://github.com/solana-foundation/anchor/pull/3455#issue-2760333954), but now that we've moved away from bulk exporting the Solana crates, it doesn't make sense to make an exception only for this crate.

### Summary of changes

Remove the `solana-account-decoder` crate export from the client.