### PR TITLE
chore: Add formatting/linting instructions to `CONTRIBUTING`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,25 @@ After coding:
 - If you've moved code around, build the docs with `cargo doc --open` and adjust broken links
 - Adjust the cli templates if necessary
 - If you've added a new folder to the `tests` directory, add it to the [CI](./.github/workflows/tests.yaml).
+
+### Formatting and Linting
+
+If you have edited and Rust or TypeScript/JavaScript code, ensure it is correctly formatted and compatible with our lint suite; this will ensure CI passes and help us quickly review your contribution.
+
+#### Rust
+
+In the root workspace, run
+```sh
+# Ensure you have the latest nightly version with `rustup update nightly`
+cargo +nightly fmt
+cargo clippy --all-targets -- -D warnings
+```
+
+#### TypeScript/JavaScript
+
+Enter the relevant JS package (e.g. `tests/`, or `ts/packages/anchor`) and run
+
+```sh
+yarn
+yarn lint:fix
+```

--- a/cli/src/keygen.rs
+++ b/cli/src/keygen.rs
@@ -32,13 +32,11 @@ fn secure_input(prompt: &str, show_spaces: bool) -> Result<String> {
                 println!();
                 break;
             }
-            Key::Backspace => {
-                if !input.is_empty() {
-                    input.pop();
-                    // Move cursor back, print space, move cursor back again
-                    print!("\x08 \x08");
-                    io::stdout().flush()?;
-                }
+            Key::Backspace if !input.is_empty() => {
+                input.pop();
+                // Move cursor back, print space, move cursor back again
+                print!("\x08 \x08");
+                io::stdout().flush()?;
             }
             Key::Char(c) => {
                 input.push(c);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3274,7 +3274,7 @@ fn test(
                         .unwrap()
                         .captures_iter(&test_script.clone())
                         .last()
-                        .and_then(|c| c.get(1).and_then(|mtch| c.get(2).map(|ext| (mtch, ext))))
+                        .and_then(|c| c.get(1).zip(c.get(2)))
                         .map(|(mtch, ext)| {
                             (
                                 mtch.as_str(),
@@ -5121,9 +5121,7 @@ fn epoch_info(cfg_override: &ConfigOverride) -> Result<()> {
                 )
             });
 
-        if total_slots > 0 {
-            let avg_slot_time_ms = (total_secs * 1000) / total_slots;
-
+        if let Some(avg_slot_time_ms) = (total_secs * 1000).checked_div(total_slots) {
             // Calculate time_remaining using average slot time (always estimated)
             let remaining_secs = (remaining_slots * avg_slot_time_ms) / 1000;
 

--- a/lang/syn/src/codegen/accounts/bumps.rs
+++ b/lang/syn/src/codegen/accounts/bumps.rs
@@ -46,15 +46,11 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         // - PDA is not init, but marked with bump without a target
 
                         match c {
-                            Constraint::Seeds(c) => {
-                                if !c.is_init && c.bump.is_none() {
-                                    return Some((bump_field, bump_default_field));
-                                }
+                            Constraint::Seeds(c) if !c.is_init && c.bump.is_none() => {
+                                return Some((bump_field, bump_default_field));
                             }
-                            Constraint::Init(c) => {
-                                if c.seeds.is_some() {
-                                    return Some((bump_field, bump_default_field));
-                                }
+                            Constraint::Init(c) if c.seeds.is_some() => {
+                                return Some((bump_field, bump_default_field));
                             }
                             _ => (),
                         }

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -228,22 +228,22 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                 // This doesn't catch cases like account.key() or account.key.
                 // My guess is that doesn't happen often and we can revisit
                 // this if I'm wrong.
-                InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. } => {
+                InitKind::Token { mint, .. } | InitKind::AssociatedToken { mint, .. }
                     if !fields.iter().any(|f| {
                         f.ident()
                             .to_string()
                             .starts_with(&mint.to_token_stream().to_string())
-                    }) {
-                        return Err(ParseError::new(
-                            field.ident.span(),
-                            "the mint constraint has to be an account field for token \
-                             initializations (not a public key)",
-                        ));
-                    }
+                    }) =>
+                {
+                    return Err(ParseError::new(
+                        field.ident.span(),
+                        "the mint constraint has to be an account field for token initializations \
+                         (not a public key)",
+                    ));
                 }
 
                 // Make sure initialized token accounts are always declared after their corresponding mint.
-                InitKind::Mint { .. } => {
+                InitKind::Mint { .. }
                     if init_fields.iter().enumerate().any(|(f_pos, f)| {
                         #[allow(
                             clippy::unwrap_used,
@@ -256,13 +256,13 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                             }
                             _ => false,
                         }
-                    }) {
-                        return Err(ParseError::new(
-                            field.ident.span(),
-                            "because of the init constraint, the mint has to be declared before \
-                             the corresponding token account",
-                        ));
-                    }
+                    }) =>
+                {
+                    return Err(ParseError::new(
+                        field.ident.span(),
+                        "because of the init constraint, the mint has to be declared before the \
+                         corresponding token account",
+                    ));
                 }
                 _ => (),
             }

--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -25,23 +25,23 @@ impl CrateContext {
     }
 
     pub fn consts(&self) -> impl Iterator<Item = &syn::ItemConst> {
-        self.modules.iter().flat_map(|(_, ctx)| ctx.consts())
+        self.modules.values().flat_map(|ctx| ctx.consts())
     }
 
     pub fn impl_consts(&self) -> impl Iterator<Item = (&Ident, &syn::ImplItemConst)> {
-        self.modules.iter().flat_map(|(_, ctx)| ctx.impl_consts())
+        self.modules.values().flat_map(|ctx| ctx.impl_consts())
     }
 
     pub fn structs(&self) -> impl Iterator<Item = &syn::ItemStruct> {
-        self.modules.iter().flat_map(|(_, ctx)| ctx.structs())
+        self.modules.values().flat_map(|ctx| ctx.structs())
     }
 
     pub fn enums(&self) -> impl Iterator<Item = &syn::ItemEnum> {
-        self.modules.iter().flat_map(|(_, ctx)| ctx.enums())
+        self.modules.values().flat_map(|ctx| ctx.enums())
     }
 
     pub fn type_aliases(&self) -> impl Iterator<Item = &syn::ItemType> {
-        self.modules.iter().flat_map(|(_, ctx)| ctx.type_aliases())
+        self.modules.values().flat_map(|ctx| ctx.type_aliases())
     }
 
     pub fn modules(&self) -> impl Iterator<Item = ModuleContext<'_>> {


### PR DESCRIPTION
After introducing Rust formatting rules, we've started running into a lot of PRs which need to be reformatted. Attempt to streamline this process by explaining how to ensure code is ready for review.

--
Additionally run new clippy lints, which appear to have been updated on the GH side