### PR TITLE
cli: Decouple Node.js from the Anchor CLI

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1116,21 +1116,8 @@ fn restore_toolchain(restore_cbs: RestoreToolchainCallbacks) -> Result<()> {
     Ok(())
 }
 
-/// Get the system's default license - what 'npm init' would use.
-fn get_npm_init_license() -> Result<String> {
-    let npm_init_license_output = std::process::Command::new("npm")
-        .arg("config")
-        .arg("get")
-        .arg("init-license")
-        .output()?;
-
-    if !npm_init_license_output.status.success() {
-        return Err(anyhow!("Failed to get npm init license"));
-    }
-
-    let license = String::from_utf8(npm_init_license_output.stdout)?;
-    Ok(license.trim().to_string())
-}
+/// Default license for generated package.json files.
+const DEFAULT_PACKAGE_LICENSE: &str = "ISC";
 
 fn process_command(opts: Opts) -> Result<()> {
     match opts.command {
@@ -1425,7 +1412,7 @@ fn init(
     let migrations_path = Path::new("migrations");
     fs::create_dir_all(migrations_path)?;
 
-    let license = get_npm_init_license()?;
+    let license = DEFAULT_PACKAGE_LICENSE.to_string();
 
     let jest = TestTemplate::Jest == test_template;
     if javascript {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4264,6 +4264,7 @@ fn upgrade(
 
 fn migrate(cfg_override: &ConfigOverride) -> Result<()> {
     with_workspace(cfg_override, |cfg| -> Result<()> {
+        ensure_node_installed()?;
         println!("Running migration deploy script");
 
         let url = cluster_url(cfg, &cfg.test_validator, &cfg.surfpool_config);
@@ -4574,6 +4575,7 @@ fn shell(cfg_override: &ConfigOverride) -> Result<()> {
                     .collect::<Vec<ProgramWorkspace>>(),
             }
         };
+        ensure_node_installed()?;
         let url = cluster_url(cfg, &cfg.test_validator, &cfg.surfpool_config);
         let js_code = rust_template::node_shell(&url, &cfg.provider.wallet.to_string(), programs)?;
         let mut child = std::process::Command::new("node")
@@ -4888,6 +4890,16 @@ fn is_hidden(entry: &walkdir::DirEntry) -> bool {
         .to_str()
         .map(|s| s == "." || s.starts_with('.') || s == "target")
         .unwrap_or(false)
+}
+
+fn ensure_node_installed() -> Result<()> {
+    std::process::Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|_| anyhow!("Node.js is required for this command but was not found. Install it from https://nodejs.org"))?;
+    Ok(())
 }
 
 fn get_node_version() -> Result<Version> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1393,8 +1393,10 @@ fn init(
     // Initialize .gitignore file
     fs::write(".gitignore", rust_template::git_ignore())?;
 
-    // Initialize .prettierignore file
-    fs::write(".prettierignore", rust_template::prettier_ignore())?;
+    // Initialize .prettierignore file (only for JS/TS projects)
+    if !test_template.is_rust_based() {
+        fs::write(".prettierignore", rust_template::prettier_ignore())?;
+    }
 
     // Remove the default program if `--force` is passed
     if force {
@@ -1412,31 +1414,33 @@ fn init(
     let migrations_path = Path::new("migrations");
     fs::create_dir_all(migrations_path)?;
 
-    let license = DEFAULT_PACKAGE_LICENSE.to_string();
+    if !test_template.is_rust_based() {
+        let license = DEFAULT_PACKAGE_LICENSE.to_string();
 
-    let jest = TestTemplate::Jest == test_template;
-    if javascript {
-        // Build javascript config
-        let mut package_json = File::create("package.json")?;
-        package_json.write_all(rust_template::package_json(jest, license).as_bytes())?;
+        let jest = TestTemplate::Jest == test_template;
+        if javascript {
+            // Build javascript config
+            let mut package_json = File::create("package.json")?;
+            package_json.write_all(rust_template::package_json(jest, license).as_bytes())?;
 
-        let mut deploy = File::create(migrations_path.join("deploy.js"))?;
-        deploy.write_all(rust_template::deploy_script().as_bytes())?;
-    } else {
-        // Build typescript config
-        let mut ts_config = File::create("tsconfig.json")?;
-        ts_config.write_all(rust_template::ts_config(jest).as_bytes())?;
+            let mut deploy = File::create(migrations_path.join("deploy.js"))?;
+            deploy.write_all(rust_template::deploy_script().as_bytes())?;
+        } else {
+            // Build typescript config
+            let mut ts_config = File::create("tsconfig.json")?;
+            ts_config.write_all(rust_template::ts_config(jest).as_bytes())?;
 
-        let mut ts_package_json = File::create("package.json")?;
-        ts_package_json.write_all(rust_template::ts_package_json(jest, license).as_bytes())?;
+            let mut ts_package_json = File::create("package.json")?;
+            ts_package_json.write_all(rust_template::ts_package_json(jest, license).as_bytes())?;
 
-        let mut deploy = File::create(migrations_path.join("deploy.ts"))?;
-        deploy.write_all(rust_template::ts_deploy_script().as_bytes())?;
+            let mut deploy = File::create(migrations_path.join("deploy.ts"))?;
+            deploy.write_all(rust_template::ts_deploy_script().as_bytes())?;
+        }
     }
 
     test_template.create_test_files(&project_name, javascript, &program_id.to_string())?;
 
-    if !no_install {
+    if !test_template.is_rust_based() && !no_install {
         let package_manager_result = install_node_modules(&package_manager_cmd)?;
 
         if !package_manager_result.status.success() && package_manager_cmd != "npm" {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3334,16 +3334,25 @@ fn run_test_suite(
     }
     let url = cluster_url(cfg, test_validator, surfpool_config);
 
-    let node_options = format!(
-        "{} {}",
-        match std::env::var_os("NODE_OPTIONS") {
-            Some(value) => value
-                .into_string()
-                .map_err(std::env::VarError::NotUnicode)?,
-            None => "".to_owned(),
-        },
-        get_node_dns_option()?,
-    );
+    let test_cmd = scripts
+        .get("test")
+        .expect("Not able to find script for `test`");
+    let is_rust_test = test_cmd.starts_with("cargo test");
+
+    let node_options = if is_rust_test {
+        String::new()
+    } else {
+        format!(
+            "{} {}",
+            match std::env::var_os("NODE_OPTIONS") {
+                Some(value) => value
+                    .into_string()
+                    .map_err(std::env::VarError::NotUnicode)?,
+                None => "".to_owned(),
+            },
+            get_node_dns_option()?,
+        )
+    };
 
     // Setup log reader - kept alive until end of scope
     let log_streams = match stream_logs(cfg, &url) {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -659,6 +659,11 @@ pub enum TestTemplate {
 }
 
 impl TestTemplate {
+    /// Returns true if this template uses Rust-based tests (no Node.js needed).
+    pub fn is_rust_based(&self) -> bool {
+        matches!(self, Self::Rust | Self::Litesvm | Self::Mollusk)
+    }
+
     pub fn get_test_script(&self, js: bool, pkg_manager: &PackageManager) -> String {
         let pkg_manager_exec_cmd = match pkg_manager {
             PackageManager::Yarn => "yarn run",


### PR DESCRIPTION
## Summary

Addresses #4279 — Remove Node.js as a hard dependency from the Anchor CLI default workflow.

### Audit Results

The CLI currently depends on Node.js in **9 integration points**:

| Area | File | Purpose |
|------|------|---------|
| `npm config` | `cli/src/lib.rs:1120-1132` | Get default license for `package.json` during `anchor init` |
| `npx` program-metadata | `cli/src/metadata.rs:43-54` | IDL write/fetch/close via `@solana-program/program-metadata` |
| `npx` skills | `cli/src/lib.rs:1506-1518` | Install Solana dev skills (`--install-agent-skills`) |
| `node` shell | `cli/src/lib.rs:4568-4572` | `anchor shell` — interactive JS REPL |
| `node` deploy | `cli/src/lib.rs:4298-4303` | Execute `deploy.js`/`deploy.ts` scripts |
| `node` version check | `cli/src/lib.rs:4883-4893` | DNS option for Node >=16.4 |
| Package manager install | `cli/src/lib.rs:1533-1549` | `npm/yarn/pnpm install` during `anchor init` |
| Test runners | `cli/src/rust_template.rs:662-690` | Jest/Mocha test script generation |
| `package.json` generation | `cli/src/rust_template.rs:400-485` | JS/TS project scaffolding |

### Implementation Plan

#### Phase 1 — Remove unnecessary Node.js calls
- [x] **Replace `npm config get init-license`** with a hardcoded default (`"ISC"`) — no reason to shell out to npm for a license string
- [x] **Gate Node version check / DNS option** — only needed when running JS tests, skip for Rust test workflows

#### Phase 2 — Gate JS features behind runtime checks
- [x] **`anchor init`**: Skip `package.json`, `node_modules`, and JS test scaffolding when Rust test framework is selected
- [x] **`anchor shell`**: Check for Node.js at invocation time, clear error if missing
- [x] **Deploy scripts**: Same — check at invocation, clear error if missing

#### Phase 3 — Out of scope (depends on other issues)
- **`npx @solana-program/program-metadata`** (`metadata.rs`): Needs a pure Rust program-metadata client — aligns with #4288
- **`npm-package/anchor.js`**: Optional npm distribution wrapper, not a runtime dependency — no change needed

## Test plan

- [x] `anchor init` with Rust test framework creates a working project without Node.js installed
- [x] `anchor init` with JS/TS test framework still works as before
- [x] `anchor test` with Rust tests works without Node.js
- [x] `anchor shell` prints a clear error when Node.js is not installed
- [x] Existing JS/TS workflows remain unbroken

Relates to #4278 (LiteSVM) and #4288 (IDL Generation)