### PR TITLE
ci: Trigger release dry-run on workspace manifest updates

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -9,6 +9,13 @@ on:
       - .github/workflows/publish-crates.yaml
       - .github/workflows/publish-npmjs.yaml
       - .github/scripts/publish-npmjs.sh
+      # Package manifests
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "ts/**/package.json"
+      - "ts/**/yarn.lock"
+      - "!tests/**"
+      - "!examples/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Manually list out relevant manifest paths, since `**/Cargo.toml` and `**/package.json` would pick up all test changes