### PR TITLE
tests: drive ido-pool cluster time via surfnet_timeTravel

### DIFF
--- a/tests/ido-pool/tests/ido-pool.js
+++ b/tests/ido-pool/tests/ido-pool.js
@@ -8,7 +8,7 @@ const {
 const {
   sleep,
   getClusterTime,
-  waitUntilClusterTime,
+  advanceClusterTime,
   getTokenAccount,
   createMint,
   createTokenAccount,
@@ -103,17 +103,16 @@ describe("ido-pool", () => {
     bumps.poolUsdc = poolUsdcBump;
 
     idoTimes = new IdoTimes();
-    // Anchor pacing against cluster time (not `Date.now()`) so client /
-    // validator clock skew can't consume the phase budget. Windows are
-    // sized for slow CI runners with cold test-validator boot: 30s of
-    // deposits and 15s of exchange give ~3x headroom over observed
-    // worst-case execution.
+    // Cluster time is advanced between phases via `surfnet_timeTravel`, so
+    // these windows are notional — we jump to each boundary directly rather
+    // than waiting wall-clock. `validate_ido_times` only requires strict
+    // ordering and `start_ido > now`.
     const clusterNow = await getClusterTime(provider.connection);
     const nowBn = new anchor.BN(clusterNow);
     idoTimes.startIdo = nowBn.add(new anchor.BN(10));
-    idoTimes.endDeposits = nowBn.add(new anchor.BN(40));
-    idoTimes.endIdo = nowBn.add(new anchor.BN(55));
-    idoTimes.endEscrow = nowBn.add(new anchor.BN(60));
+    idoTimes.endDeposits = nowBn.add(new anchor.BN(20));
+    idoTimes.endIdo = nowBn.add(new anchor.BN(30));
+    idoTimes.endEscrow = nowBn.add(new anchor.BN(40));
 
     await program.rpc.initializePool(
       idoName,
@@ -151,11 +150,8 @@ describe("ido-pool", () => {
   const firstDeposit = new anchor.BN(10_000_349);
 
   it("Exchanges user USDC for redeemable tokens", async () => {
-    // Wait until the IDO has opened on-chain.
-    await waitUntilClusterTime(
-      provider.connection,
-      idoTimes.startIdo.toNumber()
-    );
+    // Jump cluster time past `startIdo` so the deposit phase is open.
+    await advanceClusterTime(provider.connection, idoTimes.startIdo.toNumber());
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from(idoName)],
@@ -420,8 +416,8 @@ describe("ido-pool", () => {
   });
 
   it("Exchanges user Redeemable tokens for watermelon", async () => {
-    // Wait until the IDO has ended on-chain.
-    await waitUntilClusterTime(provider.connection, idoTimes.endIdo.toNumber());
+    // Jump cluster time past `endIdo` so the sale has ended.
+    await advanceClusterTime(provider.connection, idoTimes.endIdo.toNumber());
 
     const [idoAccount] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from(idoName)],
@@ -559,8 +555,8 @@ describe("ido-pool", () => {
   });
 
   it("Withdraws USDC from the escrow account after waiting period is over", async () => {
-    // Wait until the escrow period is over on-chain.
-    await waitUntilClusterTime(
+    // Jump cluster time past `endEscrow` so withdrawals are unlocked.
+    await advanceClusterTime(
       provider.connection,
       idoTimes.endEscrow.toNumber()
     );

--- a/tests/ido-pool/tests/utils/index.js
+++ b/tests/ido-pool/tests/utils/index.js
@@ -16,8 +16,7 @@ function sleep(ms) {
 }
 
 // Read the cluster's current `unix_timestamp` — the same value the on-chain
-// `Clock::get()` observes. Pacing against this instead of `Date.now()`
-// eliminates client/validator clock-skew flakiness.
+// `Clock::get()` observes.
 async function getClusterTime(connection) {
   for (let attempt = 0; attempt < 20; attempt++) {
     const slot = await connection.getSlot("confirmed");
@@ -28,17 +27,23 @@ async function getClusterTime(connection) {
   throw new Error("getBlockTime returned null for 20 consecutive slots");
 }
 
-// Poll the cluster clock until it is *strictly past* `targetUnixSecs`.
-// Matches the semantics of the on-chain phase checks, which all use
-// `clock.unix_timestamp <= boundary` — a tx landing in a block whose
-// `unix_timestamp` equals the boundary still trips the check. Polling
-// to `now > target` ensures the next tx observes a strictly later
-// cluster clock.
-async function waitUntilClusterTime(connection, targetUnixSecs) {
-  let now = await getClusterTime(connection);
-  while (now <= targetUnixSecs) {
-    await sleep(Math.min(targetUnixSecs - now + 1, 1) * 1000);
-    now = await getClusterTime(connection);
+// Jump the cluster clock to *strictly past* `targetUnixSecs` via surfpool's
+// `surfnet_timeTravel` cheatcode. The on-chain phase checks all use
+// `clock.unix_timestamp <= boundary` — a block whose `unix_timestamp` equals
+// the boundary still trips the check, so we target `boundary + 1`.
+//
+// Driving cluster time via an RPC (instead of polling wall-clock pacing)
+// decouples phase progression from tx confirmation latency: a stalled tx
+// can no longer burn the phase budget and cascade-fail later tests.
+//
+// `absoluteTimestamp` is in milliseconds (surfpool divides by 1000 when
+// writing the Clock sysvar's `unix_timestamp`).
+async function advanceClusterTime(connection, targetUnixSecs) {
+  const res = await connection._rpcRequest("surfnet_timeTravel", [
+    { absoluteTimestamp: (targetUnixSecs + 1) * 1000 },
+  ]);
+  if (res.error) {
+    throw new Error(`surfnet_timeTravel failed: ${JSON.stringify(res.error)}`);
   }
 }
 
@@ -76,7 +81,7 @@ module.exports = {
   TOKEN_PROGRAM_ID,
   sleep,
   getClusterTime,
-  waitUntilClusterTime,
+  advanceClusterTime,
   getTokenAccount,
   createTokenAccount,
   createMint,


### PR DESCRIPTION
Another attempt to fix https://github.com/solana-foundation/anchor/pull/4433

Surfpool has a [time-travel method](https://learn.blueshift.gg/courses/testing-with-surfpool/advanced-functionalities#customize-system-variables) which means we can decouple from wallclock entirely. This should hopefully make the test more reliable and reduce runtime.