### PR TITLE
fix(idl): respect active rust toolchain in `anchor idl build`

### DIFF
--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -144,14 +144,14 @@ fn build(
     no_docs: bool,
     cargo_args: &[String],
 ) -> Result<Idl> {
-    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
-        .map(|toolchain| format!("+{toolchain}"))
-        .unwrap_or_else(|_| "+stable".to_string());
+    let mut cmd = Command::new("cargo");
+    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
+        install_toolchain_if_needed(&toolchain)?;
+        cmd.arg("+{toolchain}");
+    }
 
-    install_toolchain_if_needed(&toolchain)?;
-    let output = Command::new("cargo")
+    let output = cmd
         .args([
-            &toolchain,
             "test",
             "__anchor_private_print_idl",
             "--features",


### PR DESCRIPTION
## Summary

anchor idl build was hardcoding a fallback to +stable when RUSTUP_TOOLCHAIN was unset, which overrode the project's active toolchain (rust-toolchain.toml / rustup default). This caused IDL generation to fail when the installed stable was older than the version Anchor/Solana deps require.

Fix: 
- drop the +stable fallback. When RUSTUP_TOOLCHAIN isn't set, omit the +toolchain arg entirely so rustup's normal resolution kicks in.

Behavior:
  - RUSTUP_TOOLCHAIN=1.89.0 anchor idl build → still pins to +1.89.0 (workaround unaffected)
  - anchor idl build → now honors rust-toolchain.toml / rustup default
  
closes #4482 