### PR TITLE
fix(lang): Handle user-provided `borsh` attributes in serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add missing auth account to `group_pointer_update` ([#4324](https://github.com/solana-foundation/anchor/pull/4324)).
 - lang: Make idl build time way faster by caching `CrateContext` ([#4325](https://github.com/solana-foundation/anchor/pull/4325)).
 - cli: Bind `localnet` to `127.0.0.1` by default to fix a panic in `solana-test-validator` version `3.1.10` ([#4397](https://github.com/solana-foundation/anchor/pull/4397)).
+- lang: Handle user-provided `borsh` attributes in derives ([#4380](https://github.com/solana-foundation/anchor/pull/4380)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
 name = "anchor-derive-serde"
 version = "1.0.0"
 dependencies = [
+ "anchor-lang",
  "anchor-syn",
  "proc-macro-crate 3.5.0",
  "proc-macro2",

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -20,7 +20,7 @@ indexing-slicing = "deny"
 
 [features]
 idl-build = ["anchor-syn/idl-build"]
-lazy-account = []
+lazy-account = ["anchor-lang/lazy-account"]
 
 [dependencies]
 anchor-syn = { path = "../../syn", version = "1.0.0" }
@@ -28,3 +28,7 @@ proc-macro-crate = "3.4.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+# Serialization macros require `anchor-lang` to be available to locate `borsh`
+anchor-lang = { path = "../../../lang" }

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -31,4 +31,5 @@ syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 # Serialization macros require `anchor-lang` to be available to locate `borsh`
+# This is required for doc testing
 anchor-lang = { path = "../../../lang" }

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -129,18 +129,15 @@ fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
         // `size_of` relies on. `use_discriminant = true` would encode explicit
         // discriminant values as the tag byte, breaking the Lazy match arms.
         // Other item-level borsh attrs are not yet supported.
-        let unsupported: Vec<_> = borsh_attrs
-            .iter()
-            .filter(|attr| {
-                !matches!(
-                    attr,
-                    NestedMeta::Meta(Meta::NameValue(nv))
-                        if nv.path.is_ident("use_discriminant")
-                            && matches!(&nv.lit, syn::Lit::Bool(b) if !b.value)
-                )
-            })
-            .collect();
-        if let Some(attr) = unsupported.first() {
+        let unsupported = borsh_attrs.iter().find(|attr| {
+            !matches!(
+                attr,
+                NestedMeta::Meta(Meta::NameValue(nv))
+                    if nv.path.is_ident("use_discriminant")
+                        && matches!(&nv.lit, syn::Lit::Bool(b) if !b.value)
+            )
+        });
+        if let Some(attr) = unsupported {
             return syn::Error::new(
                 attr.span(),
                 "only `#[borsh(use_discriminant = false)]` is supported with `lazy-account`; \

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -30,7 +30,6 @@ fn extract_borsh_attrs(input: &mut DeriveInput) -> Vec<NestedMeta> {
                 None
             }
         })
-        .filter(|list| list.path.is_ident("borsh"))
         .flat_map(|list| list.nested)
         .collect()
 }

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -12,10 +12,10 @@ use {
     proc_macro2::{Span, TokenStream as TokenStream2},
     proc_macro_crate::FoundCrate,
     quote::quote,
-    syn::{parse_macro_input, DeriveInput, Ident, Meta, NestedMeta},
+    syn::{parse_macro_input, spanned::Spanned, DeriveInput, Ident, Meta, NestedMeta},
 };
 
-/// Only one `#[borsh]` attribute may be present, and we apply borsh attributes.
+/// Only one item-level `#[borsh]` attribute may be present, and we apply our own borsh attribute.
 /// Remove any user-provided `#[borsh]` attributes to apply in our generated derive.
 fn extract_borsh_attrs(input: &mut DeriveInput) -> Vec<NestedMeta> {
     input
@@ -31,6 +31,29 @@ fn extract_borsh_attrs(input: &mut DeriveInput) -> Vec<NestedMeta> {
         .filter(|list| list.path.is_ident("borsh"))
         .flat_map(|list| list.nested)
         .collect()
+}
+
+/// Locate any `#[borsh]` attributes on struct/enum fields, which are currently unsupported.
+fn find_field_borsh_attr(input: &DeriveInput) -> Option<&syn::Attribute> {
+    match &input.data {
+        syn::Data::Struct(data) => data
+            .fields
+            .iter()
+            .flat_map(|field| field.attrs.iter())
+            .find(|attr| attr.path.is_ident("borsh")),
+        syn::Data::Enum(data) => data
+            .variants
+            .iter()
+            .flat_map(|variant| variant.fields.iter())
+            .flat_map(|field| field.attrs.iter())
+            .find(|attr| attr.path.is_ident("borsh")),
+        syn::Data::Union(data) => data
+            .fields
+            .named
+            .iter()
+            .flat_map(|field| field.attrs.iter())
+            .find(|attr| attr.path.is_ident("borsh")),
+    }
 }
 
 fn gen_borsh_serialize(input: TokenStream) -> TokenStream {
@@ -84,7 +107,25 @@ pub fn anchor_serialize(input: TokenStream) -> TokenStream {
 
 fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as DeriveInput);
+    if cfg!(feature = "lazy-account") {
+        if let Some(attr) = find_field_borsh_attr(&item) {
+            return syn::Error::new(
+                attr.span(),
+                "`borsh` attributes are not currently supported with `lazy-account`",
+            )
+            .into_compile_error()
+            .into();
+        }
+    }
     let borsh_attrs = extract_borsh_attrs(&mut item);
+    if !borsh_attrs.is_empty() && cfg!(feature = "lazy-account") {
+        return syn::Error::new(
+            borsh_attrs[0].span(),
+            "`borsh` attributes are not currently supported with `lazy-account`",
+        )
+        .into_compile_error()
+        .into();
+    }
     let attrs = helper_attrs("BorshDeserialize", borsh_attrs);
     quote! {
         #attrs
@@ -93,6 +134,38 @@ fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Implements `borsh` deserialization for this structure, as well as implementing lazy
+/// deserialization if the `lazy-account` feature is enabled.
+/// `#[borsh(use_discriminant = ..)]` is supported, but _not_ currently in conjunction
+/// with `lazy-account`.
+#[cfg_attr(feature = "lazy-account", doc = "```compile_fail")]
+#[cfg_attr(
+    feature = "lazy-account",
+    doc = "// Will not compile with `lazy-account`"
+)]
+#[cfg_attr(not(feature = "lazy-account"), doc = "```")]
+/// # use anchor_derive_serde::AnchorDeserialize;
+/// #[derive(AnchorDeserialize)]
+/// #[borsh(use_discriminant = true)]
+/// pub enum Example {
+///     Foo = 1,
+///     Bar = 2,
+/// }
+/// ```
+///
+#[cfg_attr(feature = "lazy-account", doc = "```compile_fail")]
+#[cfg_attr(
+    feature = "lazy-account",
+    doc = "// Will not compile with `lazy-account`"
+)]
+#[cfg_attr(not(feature = "lazy-account"), doc = "```")]
+/// # use anchor_derive_serde::AnchorDeserialize;
+/// #[derive(AnchorDeserialize)]
+/// pub struct Example {
+///     #[borsh(skip)]
+///     x: u8,
+/// }
+/// ```
 #[proc_macro_derive(AnchorDeserialize, attributes(borsh))]
 pub fn anchor_deserialize(input: TokenStream) -> TokenStream {
     #[cfg(feature = "lazy-account")]

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -33,7 +33,9 @@ fn extract_borsh_attrs(input: &mut DeriveInput) -> Vec<NestedMeta> {
         .collect()
 }
 
-/// Locate any `#[borsh]` attributes on struct/enum fields, which are currently unsupported.
+/// Locate any `#[borsh]` attributes on struct/enum fields,
+/// which are currently unsupported with `lazy-account`.
+#[cfg(feature = "lazy-account")]
 fn find_field_borsh_attr(input: &DeriveInput) -> Option<&syn::Attribute> {
     match &input.data {
         syn::Data::Struct(data) => data
@@ -107,16 +109,16 @@ pub fn anchor_serialize(input: TokenStream) -> TokenStream {
 
 fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as DeriveInput);
-    if cfg!(feature = "lazy-account") {
-        if let Some(attr) = find_field_borsh_attr(&item) {
-            return syn::Error::new(
-                attr.span(),
-                "`borsh` attributes are not currently supported with `lazy-account`",
-            )
-            .into_compile_error()
-            .into();
-        }
+    #[cfg(feature = "lazy-account")]
+    if let Some(attr) = find_field_borsh_attr(&item) {
+        return syn::Error::new(
+            attr.span(),
+            "`borsh` attributes are not currently supported with `lazy-account`",
+        )
+        .into_compile_error()
+        .into();
     }
+
     let borsh_attrs = extract_borsh_attrs(&mut item);
     if !borsh_attrs.is_empty() && cfg!(feature = "lazy-account") {
         return syn::Error::new(

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -12,19 +12,39 @@ use {
     proc_macro2::{Span, TokenStream as TokenStream2},
     proc_macro_crate::FoundCrate,
     quote::quote,
-    syn::Ident,
+    syn::{parse_macro_input, DeriveInput, Ident, Meta, NestedMeta},
 };
 
-fn gen_borsh_serialize(input: TokenStream) -> TokenStream2 {
-    let input = TokenStream2::from(input);
-    let attrs = helper_attrs("BorshSerialize");
-    quote! {
-        #attrs
-        #input
-    }
+/// Only one `#[borsh]` attribute may be present, and we apply borsh attributes.
+/// Remove any user-provided `#[borsh]` attributes to apply in our generated derive.
+fn extract_borsh_attrs(input: &mut DeriveInput) -> Vec<NestedMeta> {
+    input
+        .attrs
+        .extract_if(.., |attr| attr.path.is_ident("borsh"))
+        .filter_map(|attr| {
+            if let Ok(Meta::List(list)) = attr.parse_meta() {
+                Some(list)
+            } else {
+                None
+            }
+        })
+        .filter(|list| list.path.is_ident("borsh"))
+        .flat_map(|list| list.nested)
+        .collect()
 }
 
-#[proc_macro_derive(AnchorSerialize)]
+fn gen_borsh_serialize(input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as DeriveInput);
+    let borsh_attrs = extract_borsh_attrs(&mut item);
+    let attrs = helper_attrs("BorshSerialize", borsh_attrs);
+    quote! {
+        #attrs
+        #item
+    }
+    .into()
+}
+
+#[proc_macro_derive(AnchorSerialize, attributes(borsh))]
 pub fn anchor_serialize(input: TokenStream) -> TokenStream {
     #[cfg(not(feature = "idl-build"))]
     let ret = gen_borsh_serialize(input);
@@ -50,42 +70,47 @@ pub fn anchor_serialize(input: TokenStream) -> TokenStream {
             },
         };
 
-        return TokenStream::from(quote! {
+        let ret = TokenStream2::from(ret);
+        return quote! {
             #ret
             #idl_build_impl
-        });
+        }
+        .into();
     };
 
-    #[allow(unreachable_code)]
-    TokenStream::from(ret)
+    #[cfg(not(feature = "idl-build"))]
+    ret
 }
 
-fn gen_borsh_deserialize(input: TokenStream) -> TokenStream2 {
-    let input = TokenStream2::from(input);
-    let attrs = helper_attrs("BorshDeserialize");
+fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as DeriveInput);
+    let borsh_attrs = extract_borsh_attrs(&mut item);
+    let attrs = helper_attrs("BorshDeserialize", borsh_attrs);
     quote! {
         #attrs
-        #input
+        #item
     }
+    .into()
 }
 
-#[proc_macro_derive(AnchorDeserialize)]
-pub fn borsh_deserialize(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(AnchorDeserialize, attributes(borsh))]
+pub fn anchor_deserialize(input: TokenStream) -> TokenStream {
     #[cfg(feature = "lazy-account")]
     {
-        let deser = gen_borsh_deserialize(input.clone());
+        let deser = TokenStream2::from(gen_borsh_deserialize(input.clone()));
         let lazy = lazy::gen_lazy(input).unwrap_or_else(|e| e.to_compile_error());
-        quote::quote! {
+        quote! {
             #deser
             #lazy
         }
         .into()
     }
+
     #[cfg(not(feature = "lazy-account"))]
-    gen_borsh_deserialize(input).into()
+    gen_borsh_deserialize(input)
 }
 
-fn helper_attrs(mac: &str) -> TokenStream2 {
+fn helper_attrs(mac: &str, borsh_attrs: Vec<NestedMeta>) -> TokenStream2 {
     // We need to emit the original borsh deserialization macros on our type,
     // but derive macros can't emit other derives. To get around this, we use a hack:
     // 1. Define an `__erase` attribute macro which deletes the item it is applied to
@@ -113,11 +138,10 @@ fn helper_attrs(mac: &str) -> TokenStream2 {
     );
     let borsh_path = quote! { #anchor_path::prelude::borsh };
     let borsh_path_str = borsh_path.to_string();
-
     quote! {
         #[derive(#borsh_path::#mac_path)]
         // Borsh derives used in a re-export require providing the path to `borsh`
-        #[borsh(crate = #borsh_path_str)]
+        #[borsh(crate = #borsh_path_str, #(#borsh_attrs),*)]
         #[#anchor_path::__erase]
     }
 }

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -7,12 +7,14 @@ extern crate proc_macro;
 #[cfg(feature = "lazy-account")]
 mod lazy;
 
+#[cfg(feature = "lazy-account")]
+use syn::spanned::Spanned;
 use {
     proc_macro::TokenStream,
     proc_macro2::{Span, TokenStream as TokenStream2},
     proc_macro_crate::FoundCrate,
     quote::quote,
-    syn::{parse_macro_input, spanned::Spanned, DeriveInput, Ident, Meta, NestedMeta},
+    syn::{parse_macro_input, DeriveInput, Ident, Meta, NestedMeta},
 };
 
 /// Only one item-level `#[borsh]` attribute may be present, and we apply our own borsh attribute.

--- a/lang/derive/serde/src/lib.rs
+++ b/lang/derive/serde/src/lib.rs
@@ -120,13 +120,33 @@ fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
     }
 
     let borsh_attrs = extract_borsh_attrs(&mut item);
-    if !borsh_attrs.is_empty() && cfg!(feature = "lazy-account") {
-        return syn::Error::new(
-            borsh_attrs[0].span(),
-            "`borsh` attributes are not currently supported with `lazy-account`",
-        )
-        .into_compile_error()
-        .into();
+    #[cfg(feature = "lazy-account")]
+    {
+        // `use_discriminant = false` is safe with `lazy-account` because it preserves
+        // borsh's default sequential tag encoding (0, 1, 2, ...) which Lazy's
+        // `size_of` relies on. `use_discriminant = true` would encode explicit
+        // discriminant values as the tag byte, breaking the Lazy match arms.
+        // Other item-level borsh attrs are not yet supported.
+        let unsupported: Vec<_> = borsh_attrs
+            .iter()
+            .filter(|attr| {
+                !matches!(
+                    attr,
+                    NestedMeta::Meta(Meta::NameValue(nv))
+                        if nv.path.is_ident("use_discriminant")
+                            && matches!(&nv.lit, syn::Lit::Bool(b) if !b.value)
+                )
+            })
+            .collect();
+        if let Some(attr) = unsupported.first() {
+            return syn::Error::new(
+                attr.span(),
+                "only `#[borsh(use_discriminant = false)]` is supported with `lazy-account`; \
+                 `use_discriminant = true` and other `borsh` attributes are not yet supported",
+            )
+            .into_compile_error()
+            .into();
+        }
     }
     let attrs = helper_attrs("BorshDeserialize", borsh_attrs);
     quote! {
@@ -138,17 +158,14 @@ fn gen_borsh_deserialize(input: TokenStream) -> TokenStream {
 
 /// Implements `borsh` deserialization for this structure, as well as implementing lazy
 /// deserialization if the `lazy-account` feature is enabled.
-/// `#[borsh(use_discriminant = ..)]` is supported, but _not_ currently in conjunction
-/// with `lazy-account`.
-#[cfg_attr(feature = "lazy-account", doc = "```compile_fail")]
-#[cfg_attr(
-    feature = "lazy-account",
-    doc = "// Will not compile with `lazy-account`"
-)]
-#[cfg_attr(not(feature = "lazy-account"), doc = "```")]
+/// `#[borsh(use_discriminant = false)]` is supported with `lazy-account`;
+/// `use_discriminant = true` and other `#[borsh]` attributes (e.g. `skip`) are not yet
+/// supported in conjunction with `lazy-account`.
+///
+/// ```
 /// # use anchor_derive_serde::AnchorDeserialize;
 /// #[derive(AnchorDeserialize)]
-/// #[borsh(use_discriminant = true)]
+/// #[borsh(use_discriminant = false)]
 /// pub enum Example {
 ///     Foo = 1,
 ///     Bar = 2,

--- a/lang/tests/serialization.rs
+++ b/lang/tests/serialization.rs
@@ -35,7 +35,7 @@ fn test_instruction_data() {
     );
 }
 
-
+#[cfg(not(feature = "lazy-account"))]
 #[test]
 /// Test for <https://github.com/solana-foundation/anchor/issues/4377>;
 /// ensure that user-provided `borsh` attributes are applied.

--- a/lang/tests/serialization.rs
+++ b/lang/tests/serialization.rs
@@ -34,3 +34,22 @@ fn test_instruction_data() {
         "the different methods produced different serialized representations"
     );
 }
+
+
+#[test]
+/// Test for <https://github.com/solana-foundation/anchor/issues/4377>;
+/// ensure that user-provided `borsh` attributes are applied.
+fn test_borsh_attributes() {
+    #[derive(AnchorSerialize, AnchorDeserialize)]
+    #[borsh(use_discriminant = true)]
+    #[repr(u8)]
+    pub enum Animal {
+        Cat = 0,
+        Dog = 1,
+        Mouse = 5,
+    }
+
+    assert_eq!(borsh::to_vec(&Animal::Cat).unwrap(), vec![0]);
+    assert_eq!(borsh::to_vec(&Animal::Dog).unwrap(), vec![1]);
+    assert_eq!(borsh::to_vec(&Animal::Mouse).unwrap(), vec![5]);
+}


### PR DESCRIPTION
Fixes #4377 by removing `#[borsh]` attributes from the user-provided input and re-applying them in our synthetic derive input.

This additionally blocks the use of `#[borsh]` attributes when `lazy-account` is enabled, pending a future PR to properly support them.