### PR TITLE
Support for custom codec plugin

### DIFF
--- a/lang/src/accounts/custom_account.rs
+++ b/lang/src/accounts/custom_account.rs
@@ -1,8 +1,10 @@
 use {
     crate::{
-        AccountSerialize, Accounts, AccountsClose, AccountsExit, CustomCodec, Key, Owner, Result, ToAccountInfos, ToAccountMetas, error::{Error, ErrorCode}, prelude::Account, solana_program::{
+        error::{Error, ErrorCode},
+        solana_program::{
             account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
-        }
+        },
+        Accounts, AccountsExit, CustomCodec, Owner, Result, ToAccountInfos, ToAccountMetas,
     },
     std::{
         collections::BTreeSet,
@@ -33,7 +35,14 @@ impl<'a, T: CustomCodec + Clone> CustomAccount<'a, T> {
         expected_owner: &Pubkey,
         program_id: &Pubkey,
     ) -> Result<()> {
-    	todo!()
+        // Only persist if the owner is the current program and the account is not closed.
+        if expected_owner == program_id && !crate::common::is_closed(self.info) {
+            let mut data = self.info.try_borrow_mut_data()?;
+            let disc = T::DISCRIMINATOR;
+            data[..disc.len()].copy_from_slice(disc);
+            self.account.encode(&mut data[disc.len()..])?;
+        }
+        Ok(())
     }
 
     pub fn into_inner(self) -> T {
@@ -46,28 +55,44 @@ impl<'a, T: CustomCodec + Clone> CustomAccount<'a, T> {
 }
 
 impl<'a, T: CustomCodec + Owner + Clone> CustomAccount<'a, T> {
- 	/// Deserializes the given `info` into a `CustomAccount`.
+    /// Deserializes the given `info` into a `CustomAccount`.
     #[inline(never)]
     pub fn try_from(info: &'a AccountInfo<'a>) -> Result<CustomAccount<'a, T>> {
-    	todo!()
+        if info.owner == &system_program::ID && info.lamports() == 0 {
+            return Err(ErrorCode::AccountNotInitialized.into());
+        }
+        if info.owner != &T::owner() {
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys((*info.owner, T::owner())));
+        }
+
+        let data: &[u8] = &info.try_borrow_data()?;
+        let disc = T::DISCRIMINATOR;
+
+        if data.len() < disc.len() {
+            return Err(ErrorCode::AccountDiscriminatorNotFound.into());
+        }
+        if &data[..disc.len()] != disc {
+            return Err(ErrorCode::AccountDiscriminatorMismatch.into());
+        }
+        Ok(CustomAccount::new(info, T::decode(&data[disc.len()..])?))
     }
 }
 
-impl<'info, B, T: CustomCodec + Owner + Clone> Accounts<'info, B>
-	for CustomAccount<'info, T>
+impl<'info, B, T: CustomCodec + Owner + Clone> Accounts<'info, B> for CustomAccount<'info, T>
 where
-	T: CustomCodec + Owner + Clone
+    T: CustomCodec + Owner + Clone,
 {
     #[inline(never)]
     fn try_accounts(
-    	_program_id: &Pubkey,
+        _program_id: &Pubkey,
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
         _reallocs: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
-       		return Err(ErrorCode::AccountNotEnoughKeys.into())
+            return Err(ErrorCode::AccountNotEnoughKeys.into());
         }
         let account = &accounts[0];
         *accounts = &accounts[1..];
@@ -76,7 +101,7 @@ where
 }
 
 impl<T: CustomCodec + Clone> Deref for CustomAccount<'_, T> {
-	type Target = T;
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &(self).account
@@ -85,40 +110,34 @@ impl<T: CustomCodec + Clone> Deref for CustomAccount<'_, T> {
 
 impl<T: CustomCodec + Clone> DerefMut for CustomAccount<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-	    #[cfg(feature = "anchor-debug")]
-	    if !self.info.is_writable {
-	        crate::solana_program::msg!("The given Account is not mutable");
-	        panic!();
-	    }
-    	&mut self.account
+        #[cfg(feature = "anchor-debug")]
+        if !self.info.is_writable {
+            crate::solana_program::msg!("The given Account is not mutable");
+            panic!();
+        }
+        &mut self.account
     }
 }
 
