### PR TITLE
fix nested workspace discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bincode",
+ "cargo_metadata",
  "cargo_toml",
  "chrono",
  "clap 4.6.0",
@@ -972,12 +973,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3959,6 +3992,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ anchor-lang-idl = { path = "../idl", version = "0.1.2", features = ["build", "co
 anyhow = "1.0.32"
 base64 = "0.21"
 bincode = "1.3.3"
+cargo_metadata = "0.19.2"
 cargo_toml = "0.19.2"
 chrono = "0.4.19"
 clap = { version = "4.5.17", features = ["derive"] }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        config::{Config, Manifest, Program, WithPath},
+        config::{Config, Program, WithPath},
         target_dir, ConfigOverride, ProgramCommand,
     },
     anchor_lang_idl::types::Idl,
@@ -49,13 +49,12 @@ fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
         .exec()
     {
         Ok(metadata) => Ok(Some(metadata)),
-        Err(err) => {
-            let err = err.to_string();
-            if err.contains("could not find `Cargo.toml`") {
+        Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
+            if stderr.contains("could not find `Cargo.toml`") {
                 return Ok(None);
             }
-            if !err.contains("current package believes it's in a workspace when it's not") {
-                bail!(err);
+            if !stderr.contains("current package believes it's in a workspace when it's not") {
+                bail!(stderr);
             }
             let Some(manifest_dir) = current_manifest_dir(start_dir)? else {
                 return Ok(None);
@@ -65,16 +64,17 @@ fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
             };
             match MetadataCommand::new().current_dir(parent).no_deps().exec() {
                 Ok(metadata) => Ok(Some(metadata)),
-                Err(err) => {
-                    let err = err.to_string();
-                    if err.contains("could not find `Cargo.toml`") {
+                Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
+                    if stderr.contains("could not find `Cargo.toml`") {
                         Ok(None)
                     } else {
-                        bail!(err);
+                        bail!(stderr);
                     }
                 }
+                Err(err) => Err(err.into()),
             }
         }
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -108,10 +108,16 @@ fn manifest_lib_name(cargo_toml: &toml::Value) -> Result<String> {
     }
 }
 
-fn current_program_candidate(start_dir: &Path) -> Result<Option<(PathBuf, String)>> {
+fn current_program_candidate(
+    start_dir: &Path,
+    candidates: &BTreeMap<PathBuf, String>,
+) -> Result<Option<(PathBuf, String)>> {
     let Some(path) = current_manifest_dir(start_dir)? else {
         return Ok(None);
     };
+    if candidates.contains_key(path.as_path()) {
+        return Ok(None);
+    }
     let cargo_toml = read_cargo_toml(&path)?;
     if is_solana_program(&cargo_toml) {
         return Ok(Some((path, manifest_lib_name(&cargo_toml)?)));
@@ -135,11 +141,12 @@ fn current_manifest_dir(start_dir: &Path) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
-/// Discover Solana programs from a non-Anchor Cargo workspace
-pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Program>> {
-    let current_dir = std::env::current_dir()?;
+fn discover_solana_programs_from_path(
+    current_dir: &Path,
+    program_name: Option<String>,
+) -> Result<Vec<Program>> {
     let mut candidates = BTreeMap::new();
-    let metadata = discover_cargo_metadata(&current_dir)?;
+    let metadata = discover_cargo_metadata(current_dir)?;
 
     if let Some(metadata) = &metadata {
         let workspace_members = metadata.workspace_members.iter().collect::<HashSet<_>>();
@@ -158,7 +165,7 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
         }
     }
 
-    if let Some((path, lib_name)) = current_program_candidate(&current_dir)? {
+    if let Some((path, lib_name)) = current_program_candidate(current_dir, &candidates)? {
         candidates.entry(path).or_insert(lib_name);
     }
 
@@ -172,8 +179,10 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
                 let entry = entry?;
                 let path = entry.path();
                 if path.is_dir() && path.join("Cargo.toml").exists() {
-                    let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
-                    candidates.insert(path, cargo.lib_name()?);
+                    let cargo_toml = read_cargo_toml(&path)?;
+                    if is_solana_program(&cargo_toml) {
+                        candidates.insert(path, manifest_lib_name(&cargo_toml)?);
+                    }
                 }
             }
         }
@@ -206,18 +215,23 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
     Ok(programs)
 }
 
+/// Discover Solana programs from a non-Anchor Cargo workspace
+pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Program>> {
+    discover_solana_programs_from_path(&std::env::current_dir()?, program_name)
+}
+
 /// Check if a given Cargo project is a Solana program
 /// A deployable Solana program must have crate-type = ["cdylib", ...]
 fn is_solana_program(cargo_toml: &toml::Value) -> bool {
-    if let Some(lib) = cargo_toml.get("lib") {
-        if let Some(crate_type) = lib.get("crate-type").and_then(|ct| ct.as_array()) {
-            if crate_type.iter().any(|ct| ct.as_str() == Some("cdylib")) {
-                return true;
-            }
-        }
-    }
-
-    false
+    cargo_toml
+        .get("lib")
+        .and_then(|lib| lib.get("crate-type"))
+        .and_then(|crate_type| crate_type.as_array())
+        .is_some_and(|crate_types| {
+            crate_types
+                .iter()
+                .any(|crate_type| crate_type.as_str() == Some("cdylib"))
+        })
 }
 
 /// Get programs from workspace (Anchor or non-Anchor)
@@ -2087,30 +2101,9 @@ fn send_messages_in_batches(
 mod tests {
     use {
         super::*,
-        std::{
-            collections::BTreeSet,
-            env, fs,
-            path::{Path, PathBuf},
-            sync::{Mutex, OnceLock},
-        },
+        std::{collections::BTreeSet, fs, path::Path},
         tempfile::tempdir,
     };
-
-    struct CurrentDirGuard(PathBuf);
-
-    impl Drop for CurrentDirGuard {
-        fn drop(&mut self) {
-            env::set_current_dir(&self.0).unwrap();
-        }
-    }
-
-    fn in_dir<T>(path: &Path, f: impl FnOnce() -> T) -> T {
-        let guard = CurrentDirGuard(env::current_dir().unwrap());
-        env::set_current_dir(path).unwrap();
-        let result = f();
-        drop(guard);
-        result
-    }
 
     fn write_file(path: &Path, contents: &str) {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -2160,23 +2153,18 @@ resolver = "2"
         create_program(&root.join("programs").join("bar"), "bar");
     }
 
-    fn current_dir_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     #[test]
     fn discover_solana_programs_finds_sibling_programs_from_nested_member() {
-        let _lock = current_dir_lock().lock().unwrap();
         let dir = tempdir().unwrap();
         create_workspace(dir.path());
 
-        let root_programs = in_dir(dir.path(), || {
-            discover_solana_programs(Some("bar".into())).unwrap()
-        });
-        let nested_programs = in_dir(&dir.path().join("programs").join("foo"), || {
-            discover_solana_programs(Some("bar".into())).unwrap()
-        });
+        let root_programs =
+            discover_solana_programs_from_path(dir.path(), Some("bar".into())).unwrap();
+        let nested_programs = discover_solana_programs_from_path(
+            &dir.path().join("programs").join("foo"),
+            Some("bar".into()),
+        )
+        .unwrap();
 
         assert_eq!(root_programs.len(), 1);
         assert_eq!(nested_programs.len(), 1);
@@ -2187,13 +2175,12 @@ resolver = "2"
 
     #[test]
     fn discover_solana_programs_lists_all_members_from_nested_member() {
-        let _lock = current_dir_lock().lock().unwrap();
         let dir = tempdir().unwrap();
         create_workspace(dir.path());
 
-        let programs = in_dir(&dir.path().join("programs").join("foo"), || {
-            discover_solana_programs(None).unwrap()
-        });
+        let programs =
+            discover_solana_programs_from_path(&dir.path().join("programs").join("foo"), None)
+                .unwrap();
 
         let names = programs
             .into_iter()
@@ -2208,14 +2195,13 @@ resolver = "2"
 
     #[test]
     fn discover_solana_programs_includes_current_program_outside_workspace_members() {
-        let _lock = current_dir_lock().lock().unwrap();
         let dir = tempdir().unwrap();
         create_workspace(dir.path());
         create_program(&dir.path().join("tools").join("baz"), "baz");
 
-        let programs = in_dir(&dir.path().join("tools").join("baz"), || {
-            discover_solana_programs(None).unwrap()
-        });
+        let programs =
+            discover_solana_programs_from_path(&dir.path().join("tools").join("baz"), None)
+                .unwrap();
 
         let names = programs
             .into_iter()
@@ -2230,14 +2216,13 @@ resolver = "2"
 
     #[test]
     fn discover_solana_programs_from_nonmember_crate_keeps_workspace_members() {
-        let _lock = current_dir_lock().lock().unwrap();
         let dir = tempdir().unwrap();
         create_workspace(dir.path());
         create_library(&dir.path().join("tools").join("helper"), "helper");
 
-        let programs = in_dir(&dir.path().join("tools").join("helper"), || {
-            discover_solana_programs(None).unwrap()
-        });
+        let programs =
+            discover_solana_programs_from_path(&dir.path().join("tools").join("helper"), None)
+                .unwrap();
 
         let names = programs
             .into_iter()

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -39,39 +39,56 @@ fn parse_priority_fee_from_args(args: &[String]) -> Option<u64> {
         .and_then(|pair| pair[1].parse().ok())
 }
 
+fn find_workspace_root(start_dir: &Path) -> Result<Option<PathBuf>> {
+    let mut dir = Some(start_dir);
+
+    while let Some(path) = dir {
+        let cargo_toml_path = path.join("Cargo.toml");
+        if cargo_toml_path.exists() {
+            let cargo_content = fs::read_to_string(&cargo_toml_path)?;
+            let cargo_toml: toml::Value = toml::from_str(&cargo_content)?;
+
+            if cargo_toml.get("workspace").is_some() {
+                return Ok(Some(path.to_path_buf()));
+            }
+        }
+
+        dir = path.parent();
+    }
+
+    Ok(None)
+}
+
 /// Discover Solana programs from a non-Anchor Cargo workspace
 pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Program>> {
     let current_dir = std::env::current_dir()?;
+    let workspace_dir = find_workspace_root(&current_dir)?;
+    let manifest_dir = workspace_dir.as_ref().unwrap_or(&current_dir);
     let mut program_paths = Vec::new();
 
-    // Check if current directory has Cargo.toml
-    let cargo_toml_path = current_dir.join("Cargo.toml");
+    let cargo_toml_path = manifest_dir.join("Cargo.toml");
     if cargo_toml_path.exists() {
         let cargo_content = fs::read_to_string(&cargo_toml_path)?;
         let cargo_toml: toml::Value = toml::from_str(&cargo_content)?;
 
-        // Check if it's a workspace Cargo.toml
         if let Some(workspace) = cargo_toml.get("workspace") {
-            // It's a workspace - iterate over members
             if let Some(members) = workspace.get("members").and_then(|m| m.as_array()) {
                 for member in members {
                     if let Some(member_path) = member.as_str() {
-                        let full_path = current_dir.join(member_path);
+                        let full_path = manifest_dir.join(member_path);
                         if full_path.is_dir() && full_path.join("Cargo.toml").exists() {
                             program_paths.push(full_path);
                         }
                     }
                 }
             }
-        } else if is_solana_program(&current_dir)? {
-            // It's a single program Cargo.toml with cdylib - use current directory
+        } else if is_solana_program(manifest_dir)? {
             program_paths.push(current_dir.clone());
         }
     }
 
-    // If no programs found yet, fallback to looking in programs/ directory
     if program_paths.is_empty() {
-        let programs_dir = current_dir.join("programs");
+        let programs_dir = manifest_dir.join("programs");
         if programs_dir.is_dir() {
             for entry in fs::read_dir(programs_dir)? {
                 let entry = entry?;
@@ -83,7 +100,6 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
         }
     }
 
-    // Filter to only Solana programs and build Program structs
     let mut programs = Vec::new();
     for path in program_paths {
         if !is_solana_program(&path)? {
@@ -93,7 +109,6 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
         let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
         let lib_name = cargo.lib_name()?;
 
-        // Check if this is the program we're looking for (if name specified)
         if let Some(ref name) = program_name {
             let matches = *name == lib_name || *name == path.file_name().unwrap().to_str().unwrap();
             if !matches {
@@ -101,7 +116,6 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
             }
         }
 
-        // Try to read IDL if it exists (will be None for non-Anchor programs)
         let idl_filepath = target_dir()?
             .join("idl")
             .join(&lib_name)
@@ -2005,4 +2019,114 @@ fn send_messages_in_batches(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{
+            collections::BTreeSet,
+            env, fs,
+            path::{Path, PathBuf},
+            sync::{Mutex, OnceLock},
+        },
+        tempfile::tempdir,
+    };
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            env::set_current_dir(&self.0).unwrap();
+        }
+    }
+
+    fn in_dir<T>(path: &Path, f: impl FnOnce() -> T) -> T {
+        let guard = CurrentDirGuard(env::current_dir().unwrap());
+        env::set_current_dir(path).unwrap();
+        let result = f();
+        drop(guard);
+        result
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    fn create_program(root: &Path, name: &str) {
+        write_file(
+            &root.join("Cargo.toml"),
+            &format!(
+                r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+"#
+            ),
+        );
+        write_file(&root.join("src").join("lib.rs"), "");
+    }
+
+    fn create_workspace(root: &Path) {
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"[workspace]
+members = ["programs/*"]
+resolver = "2"
+"#,
+        );
+        create_program(&root.join("programs").join("foo"), "foo");
+        create_program(&root.join("programs").join("bar"), "bar");
+    }
+
+    fn current_dir_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn discover_solana_programs_finds_sibling_programs_from_nested_member() {
+        let _lock = current_dir_lock().lock().unwrap();
+        let dir = tempdir().unwrap();
+        create_workspace(dir.path());
+
+        let root_programs = in_dir(dir.path(), || {
+            discover_solana_programs(Some("bar".into())).unwrap()
+        });
+        let nested_programs = in_dir(&dir.path().join("programs").join("foo"), || {
+            discover_solana_programs(Some("bar".into())).unwrap()
+        });
+
+        assert_eq!(root_programs.len(), 1);
+        assert_eq!(nested_programs.len(), 1);
+        assert_eq!(root_programs[0].lib_name, "bar");
+        assert_eq!(nested_programs[0].lib_name, "bar");
+        assert_eq!(root_programs[0].path, nested_programs[0].path);
+    }
+
+    #[test]
+    fn discover_solana_programs_lists_all_members_from_nested_member() {
+        let _lock = current_dir_lock().lock().unwrap();
+        let dir = tempdir().unwrap();
+        create_workspace(dir.path());
+
+        let programs = in_dir(&dir.path().join("programs").join("foo"), || {
+            discover_solana_programs(None).unwrap()
+        });
+
+        let names = programs
+            .into_iter()
+            .map(|program| program.lib_name)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            names,
+            BTreeSet::from(["bar".to_string(), "foo".to_string()])
+        );
+    }
 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -6,7 +6,6 @@ use {
     anchor_lang_idl::types::Idl,
     anyhow::{anyhow, bail, Result},
     cargo_metadata::{Metadata, MetadataCommand, Package, TargetKind},
-    heck::ToSnakeCase,
     solana_client::send_and_confirm_transactions_in_parallel::{
         send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
     },
@@ -51,27 +50,9 @@ fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
         Ok(metadata) => Ok(Some(metadata)),
         Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
             if stderr.contains("could not find `Cargo.toml`") {
-                return Ok(None);
-            }
-            if !stderr.contains("current package believes it's in a workspace when it's not") {
+                Ok(None)
+            } else {
                 bail!(stderr);
-            }
-            let Some(manifest_dir) = current_manifest_dir(start_dir)? else {
-                return Ok(None);
-            };
-            let Some(parent) = manifest_dir.parent() else {
-                return Ok(None);
-            };
-            match MetadataCommand::new().current_dir(parent).no_deps().exec() {
-                Ok(metadata) => Ok(Some(metadata)),
-                Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
-                    if stderr.contains("could not find `Cargo.toml`") {
-                        Ok(None)
-                    } else {
-                        bail!(stderr);
-                    }
-                }
-                Err(err) => Err(err.into()),
             }
         }
         Err(err) => Err(err.into()),
@@ -84,61 +65,6 @@ fn package_lib_name(package: &Package) -> Option<String> {
         .iter()
         .find(|target| target.kind.iter().any(|kind| kind == &TargetKind::CDyLib))
         .map(|target| target.name.clone())
-}
-
-fn read_cargo_toml(path: &Path) -> Result<toml::Value> {
-    Ok(toml::from_str(&fs::read_to_string(
-        path.join("Cargo.toml"),
-    )?)?)
-}
-
-fn manifest_lib_name(cargo_toml: &toml::Value) -> Result<String> {
-    match cargo_toml
-        .get("lib")
-        .and_then(|lib| lib.get("name"))
-        .and_then(|name| name.as_str())
-    {
-        Some(name) => Ok(name.to_string()),
-        None => cargo_toml
-            .get("package")
-            .and_then(|package| package.get("name"))
-            .and_then(|name| name.as_str())
-            .map(ToSnakeCase::to_snake_case)
-            .ok_or_else(|| anyhow!("package section not provided")),
-    }
-}
-
-fn current_program_candidate(
-    start_dir: &Path,
-    candidates: &BTreeMap<PathBuf, String>,
-) -> Result<Option<(PathBuf, String)>> {
-    let Some(path) = current_manifest_dir(start_dir)? else {
-        return Ok(None);
-    };
-    if candidates.contains_key(path.as_path()) {
-        return Ok(None);
-    }
-    let cargo_toml = read_cargo_toml(&path)?;
-    if is_solana_program(&cargo_toml) {
-        return Ok(Some((path, manifest_lib_name(&cargo_toml)?)));
-    }
-    Ok(None)
-}
-
-fn current_manifest_dir(start_dir: &Path) -> Result<Option<PathBuf>> {
-    let mut dir = Some(start_dir);
-
-    while let Some(path) = dir {
-        if path.join("Cargo.toml").exists() {
-            return Ok(Some(path.to_path_buf()));
-        }
-        if path.join("Anchor.toml").exists() {
-            return Ok(None);
-        }
-        dir = path.parent();
-    }
-
-    Ok(None)
 }
 
 fn discover_solana_programs_from_path(
@@ -162,29 +88,6 @@ fn discover_solana_programs_from_path(
             let manifest_path = package.manifest_path.clone().into_std_path_buf();
             let path = manifest_path.parent().unwrap().to_path_buf();
             candidates.insert(path, lib_name);
-        }
-    }
-
-    if let Some((path, lib_name)) = current_program_candidate(current_dir, &candidates)? {
-        candidates.entry(path).or_insert(lib_name);
-    }
-
-    if candidates.is_empty() {
-        let programs_dir = metadata
-            .as_ref()
-            .map(|metadata| metadata.workspace_root.join("programs").into_std_path_buf())
-            .unwrap_or_else(|| current_dir.join("programs"));
-        if programs_dir.is_dir() {
-            for entry in fs::read_dir(programs_dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() && path.join("Cargo.toml").exists() {
-                    let cargo_toml = read_cargo_toml(&path)?;
-                    if is_solana_program(&cargo_toml) {
-                        candidates.insert(path, manifest_lib_name(&cargo_toml)?);
-                    }
-                }
-            }
         }
     }
 
@@ -220,20 +123,6 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
     discover_solana_programs_from_path(&std::env::current_dir()?, program_name)
 }
 
-/// Check if a given Cargo project is a Solana program
-/// A deployable Solana program must have crate-type = ["cdylib", ...]
-fn is_solana_program(cargo_toml: &toml::Value) -> bool {
-    cargo_toml
-        .get("lib")
-        .and_then(|lib| lib.get("crate-type"))
-        .and_then(|crate_type| crate_type.as_array())
-        .is_some_and(|crate_types| {
-            crate_types
-                .iter()
-                .any(|crate_type| crate_type.as_str() == Some("cdylib"))
-        })
-}
-
 /// Get programs from workspace (Anchor or non-Anchor)
 pub fn get_programs_from_workspace(
     cfg_override: &ConfigOverride,
@@ -251,15 +140,13 @@ pub fn get_programs_from_workspace(
         if let Some(name) = program_name {
             return Err(anyhow!(
                 "Program '{}' not found. Make sure you're in a Solana workspace (Anchor or \
-                 non-Anchor) with programs in the programs/ directory, or provide a program \
-                 filepath.",
+                 non-Anchor), or provide a program filepath.",
                 name
             ));
         } else {
             return Err(anyhow!(
                 "No Solana programs found. Make sure you're in a Solana workspace (Anchor or \
-                 non-Anchor) with programs in the programs/ directory, or provide a program \
-                 filepath."
+                 non-Anchor), or provide a program filepath."
             ));
         }
     }
@@ -2127,20 +2014,6 @@ crate-type = ["cdylib", "lib"]
         write_file(&root.join("src").join("lib.rs"), "");
     }
 
-    fn create_library(root: &Path, name: &str) {
-        write_file(
-            &root.join("Cargo.toml"),
-            &format!(
-                r#"[package]
-name = "{name}"
-version = "0.1.0"
-edition = "2021"
-"#
-            ),
-        );
-        write_file(&root.join("src").join("lib.rs"), "");
-    }
-
     fn create_workspace(root: &Path) {
         write_file(
             &root.join("Cargo.toml"),
@@ -2194,44 +2067,15 @@ resolver = "2"
     }
 
     #[test]
-    fn discover_solana_programs_includes_current_program_outside_workspace_members() {
+    fn discover_solana_programs_errors_for_nonmember_current_crate() {
         let dir = tempdir().unwrap();
         create_workspace(dir.path());
         create_program(&dir.path().join("tools").join("baz"), "baz");
 
-        let programs =
-            discover_solana_programs_from_path(&dir.path().join("tools").join("baz"), None)
-                .unwrap();
+        let err = discover_solana_programs_from_path(&dir.path().join("tools").join("baz"), None)
+            .unwrap_err()
+            .to_string();
 
-        let names = programs
-            .into_iter()
-            .map(|program| program.lib_name)
-            .collect::<BTreeSet<_>>();
-
-        assert_eq!(
-            names,
-            BTreeSet::from(["bar".to_string(), "baz".to_string(), "foo".to_string()])
-        );
-    }
-
-    #[test]
-    fn discover_solana_programs_from_nonmember_crate_keeps_workspace_members() {
-        let dir = tempdir().unwrap();
-        create_workspace(dir.path());
-        create_library(&dir.path().join("tools").join("helper"), "helper");
-
-        let programs =
-            discover_solana_programs_from_path(&dir.path().join("tools").join("helper"), None)
-                .unwrap();
-
-        let names = programs
-            .into_iter()
-            .map(|program| program.lib_name)
-            .collect::<BTreeSet<_>>();
-
-        assert_eq!(
-            names,
-            BTreeSet::from(["bar".to_string(), "foo".to_string()])
-        );
+        assert!(err.contains("current package believes it's in a workspace when it's not"));
     }
 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -5,6 +5,8 @@ use {
     },
     anchor_lang_idl::types::Idl,
     anyhow::{anyhow, bail, Result},
+    cargo_metadata::{Metadata, MetadataCommand, Package, TargetKind},
+    heck::ToSnakeCase,
     solana_client::send_and_confirm_transactions_in_parallel::{
         send_and_confirm_transactions_in_parallel_blocking_v2, SendAndConfirmConfigV2,
     },
@@ -23,6 +25,7 @@ use {
     solana_signer::{EncodableKey, Signer},
     solana_transaction::Transaction,
     std::{
+        collections::{BTreeMap, HashSet},
         fs::{self, File},
         io::Write,
         path::{Path, PathBuf},
@@ -39,18 +42,73 @@ fn parse_priority_fee_from_args(args: &[String]) -> Option<u64> {
         .and_then(|pair| pair[1].parse().ok())
 }
 
-fn find_workspace_root(start_dir: &Path) -> Result<Option<PathBuf>> {
+fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
     let mut dir = Some(start_dir);
 
     while let Some(path) = dir {
-        let cargo_toml_path = path.join("Cargo.toml");
-        if cargo_toml_path.exists() {
-            let cargo_content = fs::read_to_string(&cargo_toml_path)?;
-            let cargo_toml: toml::Value = toml::from_str(&cargo_content)?;
-
-            if cargo_toml.get("workspace").is_some() {
-                return Ok(Some(path.to_path_buf()));
+        match MetadataCommand::new().current_dir(path).no_deps().exec() {
+            Ok(metadata) => return Ok(Some(metadata)),
+            Err(err) => {
+                let err = err.to_string();
+                if err.contains("could not find `Cargo.toml`") {
+                    return Ok(None);
+                }
+                if !err.contains("current package believes it's in a workspace when it's not") {
+                    bail!(err);
+                }
             }
+        }
+
+        dir = path.parent();
+    }
+
+    Ok(None)
+}
+
+fn package_lib_name(package: &Package) -> Option<String> {
+    package
+        .targets
+        .iter()
+        .find(|target| target.kind.iter().any(|kind| kind == &TargetKind::CDyLib))
+        .map(|target| target.name.clone())
+}
+
+fn read_cargo_toml(path: &Path) -> Result<toml::Value> {
+    Ok(toml::from_str(&fs::read_to_string(
+        path.join("Cargo.toml"),
+    )?)?)
+}
+
+fn manifest_lib_name(cargo_toml: &toml::Value) -> Result<String> {
+    match cargo_toml
+        .get("lib")
+        .and_then(|lib| lib.get("name"))
+        .and_then(|name| name.as_str())
+    {
+        Some(name) => Ok(name.to_string()),
+        None => cargo_toml
+            .get("package")
+            .and_then(|package| package.get("name"))
+            .and_then(|name| name.as_str())
+            .map(ToSnakeCase::to_snake_case)
+            .ok_or_else(|| anyhow!("package section not provided")),
+    }
+}
+
+fn current_program_candidate(start_dir: &Path) -> Result<Option<(PathBuf, String)>> {
+    let mut dir = Some(start_dir);
+
+    while let Some(path) = dir {
+        if path.join("Cargo.toml").exists() {
+            let cargo_toml = read_cargo_toml(path)?;
+            if is_solana_program(&cargo_toml) {
+                return Ok(Some((path.to_path_buf(), manifest_lib_name(&cargo_toml)?)));
+            }
+            return Ok(None);
+        }
+
+        if path.join("Anchor.toml").exists() {
+            return Ok(None);
         }
 
         dir = path.parent();
@@ -62,53 +120,49 @@ fn find_workspace_root(start_dir: &Path) -> Result<Option<PathBuf>> {
 /// Discover Solana programs from a non-Anchor Cargo workspace
 pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Program>> {
     let current_dir = std::env::current_dir()?;
-    let workspace_dir = find_workspace_root(&current_dir)?;
-    let manifest_dir = workspace_dir.as_ref().unwrap_or(&current_dir);
-    let mut program_paths = Vec::new();
+    let mut candidates = BTreeMap::new();
+    let metadata = discover_cargo_metadata(&current_dir)?;
 
-    let cargo_toml_path = manifest_dir.join("Cargo.toml");
-    if cargo_toml_path.exists() {
-        let cargo_content = fs::read_to_string(&cargo_toml_path)?;
-        let cargo_toml: toml::Value = toml::from_str(&cargo_content)?;
+    if let Some(metadata) = &metadata {
+        let workspace_members = metadata.workspace_members.iter().collect::<HashSet<_>>();
 
-        if let Some(workspace) = cargo_toml.get("workspace") {
-            if let Some(members) = workspace.get("members").and_then(|m| m.as_array()) {
-                for member in members {
-                    if let Some(member_path) = member.as_str() {
-                        let full_path = manifest_dir.join(member_path);
-                        if full_path.is_dir() && full_path.join("Cargo.toml").exists() {
-                            program_paths.push(full_path);
-                        }
-                    }
-                }
+        for package in &metadata.packages {
+            if !workspace_members.contains(&package.id) {
+                continue;
             }
-        } else if is_solana_program(manifest_dir)? {
-            program_paths.push(current_dir.clone());
+
+            let Some(lib_name) = package_lib_name(package) else {
+                continue;
+            };
+            let manifest_path = package.manifest_path.clone().into_std_path_buf();
+            let path = manifest_path.parent().unwrap().to_path_buf();
+            candidates.insert(path, lib_name);
         }
     }
 
-    if program_paths.is_empty() {
-        let programs_dir = manifest_dir.join("programs");
+    if let Some((path, lib_name)) = current_program_candidate(&current_dir)? {
+        candidates.entry(path).or_insert(lib_name);
+    }
+
+    if candidates.is_empty() {
+        let programs_dir = metadata
+            .as_ref()
+            .map(|metadata| metadata.workspace_root.join("programs").into_std_path_buf())
+            .unwrap_or_else(|| current_dir.join("programs"));
         if programs_dir.is_dir() {
             for entry in fs::read_dir(programs_dir)? {
                 let entry = entry?;
                 let path = entry.path();
                 if path.is_dir() && path.join("Cargo.toml").exists() {
-                    program_paths.push(path);
+                    let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
+                    candidates.insert(path, cargo.lib_name()?);
                 }
             }
         }
     }
 
     let mut programs = Vec::new();
-    for path in program_paths {
-        if !is_solana_program(&path)? {
-            continue;
-        }
-
-        let cargo = Manifest::from_path(path.join("Cargo.toml"))?;
-        let lib_name = cargo.lib_name()?;
-
+    for (path, lib_name) in candidates {
         if let Some(ref name) = program_name {
             let matches = *name == lib_name || *name == path.file_name().unwrap().to_str().unwrap();
             if !matches {
@@ -136,26 +190,16 @@ pub fn discover_solana_programs(program_name: Option<String>) -> Result<Vec<Prog
 
 /// Check if a given Cargo project is a Solana program
 /// A deployable Solana program must have crate-type = ["cdylib", ...]
-fn is_solana_program(path: &Path) -> Result<bool> {
-    let cargo_path = path.join("Cargo.toml");
-    if !cargo_path.exists() {
-        return Ok(false);
-    }
-
-    let cargo_content = fs::read_to_string(&cargo_path)?;
-    let cargo_toml: toml::Value = toml::from_str(&cargo_content)?;
-
-    // Check if it has cdylib (required for deployable Solana programs)
-    // This is the definitive marker - libraries and client tools won't have this
+fn is_solana_program(cargo_toml: &toml::Value) -> bool {
     if let Some(lib) = cargo_toml.get("lib") {
         if let Some(crate_type) = lib.get("crate-type").and_then(|ct| ct.as_array()) {
             if crate_type.iter().any(|ct| ct.as_str() == Some("cdylib")) {
-                return Ok(true);
+                return true;
             }
         }
     }
 
-    Ok(false)
+    false
 }
 
 /// Get programs from workspace (Anchor or non-Anchor)
@@ -2127,6 +2171,28 @@ resolver = "2"
         assert_eq!(
             names,
             BTreeSet::from(["bar".to_string(), "foo".to_string()])
+        );
+    }
+
+    #[test]
+    fn discover_solana_programs_includes_current_program_outside_workspace_members() {
+        let _lock = current_dir_lock().lock().unwrap();
+        let dir = tempdir().unwrap();
+        create_workspace(dir.path());
+        create_program(&dir.path().join("tools").join("baz"), "baz");
+
+        let programs = in_dir(&dir.path().join("tools").join("baz"), || {
+            discover_solana_programs(None).unwrap()
+        });
+
+        let names = programs
+            .into_iter()
+            .map(|program| program.lib_name)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            names,
+            BTreeSet::from(["bar".to_string(), "baz".to_string(), "foo".to_string()])
         );
     }
 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -43,26 +43,39 @@ fn parse_priority_fee_from_args(args: &[String]) -> Option<u64> {
 }
 
 fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
-    let mut dir = Some(start_dir);
-
-    while let Some(path) = dir {
-        match MetadataCommand::new().current_dir(path).no_deps().exec() {
-            Ok(metadata) => return Ok(Some(metadata)),
-            Err(err) => {
-                let err = err.to_string();
-                if err.contains("could not find `Cargo.toml`") {
-                    return Ok(None);
-                }
-                if !err.contains("current package believes it's in a workspace when it's not") {
-                    bail!(err);
+    match MetadataCommand::new()
+        .current_dir(start_dir)
+        .no_deps()
+        .exec()
+    {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(err) => {
+            let err = err.to_string();
+            if err.contains("could not find `Cargo.toml`") {
+                return Ok(None);
+            }
+            if !err.contains("current package believes it's in a workspace when it's not") {
+                bail!(err);
+            }
+            let Some(manifest_dir) = current_manifest_dir(start_dir)? else {
+                return Ok(None);
+            };
+            let Some(parent) = manifest_dir.parent() else {
+                return Ok(None);
+            };
+            match MetadataCommand::new().current_dir(parent).no_deps().exec() {
+                Ok(metadata) => Ok(Some(metadata)),
+                Err(err) => {
+                    let err = err.to_string();
+                    if err.contains("could not find `Cargo.toml`") {
+                        Ok(None)
+                    } else {
+                        bail!(err);
+                    }
                 }
             }
         }
-
-        dir = path.parent();
     }
-
-    Ok(None)
 }
 
 fn package_lib_name(package: &Package) -> Option<String> {
@@ -96,21 +109,26 @@ fn manifest_lib_name(cargo_toml: &toml::Value) -> Result<String> {
 }
 
 fn current_program_candidate(start_dir: &Path) -> Result<Option<(PathBuf, String)>> {
+    let Some(path) = current_manifest_dir(start_dir)? else {
+        return Ok(None);
+    };
+    let cargo_toml = read_cargo_toml(&path)?;
+    if is_solana_program(&cargo_toml) {
+        return Ok(Some((path, manifest_lib_name(&cargo_toml)?)));
+    }
+    Ok(None)
+}
+
+fn current_manifest_dir(start_dir: &Path) -> Result<Option<PathBuf>> {
     let mut dir = Some(start_dir);
 
     while let Some(path) = dir {
         if path.join("Cargo.toml").exists() {
-            let cargo_toml = read_cargo_toml(path)?;
-            if is_solana_program(&cargo_toml) {
-                return Ok(Some((path.to_path_buf(), manifest_lib_name(&cargo_toml)?)));
-            }
-            return Ok(None);
+            return Ok(Some(path.to_path_buf()));
         }
-
         if path.join("Anchor.toml").exists() {
             return Ok(None);
         }
-
         dir = path.parent();
     }
 
@@ -2116,6 +2134,20 @@ crate-type = ["cdylib", "lib"]
         write_file(&root.join("src").join("lib.rs"), "");
     }
 
+    fn create_library(root: &Path, name: &str) {
+        write_file(
+            &root.join("Cargo.toml"),
+            &format!(
+                r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+"#
+            ),
+        );
+        write_file(&root.join("src").join("lib.rs"), "");
+    }
+
     fn create_workspace(root: &Path) {
         write_file(
             &root.join("Cargo.toml"),
@@ -2193,6 +2225,28 @@ resolver = "2"
         assert_eq!(
             names,
             BTreeSet::from(["bar".to_string(), "baz".to_string(), "foo".to_string()])
+        );
+    }
+
+    #[test]
+    fn discover_solana_programs_from_nonmember_crate_keeps_workspace_members() {
+        let _lock = current_dir_lock().lock().unwrap();
+        let dir = tempdir().unwrap();
+        create_workspace(dir.path());
+        create_library(&dir.path().join("tools").join("helper"), "helper");
+
+        let programs = in_dir(&dir.path().join("tools").join("helper"), || {
+            discover_solana_programs(None).unwrap()
+        });
+
+        let names = programs
+            .into_iter()
+            .map(|program| program.lib_name)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            names,
+            BTreeSet::from(["bar".to_string(), "foo".to_string()])
         );
     }
 }


### PR DESCRIPTION
Fixes #4447

`discover_solana_programs` only checked the current directory for a Cargo workspace, so running `anchor program deploy` from a nested member of a non-Anchor workspace could miss sibling programs.

This resolves the nearest parent Cargo workspace before scanning workspace members and reading generated IDLs. It also adds focused tests for nested member discovery.

Tests:
- `cargo +nightly fmt --check`
- `cargo test -p anchor-cli`
- `cargo clippy -p anchor-cli --tests -- -D warnings`
