### PR TITLE
feat(v2): Use mask-based checks for duplicate prevention

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -30,6 +30,126 @@
           }
         },
         "hello_world_v2": {
+          "binary_size_bytes": 6440,
+          "compute_units": {
+            "init": 1381
+          }
+        },
+        "multisig_v1": {
+          "binary_size_bytes": 169920,
+          "compute_units": {
+            "create": 12031,
+            "deposit": 4872,
+            "execute_transfer": 7446,
+            "set_label": 4324
+          }
+        },
+        "multisig_v2": {
+          "binary_size_bytes": 30976,
+          "compute_units": {
+            "create": 3016,
+            "deposit": 1613,
+            "execute_transfer": 2170,
+            "set_label": 469
+          }
+        },
+        "nested_v1": {
+          "binary_size_bytes": 157160,
+          "compute_units": {
+            "increment": 4751,
+            "initialize": 19842,
+            "reset": 4752
+          }
+        },
+        "nested_v2": {
+          "binary_size_bytes": 12424,
+          "compute_units": {
+            "increment": 474,
+            "initialize": 2716,
+            "reset": 473
+          }
+        },
+        "prop_amm_v1": {
+          "binary_size_bytes": 140280,
+          "compute_units": {
+            "initialize": 4314,
+            "rotate_authority": 1340,
+            "update": 1310
+          }
+        },
+        "prop_amm_v2": {
+          "binary_size_bytes": 8592,
+          "compute_units": {
+            "initialize": 1375,
+            "rotate_authority": 84,
+            "update": 26
+          }
+        },
+        "vault_pinocchio": {
+          "binary_size_bytes": 5072,
+          "compute_units": {
+            "deposit": 1229,
+            "withdraw": 57
+          }
+        },
+        "vault_quasar": {
+          "binary_size_bytes": 6080,
+          "compute_units": {
+            "deposit": 1889,
+            "withdraw": 396
+          }
+        },
+        "vault_steel": {
+          "binary_size_bytes": 65160,
+          "compute_units": {
+            "deposit": 2452,
+            "withdraw": 530
+          }
+        },
+        "vault_v1": {
+          "binary_size_bytes": 107368,
+          "compute_units": {
+            "deposit": 5707,
+            "withdraw": 2478
+          }
+        },
+        "vault_v2": {
+          "binary_size_bytes": 5384,
+          "compute_units": {
+            "deposit": 1899,
+            "withdraw": 389
+          }
+        }
+      }
+    },
+    {
+      "commit": "2e135c69743b54245a5ddebe6b3f840d53a3032a",
+      "programs": {
+        "hello_world": {
+          "binary_size_bytes": 124624,
+          "compute_units": {
+            "init": 5855
+          }
+        },
+        "hello_world_pinocchio": {
+          "binary_size_bytes": 8040,
+          "compute_units": {
+            "init": 1680
+          }
+        },
+        "hello_world_quasar": {
+          "binary_size_bytes": 6960,
+          "compute_units": {
+            "init": 1412
+          }
+        },
+        "hello_world_steel": {
+          "binary_size_bytes": 77600,
+          "compute_units": {
+            "init": 4867
+          }
+        },
+        "hello_world_v2": {
           "binary_size_bytes": 6464,
           "compute_units": {
             "init": 1382

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -318,6 +318,46 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         }
     };
 
+    // Compile-time `MUT_MASK` composition:
+    //   - bit at `offset` per direct mut field (non-Option, non-`unsafe(dup)`)
+    //   - `<Inner as TryAccounts>::MUT_MASK << child_offset` per `Nested<Inner>`
+    // Folded into a single `const` expression so LLVM sees a literal at
+    // `run_handler`'s inline site — zero runtime composition cost, and the
+    // `intersects(&T::MUT_MASK)` call const-folds away entirely when the
+    // resulting mask is all-zero.
+    let mut_mask_steps: Vec<proc_macro2::TokenStream> = fields
+        .iter()
+        .filter_map(|f| {
+            let offset = &f.offset_expr;
+            if f.contributes_mut_bit {
+                Some(quote! {
+                    __mask = anchor_lang_v2::mut_mask_set_bit(__mask, #offset);
+                })
+            } else if let Some(inner_ty) = parse::extract_nested_inner_type(&f.ty) {
+                Some(quote! {
+                    __mask = anchor_lang_v2::mut_mask_or_shifted(
+                        __mask,
+                        <#inner_ty as anchor_lang_v2::TryAccounts>::MUT_MASK,
+                        #offset,
+                    );
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    let mut_mask_expr = if mut_mask_steps.is_empty() {
+        quote::quote! { [0u64; 4] }
+    } else {
+        quote::quote! {
+            {
+                let mut __mask = [0u64; 4];
+                #(#mut_mask_steps)*
+                __mask
+            }
+        }
+    };
+
     // IDL collection — the accounts-JSON emission is a runtime function
     // (not a `&'static str` const) so it can read
     // `<FieldTy as IdlAccountType>::__IDL_IS_SIGNER / __IDL_ADDRESS` off
@@ -813,6 +853,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
 
         impl anchor_lang_v2::TryAccounts for #name {
             const HEADER_SIZE: usize = #header_size_expr;
+            const MUT_MASK: [u64; 4] = #mut_mask_expr;
 
             #[inline]
             fn try_accounts(

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -382,6 +382,18 @@ pub struct AccountField {
     pub has_bump: bool,
     /// True when the field type is `Option<T>` (optional account).
     pub is_optional: bool,
+    /// Offset expression for this field within the enclosing struct's
+    /// views slice (a compile-time usize). Retained so the trait-impl
+    /// emitter can fold direct-mut fields into `MUT_MASK` at the right
+    /// bit position and shift each `Nested<U>` child's `MUT_MASK` by
+    /// this offset.
+    pub offset_expr: TokenStream2,
+    /// `true` iff this field contributes a `1` to the enclosing struct's
+    /// `MUT_MASK`: a non-`Option<_>` mut field without `unsafe(dup)`.
+    /// `Option<T>` mut fields are excluded because a `None` slot (the
+    /// client sends `program_id` as the address) should still silence the
+    /// dup check; the derive keeps the gated per-field `get()` for those.
+    pub contributes_mut_bit: bool,
     // IDL metadata
     pub idl_writable: bool,
     /// True when this is a fresh-keypair init site (attrs: `init` or
@@ -852,6 +864,11 @@ pub fn parse_field(
             exit,
             has_bump: false,
             is_optional: false,
+            offset_expr,
+            // Nested children contribute via their own `MUT_MASK` shifted
+            // into the parent's; they don't set a bit at the nested field's
+            // own offset.
+            contributes_mut_bit: false,
             idl_writable: false,
             idl_init_signer: false,
             idl_has_one: vec![],
@@ -1313,11 +1330,17 @@ pub fn parse_field(
         None
     };
 
-    // Dup-check emission: stored separately from `constraints` so the
-    // struct-level codegen can aggregate all mut fields' dup checks under a
-    // single outer `if let Some(__dups) = __duplicates { ... }` gate. That
-    // way non-dup txs pay one Option-tag branch regardless of field count.
-    let dup_check = if attrs.is_mut && !attrs.is_dup {
+    // Dup-check emission: only `Option<_>` mut fields keep a gated
+    // per-field `get()` check — a `None` slot (the client encodes
+    // `program_id` as the address) must stay silent even when that slot
+    // is also the dup target of another account, and the
+    // `if let Some(...)` wrapper built below preserves that. Non-`Option`
+    // mut fields are folded into the enclosing struct's `MUT_MASK` const
+    // and checked once per dispatch by `run_handler`. Stored separately
+    // from `constraints` so the struct-level codegen can aggregate all
+    // mut fields' dup checks under a single outer
+    // `if let Some(__dups) = __duplicates { ... }` gate.
+    let dup_check = if attrs.is_mut && !attrs.is_dup && is_optional {
         Some(quote! {
             if __dups.get((__base_offset + #offset_expr) as u8) {
                 return Err(anchor_lang_v2::ErrorCode::ConstraintDuplicateMutableAccount.into());
@@ -1397,6 +1420,8 @@ pub fn parse_field(
         (constraints, exit)
     };
 
+    let contributes_mut_bit = attrs.is_mut && !attrs.is_dup && !is_optional;
+
     Ok(AccountField {
         name: field_name.clone(),
         ty: field.ty.clone(),
@@ -1406,6 +1431,8 @@ pub fn parse_field(
         exit,
         has_bump,
         is_optional,
+        offset_expr,
+        contributes_mut_bit,
         idl_writable,
         idl_init_signer,
         idl_has_one,

--- a/lang-v2/src/cursor.rs
+++ b/lang-v2/src/cursor.rs
@@ -193,6 +193,50 @@ impl AccountBitvec {
         let bit_index = index % 64;
         self.data[arr_index] |= 1 << bit_index
     }
+
+    /// `true` iff any bit set in `self` is also set in `mask`. Used by the
+    /// dispatcher to fold every mutable-field dup check in a struct into a
+    /// single 4-word AND+test instead of one `get()` per mut field.
+    #[inline]
+    pub fn intersects(&self, mask: &[u64; 4]) -> bool {
+        (self.data[0] & mask[0])
+            | (self.data[1] & mask[1])
+            | (self.data[2] & mask[2])
+            | (self.data[3] & mask[3])
+            != 0
+    }
+}
+
+/// OR `1 << bit` into `mask`. Used by the derive to build `TryAccounts::MUT_MASK`
+/// at compile time from each direct mut field's offset.
+pub const fn mut_mask_set_bit(mut mask: [u64; 4], bit: usize) -> [u64; 4] {
+    mask[bit / 64] |= 1u64 << (bit % 64);
+    mask
+}
+
+/// OR `other << shift` (as a 256-bit shift) into `mask`. Used by the derive
+/// to fold a `Nested<U>` child's `MUT_MASK` into its parent's at the child's
+/// account offset.
+pub const fn mut_mask_or_shifted(
+    mut mask: [u64; 4],
+    other: [u64; 4],
+    shift: usize,
+) -> [u64; 4] {
+    let word_shift = shift / 64;
+    let bit_shift = shift % 64;
+    let mut i = 0;
+    while i < 4 {
+        let src = other[i];
+        let dst_lo = i + word_shift;
+        if dst_lo < 4 {
+            mask[dst_lo] |= src << bit_shift;
+            if bit_shift != 0 && dst_lo + 1 < 4 {
+                mask[dst_lo + 1] |= src >> (64 - bit_shift);
+            }
+        }
+        i += 1;
+    }
+    mask
 }
 
 #[cfg(test)]

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -21,6 +21,16 @@ use {
 pub trait TryAccounts: Bumps + Sized {
     const HEADER_SIZE: usize;
 
+    /// Bit `i` is set iff account-view index `i` (global, across nested
+    /// children) is a non-`Option` mut field without `unsafe(dup)`. The
+    /// dispatcher AND's this against the walked `AccountBitvec` once per
+    /// `run_handler` call — a single 4-word test replaces N per-field
+    /// `get()` checks across the whole struct tree. `Option<T>` mut
+    /// fields are excluded here and keep their gated per-field check so
+    /// a `None` slot (encoded as `program_id`) stays silent the way it
+    /// does today.
+    const MUT_MASK: [u64; 4];
+
     /// `base_offset` is the index of the first view in the global bitvec.
     /// Top-level callers pass 0; `Nested<T>` passes its field's offset so
     /// the inner struct's duplicate-mutable-account checks hit the correct
@@ -56,6 +66,18 @@ pub fn run_handler<'a, T: TryAccounts>(
     let (ctx_accounts, bumps) = {
         let mut loader = AccountLoader::new(program_id, cursor);
         let (views, duplicates) = loader.walk_n(T::HEADER_SIZE);
+        // Single AND+test across the whole struct tree — replaces the
+        // per-mut-field `__duplicates.get()` checks the derive used to
+        // emit at each field site. `MUT_MASK == [0; 4]` (no mut fields
+        // anywhere) const-folds the intersect away at inline time. The
+        // outer `Some` guard short-circuits when the walker didn't need
+        // to materialize a bitvec (no account appeared twice), so the
+        // no-dup path pays a single Option-tag test.
+        if let Some(dups) = duplicates {
+            if dups.intersects(&T::MUT_MASK) {
+                return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
+            }
+        }
         T::try_accounts(program_id, views, duplicates, 0, ix_data)?
     };
     let remaining_num = (num_accounts - T::HEADER_SIZE) as u8;

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -129,7 +129,7 @@ pub use {
         find_program_address, verify_program_address,
     },
     context_cpi::CpiContext,
-    cursor::{AccountBitvec, AccountCursor},
+    cursor::{mut_mask_or_shifted, mut_mask_set_bit, AccountBitvec, AccountCursor},
     dispatch::{run_handler, TryAccounts},
     event::{sol_log_data, Event},
     hash::sha256,


### PR DESCRIPTION
Currently, each mutable account emits a check to the duplicates bitvec which results in a lot of extra instructions. Instead, record a bitvec of mutable accounts and duplicate accounts, then AND them together to determine if there is a violation.

This does improve performance in the order of approx. 3 CU per mutable account. Not sure if this is worth the complexity.