### PR TITLE
fix(spl): deprecate `cpi_guard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Bind `localnet` to `127.0.0.1` by default to fix a panic in `solana-test-validator` version `3.1.10` ([#4397](https://github.com/solana-foundation/anchor/pull/4397)).
 - cli: Fallback to a priority fee of 0 on localnet ([#4259](https://github.com/solana-foundation/anchor/pull/4259/)).
 - lang: Support module constants in `max_len` attribute ([#3879](https://github.com/solana-foundation/anchor/pull/3879)).
-- spl: Deprecate broken `cpi_guard_enable/disable` feature ([#4465](https://github.com/solana-foundation/anchor/pull/4465)).
+- spl: Deprecate broken `cpi_guard_enable/disable` functions ([#4465](https://github.com/solana-foundation/anchor/pull/4465)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Bind `localnet` to `127.0.0.1` by default to fix a panic in `solana-test-validator` version `3.1.10` ([#4397](https://github.com/solana-foundation/anchor/pull/4397)).
 - cli: Fallback to a priority fee of 0 on localnet ([#4259](https://github.com/solana-foundation/anchor/pull/4259/)).
 - lang: Support module constants in `max_len` attribute ([#3879](https://github.com/solana-foundation/anchor/pull/3879)).
+- spl: Deprecate broken `cpi_guard_enable/disable` feature ([#4465](https://github.com/solana-foundation/anchor/pull/4465)).
 
 ### Breaking
 

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -9,6 +9,12 @@ use {
     spl_token_2022_interface as spl_token_2022,
 };
 
+#[deprecated(
+    note = "Token-2022 rejects CPI-initiated toggling of the CPI Guard with \
+            CpiGuardSettingsLocked, so this wrapper is unreachable from any on-chain program. \
+            Build and send the enable instruction client-side with \
+            `spl_token_2022_interface::extension::cpi_guard::instruction::enable_cpi_guard`."
+)]
 pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(
         ctx.accounts.token_program_id.key,
@@ -28,6 +34,12 @@ pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info
     .map_err(Into::into)
 }
 
+#[deprecated(
+    note = "Token-2022 rejects CPI-initiated toggling of the CPI Guard with \
+            CpiGuardSettingsLocked, so this wrapper is unreachable from any on-chain program. \
+            Build and send the disable instruction client-side with \
+            `spl_token_2022_interface::extension::cpi_guard::instruction::disable_cpi_guard`."
+)]
 pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::disable_cpi_guard(
         ctx.accounts.token_program_id.key,
@@ -48,6 +60,11 @@ pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'inf
     .map_err(Into::into)
 }
 
+#[deprecated(
+    note = "CPI Guard enable/disable cannot be invoked via CPI (Token-2022 returns \
+            CpiGuardSettingsLocked). Kept only for the deprecated `cpi_guard_enable` / \
+            `cpi_guard_disable` wrappers; do not use in new code."
+)]
 #[derive(Accounts)]
 pub struct CpiGuard<'info> {
     pub token_program_id: AccountInfo<'info>,

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -231,44 +231,6 @@ pub fn update_group_pointer_handler(
 }
 
 #[derive(Accounts)]
-pub struct EnableCpiGuard<'info> {
-    pub authority: Signer<'info>,
-    #[account(mut)]
-    /// CHECK: token account with CPI Guard extension
-    pub token_account: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token2022>,
-}
-
-pub fn enable_cpi_guard_handler(ctx: Context<EnableCpiGuard>) -> Result<()> {
-    let cpi_accounts = token_2022_extensions::cpi_guard::CpiGuard {
-        token_program_id: ctx.accounts.token_program.to_account_info(),
-        account: ctx.accounts.token_account.to_account_info(),
-        owner: ctx.accounts.authority.to_account_info(),
-    };
-    let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
-    token_2022_extensions::cpi_guard::cpi_guard_enable(cpi_ctx)
-}
-
-#[derive(Accounts)]
-pub struct DisableCpiGuard<'info> {
-    pub authority: Signer<'info>,
-    #[account(mut)]
-    /// CHECK: token account with CPI Guard extension
-    pub token_account: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token2022>,
-}
-
-pub fn disable_cpi_guard_handler(ctx: Context<DisableCpiGuard>) -> Result<()> {
-    let cpi_accounts = token_2022_extensions::cpi_guard::CpiGuard {
-        token_program_id: ctx.accounts.token_program.to_account_info(),
-        account: ctx.accounts.token_account.to_account_info(),
-        owner: ctx.accounts.authority.to_account_info(),
-    };
-    let cpi_ctx = CpiContext::new(*ctx.accounts.token_program.key, cpi_accounts);
-    token_2022_extensions::cpi_guard::cpi_guard_disable(cpi_ctx)
-}
-
-#[derive(Accounts)]
 #[instruction()]
 pub struct CheckTogglePause<'info> {
     #[account(mut)]

--- a/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
@@ -40,14 +40,6 @@ pub mod token_extensions {
         instructions::update_group_pointer_handler(ctx, new_group_address)
     }
 
-    pub fn enable_cpi_guard(ctx: Context<EnableCpiGuard>) -> Result<()> {
-        instructions::enable_cpi_guard_handler(ctx)
-    }
-
-    pub fn disable_cpi_guard(ctx: Context<DisableCpiGuard>) -> Result<()> {
-        instructions::disable_cpi_guard_handler(ctx)
-    }
-
     pub fn check_toggle_pause(ctx: Context<CheckTogglePause>) -> Result<()> {
         instructions::toggle_pause_handler(ctx)
     }

--- a/tests/spl/token-extensions/tests/token-extensions.ts
+++ b/tests/spl/token-extensions/tests/token-extensions.ts
@@ -1,22 +1,10 @@
 import * as anchor from "@anchor-lang/core";
 import { AnchorError, Program } from "@anchor-lang/core";
 import { strict as assert } from "node:assert";
-import {
-  PublicKey,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-} from "@solana/web3.js";
+import { PublicKey, Keypair } from "@solana/web3.js";
 import { TokenExtensions } from "../target/types/token_extensions";
 import { ASSOCIATED_PROGRAM_ID } from "@anchor-lang/core/dist/cjs/utils/token";
-import {
-  createInitializeAccountInstruction,
-  createMint,
-  ExtensionType,
-  getAccountLen,
-} from "@solana/spl-token";
-import { it } from "node:test";
+import { createMint } from "@solana/spl-token";
 
 const TOKEN_2022_PROGRAM_ID = new anchor.web3.PublicKey(
   "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
@@ -131,85 +119,6 @@ describe("token extensions", () => {
         .accountsStrict({
           authority: payer.publicKey,
           mint: groupPointerMint.publicKey,
-          tokenProgram: TOKEN_2022_PROGRAM_ID,
-        })
-        .signers([payer])
-        .rpc();
-    });
-  });
-
-  describe("cpi_guard", () => {
-    let cpiGuardMint: PublicKey;
-    let enableAccount = Keypair.generate();
-    let disableAccount = Keypair.generate();
-
-    async function createCpiGuardTokenAccount(
-      tokenAccountKeypair: Keypair
-    ): Promise<void> {
-      const accountLen = getAccountLen([ExtensionType.CpiGuard]);
-      const lamports =
-        await provider.connection.getMinimumBalanceForRentExemption(accountLen);
-
-      const tx = new Transaction().add(
-        SystemProgram.createAccount({
-          fromPubkey: payer.publicKey,
-          newAccountPubkey: tokenAccountKeypair.publicKey,
-          space: accountLen,
-          lamports,
-          programId: TOKEN_2022_PROGRAM_ID,
-        }),
-        createInitializeAccountInstruction(
-          tokenAccountKeypair.publicKey,
-          cpiGuardMint,
-          payer.publicKey,
-          TOKEN_2022_PROGRAM_ID
-        )
-      );
-
-      await sendAndConfirmTransaction(
-        provider.connection,
-        tx,
-        [payer, tokenAccountKeypair],
-        { commitment: "confirmed" }
-      );
-    }
-
-    it("Create mint and token accounts with CPI Guard extension", async () => {
-      cpiGuardMint = await createMint(
-        provider.connection,
-        payer,
-        payer.publicKey,
-        null,
-        9,
-        Keypair.generate(),
-        { commitment: "confirmed" },
-        TOKEN_2022_PROGRAM_ID
-      );
-
-      await createCpiGuardTokenAccount(enableAccount);
-      await createCpiGuardTokenAccount(disableAccount);
-    });
-
-    it("Enable CPI Guard via CPI succeeds", async () => {
-      await program.methods
-        .enableCpiGuard()
-        .accountsStrict({
-          authority: payer.publicKey,
-          tokenAccount: enableAccount.publicKey,
-          tokenProgram: TOKEN_2022_PROGRAM_ID,
-        })
-        .signers([payer])
-        .rpc();
-    });
-
-    it("Disable CPI Guard via CPI succeeds", async () => {
-      // Uses a separate account where guard is not active,
-      // since an active CPI Guard blocks disable via CPI
-      await program.methods
-        .disableCpiGuard()
-        .accountsStrict({
-          authority: payer.publicKey,
-          tokenAccount: disableAccount.publicKey,
           tokenProgram: TOKEN_2022_PROGRAM_ID,
         })
         .signers([payer])


### PR DESCRIPTION
Closes #4458

This feature was originally added in https://github.com/solana-foundation/anchor/pull/2789. However, the `cpi_guard_enable/disable` instructions are not usable from in a CPI (https://docs.rs/crate/spl-token-2022/10.0.0/source/src/extension/cpi_guard/processor.rs#42-44), which means an Anchor CPI wrapper is not useful.

I added these tests in #4322 (cc @0xIchigo), but due to the pre-existing `import { it } from "node:test";`, `ts-mocha` was not able to properly recognise the test failures. This test has been failing since then without marking CI as failed.

Remove the broken tests, fix the incorrect import, and deprecate the feature.

cc @acheroncrypto as the original reviewer for a double-check.