-impl<'info, T: CustomCodec + Owner + Clone> AccountsExit<'info>
-	for CustomAccount<'info, T>
-{
+impl<'info, T: CustomCodec + Owner + Clone> AccountsExit<'info> for CustomAccount<'info, T> {
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
         self.exit_with_expected_owner(&T::owner(), program_id)
     }
 }
 
-impl<'info, T: CustomCodec + Clone> ToAccountInfos<'info>
-	for CustomAccount<'info, T>
-{
-	fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
-		vec![self.info.clone()]
-	}
+impl<'info, T: CustomCodec + Clone> ToAccountInfos<'info> for CustomAccount<'info, T> {
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.info.clone()]
+    }
 }
 
-impl<T: CustomCodec + Clone> ToAccountMetas
-	for CustomAccount<'_, T>
-{
-	fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
-		let is_signer = is_signer.unwrap_or(self.info.is_signer);
-		let meta = match self.info.is_writable {
-			false => AccountMeta::new_readonly(*self.info.key, is_signer),
+impl<T: CustomCodec + Clone> ToAccountMetas for CustomAccount<'_, T> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        let is_signer = is_signer.unwrap_or(self.info.is_signer);
+        let meta = match self.info.is_writable {
+            false => AccountMeta::new_readonly(*self.info.key, is_signer),
             true => AccountMeta::new(*self.info.key, is_signer),
-		};
-		vec![meta]
-	}
+        };
+        vec![meta]
+    }
 }

--- a/lang/src/accounts/custom_account.rs
+++ b/lang/src/accounts/custom_account.rs
@@ -1,0 +1,124 @@
+use {
+    crate::{
+        AccountSerialize, Accounts, AccountsClose, AccountsExit, CustomCodec, Key, Owner, Result, ToAccountInfos, ToAccountMetas, error::{Error, ErrorCode}, prelude::Account, solana_program::{
+            account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
+        }
+    },
+    std::{
+        collections::BTreeSet,
+        ops::{Deref, DerefMut},
+    },
+};
+
+/// Wrapper around [`AccountInfo`] that verifies program ownership and
+/// deserializes account data using a [`CustomCodec`] instead of the default
+/// Borsh-based path.
+///
+/// Use this in place of [`Account`](crate::accounts::account::Account) when
+/// your account type implements [`CustomCodec`] rather than
+/// `AccountSerialize + AccountDeserialize`.
+#[derive(Clone)]
+pub struct CustomAccount<'info, T: CustomCodec + Clone> {
+    account: T,
+    info: &'info AccountInfo<'info>,
+}
+
+impl<'a, T: CustomCodec + Clone> CustomAccount<'a, T> {
+    pub(crate) fn new(info: &'a AccountInfo<'a>, account: T) -> Self {
+        Self { info, account }
+    }
+
+    pub(crate) fn exit_with_expected_owner(
+        &self,
+        expected_owner: &Pubkey,
+        program_id: &Pubkey,
+    ) -> Result<()> {
+    	todo!()
+    }
+
+    pub fn into_inner(self) -> T {
+        self.account
+    }
+
+    pub fn set_inner(&mut self, inner: T) {
+        self.account = inner;
+    }
+}
+
+impl<'a, T: CustomCodec + Owner + Clone> CustomAccount<'a, T> {
+ 	/// Deserializes the given `info` into a `CustomAccount`.
+    #[inline(never)]
+    pub fn try_from(info: &'a AccountInfo<'a>) -> Result<CustomAccount<'a, T>> {
+    	todo!()
+    }
+}
+
+impl<'info, B, T: CustomCodec + Owner + Clone> Accounts<'info, B>
+	for CustomAccount<'info, T>
+where
+	T: CustomCodec + Owner + Clone
+{
+    #[inline(never)]
+    fn try_accounts(
+    	_program_id: &Pubkey,
+        accounts: &mut &'info [AccountInfo<'info>],
+        _ix_data: &[u8],
+        _bumps: &mut B,
+        _reallocs: &mut BTreeSet<Pubkey>,
+    ) -> Result<Self> {
+        if accounts.is_empty() {
+       		return Err(ErrorCode::AccountNotEnoughKeys.into())
+        }
+        let account = &accounts[0];
+        *accounts = &accounts[1..];
+        CustomAccount::try_from(account)
+    }
+}
+
+impl<T: CustomCodec + Clone> Deref for CustomAccount<'_, T> {
+	type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &(self).account
+    }
+}
+
+impl<T: CustomCodec + Clone> DerefMut for CustomAccount<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+	    #[cfg(feature = "anchor-debug")]
+	    if !self.info.is_writable {
+	        crate::solana_program::msg!("The given Account is not mutable");
+	        panic!();
+	    }
+    	&mut self.account
+    }
+}
+
+impl<'info, T: CustomCodec + Owner + Clone> AccountsExit<'info>
+	for CustomAccount<'info, T>
+{
+    fn exit(&self, program_id: &Pubkey) -> Result<()> {
+        self.exit_with_expected_owner(&T::owner(), program_id)
+    }
+}
+
+impl<'info, T: CustomCodec + Clone> ToAccountInfos<'info>
+	for CustomAccount<'info, T>
+{
+	fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+		vec![self.info.clone()]
+	}
+}
+
+impl<T: CustomCodec + Clone> ToAccountMetas
+	for CustomAccount<'_, T>
+{
+	fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+		let is_signer = is_signer.unwrap_or(self.info.is_signer);
+		let meta = match self.info.is_writable {
+			false => AccountMeta::new_readonly(*self.info.key, is_signer),
+            true => AccountMeta::new(*self.info.key, is_signer),
+		};
+		vec![meta]
+	}
+}

