### PR TITLE
fix(workspace): improve IDL resolution error messages

### DIFF
--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as toml from "toml";
 import camelcase from "camelcase";
 import { execSync } from "child_process";
@@ -16,9 +18,6 @@ export function resolveIdlFileName(
   idlDirPath: string,
   programName: string
 ): string {
-  const fs = require("fs");
-  const path = require("path");
-
   let dirEntries: string[];
   try {
     dirEntries = fs.readdirSync(idlDirPath);
@@ -108,11 +107,8 @@ const workspace = new Proxy(
       // Return early if the program is in cache
       if (workspaceCache[programName]) return workspaceCache[programName];
 
-      const fs = require("fs");
-      const path = require("path");
-
       // Override the workspace programs if the user put them in the config.
-      const anchorToml = toml.parse(fs.readFileSync("Anchor.toml"));
+      const anchorToml = toml.parse(fs.readFileSync("Anchor.toml", "utf8"));
       const clusterId = anchorToml.provider.cluster;
       const programs = anchorToml.programs?.[clusterId];
       let programEntry;
@@ -146,7 +142,7 @@ const workspace = new Proxy(
         );
       }
 
-      const idl: Idl = JSON.parse(fs.readFileSync(idlPath));
+      const idl: Idl = JSON.parse(fs.readFileSync(idlPath, "utf8"));
       if (programId) {
         idl.address = programId;
       }

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -79,11 +79,47 @@ const workspace = new Proxy(
         // To avoid the above problem with numbers, read the `idl` directory and
         // compare the camelCased  version of both file names and `programName`.
         const idlDirPath = path.join(getCargoTargetDirectory(), "idl");
-        const fileName = fs
-          .readdirSync(idlDirPath)
-          .find((name) => camelcase(path.parse(name).name) === programName);
+
+        let dirEntries: string[];
+        try {
+          dirEntries = fs.readdirSync(idlDirPath);
+        } catch (err: any) {
+          if (err.code === "ENOENT") {
+            throw new Error(
+              `IDL directory not found at \`${idlDirPath}\`. Did you run \`anchor build\`?`
+            );
+          }
+          throw err;
+        }
+
+        const jsonFiles = dirEntries.filter(
+          (name) =>
+            path.extname(name) === ".json" &&
+            fs.statSync(path.join(idlDirPath, name)).isFile()
+        );
+
+        const fileName = jsonFiles.find(
+          (name) => camelcase(path.parse(name).name) === programName
+        );
+
         if (!fileName) {
-          throw new Error(`Failed to find IDL of program \`${programName}\``);
+          if (jsonFiles.length === 0) {
+            throw new Error(
+              `No IDL files found in \`${idlDirPath}\`. Did you run \`anchor build\`?`
+            );
+          }
+          const available = jsonFiles
+            .map((n) => path.parse(n).name)
+            .sort()
+            .join(", ");
+          throw new Error(
+            `Failed to find IDL for program \`${programName}\`.\n` +
+              `Available programs in \`${idlDirPath}\`: ${available}\n` +
+              `Ensure the following all use the same snake_case name:\n` +
+              `  - \`[lib].name\` in Cargo.toml\n` +
+              `  - \`#[program]\` module name in your Rust program\n` +
+              `  - Program key in Anchor.toml under \`[programs.<cluster>]\``
+          );
         }
 
         idlPath = path.join(idlDirPath, fileName);

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -7,6 +7,63 @@ import { Idl } from "./idl.js";
 
 let cargoTargetDirectoryCache: string | undefined;
 
+/**
+ * Resolves the IDL file name in `idlDirPath` matching `programName`
+ * (already camelCased). Throws a descriptive error if the directory
+ * is missing, empty, or no match is found.
+ */
+export function resolveIdlFileName(
+  idlDirPath: string,
+  programName: string
+): string {
+  const fs = require("fs");
+  const path = require("path");
+
+  let dirEntries: string[];
+  try {
+    dirEntries = fs.readdirSync(idlDirPath);
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      throw new Error(
+        `IDL directory not found at \`${idlDirPath}\`. Did you run \`anchor build\`?`
+      );
+    }
+    throw err;
+  }
+
+  const jsonFiles = dirEntries.filter(
+    (name: string) =>
+      path.extname(name) === ".json" &&
+      fs.statSync(path.join(idlDirPath, name)).isFile()
+  );
+
+  const fileName = jsonFiles.find(
+    (name: string) => camelcase(path.parse(name).name) === programName
+  );
+
+  if (!fileName) {
+    if (jsonFiles.length === 0) {
+      throw new Error(
+        `No IDL files found in \`${idlDirPath}\`. Did you run \`anchor build\`?`
+      );
+    }
+    const available = jsonFiles
+      .map((n: string) => path.parse(n).name)
+      .sort()
+      .join(", ");
+    throw new Error(
+      `Failed to find IDL for program \`${programName}\`.\n` +
+        `Available programs in \`${idlDirPath}\`: ${available}\n` +
+        `Ensure the following all use the same snake_case name:\n` +
+        `  - \`[lib].name\` in Cargo.toml\n` +
+        `  - \`#[program]\` module name in your Rust program\n` +
+        `  - Program key in Anchor.toml under \`[programs.<cluster>]\``
+    );
+  }
+
+  return fileName;
+}
+
 function getCargoTargetDirectory(): string {
   if (cargoTargetDirectoryCache !== undefined) {
     return cargoTargetDirectoryCache;
@@ -79,49 +136,7 @@ const workspace = new Proxy(
         // To avoid the above problem with numbers, read the `idl` directory and
         // compare the camelCased  version of both file names and `programName`.
         const idlDirPath = path.join(getCargoTargetDirectory(), "idl");
-
-        let dirEntries: string[];
-        try {
-          dirEntries = fs.readdirSync(idlDirPath);
-        } catch (err: any) {
-          if (err.code === "ENOENT") {
-            throw new Error(
-              `IDL directory not found at \`${idlDirPath}\`. Did you run \`anchor build\`?`
-            );
-          }
-          throw err;
-        }
-
-        const jsonFiles = dirEntries.filter(
-          (name) =>
-            path.extname(name) === ".json" &&
-            fs.statSync(path.join(idlDirPath, name)).isFile()
-        );
-
-        const fileName = jsonFiles.find(
-          (name) => camelcase(path.parse(name).name) === programName
-        );
-
-        if (!fileName) {
-          if (jsonFiles.length === 0) {
-            throw new Error(
-              `No IDL files found in \`${idlDirPath}\`. Did you run \`anchor build\`?`
-            );
-          }
-          const available = jsonFiles
-            .map((n) => path.parse(n).name)
-            .sort()
-            .join(", ");
-          throw new Error(
-            `Failed to find IDL for program \`${programName}\`.\n` +
-              `Available programs in \`${idlDirPath}\`: ${available}\n` +
-              `Ensure the following all use the same snake_case name:\n` +
-              `  - \`[lib].name\` in Cargo.toml\n` +
-              `  - \`#[program]\` module name in your Rust program\n` +
-              `  - Program key in Anchor.toml under \`[programs.<cluster>]\``
-          );
-        }
-
+        const fileName = resolveIdlFileName(idlDirPath, programName);
         idlPath = path.join(idlDirPath, fileName);
       }
 

--- a/ts/packages/anchor/tests/workspace.spec.ts
+++ b/ts/packages/anchor/tests/workspace.spec.ts
@@ -1,55 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import camelcase from "camelcase";
-
-// Replicates the IDL-lookup logic from workspace.ts so it can be unit-tested
-// in isolation without spinning up a full Anchor workspace.
-function resolveIdlFileName(idlDirPath: string, programName: string): string {
-  let dirEntries: string[];
-  try {
-    dirEntries = fs.readdirSync(idlDirPath);
-  } catch (err: any) {
-    if (err.code === "ENOENT") {
-      throw new Error(
-        `IDL directory not found at \`${idlDirPath}\`. Did you run \`anchor build\`?`
-      );
-    }
-    throw err;
-  }
-
-  const jsonFiles = dirEntries.filter(
-    (name) =>
-      path.extname(name) === ".json" &&
-      fs.statSync(path.join(idlDirPath, name)).isFile()
-  );
-
-  const fileName = jsonFiles.find(
-    (name) => camelcase(path.parse(name).name) === programName
-  );
-
-  if (!fileName) {
-    if (jsonFiles.length === 0) {
-      throw new Error(
-        `No IDL files found in \`${idlDirPath}\`. Did you run \`anchor build\`?`
-      );
-    }
-    const available = jsonFiles
-      .map((n) => path.parse(n).name)
-      .sort()
-      .join(", ");
-    throw new Error(
-      `Failed to find IDL for program \`${programName}\`.\n` +
-        `Available programs in \`${idlDirPath}\`: ${available}\n` +
-        `Ensure the following all use the same snake_case name:\n` +
-        `  - \`[lib].name\` in Cargo.toml\n` +
-        `  - \`#[program]\` module name in your Rust program\n` +
-        `  - Program key in Anchor.toml under \`[programs.<cluster>]\``
-    );
-  }
-
-  return fileName;
-}
+import { resolveIdlFileName } from "../src/workspace";
 
 describe("workspace IDL resolution", () => {
   let tmpDir: string;

--- a/ts/packages/anchor/tests/workspace.spec.ts
+++ b/ts/packages/anchor/tests/workspace.spec.ts
@@ -1,0 +1,138 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import camelcase from "camelcase";
+
+// Replicates the IDL-lookup logic from workspace.ts so it can be unit-tested
+// in isolation without spinning up a full Anchor workspace.
+function resolveIdlFileName(idlDirPath: string, programName: string): string {
+  let dirEntries: string[];
+  try {
+    dirEntries = fs.readdirSync(idlDirPath);
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      throw new Error(
+        `IDL directory not found at \`${idlDirPath}\`. Did you run \`anchor build\`?`
+      );
+    }
+    throw err;
+  }
+
+  const jsonFiles = dirEntries.filter(
+    (name) =>
+      path.extname(name) === ".json" &&
+      fs.statSync(path.join(idlDirPath, name)).isFile()
+  );
+
+  const fileName = jsonFiles.find(
+    (name) => camelcase(path.parse(name).name) === programName
+  );
+
+  if (!fileName) {
+    if (jsonFiles.length === 0) {
+      throw new Error(
+        `No IDL files found in \`${idlDirPath}\`. Did you run \`anchor build\`?`
+      );
+    }
+    const available = jsonFiles
+      .map((n) => path.parse(n).name)
+      .sort()
+      .join(", ");
+    throw new Error(
+      `Failed to find IDL for program \`${programName}\`.\n` +
+        `Available programs in \`${idlDirPath}\`: ${available}\n` +
+        `Ensure the following all use the same snake_case name:\n` +
+        `  - \`[lib].name\` in Cargo.toml\n` +
+        `  - \`#[program]\` module name in your Rust program\n` +
+        `  - Program key in Anchor.toml under \`[programs.<cluster>]\``
+    );
+  }
+
+  return fileName;
+}
+
+describe("workspace IDL resolution", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "anchor-idl-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds the correct IDL when the program name matches exactly", () => {
+    fs.writeFileSync(path.join(tmpDir, "user_g_market.json"), "{}");
+    expect(resolveIdlFileName(tmpDir, "userGMarket")).toBe(
+      "user_g_market.json"
+    );
+  });
+
+  it("throws a helpful error listing available IDLs when name has a typo", () => {
+    // Replicates: Cargo.toml has `name = "user_g_market"` (singular)
+    // but workspace references `user_g_markets` (plural)
+    fs.writeFileSync(path.join(tmpDir, "user_g_market.json"), "{}");
+
+    expect(() => resolveIdlFileName(tmpDir, "userGMarkets")).toThrowError(
+      /Failed to find IDL for program `userGMarkets`/
+    );
+    expect(() => resolveIdlFileName(tmpDir, "userGMarkets")).toThrowError(
+      /user_g_market/
+    );
+    expect(() => resolveIdlFileName(tmpDir, "userGMarkets")).toThrowError(
+      /\[lib\]\.name.*Cargo\.toml/
+    );
+    expect(() => resolveIdlFileName(tmpDir, "userGMarkets")).toThrowError(
+      /\#\[program\].*Rust program/
+    );
+    expect(() => resolveIdlFileName(tmpDir, "userGMarkets")).toThrowError(
+      /Anchor\.toml/
+    );
+  });
+
+  it("lists multiple available IDLs sorted alphabetically on typo", () => {
+    fs.writeFileSync(path.join(tmpDir, "my_program.json"), "{}");
+    fs.writeFileSync(path.join(tmpDir, "another_program.json"), "{}");
+
+    expect(() => resolveIdlFileName(tmpDir, "missingProgram")).toThrowError(
+      /another_program, my_program/
+    );
+  });
+
+  it("throws a friendly error when the idl/ directory doesn't exist", () => {
+    const nonExistentDir = path.join(tmpDir, "idl");
+    expect(() => resolveIdlFileName(nonExistentDir, "anyProgram")).toThrowError(
+      /IDL directory not found.*Did you run `anchor build`/
+    );
+  });
+
+  it("throws a friendly error when the idl/ directory exists but is empty", () => {
+    expect(() => resolveIdlFileName(tmpDir, "anyProgram")).toThrowError(
+      /No IDL files found.*Did you run `anchor build`/
+    );
+  });
+
+  it("ignores non-JSON files and directories when scanning for IDLs", () => {
+    fs.writeFileSync(path.join(tmpDir, "user_g_market.json"), "{}");
+    fs.writeFileSync(path.join(tmpDir, "readme.txt"), "ignore me");
+    fs.mkdirSync(path.join(tmpDir, "user_g_market"));
+
+    // Should still find the correct JSON IDL and not trip over the txt or dir
+    expect(resolveIdlFileName(tmpDir, "userGMarket")).toBe(
+      "user_g_market.json"
+    );
+  });
+
+  it("does not list non-JSON files in the available programs error", () => {
+    fs.writeFileSync(path.join(tmpDir, "user_g_market.json"), "{}");
+    fs.writeFileSync(path.join(tmpDir, "readme.txt"), "ignore me");
+
+    expect(() => resolveIdlFileName(tmpDir, "missingProgram")).toThrowError(
+      /user_g_market/
+    );
+    expect(() => resolveIdlFileName(tmpDir, "missingProgram")).not.toThrowError(
+      /readme/
+    );
+  });
+});

--- a/ts/packages/anchor/tests/workspace.spec.ts
+++ b/ts/packages/anchor/tests/workspace.spec.ts
@@ -76,6 +76,28 @@ describe("workspace IDL resolution", () => {
     );
   });
 
+  it("rethrows non-ENOENT errors from readdirSync unchanged (e.g. EACCES)", () => {
+    const accessError = Object.assign(
+      new Error("EACCES: permission denied, scandir '/protected'"),
+      { code: "EACCES" }
+    );
+
+    // resolveIdlFileName calls require("fs") internally; patch that shared
+    // module object directly so our throw propagates into the function.
+    const fsModule = require("fs");
+    const original = fsModule.readdirSync;
+    fsModule.readdirSync = () => {
+      throw accessError;
+    };
+    try {
+      expect(() => resolveIdlFileName(tmpDir, "anyProgram")).toThrow(
+        accessError
+      );
+    } finally {
+      fsModule.readdirSync = original;
+    }
+  });
+
   it("does not list non-JSON files in the available programs error", () => {
     fs.writeFileSync(path.join(tmpDir, "user_g_market.json"), "{}");
     fs.writeFileSync(path.join(tmpDir, "readme.txt"), "ignore me");

--- a/ts/packages/anchor/tests/workspace.spec.ts
+++ b/ts/packages/anchor/tests/workspace.spec.ts
@@ -82,8 +82,8 @@ describe("workspace IDL resolution", () => {
       { code: "EACCES" }
     );
 
-    // resolveIdlFileName calls require("fs") internally; patch that shared
-    // module object directly so our throw propagates into the function.
+    // `import * as fs` produces a getter-only namespace; require() gives the
+    // raw mutable CJS module object needed to patch the property.
     const fsModule = require("fs");
     const original = fsModule.readdirSync;
     fsModule.readdirSync = () => {


### PR DESCRIPTION
## Summary
 
 Improves the error message thrown by `anchor.workspace.X` when an IDL file cannot be found, typically caused by a naming mismatch between the workspace accessor and the program name.
 
 **Before:**

```
Error: Failed to find IDL of program userGMarkets
```
 
 **After (name mismatch):**

```
Error: Failed to find IDL for program userGMarkets.
Available programs in target/idl: user_g_market
Ensure the following all use the same snake_case name:
 - [lib].name in Cargo.toml
 - #[program] module name in your Rust program
 - Program key in Anchor.toml under [programs.<cluster>]
 ```

 
 **After (IDL directory missing):**

```
Error: IDL directory not found at target/idl. Did you run anchor build?
```


 **After (IDL directory empty):**

```
Error: No IDL files found in target/idl. Did you run anchor build?
```


 
 Other improvements:
 - IDL directory scan is restricted to `.json` files only (ignores dirs, `.txt`, etc.)
 - Non-`ENOENT` filesystem errors are rethrown as-is instead of being swallowed
 - Available program names are sorted alphabetically for deterministic output
 - Unit tests added in `ts/packages/anchor/tests/workspace.spec.ts`
 
 Closes #4439
 Refs #3505
 
 ## Branch Target
 
 This does not contain breaking changes and targets the default branch.