### PR TITLE
tests: Remove duplicate tests in `declare-program`

### DIFF
--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -95,57 +95,6 @@ pub mod declare_program {
         Ok(())
     }
 
-    #[cfg(not(target_os = "solana"))]
-    pub fn account_utils(_ctx: Context<Utils>) -> Result<()> {
-        use external::parsers::Account;
-
-        // Empty
-        if Account::parse(&[]).is_ok() {
-            return Err(ProgramError::Custom(0).into());
-        }
-
-        const DISC: &[u8] = external::accounts::MyAccount::DISCRIMINATOR;
-
-        // Correct discriminator but invalid data
-        if Account::parse(DISC).is_ok() {
-            return Err(ProgramError::Custom(1).into());
-        };
-
-        // Correct discriminator and valid data
-        match Account::parse(&[DISC, &[1, 0, 0, 0]].concat()) {
-            Ok(Account::MyAccount(my_account)) => require_eq!(my_account.field, 1),
-            Ok(_) => return Err(ProgramError::Custom(2).into()),
-            Err(e) => return Err(e.into()),
-        }
-
-        Ok(())
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    pub fn event_utils(_ctx: Context<Utils>) -> Result<()> {
-        use external::parsers::Event;
-
-        // Empty
-        if Event::parse(&[]).is_ok() {
-            return Err(ProgramError::Custom(0).into());
-        }
-
-        const DISC: &[u8] = external::events::MyEvent::DISCRIMINATOR;
-
-        // Correct discriminator but invalid data
-        if Event::parse(DISC).is_ok() {
-            return Err(ProgramError::Custom(1).into());
-        };
-
-        // Correct discriminator and valid data
-        match Event::parse(&[DISC, &[1, 0, 0, 0]].concat()) {
-            Ok(Event::MyEvent(my_event)) => require_eq!(my_event.value, 1),
-            Err(e) => return Err(e.into()),
-        }
-
-        Ok(())
-    }
-
     pub fn proxy(ctx: Context<Proxy>, data: Vec<u8>) -> Result<()> {
         let (authority, bump) = Pubkey::find_program_address(&[GLOBAL], &ID);
 


### PR DESCRIPTION
### Problem

https://github.com/solana-foundation/anchor/pull/3322 added duplicate tests during rebase. These parser tests already exist in [`tests/parser.rs`](https://github.com/solana-foundation/anchor/blob/55daadb600ed42d6b6015f742b722598f77dfd64/tests/declare-program/programs/declare-program/tests/parsers.rs).

### Summary of changes

Remove the duplicate tests in `declare-program`.

**Note:** There are more issues with the new test (e.g. it doesn't compile and also not checked in CI), but that will be more involved to fix. I'll work on that later.