### PR TITLE
fix(cli): Handle missing home directory in skill installation

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1411,11 +1411,14 @@ fn init(
 
     // Remove the default program if `--force` is passed
     if force {
-        fs::remove_dir_all(
-            std::env::current_dir()?
-                .join("programs")
-                .join(&project_name),
-        )?;
+        let default_program_path = std::env::current_dir()?
+            .join("programs")
+            .join(&project_name);
+        if let Err(err) = fs::remove_dir_all(&default_program_path) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(err.into());
+            }
+        }
     }
 
     // Build the program.
@@ -1485,14 +1488,16 @@ fn install_solana_skill() {
     const SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
     const SKILL_NAME: &str = "solana-dev";
 
-    // Skip if globally installed (active across all projects already)
-    let global_path = home_dir()
-        .unwrap_or_default()
-        .join(".agents")
-        .join("skills")
-        .join(SKILL_NAME);
-    if global_path.exists() {
-        return;
+    // Skip if globally installed (active across all projects already).
+    // If the home directory is unavailable, we can only check the project-scoped install.
+    if let Some(global_path) = home_dir().map(|home| {
+        home.join(".agents")
+            .join("skills")
+            .join(SKILL_NAME)
+    }) {
+        if global_path.exists() {
+            return;
+        }
     }
 
     // Skip if already project-scoped (could be anchor init --force on existing folder)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1490,11 +1490,9 @@ fn install_solana_skill() {
 
     // Skip if globally installed (active across all projects already).
     // If the home directory is unavailable, we can only check the project-scoped install.
-    if let Some(global_path) = home_dir().map(|home| {
-        home.join(".agents")
-            .join("skills")
-            .join(SKILL_NAME)
-    }) {
+    if let Some(global_path) =
+        home_dir().map(|home| home.join(".agents").join("skills").join(SKILL_NAME))
+    {
         if global_path.exists() {
             return;
         }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1411,14 +1411,11 @@ fn init(
 
     // Remove the default program if `--force` is passed
     if force {
-        let default_program_path = std::env::current_dir()?
-            .join("programs")
-            .join(&project_name);
-        if let Err(err) = fs::remove_dir_all(&default_program_path) {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                return Err(err.into());
-            }
-        }
+        fs::remove_dir_all(
+            std::env::current_dir()?
+                .join("programs")
+                .join(&project_name),
+        )?;
     }
 
     // Build the program.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1488,14 +1488,14 @@ fn install_solana_skill() {
     const SKILL_REPO: &str = "https://github.com/solana-foundation/solana-dev-skill";
     const SKILL_NAME: &str = "solana-dev";
 
-    // Skip if globally installed (active across all projects already).
-    // If the home directory is unavailable, we can only check the project-scoped install.
-    if let Some(global_path) =
-        home_dir().map(|home| home.join(".agents").join("skills").join(SKILL_NAME))
-    {
-        if global_path.exists() {
-            return;
-        }
+    // Skip if globally installed (active across all projects already)
+    if home_dir().is_some_and(|home| {
+        home.join(".agents")
+            .join("skills")
+            .join(SKILL_NAME)
+            .exists()
+    }) {
+        return;
     }
 
     // Skip if already project-scoped (could be anchor init --force on existing folder)


### PR DESCRIPTION
## Summary

Handle the global skill-install check in `anchor init --install-agent-skills` only when a home directory is available.
This avoids collapsing the global path to `.agents/skills/solana-dev` when `HOME` is missing, so the global and project-scoped checks keep their intended semantics in CI and container environments.

## Branch Target

This change is non-breaking and should target the current release branch.