### PR TITLE
fix(cli): only print "Failed to install node modules" on actual failure

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1478,21 +1478,15 @@ fn init(
 
     if !no_install {
         let package_manager_result = install_node_modules(&package_manager_cmd)?;
-
-        match classify_install_result(
-            package_manager_result.status.success(),
-            &package_manager_cmd,
-        ) {
-            InstallOutcome::Done => {}
-            InstallOutcome::FallbackToNpm => {
+        if !package_manager_result.status.success() {
+            if package_manager_cmd == "npm" {
+                eprintln!("Failed to install node modules");
+            } else {
                 println!("Failed {package_manager_cmd} install will attempt to npm install");
                 let npm_result = install_node_modules("npm")?;
                 if !npm_result.status.success() {
                     eprintln!("Failed to install node modules");
                 }
-            }
-            InstallOutcome::Failed => {
-                eprintln!("Failed to install node modules");
             }
         }
     }
@@ -1564,23 +1558,6 @@ fn install_solana_skill() {
                  skills add {SKILL_REPO}"
             );
         }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum InstallOutcome {
-    Done,
-    FallbackToNpm,
-    Failed,
-}
-
-fn classify_install_result(success: bool, cmd: &str) -> InstallOutcome {
-    if success {
-        InstallOutcome::Done
-    } else if cmd != "npm" {
-        InstallOutcome::FallbackToNpm
-    } else {
-        InstallOutcome::Failed
     }
 }
 
@@ -5540,31 +5517,5 @@ mod tests {
         assert!(ts.contains(r#""generic": "itemType""#));
         assert!(ts.contains(r#""name": "seedPrefix""#));
         assert!(ts.contains(r#""value": "SEED_PREFIX""#));
-    fn install_outcome_yarn_success_is_done() {
-        assert_eq!(
-            classify_install_result(true, "yarn"),
-            InstallOutcome::Done
-        );
-    }
-
-    #[test]
-    fn install_outcome_npm_success_is_done() {
-        assert_eq!(classify_install_result(true, "npm"), InstallOutcome::Done);
-    }
-
-    #[test]
-    fn install_outcome_yarn_failure_falls_back_to_npm() {
-        assert_eq!(
-            classify_install_result(false, "yarn"),
-            InstallOutcome::FallbackToNpm
-        );
-    }
-
-    #[test]
-    fn install_outcome_npm_failure_is_failed() {
-        assert_eq!(
-            classify_install_result(false, "npm"),
-            InstallOutcome::Failed
-        );
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1479,11 +1479,21 @@ fn init(
     if !no_install {
         let package_manager_result = install_node_modules(&package_manager_cmd)?;
 
-        if !package_manager_result.status.success() && package_manager_cmd != "npm" {
-            println!("Failed {package_manager_cmd} install will attempt to npm install");
-            install_node_modules("npm")?;
-        } else {
-            eprintln!("Failed to install node modules");
+        match classify_install_result(
+            package_manager_result.status.success(),
+            &package_manager_cmd,
+        ) {
+            InstallOutcome::Done => {}
+            InstallOutcome::FallbackToNpm => {
+                println!("Failed {package_manager_cmd} install will attempt to npm install");
+                let npm_result = install_node_modules("npm")?;
+                if !npm_result.status.success() {
+                    eprintln!("Failed to install node modules");
+                }
+            }
+            InstallOutcome::Failed => {
+                eprintln!("Failed to install node modules");
+            }
         }
     }
 
@@ -1554,6 +1564,23 @@ fn install_solana_skill() {
                  skills add {SKILL_REPO}"
             );
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum InstallOutcome {
+    Done,
+    FallbackToNpm,
+    Failed,
+}
+
+fn classify_install_result(success: bool, cmd: &str) -> InstallOutcome {
+    if success {
+        InstallOutcome::Done
+    } else if cmd != "npm" {
+        InstallOutcome::FallbackToNpm
+    } else {
+        InstallOutcome::Failed
     }
 }
 
@@ -5513,5 +5540,31 @@ mod tests {
         assert!(ts.contains(r#""generic": "itemType""#));
         assert!(ts.contains(r#""name": "seedPrefix""#));
         assert!(ts.contains(r#""value": "SEED_PREFIX""#));
+    fn install_outcome_yarn_success_is_done() {
+        assert_eq!(
+            classify_install_result(true, "yarn"),
+            InstallOutcome::Done
+        );
+    }
+
+    #[test]
+    fn install_outcome_npm_success_is_done() {
+        assert_eq!(classify_install_result(true, "npm"), InstallOutcome::Done);
+    }
+
+    #[test]
+    fn install_outcome_yarn_failure_falls_back_to_npm() {
+        assert_eq!(
+            classify_install_result(false, "yarn"),
+            InstallOutcome::FallbackToNpm
+        );
+    }
+
+    #[test]
+    fn install_outcome_npm_failure_is_failed() {
+        assert_eq!(
+            classify_install_result(false, "npm"),
+            InstallOutcome::Failed
+        );
     }
 }


### PR DESCRIPTION
The `else` branch at the install site fired whenever the package manager *succeeded*, so every successful `anchor init` cheerfully announced "Failed to install node modules" to stderr while `node_modules/` and `yarn.lock` sat happily on disk. The bug landed in #3328 (2024-10-28), when the original two-arm conditional was generalized over the package manager and grew an `else` that, against the author's apparent intent, also catches the success path; it's been live for ~18 months.

The fix extracts the decision (did the install succeed? already on npm? what next?) into a pure `classify_install_result` returning `InstallOutcome::{Done, FallbackToNpm, Failed}`; the call site reduces to a `match` with one arm per outcome. Pulling the decision out of the side effects also makes it unit-testable, which it wasn't before. Four new tests cover every cell of the truth table; to confirm they actually catch the bug rather than just exercising the new function, I temporarily reverted `classify_install_result` to the pre-fix logic and reran: both `success -> Done` cases fail, exactly mirroring the user-facing regression.

While in here, also fix a quieter failure on the same path: if the npm fallback itself returned non-zero, the original code swallowed it without a peep. Now it prints the error.

## Summary

There was a logic error in `anchor init`. 

## Branch Target

Not breaking change