### PR TITLE
fix(lang): replace unwrap() with graceful error in close() (#4224)

### DIFF
--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -1,19 +1,36 @@
 use crate::{
+    error::ErrorCode,
     prelude::{Id, System},
     solana_program::{account_info::AccountInfo, system_program},
     Result,
 };
 
+/// Closes `info` by transferring all of its lamports to `sol_destination` and
+/// zeroing out its data and owner.
+///
+/// # Errors
+///
+/// Returns [`ErrorCode::ArithmeticOverflow`] if adding `info`'s lamports to
+/// `sol_destination`'s existing balance would overflow a `u64`. In practice
+/// this can only happen if the combined SOL exceeds `u64::MAX`, which is
+/// impossible on mainnet given current total supply.
 pub(crate) fn close<'info>(
     info: &AccountInfo<'info>,
     sol_destination: &AccountInfo<'info>,
 ) -> Result<()> {
-    // Transfer tokens from the account to the sol_destination.
+    // Transfer all lamports from the closing account to the destination.
+    // We use `checked_add` to guard against arithmetic overflow and propagate
+    // a graceful error instead of panicking with `unwrap()`.
     let dest_starting_lamports = sol_destination.lamports();
-    **sol_destination.lamports.borrow_mut() =
-        dest_starting_lamports.checked_add(info.lamports()).unwrap();
+    **sol_destination.lamports.borrow_mut() = dest_starting_lamports
+        .checked_add(info.lamports())
+        .ok_or(ErrorCode::ArithmeticOverflow)?;
+
+    // Zero out the closing account's lamports so it becomes rent-exempt-clean.
     **info.lamports.borrow_mut() = 0;
 
+    // Reassign ownership to the System Program and clear all data, which is the
+    // canonical on-chain representation of a "closed" account.
     info.assign(&system_program::ID);
     info.resize(0).map_err(Into::into)
 }

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -273,6 +273,13 @@ pub enum ErrorCode {
     /// 4102 - Invalid numeric conversion error
     #[msg("Error during numeric conversion")]
     InvalidNumericConversion = 4102,
+    /// 4103 - Arithmetic operation caused an overflow.
+    ///
+    /// This error is returned when an arithmetic operation (e.g. adding lamports
+    /// during account closure) would overflow a `u64` value, which in practice
+    /// is only possible if the total SOL in an instruction exceeds `u64::MAX`.
+    #[msg("An arithmetic operation caused an overflow")]
+    ArithmeticOverflow = 4103,
 
     // Deprecated
     /// 5000 - The API being used is deprecated and should no longer be used


### PR DESCRIPTION
## Summary
Fixes #4224

The [close()](cci:1://file:///home/ibrahim/Desktop/anchor/lang/src/common.rs:7:0-35:1) function in [lang/src/common.rs](cci:7://file:///home/ibrahim/Desktop/anchor/lang/src/common.rs:0:0-0:0) was calling `.unwrap()` on a
`checked_add` operation, which could theoretically panic instead of returning
a proper error.

## Changes
- Added `ErrorCode::ArithmeticOverflow = 4103` to the error enum in [error.rs](cci:7://file:///home/ibrahim/Desktop/anchor/lang/src/error.rs:0:0-0:0)
- Replaced `.unwrap()` with `.ok_or(ErrorCode::ArithmeticOverflow)?` in [common.rs](cci:7://file:///home/ibrahim/Desktop/anchor/lang/src/common.rs:0:0-0:0)

## Impact
No behavioral change in practice — overflow requires total lamports > u64::MAX.
Only affects two files with additive, non-breaking changes.
