### PR TITLE
docs: Update `Context` lifetimes

### DIFF
--- a/docs/content/docs/basics/program-structure.mdx
+++ b/docs/content/docs/basics/program-structure.mdx
@@ -145,14 +145,14 @@ The
 type provides the instruction with access to the following non-argument inputs:
 
 ```rust
-pub struct Context<'a, 'b, 'c, 'info, T: Bumps> {
+pub struct Context<'info, T: Bumps> {
     /// Currently executing program id.
-    pub program_id: &'a Pubkey,
+    pub program_id: &'info Pubkey,
     /// Deserialized accounts.
-    pub accounts: &'b mut T,
+    pub accounts: &'info mut T,
     /// Remaining accounts given but not deserialized or validated.
     /// Be very careful when using this directly.
-    pub remaining_accounts: &'c [AccountInfo<'info>],
+    pub remaining_accounts: &'info [AccountInfo<'info>],
     /// Bump seeds found during constraint validation. This is provided as a
     /// convenience so that handlers don't have to recalculate bump seeds or
     /// pass them in as arguments.


### PR DESCRIPTION
### Problem

The definition of [`Context`](https://github.com/solana-foundation/anchor/blob/81d749be1ba35b589551fc4931b957eb3ba7cd5e/lang/src/context.rs#L26) is outdated after https://github.com/solana-foundation/anchor/pull/3340:

https://github.com/solana-foundation/anchor/blob/81d749be1ba35b589551fc4931b957eb3ba7cd5e/docs/content/docs/basics/program-structure.mdx#L148-L161

### Summary of changes

Update the `Context` struct definition in docs.
