### PR TITLE
use UncheckedAccount instead of AccountInfo in #[event_cpi] macro

### DIFF
--- a/lang/attribute/event/src/lib.rs
+++ b/lang/attribute/event/src/lib.rs
@@ -217,9 +217,9 @@ pub fn emit_cpi(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///    pub signer: Signer<'info>,
 ///    /// CHECK: Only the event authority can invoke self-CPI
 ///    #[account(seeds = [b"__event_authority"], bump)]
-///    pub event_authority: AccountInfo<'info>,
+///    pub event_authority: UncheckedAccount<'info>,
 ///    /// CHECK: Self-CPI will fail if the program is not the current program
-///    pub program: AccountInfo<'info>,
+///    pub program: UncheckedAccount<'info>,
 /// }
 /// ```
 ///

--- a/lang/syn/src/parser/accounts/event_cpi.rs
+++ b/lang/syn/src/parser/accounts/event_cpi.rs
@@ -60,9 +60,9 @@ pub fn add_event_cpi_accounts(
 
             /// CHECK: Only the event authority can invoke self-CPI
             #[account(address = crate::EVENT_AUTHORITY_AND_BUMP.0)]
-            pub #authority_name: AccountInfo<#info_lifetime>,
+            pub #authority_name: UncheckedAccount<#info_lifetime>,
             /// CHECK: Self-CPI will fail if the program is not the current program
-            pub program: AccountInfo<#info_lifetime>,
+            pub program: UncheckedAccount<#info_lifetime>,
         }
     };
     syn::parse2(accounts_struct)


### PR DESCRIPTION
#[event_cpi] macro was still generating AccountInfo fields for event_authority and program, which were deprecated in anchor 1.0.0. this causes unavoidable compiler warnings for every user of the macro since the fields are injected not written by the user. swapped both fields to UncheckedAccount in lang/syn/src/parser/accounts/event_cpi.rs and updated the doc example in lang/attribute/event/src/lib.rs to match.

Closes #4378