--- a/lang/src/accounts/custom_account.rs
+++ b/lang/src/accounts/custom_account.rs
@@ -1,10 +1,8 @@
 use {
     crate::{
-        error::{Error, ErrorCode},
-        solana_program::{
+        Accounts, AccountsClose, AccountsExit, CustomCodec, Owner, Result, ToAccountInfos, ToAccountMetas, error::{Error, ErrorCode}, solana_program::{
             account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey, system_program,
-        },
-        Accounts, AccountsExit, CustomCodec, Owner, Result, ToAccountInfos, ToAccountMetas,
+        }
     },
     std::{
         collections::BTreeSet,
@@ -100,6 +98,20 @@ where
     }
 }
 
+impl<'info, T: CustomCodec + Clone> AsRef<AccountInfo<'info>>
+	for CustomAccount<'info, T>
+{
+	fn as_ref(&self) -> &AccountInfo<'info> {
+		self.info
+	}
+}
+
+impl<T: CustomCodec + Clone> AsRef<T> for CustomAccount<'_, T> {
+    fn as_ref(&self) -> &T {
+        &self.account
+    }
+}
+
 impl<T: CustomCodec + Clone> Deref for CustomAccount<'_, T> {
     type Target = T;
 
@@ -119,16 +131,20 @@ impl<T: CustomCodec + Clone> DerefMut for CustomAccount<'_, T> {
     }
 }
 
-impl<'info, T: CustomCodec + Owner + Clone> AccountsExit<'info> for CustomAccount<'info, T> {
+impl<'info, T: CustomCodec + Owner + Clone> AccountsExit<'info>
+	for CustomAccount<'info, T>
+{
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
         self.exit_with_expected_owner(&T::owner(), program_id)
     }
 }
 
-impl<'info, T: CustomCodec + Clone> ToAccountInfos<'info> for CustomAccount<'info, T> {
-    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
-        vec![self.info.clone()]
-    }
+impl<'info, T: CustomCodec + Clone> AccountsClose<'info>
+	for CustomAccount<'info, T>
+{
+	fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()> {
+		crate::common::close(self.as_ref(), sol_destination.as_ref())
+	}
 }
 
 impl<T: CustomCodec + Clone> ToAccountMetas for CustomAccount<'_, T> {
