### PR TITLE
lang: Fix name collision in composite account de-duplicator

### DIFF
--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -69,14 +69,14 @@ pub struct IdlInstruction {
     pub returns: Option<IdlType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum IdlInstructionAccountItem {
     Composite(IdlInstructionAccounts),
     Single(IdlInstructionAccount),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlInstructionAccount {
     pub name: String,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -95,20 +95,20 @@ pub struct IdlInstructionAccount {
     pub relations: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlInstructionAccounts {
     pub name: String,
     pub accounts: Vec<IdlInstructionAccountItem>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlPda {
     pub seeds: Vec<IdlSeed>,
     #[serde(skip_serializing_if = "is_default")]
     pub program: Option<IdlSeed>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum IdlSeed {
     Const(IdlSeedConst),
@@ -116,17 +116,17 @@ pub enum IdlSeed {
     Account(IdlSeedAccount),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlSeedConst {
     pub value: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlSeedArg {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IdlSeedAccount {
     pub path: String,
     #[serde(skip_serializing_if = "is_default")]

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -69,14 +69,14 @@ pub struct IdlInstruction {
     pub returns: Option<IdlType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum IdlInstructionAccountItem {
     Composite(IdlInstructionAccounts),
     Single(IdlInstructionAccount),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlInstructionAccount {
     pub name: String,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -95,20 +95,20 @@ pub struct IdlInstructionAccount {
     pub relations: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlInstructionAccounts {
     pub name: String,
     pub accounts: Vec<IdlInstructionAccountItem>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlPda {
     pub seeds: Vec<IdlSeed>,
     #[serde(skip_serializing_if = "is_default")]
     pub program: Option<IdlSeed>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum IdlSeed {
     Const(IdlSeedConst),
@@ -116,17 +116,17 @@ pub enum IdlSeed {
     Account(IdlSeedAccount),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlSeedConst {
     pub value: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlSeedArg {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdlSeedAccount {
     pub path: String,
     #[serde(skip_serializing_if = "is_default")]

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -462,35 +462,32 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
 
     get_non_instruction_composite_accounts(&ix_accs, idl)
         .into_iter()
-        .fold(
-            instruction_accounts.clone(),
-            |mut all, accs| {
-                // Skip if the account layout is already represented.
-                if all.iter().any(|a| a.accounts == accs.accounts) {
-                    return all;
-                }
+        .fold(instruction_accounts.clone(), |mut all, accs| {
+            // Skip if the account layout is already represented.
+            if all.iter().any(|a| a.accounts == accs.accounts) {
+                return all;
+            }
 
-                let name = if all.iter().all(|a| a.name != accs.name) {
-                    accs.name.to_owned()
-                } else {
-                    // Append numbers to the field name until we find a unique name
-                    #[allow(
-                        clippy::expect_used,
-                        reason = "unbounded integer search always finds a free slot"
-                    )]
-                    (2..)
-                        .find_map(|i| {
-                            let candidate = format!("{}{i}", accs.name);
-                            all.iter().all(|a| a.name != candidate).then_some(candidate)
-                        })
-                        .expect("Should always find a valid name")
-                };
+            let name = if all.iter().all(|a| a.name != accs.name) {
+                accs.name.to_owned()
+            } else {
+                // Append numbers to the field name until we find a unique name
+                #[allow(
+                    clippy::expect_used,
+                    reason = "unbounded integer search always finds a free slot"
+                )]
+                (2..)
+                    .find_map(|i| {
+                        let name = format!("{}{i}", accs.name);
+                        all.iter().all(|a| a.name != name).then_some(name)
+                    })
+                    .expect("Should always find a valid name")
+            };
 
-                all.push(IdlInstructionAccounts {
-                    name,
-                    accounts: accs.accounts.to_owned(),
-                });
-                all
-            },
-        )
+            all.push(IdlInstructionAccounts {
+                name,
+                accounts: accs.accounts.to_owned(),
+            });
+            all
+        })
 }

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -6,7 +6,6 @@ use {
     },
     proc_macro2::Literal,
     quote::{format_ident, quote},
-    std::collections::HashSet,
 };
 
 /// This function should ideally return the absolute path to the declared program's id but because
@@ -461,47 +460,37 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
         })
         .collect();
 
-    // Seed both sets from the regular instruction accounts so composites are
-    // checked against them before being accepted.
-    let mut seen_accounts: HashSet<Vec<IdlInstructionAccountItem>> = instruction_accounts
-        .iter()
-        .map(|a| a.accounts.clone())
-        .collect();
-    let mut seen_names: HashSet<String> = instruction_accounts
-        .iter()
-        .map(|a| a.name.clone())
-        .collect();
-
-    let composites = get_non_instruction_composite_accounts(&ix_accs, idl)
+    get_non_instruction_composite_accounts(&ix_accs, idl)
         .into_iter()
-        .filter_map(|accs| {
-            // Skip if the account layout is already represented.
-            if !seen_accounts.insert(accs.accounts.to_vec()) {
-                return None;
-            }
+        .fold(
+            instruction_accounts.clone(),
+            |mut all, accs| {
+                // Skip if the account layout is already represented.
+                if all.iter().any(|a| a.accounts == accs.accounts) {
+                    return all;
+                }
 
-            let name = if seen_names.insert(accs.name.to_owned()) {
-                accs.name.to_owned()
-            } else {
-                // Append numbers to the field name until we find a unique name
-                #[allow(
-                    clippy::expect_used,
-                    reason = "unbounded integer search always finds a free slot"
-                )]
-                (2..)
-                    .find_map(|i| {
-                        let candidate = format!("{}{i}", accs.name);
-                        seen_names.insert(candidate.clone()).then_some(candidate)
-                    })
-                    .expect("Should always find a valid name")
-            };
+                let name = if all.iter().all(|a| a.name != accs.name) {
+                    accs.name.to_owned()
+                } else {
+                    // Append numbers to the field name until we find a unique name
+                    #[allow(
+                        clippy::expect_used,
+                        reason = "unbounded integer search always finds a free slot"
+                    )]
+                    (2..)
+                        .find_map(|i| {
+                            let candidate = format!("{}{i}", accs.name);
+                            all.iter().all(|a| a.name != candidate).then_some(candidate)
+                        })
+                        .expect("Should always find a valid name")
+                };
 
-            Some(IdlInstructionAccounts {
-                name,
-                accounts: accs.accounts.to_vec(),
-            })
-        })
-        .collect::<Vec<_>>();
-
-    composites.into_iter().chain(instruction_accounts).collect()
+                all.push(IdlInstructionAccounts {
+                    name,
+                    accounts: accs.accounts.to_owned(),
+                });
+                all
+            },
+        )
 }

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -6,6 +6,7 @@ use {
     },
     proc_macro2::Literal,
     quote::{format_ident, quote},
+    std::collections::HashSet,
 };
 
 /// This function should ideally return the absolute path to the declared program's id but because
@@ -450,42 +451,57 @@ pub fn get_all_instruction_accounts(idl: &Idl) -> Vec<IdlInstructionAccounts> {
         .iter()
         .flat_map(|ix| ix.accounts.to_owned())
         .collect::<Vec<_>>();
-    get_non_instruction_composite_accounts(&ix_accs, idl)
-        .into_iter()
-        .fold(Vec::<IdlInstructionAccounts>::default(), |mut all, accs| {
-            // Make sure they are unique
-            if all.iter().all(|a| a.accounts != accs.accounts) {
-                // The name is not guaranteed to be the same as the one used in the actual source
-                // code of the program because the IDL only stores the field names
-                let name = if all.iter().all(|a| a.name != accs.name) {
-                    accs.name.to_owned()
-                } else {
-                    // Append numbers to the field name until we find a unique name
-                    #[allow(
-                        clippy::expect_used,
-                        reason = "unbounded integer search always finds a free slot"
-                    )]
-                    let unique = (2..)
-                        .find_map(|i| {
-                            let name = format!("{}{i}", accs.name);
-                            all.iter().all(|a| a.name != name).then_some(name)
-                        })
-                        .expect("Should always find a valid name");
-                    unique
-                };
 
-                all.push(IdlInstructionAccounts {
-                    name,
-                    accounts: accs.accounts.to_owned(),
-                })
-            }
-
-            all
-        })
-        .into_iter()
-        .chain(idl.instructions.iter().map(|ix| IdlInstructionAccounts {
+    let instruction_accounts: Vec<IdlInstructionAccounts> = idl
+        .instructions
+        .iter()
+        .map(|ix| IdlInstructionAccounts {
             name: ix.name.to_owned(),
             accounts: ix.accounts.to_owned(),
-        }))
-        .collect()
+        })
+        .collect();
+
+    // Seed both sets from the regular instruction accounts so composites are
+    // checked against them before being accepted.
+    let mut seen_accounts: HashSet<Vec<IdlInstructionAccountItem>> = instruction_accounts
+        .iter()
+        .map(|a| a.accounts.clone())
+        .collect();
+    let mut seen_names: HashSet<String> = instruction_accounts
+        .iter()
+        .map(|a| a.name.clone())
+        .collect();
+
+    let composites = get_non_instruction_composite_accounts(&ix_accs, idl)
+        .into_iter()
+        .filter_map(|accs| {
+            // Skip if the account layout is already represented.
+            if !seen_accounts.insert(accs.accounts.to_vec()) {
+                return None;
+            }
+
+            let name = if seen_names.insert(accs.name.to_owned()) {
+                accs.name.to_owned()
+            } else {
+                // Append numbers to the field name until we find a unique name
+                #[allow(
+                    clippy::expect_used,
+                    reason = "unbounded integer search always finds a free slot"
+                )]
+                (2..)
+                    .find_map(|i| {
+                        let candidate = format!("{}{i}", accs.name);
+                        seen_names.insert(candidate.clone()).then_some(candidate)
+                    })
+                    .expect("Should always find a valid name")
+            };
+
+            Some(IdlInstructionAccounts {
+                name,
+                accounts: accs.accounts.to_vec(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    composites.into_iter().chain(instruction_accounts).collect()
 }


### PR DESCRIPTION
Issue report:

> The composite de-duplicator only checks new non-instruction composites against previously collected composites, not against the normal top-level instruction account entries. So a composite may still be added even if it has the same account layout or the same generated name as a vanilla instruction account that gets appended later, producing duplicate names or duplicate account-group definitions in the final output. Once this output is reused by the new instruction parser, those collisions can cause ambiguous parsing or duplicate generated items.