### PR TITLE
fix(idl): bump anchor-lang-idl-spec from 0.1.0 to 0.2.0 (#3832)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang-idl-spec"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -17,7 +17,7 @@ build = ["dep:regex", "dep:serde_json"]
 convert = ["dep:heck", "dep:serde_json", "dep:sha2"]
 
 [dependencies]
-anchor-lang-idl-spec = { path = "./spec", version = "0.1.0" }
+anchor-lang-idl-spec = { path = "./spec", version = "0.2.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }

--- a/idl/spec/Cargo.toml
+++ b/idl/spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor-lang-idl-spec"
-version = "0.1.0"
+version = "0.2.0"
 publish = false
 authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/solana-foundation/anchor"

--- a/idl/src/convert.rs
+++ b/idl/src/convert.rs
@@ -18,9 +18,12 @@ pub fn convert_idl(idl: &[u8]) -> Result<Idl> {
         .and_then(|m| m.get("spec"))
         .and_then(|spec| spec.as_str());
     match spec {
-        // New standard
+        // New standard. `0.2.0` was bumped from `0.1.0` once IdlAccount/IdlEvent gained the
+        // required `discriminator` field in Anchor `0.31`. Both versions deserialize through the
+        // same struct (newer IDLs carry discriminators, older ones do not), so we accept either
+        // marker here rather than refusing newly-tagged IDLs.
         Some(spec) => match spec {
-            "0.1.0" => serde_json::from_value(value).map_err(Into::into),
+            "0.1.0" | "0.2.0" => serde_json::from_value(value).map_err(Into::into),
             _ => Err(anyhow!("IDL spec not supported: `{spec}`")),
         },
         // Legacy


### PR DESCRIPTION
Closes #3832.

## Summary
The IDL spec crate has been pinned at `0.1.0` since the new IDL standard was introduced in Anchor 0.30, but the spec has materially evolved since. For example, `IdlAccount` and `IdlEvent` gained a required `discriminator: IdlDiscriminator` field in 0.31 — a real schema change that consumers cannot detect, because every emitted IDL still claims `metadata.spec = "0.1.0"`.

This is exactly the case @ngundotra called out in #3832:
> 0.31 has support for account discriminators. This did not exist with 0.30.

## Changes
- **`idl/spec/Cargo.toml`** — bump `anchor-lang-idl-spec` from `0.1.0` to `0.2.0`. Additive schema changes get a minor bump under semver in 0.x.
- **`idl/Cargo.toml`** — update the workspace dependency declaration to `0.2.0` to match the spec crate.
- **`idl/src/convert.rs`** — `convert_idl` now accepts both `"0.1.0"` and `"0.2.0"` as new-standard markers. They deserialize through the same `Idl` struct today (newer IDLs carry discriminators, older ones do not), so it would be wrong to start refusing IDLs simply because they carry the new marker.
- **`Cargo.lock`** — auto-regenerated by `cargo check`.

## Effect
Newly-built programs (using master after this PR) will emit `metadata.spec = "0.2.0"`, so consumers can finally distinguish 0.30-era IDLs from 0.31-era IDLs from on-IDL data alone — exactly as the issue requested.

Older `0.1.0`-tagged IDLs continue to deserialize through the unchanged path, with the same caveats they always had.

## Tests
`cargo check -p anchor-lang-idl-spec -p anchor-lang-idl --tests` passes locally.

## Notes
- A future PR could differentiate the two version paths (e.g. a 0.1.0 fallback struct that makes `discriminator` optional, so 0.30-era on-chain IDLs deserialize cleanly). That's beyond the scope of this issue, but happy to follow up if maintainers want it.