### PR TITLE
refactor(lang): Split `error` into a new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "anchor-derive-accounts",
  "anchor-derive-serde",
  "anchor-derive-space",
+ "anchor-lang-error",
  "anchor-lang-idl",
  "base64 0.21.7",
  "bincode",
@@ -352,6 +353,17 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "anchor-lang-error"
+version = "1.0.1"
+dependencies = [
+ "anchor-attribute-error",
+ "borsh 1.6.1",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "lang",
     "lang/attribute/*",
     "lang/derive/*",
+    "lang/error",
     "lang/syn",
     "spl",
 ]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -53,6 +53,7 @@ anchor-attribute-program = { path = "./attribute/program", version = "1.0.1" }
 anchor-derive-accounts = { path = "./derive/accounts", version = "1.0.1" }
 anchor-derive-serde = { path = "./derive/serde", version = "1.0.1" }
 anchor-derive-space = { path = "./derive/space", version = "1.0.1" }
+anchor-lang-error = { path = "error", version = "1.0.1"}
 
 # `anchor-lang-idl` should only be included with `idl-build` feature
 anchor-lang-idl = { path = "../idl", version = "0.1.2", optional = true }

--- a/lang/error/Cargo.toml
+++ b/lang/error/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "anchor-lang-error"
+version.workspace = true
+publish = true
+edition = "2021"
+repository = "https://github.com/solana-foundation/anchor"
+license = "Apache-2.0"
+description = "Error definitions for anchor-lang"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+borsh = "1.5.7"
+
+solana-msg.workspace = true
+solana-program-error = { workspace = true, features = ["borsh"] }
+solana-pubkey.workspace = true
+
+anchor-attribute-error = { path = "../attribute/error", version = "1.0.1" }

--- a/lang/error/Cargo.toml
+++ b/lang/error/Cargo.toml
@@ -16,10 +16,10 @@ default = ["borsh"]
 borsh = ["dep:borsh", "solana-program-error/borsh"]
 
 [dependencies]
+anchor-attribute-error = { path = "../attribute/error", version = "1.0.1" }
+
 borsh = { version = "1.5.7", optional = true }
 
 solana-msg.workspace = true
 solana-program-error = { workspace = true }
 solana-pubkey.workspace = true
-
-anchor-attribute-error = { path = "../attribute/error", version = "1.0.1" }

--- a/lang/error/Cargo.toml
+++ b/lang/error/Cargo.toml
@@ -11,11 +11,15 @@ description = "Error definitions for anchor-lang"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+default = ["borsh"]
+borsh = ["dep:borsh", "solana-program-error/borsh"]
+
 [dependencies]
-borsh = "1.5.7"
+borsh = { version = "1.5.7", optional = true }
 
 solana-msg.workspace = true
-solana-program-error = { workspace = true, features = ["borsh"] }
+solana-program-error = { workspace = true }
 solana-pubkey.workspace = true
 
 anchor-attribute-error = { path = "../attribute/error", version = "1.0.1" }