@@ -139,5 +155,11 @@ impl<T: CustomCodec + Clone> ToAccountMetas for CustomAccount<'_, T> {
             true => AccountMeta::new(*self.info.key, is_signer),
         };
         vec![meta]
+    }
+}
+
+impl<'info, T: CustomCodec + Clone> ToAccountInfos<'info> for CustomAccount<'info, T> {
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.info.clone()]
     }
 }

--- a/lang/src/accounts/mod.rs
+++ b/lang/src/accounts/mod.rs
@@ -4,6 +4,7 @@ pub mod account;
 pub mod account_info;
 pub mod account_loader;
 pub mod boxed;
+pub mod custom_account;
 pub mod interface;
 pub mod interface_account;
 pub mod migration;

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -366,6 +366,12 @@ pub trait AccountDeserialize: Sized {
 }
 
 pub trait CustomCodec: Discriminator + Sized {
+	/// An name for the custom codec.
+	///
+	/// Corresponds to the `Custom(String)` variant in
+	/// [`IdlSerialization`](anchor_lang_idl_spec::IdlSerialization).
+	const CODEC_ID: &'static str;
+
 	fn encode(&self, buf: &mut [u8]) -> Result<()>;
 
 	fn decode(data: &[u8]) -> Result<Self>;

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -365,6 +365,12 @@ pub trait AccountDeserialize: Sized {
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self>;
 }
 
+pub trait CustomCodec: Discriminator + Sized {
+	fn encode(&self, buf: &mut [u8]) -> Result<()>;
+
+	fn decode(data: &[u8]) -> Result<Self>;
+}
+
 /// An account data structure capable of zero copy deserialization.
 pub trait ZeroCopy: Discriminator + Copy + Clone + Zeroable + Pod {}
 
@@ -506,9 +512,9 @@ pub mod prelude {
         super::{
             access_control, account,
             accounts::{
-                account::Account, account_loader::AccountLoader, interface::Interface,
-                interface_account::InterfaceAccount, migration::Migration, program::Program,
-                signer::Signer, system_account::SystemAccount, sysvar::Sysvar,
+                account::Account, account_loader::AccountLoader, custom_account::CustomAccount,
+                interface::Interface, interface_account::InterfaceAccount, migration::Migration,
+                program::Program, signer::Signer, system_account::SystemAccount, sysvar::Sysvar,
                 unchecked_account::UncheckedAccount,
             },
             constant,
@@ -520,9 +526,9 @@ pub mod prelude {
             source,
             system_program::System,
             zero_copy, AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit,
-            AnchorDeserialize, AnchorSerialize, Discriminator, DuplicateMutableAccountKeys, Id,
-            InitSpace, Key, Lamports, Owner, Owners, ProgramData, Result, Space, ToAccountInfo,
-            ToAccountInfos, ToAccountMetas,
+            AnchorDeserialize, AnchorSerialize, CustomCodec, Discriminator,
+            DuplicateMutableAccountKeys, Id, InitSpace, Key, Lamports, Owner, Owners,
+            ProgramData, Result, Space, ToAccountInfo, ToAccountInfos, ToAccountMetas,
         },
         crate::solana_program::{
             account_info::{next_account_info, AccountInfo},

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -257,6 +257,7 @@ impl AccountField {
             AccountField::Field(field) => match &field.ty {
                 Ty::Account(account) => Some(parser::tts_to_string(&account.account_type_path)),
                 Ty::LazyAccount(account) => Some(parser::tts_to_string(&account.account_type_path)),
+                Ty::CustomAccount(account) => Some(parser::tts_to_string(&account.account_type_path)),
                 _ => None,
             },
             AccountField::CompositeField(field) => Some(field.symbol.clone()),
@@ -309,7 +310,8 @@ impl Field {
                 SystemAccount
             },
             Ty::Account(AccountTy { boxed, .. })
-            | Ty::InterfaceAccount(InterfaceAccountTy { boxed, .. }) => {
+            | Ty::InterfaceAccount(InterfaceAccountTy { boxed, .. })
+            | Ty::CustomAccount(CustomAccountTy { boxed, .. }) => {
                 if *boxed {
                     quote! {
                         Box<#container_ty<#account_ty>>
@@ -398,7 +400,8 @@ impl Field {
                 quote! { UncheckedAccount::try_from(&#field) }
             }
             Ty::Account(AccountTy { boxed, .. })
-            | Ty::InterfaceAccount(InterfaceAccountTy { boxed, .. }) => {
+            | Ty::InterfaceAccount(InterfaceAccountTy { boxed, .. })
+            | Ty::CustomAccount(CustomAccountTy { boxed, .. })=> {
                 let stream = if checked {
                     quote! {
                         match #container_ty::try_from(&#field) {
@@ -501,6 +504,9 @@ impl Field {
             Ty::Signer => quote! {},
             Ty::SystemAccount => quote! {},
             Ty::ProgramData => quote! {},
+            Ty::CustomAccount(_) => quote! {
+            	anchor_lang::accounts::custom_account::CustomAccount
+            }
         }
     }
 
@@ -545,6 +551,12 @@ impl Field {
                 quote! {
                     #ident
                 }
+            },
+            Ty::CustomAccount(ty) => {
+            	let ident = &ty.account_type_path;
+             	quote! {
+              		#ident
+              	}
             }
             Ty::Migration(ty) => {
                 // Return just the From type for IDL and other uses
@@ -613,6 +625,7 @@ pub enum Ty {
     Signer,
     SystemAccount,
     ProgramData,
+    CustomAccount(CustomAccountTy)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -674,6 +687,14 @@ pub struct ProgramTy {
 pub struct InterfaceTy {
     // The struct type of the account.
     pub account_type_path: TypePath,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CustomAccountTy {
+ 	// The struct type of the account.
+    pub account_type_path: TypePath,
+    // True if the account has been boxed via `Box<T>`.
+    pub boxed: bool,
 }
 
 #[derive(Debug)]

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -362,6 +362,7 @@ fn is_field_primitive(f: &syn::Field) -> ParseResult<bool> {
             | "Signer"
             | "SystemAccount"
             | "ProgramData"
+            | "CustomAccount"
     );
     Ok(r)
 }
@@ -382,6 +383,7 @@ fn parse_ty(f: &syn::Field) -> ParseResult<(Ty, bool)> {
         "Signer" => Ty::Signer,
         "SystemAccount" => Ty::SystemAccount,
         "ProgramData" => Ty::ProgramData,
+        "CustomAccount" => Ty::CustomAccount(parse_custom_account_ty(&path)?),
         _ => return Err(ParseError::new(f.ty.span(), "invalid account type given")),
     };
 
@@ -588,7 +590,9 @@ fn parse_program_account(path: &syn::Path) -> ParseResult<syn::TypePath> {
 // TODO: this whole method is a hack. Do something more idiomatic.
 fn parse_account(mut path: &syn::Path) -> ParseResult<syn::TypePath> {
     let path_str = parser::tts_to_string(path).replace(' ', "");
-    if path_str.starts_with("Box<Account<") || path_str.starts_with("Box<InterfaceAccount<") {
+    if path_str.starts_with("Box<Account<")
+    || path_str.starts_with("Box<InterfaceAccount<")
+    || path_str.starts_with("Box<CustomAccount<") {
         let segments = &path.segments[0];
         match &segments.arguments {
             syn::PathArguments::AngleBracketed(args) => {
@@ -702,4 +706,15 @@ fn parse_sysvar(path: &syn::Path) -> ParseResult<SysvarTy> {
         }
     };
     Ok(ty)
+}
+
+fn parse_custom_account_ty(path: &syn::Path) -> ParseResult<CustomAccountTy> {
+    let account_type_path = parse_account(path)?;
+    let boxed = parser::tts_to_string(path)
+        .replace(' ', "")
+        .starts_with("Box<CustomAccount<");
+    Ok(CustomAccountTy {
+        account_type_path,
+        boxed,
+    })
 }


### PR DESCRIPTION
Currently account data is (de)serialized with the framework default. This PR provides a CustomAccount<T: CustomCodec> wrapper that enables developers to use their own codec of choice.

Solves #4276