### PR TITLE
fix(CLI): package manager not found fallback

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1395,7 +1395,8 @@ fn init(
 
     if !is_package_manager_available(&package_manager) {
         return Err(anyhow!(
-            "Package manager {package_manager} not found. Install it or pass --package-manager <pm>."
+            "Package manager {package_manager} not found. Install it or pass --package-manager \
+             <pm>."
         ));
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -100,9 +100,9 @@ pub enum Command {
         /// Don't install JavaScript dependencies
         #[clap(long)]
         no_install: bool,
-        /// Package Manager to use (auto-detects bun, pnpm, npm if not specified)
-        #[clap(value_enum, long)]
-        package_manager: Option<PackageManager>,
+        /// Package Manager to use (defaults to yarn if not specified)
+        #[clap(value_enum, long, default_value = "yarn")]
+        package_manager: PackageManager,
         /// Don't initialize git
         #[clap(long)]
         no_git: bool,
@@ -1357,13 +1357,12 @@ fn is_package_manager_available(pm: &PackageManager) -> bool {
         .is_ok()
 }
 
-
 fn init(
     cfg_override: &ConfigOverride,
     name: String,
     javascript: bool,
     no_install: bool,
-    package_manager: Option<PackageManager>,
+    package_manager: PackageManager,
     no_git: bool,
     template: ProgramTemplate,
     test_template: TestTemplate,
@@ -1394,23 +1393,11 @@ fn init(
         ));
     }
 
-    // Resolve package manager before touching the filesystem
-    let package_manager = match package_manager {
-        Some(pm) => {
-            if !is_package_manager_available(&pm) {
-                return Err(anyhow!("{pm} not found. Install it or pass a different --package-manager."));
-            }
-            pm
-        }
-        None => {
-            if !is_package_manager_available(&PackageManager::Yarn) {
-                return Err(anyhow!(
-                    "Default package manager yarn not found. Install it or pass --package-manager <pm>."
-                ));
-            }
-            PackageManager::Yarn
-        }
-    };
+    if !is_package_manager_available(&package_manager) {
+        return Err(anyhow!(
+            "Package manager {package_manager} not found. Install it or pass --package-manager <pm>."
+        ));
+    }
 
     if force {
         fs::create_dir_all(&project_name)?;
@@ -1418,7 +1405,6 @@ fn init(
         fs::create_dir(&project_name)?;
     }
 
-    let _parent_dir = std::env::current_dir()?;
     std::env::set_current_dir(&project_name)?;
     fs::create_dir_all("app")?;
 
@@ -5340,7 +5326,7 @@ mod tests {
             "await".to_string(),
             true,
             true,
-            None,
+            PackageManager::default(),
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),
@@ -5362,7 +5348,7 @@ mod tests {
             "fn".to_string(),
             true,
             true,
-            None,
+            PackageManager::default(),
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),
@@ -5384,7 +5370,7 @@ mod tests {
             "1project".to_string(),
             true,
             true,
-            None,
+            PackageManager::default(),
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1405,7 +1405,6 @@ fn init(
     } else {
         fs::create_dir(&project_name)?;
     }
-
     std::env::set_current_dir(&project_name)?;
     fs::create_dir_all("app")?;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1357,21 +1357,6 @@ fn is_package_manager_available(pm: &PackageManager) -> bool {
         .is_ok()
 }
 
-fn detect_package_manager() -> Result<PackageManager> {
-    for pm in [
-        PackageManager::Yarn,
-        PackageManager::Bun,
-        PackageManager::PNPM,
-        PackageManager::NPM,
-    ] {
-        if is_package_manager_available(&pm) {
-            return Ok(pm);
-        }
-    }
-    Err(anyhow!(
-        "No supported package manager found. Install yarn, bun, pnpm, or npm and retry, or pass --package-manager <pm>."
-    ))
-}
 
 fn init(
     cfg_override: &ConfigOverride,
@@ -1413,21 +1398,17 @@ fn init(
     let package_manager = match package_manager {
         Some(pm) => {
             if !is_package_manager_available(&pm) {
-                return Err(anyhow!(
-                    "{pm} not found. Install it or omit --package-manager to auto-detect."
-                ));
+                return Err(anyhow!("{pm} not found. Install it or pass a different --package-manager."));
             }
             pm
         }
         None => {
-            let detected = detect_package_manager()?;
-            if detected.to_string() != PackageManager::default().to_string() {
-                println!(
-                    "{} not found, using {detected} instead",
-                    PackageManager::default()
-                );
+            if !is_package_manager_available(&PackageManager::Yarn) {
+                return Err(anyhow!(
+                    "Default package manager yarn not found. Install it or pass --package-manager <pm>."
+                ));
             }
-            detected
+            PackageManager::Yarn
         }
     };
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1347,7 +1347,6 @@ fn process_command(opts: Opts) -> Result<()> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn is_package_manager_available(pm: &PackageManager) -> bool {
     std::process::Command::new(pm.to_string())
         .arg("--version")
@@ -1357,6 +1356,7 @@ fn is_package_manager_available(pm: &PackageManager) -> bool {
         .is_ok()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn init(
     cfg_override: &ConfigOverride,
     name: String,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -100,9 +100,9 @@ pub enum Command {
         /// Don't install JavaScript dependencies
         #[clap(long)]
         no_install: bool,
-        /// Package Manager to use
-        #[clap(value_enum, long, default_value = "yarn")]
-        package_manager: PackageManager,
+        /// Package Manager to use (auto-detects bun, pnpm, npm if not specified)
+        #[clap(value_enum, long)]
+        package_manager: Option<PackageManager>,
         /// Don't initialize git
         #[clap(long)]
         no_git: bool,
@@ -1348,12 +1348,37 @@ fn process_command(opts: Opts) -> Result<()> {
 }
 
 #[allow(clippy::too_many_arguments)]
+fn is_package_manager_available(pm: &PackageManager) -> bool {
+    std::process::Command::new(pm.to_string())
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+fn detect_package_manager() -> Result<PackageManager> {
+    for pm in [
+        PackageManager::Yarn,
+        PackageManager::Bun,
+        PackageManager::PNPM,
+        PackageManager::NPM,
+    ] {
+        if is_package_manager_available(&pm) {
+            return Ok(pm);
+        }
+    }
+    Err(anyhow!(
+        "No supported package manager found. Install yarn, bun, pnpm, or npm and retry, or pass --package-manager <pm>."
+    ))
+}
+
 fn init(
     cfg_override: &ConfigOverride,
     name: String,
     javascript: bool,
     no_install: bool,
-    package_manager: PackageManager,
+    package_manager: Option<PackageManager>,
     no_git: bool,
     template: ProgramTemplate,
     test_template: TestTemplate,
@@ -1384,11 +1409,35 @@ fn init(
         ));
     }
 
+    // Resolve package manager before touching the filesystem
+    let package_manager = match package_manager {
+        Some(pm) => {
+            if !is_package_manager_available(&pm) {
+                return Err(anyhow!(
+                    "{pm} not found. Install it or omit --package-manager to auto-detect."
+                ));
+            }
+            pm
+        }
+        None => {
+            let detected = detect_package_manager()?;
+            if detected.to_string() != PackageManager::default().to_string() {
+                println!(
+                    "{} not found, using {detected} instead",
+                    PackageManager::default()
+                );
+            }
+            detected
+        }
+    };
+
     if force {
         fs::create_dir_all(&project_name)?;
     } else {
         fs::create_dir(&project_name)?;
     }
+
+    let _parent_dir = std::env::current_dir()?;
     std::env::set_current_dir(&project_name)?;
     fs::create_dir_all("app")?;
 
@@ -5310,7 +5359,7 @@ mod tests {
             "await".to_string(),
             true,
             true,
-            PackageManager::default(),
+            None,
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),
@@ -5332,7 +5381,7 @@ mod tests {
             "fn".to_string(),
             true,
             true,
-            PackageManager::default(),
+            None,
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),
@@ -5354,7 +5403,7 @@ mod tests {
             "1project".to_string(),
             true,
             true,
-            PackageManager::default(),
+            None,
             false,
             ProgramTemplate::default(),
             TestTemplate::default(),


### PR DESCRIPTION
Currently, the default package manager is yarn. When not found, anchor will still create the project directory and associated files, but fail in the `node_modules` installation. 

While you could --force to initialise with the desired --package-manger, 

Show warning if default package manger yarn isn't found instead of creating an empty project that errs out 