--- a/lang/error/src/lib.rs
+++ b/lang/error/src/lib.rs
@@ -1,7 +1,8 @@
 use {
-    crate::solana_program::{program_error::ProgramError, pubkey::Pubkey},
-    anchor_lang::error_code,
+    anchor_attribute_error::error_code,
     borsh::io::Error as BorshIoError,
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
     std::{
         fmt::{Debug, Display},
         num::TryFromIntError,
@@ -10,6 +11,14 @@ use {
 
 /// The starting point for user defined error codes.
 pub const ERROR_CODE_OFFSET: u32 = 6000;
+
+// `#[error_code]` macro below accesses `anchor_lang::error::...` so set up
+// a fake module for it.
+mod anchor_lang {
+    pub(crate) mod error {
+        pub(crate) use crate::{AnchorError, Error};
+    }
+}
 
 /// Error codes that can be returned by internal framework code.
 ///
@@ -430,7 +439,7 @@ impl ProgramErrorWithOrigin {
     pub fn log(&self) {
         match &self.error_origin {
             None => {
-                anchor_lang::solana_program::msg!(
+                solana_msg::msg!(
                     "ProgramError occurred. Error Code: {:?}. Error Number: {}. Error Message: {}.",
                     self.program_error,
                     u64::from(self.program_error.clone()),
@@ -438,7 +447,7 @@ impl ProgramErrorWithOrigin {
                 );
             }
             Some(ErrorOrigin::Source(source)) => {
-                anchor_lang::solana_program::msg!(
+                solana_msg::msg!(
                     "ProgramError thrown in {}:{}. Error Code: {:?}. Error Number: {}. Error \
                      Message: {}.",
                     source.filename,
@@ -450,7 +459,7 @@ impl ProgramErrorWithOrigin {
             }
             Some(ErrorOrigin::AccountName(account_name)) => {
                 // using sol_log because msg! wrongly interprets 5 inputs as u64
-                anchor_lang::solana_program::log::sol_log(&format!(
+                solana_msg::msg!(&format!(
                     "ProgramError caused by account: {}. Error Code: {:?}. Error Number: {}. \
                      Error Message: {}.",
                     account_name,
@@ -462,14 +471,14 @@ impl ProgramErrorWithOrigin {
         }
         match &self.compared_values {
             Some(ComparedValues::Pubkeys((left, right))) => {
-                anchor_lang::solana_program::msg!("Left:");
+                solana_msg::msg!("Left:");
                 left.log();
-                anchor_lang::solana_program::msg!("Right:");
+                solana_msg::msg!("Right:");
                 right.log();
             }
             Some(ComparedValues::Values((left, right))) => {
-                anchor_lang::solana_program::msg!("Left: {}", left);
-                anchor_lang::solana_program::msg!("Right: {}", right);
+                solana_msg::msg!("Left: {}", left);
+                solana_msg::msg!("Right: {}", right);
             }
             None => (),
         }
@@ -521,13 +530,15 @@ impl AnchorError {
     pub fn log(&self) {
         match &self.error_origin {
             None => {
-                anchor_lang::solana_program::log::sol_log(&format!(
+                solana_msg::msg!(
                     "AnchorError occurred. Error Code: {}. Error Number: {}. Error Message: {}.",
-                    self.error_name, self.error_code_number, self.error_msg
-                ));
+                    self.error_name,
+                    self.error_code_number,
+                    self.error_msg
+                );
             }
             Some(ErrorOrigin::Source(source)) => {
-                anchor_lang::solana_program::msg!(
+                solana_msg::msg!(
                     "AnchorError thrown in {}:{}. Error Code: {}. Error Number: {}. Error \
                      Message: {}.",
                     source.filename,
@@ -538,23 +549,26 @@ impl AnchorError {
                 );
             }
             Some(ErrorOrigin::AccountName(account_name)) => {
-                anchor_lang::solana_program::log::sol_log(&format!(
+                solana_msg::msg!(
                     "AnchorError caused by account: {}. Error Code: {}. Error Number: {}. Error \
                      Message: {}.",
-                    account_name, self.error_name, self.error_code_number, self.error_msg
-                ));
+                    account_name,
+                    self.error_name,
+                    self.error_code_number,
+                    self.error_msg
+                );
             }
         }
         match &self.compared_values {
             Some(ComparedValues::Pubkeys((left, right))) => {
-                anchor_lang::solana_program::msg!("Left:");
+                solana_msg::msg!("Left:");
                 left.log();
-                anchor_lang::solana_program::msg!("Right:");
+                solana_msg::msg!("Right:");
                 right.log();
             }
             Some(ComparedValues::Values((left, right))) => {
-                anchor_lang::solana_program::msg!("Left: {}", left);
-                anchor_lang::solana_program::msg!("Right: {}", right);
+                solana_msg::msg!("Left: {}", left);
+                solana_msg::msg!("Right: {}", right);
             }
             None => (),
         }
@@ -586,14 +600,10 @@ impl PartialEq for AnchorError {
 
 impl Eq for AnchorError {}
 
-impl std::convert::From<Error> for anchor_lang::solana_program::program_error::ProgramError {
-    fn from(e: Error) -> anchor_lang::solana_program::program_error::ProgramError {
+impl std::convert::From<Error> for ProgramError {
+    fn from(e: Error) -> ProgramError {
         match e {
-            Error::AnchorError(error) => {
-                anchor_lang::solana_program::program_error::ProgramError::Custom(
-                    error.error_code_number,
-                )
-            }
+            Error::AnchorError(error) => ProgramError::Custom(error.error_code_number),
             Error::ProgramError(program_error) => program_error.program_error,
         }
     }

--- a/lang/error/src/lib.rs
+++ b/lang/error/src/lib.rs
@@ -1,6 +1,5 @@
 use {
     anchor_attribute_error::error_code,
-    borsh::io::Error as BorshIoError,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
     std::{
@@ -324,8 +323,10 @@ impl From<ProgramError> for Error {
         Self::ProgramError(Box::new(program_error.into()))
     }
 }
-impl From<BorshIoError> for Error {
-    fn from(error: BorshIoError) -> Self {
+
+#[cfg(feature = "borsh")]
+impl From<borsh::io::Error> for Error {
+    fn from(error: borsh::io::Error) -> Self {
         Error::ProgramError(Box::new(ProgramError::from(error).into()))
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -40,7 +40,7 @@ mod bpf_upgradeable_state;
 mod bpf_writer;
 mod common;
 pub mod context;
-pub mod error;
+pub use anchor_lang_error as error;
 #[doc(hidden)]
 pub mod event;
 #[doc(hidden)]


### PR DESCRIPTION
Closes #2764

Now that the monolithic `solana-program` has been split up, the `error` module can cut its dep tree and be split into a new crate. Clean build benchmarks on my machine:

```
# `anchor-lang-error`
> time cargo check 2>/dev/null
cargo check 2> /dev/null  11.98s user 2.23s system 468% cpu 3.033 total
> rm -rf target
# `anchor-lang`
> time cargo check 2>/dev/null
cargo check 2> /dev/null  22.38s user 4.73s system 422% cpu 6.418 total
```

i.e. approximately a 2x speedup when using only the errors module. By threading through a `borsh` feature we could probably reduce that even more but that will be more involved. For now, submitted to evaluate the usefulness.