### PR TITLE
test: Pace ido-pool against cluster time to fix CI flakiness

### DIFF
--- a/tests/ido-pool/tests/ido-pool.js
+++ b/tests/ido-pool/tests/ido-pool.js
@@ -562,7 +562,7 @@ describe("ido-pool", () => {
     // Wait until the escrow period is over on-chain.
     await waitUntilClusterTime(
       provider.connection,
-      idoTimes.endEscrow.toNumber() + 1
+      idoTimes.endEscrow.toNumber()
     );
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(

--- a/tests/ido-pool/tests/ido-pool.js
+++ b/tests/ido-pool/tests/ido-pool.js
@@ -7,6 +7,8 @@ const {
 } = require("@solana/spl-token");
 const {
   sleep,
+  getClusterTime,
+  waitUntilClusterTime,
   getTokenAccount,
   createMint,
   createTokenAccount,
@@ -101,11 +103,17 @@ describe("ido-pool", () => {
     bumps.poolUsdc = poolUsdcBump;
 
     idoTimes = new IdoTimes();
-    const nowBn = new anchor.BN(Date.now() / 1000);
-    idoTimes.startIdo = nowBn.add(new anchor.BN(5));
-    idoTimes.endDeposits = nowBn.add(new anchor.BN(10));
-    idoTimes.endIdo = nowBn.add(new anchor.BN(15));
-    idoTimes.endEscrow = nowBn.add(new anchor.BN(16));
+    // Anchor pacing against cluster time (not `Date.now()`) so client /
+    // validator clock skew can't consume the phase budget. Windows are
+    // sized for slow CI runners with cold test-validator boot: 30s of
+    // deposits and 15s of exchange give ~3x headroom over observed
+    // worst-case execution.
+    const clusterNow = await getClusterTime(provider.connection);
+    const nowBn = new anchor.BN(clusterNow);
+    idoTimes.startIdo = nowBn.add(new anchor.BN(10));
+    idoTimes.endDeposits = nowBn.add(new anchor.BN(40));
+    idoTimes.endIdo = nowBn.add(new anchor.BN(55));
+    idoTimes.endEscrow = nowBn.add(new anchor.BN(60));
 
     await program.rpc.initializePool(
       idoName,
@@ -143,10 +151,11 @@ describe("ido-pool", () => {
   const firstDeposit = new anchor.BN(10_000_349);
 
   it("Exchanges user USDC for redeemable tokens", async () => {
-    // Wait until the IDO has opened.
-    if (Date.now() < idoTimes.startIdo.toNumber() * 1000) {
-      await sleep(idoTimes.startIdo.toNumber() * 1000 - Date.now() + 2000);
-    }
+    // Wait until the IDO has opened on-chain.
+    await waitUntilClusterTime(
+      provider.connection,
+      idoTimes.startIdo.toNumber()
+    );
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from(idoName)],
@@ -411,10 +420,8 @@ describe("ido-pool", () => {
   });
 
   it("Exchanges user Redeemable tokens for watermelon", async () => {
-    // Wait until the IDO has ended.
-    if (Date.now() < idoTimes.endIdo.toNumber() * 1000) {
-      await sleep(idoTimes.endIdo.toNumber() * 1000 - Date.now() + 3000);
-    }
+    // Wait until the IDO has ended on-chain.
+    await waitUntilClusterTime(provider.connection, idoTimes.endIdo.toNumber());
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from(idoName)],
@@ -552,10 +559,11 @@ describe("ido-pool", () => {
   });
 
   it("Withdraws USDC from the escrow account after waiting period is over", async () => {
-    // Wait until the escrow period is over.
-    if (Date.now() < idoTimes.endEscrow.toNumber() * 1000 + 1000) {
-      await sleep(idoTimes.endEscrow.toNumber() * 1000 - Date.now() + 4000);
-    }
+    // Wait until the escrow period is over on-chain.
+    await waitUntilClusterTime(
+      provider.connection,
+      idoTimes.endEscrow.toNumber() + 1
+    );
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from(idoName)],

--- a/tests/ido-pool/tests/utils/index.js
+++ b/tests/ido-pool/tests/utils/index.js
@@ -28,13 +28,16 @@ async function getClusterTime(connection) {
   throw new Error("getBlockTime returned null for 20 consecutive slots");
 }
 
-// Poll the cluster clock until it reaches `targetUnixSecs`. Polls at 1s
-// granularity so tests don't busy-loop but also don't oversleep on a slow
-// validator.
+// Poll the cluster clock until it is *strictly past* `targetUnixSecs`.
+// Matches the semantics of the on-chain phase checks, which all use
+// `clock.unix_timestamp <= boundary` — a tx landing in a block whose
+// `unix_timestamp` equals the boundary still trips the check. Polling
+// to `now > target` ensures the next tx observes a strictly later
+// cluster clock.
 async function waitUntilClusterTime(connection, targetUnixSecs) {
   let now = await getClusterTime(connection);
-  while (now < targetUnixSecs) {
-    await sleep(Math.min(targetUnixSecs - now, 1) * 1000);
+  while (now <= targetUnixSecs) {
+    await sleep(Math.min(targetUnixSecs - now + 1, 1) * 1000);
     now = await getClusterTime(connection);
   }
 }

--- a/tests/ido-pool/tests/utils/index.js
+++ b/tests/ido-pool/tests/utils/index.js
@@ -15,6 +15,30 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Read the cluster's current `unix_timestamp` — the same value the on-chain
+// `Clock::get()` observes. Pacing against this instead of `Date.now()`
+// eliminates client/validator clock-skew flakiness.
+async function getClusterTime(connection) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const slot = await connection.getSlot("confirmed");
+    const time = await connection.getBlockTime(slot);
+    if (time !== null) return time;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("getBlockTime returned null for 20 consecutive slots");
+}
+
+// Poll the cluster clock until it reaches `targetUnixSecs`. Polls at 1s
+// granularity so tests don't busy-loop but also don't oversleep on a slow
+// validator.
+async function waitUntilClusterTime(connection, targetUnixSecs) {
+  let now = await getClusterTime(connection);
+  while (now < targetUnixSecs) {
+    await sleep(Math.min(targetUnixSecs - now, 1) * 1000);
+    now = await getClusterTime(connection);
+  }
+}
+
 async function getTokenAccount(provider, addr) {
   return await serumCmn.getTokenAccount(provider, addr);
 }
@@ -48,6 +72,8 @@ async function createTokenAccount(provider, mint, owner) {
 module.exports = {
   TOKEN_PROGRAM_ID,
   sleep,
+  getClusterTime,
+  waitUntilClusterTime,
   getTokenAccount,
   createTokenAccount,
   createMint,


### PR DESCRIPTION
`tests/ido-pool` has been extremely flakey due to clock skew. Attempt to make this more reliable by synchronizing with the validator.