### PR TITLE
Fix NPM package hyperlink errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To jump straight to examples, go [here](https://github.com/solana-foundation/anc
 | `anchor-spl`            | CPI clients for SPL programs on Solana                   | [![crates](https://img.shields.io/crates/v/anchor-spl?color=blue)](https://crates.io/crates/anchor-spl)                          | [![Docs.rs](https://docs.rs/anchor-spl/badge.svg)](https://docs.rs/anchor-spl)                                  |
 | `anchor-client`         | Rust client for Anchor programs                          | [![crates](https://img.shields.io/crates/v/anchor-client?color=blue)](https://crates.io/crates/anchor-client)                    | [![Docs.rs](https://docs.rs/anchor-client/badge.svg)](https://docs.rs/anchor-client)                            |
 | `@anchor-lang/core`     | TypeScript client for Anchor programs                    | [![npm](https://img.shields.io/npm/v/@anchor-lang/core.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/core)         | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://solana-foundation.github.io/anchor/ts/index.html)     |
-| `@anchor-lang/cli` | CLI to support building and managing an Anchor workspace | [![npm](https://img.shields.io/npm/v/@anchor-lang/cli.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/core-cli) | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://www.anchor-lang.com/docs/references/cli) |
+| `@anchor-lang/cli` | CLI to support building and managing an Anchor workspace | [![npm](https://img.shields.io/npm/v/@anchor-lang/cli.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/cli) | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://www.anchor-lang.com/docs/references/cli) |
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To jump straight to examples, go [here](https://github.com/solana-foundation/anc
 | `anchor-spl`            | CPI clients for SPL programs on Solana                   | [![crates](https://img.shields.io/crates/v/anchor-spl?color=blue)](https://crates.io/crates/anchor-spl)                          | [![Docs.rs](https://docs.rs/anchor-spl/badge.svg)](https://docs.rs/anchor-spl)                                  |
 | `anchor-client`         | Rust client for Anchor programs                          | [![crates](https://img.shields.io/crates/v/anchor-client?color=blue)](https://crates.io/crates/anchor-client)                    | [![Docs.rs](https://docs.rs/anchor-client/badge.svg)](https://docs.rs/anchor-client)                            |
 | `@anchor-lang/core`     | TypeScript client for Anchor programs                    | [![npm](https://img.shields.io/npm/v/@anchor-lang/core.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/core)         | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://solana-foundation.github.io/anchor/ts/index.html)     |
-| `@anchor-lang/cli` | CLI to support building and managing an Anchor workspace | [![npm](https://img.shields.io/npm/v/@anchor-lang/cli.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/cli) | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://www.anchor-lang.com/docs/references/cli) |
+| `@anchor-lang/cli` | CLI to support building and managing an Anchor workspace | [![npm](https://img.shields.io/npm/v/@anchor-lang/cli.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/cli) | [![Docs](https://img.shields.io/badge/docs-cli-blue)](https://www.anchor-lang.com/docs/references/cli) |
 
 ## Note
 

--- a/cli/npm-package/README.md
+++ b/cli/npm-package/README.md
@@ -1,0 +1,29 @@
+# @anchor-lang/cli
+
+[![npm](https://img.shields.io/npm/v/@anchor-lang/cli.svg?color=blue)](https://www.npmjs.com/package/@anchor-lang/cli)
+[![Docs](https://img.shields.io/badge/docs-anchor--cli-blue)](https://www.anchor-lang.com/docs/references/cli)
+
+The Anchor CLI for building and managing Anchor workspaces.
+
+## Install
+
+```sh
+npm install -g @anchor-lang/cli
+anchor --version
+```
+
+For most users, the recommended installation method is [AVM](https://www.anchor-lang.com/docs/installation).
+
+## Platform Support
+
+This npm package currently bundles the `anchor` binary for `x86_64` Linux only.
+
+On other platforms, the wrapper will try to use a globally installed `anchor`
+binary with the same version. If you need a native installation flow, use the
+[installation guide](https://www.anchor-lang.com/docs/installation).
+
+## Documentation
+
+- [Installation](https://www.anchor-lang.com/docs/installation)
+- [CLI reference](https://www.anchor-lang.com/docs/references/cli)
+- [Repository](https://github.com/solana-foundation/anchor)


### PR DESCRIPTION
## Summary

- Added new `Readme` in `cli/npm-package`
- Fixed rpm package link in `{root}/Readme.md`

closes #1091 