### PR TITLE
chore(v2): Re-export third party crates and access them in macros

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -456,7 +456,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let (struct_attrs, pod_impls) = if is_borsh {
         (
-            quote! { #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Default)] },
+            quote! { #[derive(anchor_lang_v2::borsh::BorshSerialize, anchor_lang_v2::borsh::BorshDeserialize, Default)] },
             quote! {},
         )
     } else {
@@ -980,9 +980,9 @@ fn impl_program(module: &ItemMod) -> TokenStream2 {
 
         // Custom 2-arg (r1, r2) entrypoint using SIMD-0321 convention.
         #[cfg(not(feature = "no-entrypoint"))]
-        pinocchio::default_allocator!();
+        anchor_lang_v2::pinocchio::default_allocator!();
         #[cfg(not(feature = "no-entrypoint"))]
-        pinocchio::default_panic_handler!();
+        anchor_lang_v2::pinocchio::default_panic_handler!();
 
         /// Matches Solana's transaction-wide account cap (u8 index space).
         /// The lookup array holds `[AccountView; 256]` = ~2 KiB of frame

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -102,7 +102,7 @@ pub use {
     event::{sol_log_data, Event},
     hash::sha256,
     loader::AccountLoader,
-    pinocchio::{account::AccountView, address::Address},
+    pinocchio::{self, account::AccountView, address::Address},
     traits::*,
 };
 


### PR DESCRIPTION
There is a remaining issue, in that Wincode derive macros access `::wincode`, which would mean that the end user needs `wincode` in their crate to use it.
`borsh` provides a `#[borsh(crate = "path::to::borsh")]` attribute, which allows borsh to be used via a re-export.