### PR TITLE
Handle ts-docs and changelog in release CI

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -7,12 +7,17 @@ on:
         description: "Version to bump to without the v[...] prefix (e.g. 1.0.0-rc.5)"
         required: true
         type: string
+      create_ts_docs_pr:
+        description: "Create a PR to publish TS docs for this version"
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
 
 jobs:
-  prepare-release:
+  prepare-release-bump:
     runs-on: ubuntu-latest
 
     steps:
@@ -73,3 +78,69 @@ jobs:
           git add -A
           git commit -m "v$VERSION"
           git push --set-upstream origin "$BRANCH"
+
+  # I would love to automatically push this to the branch, but again, GitHub does not
+  # allow for this.
+  prepare-ts-docs:
+    runs-on: ubuntu-latest
+    needs: prepare-release-bump
+    if: ${{ inputs.create_ts_docs_pr }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Force fetch upstream tags
+        run: git fetch --tags --force
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - name: Generate TS docs
+        run: |
+          set -xeou pipefail
+
+          cd ts/packages/borsh && yarn --frozen-lockfile && yarn build && yarn link --force && cd ../../../
+          cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build && yarn link --force && cd ../../../
+          cd ts/packages/anchor && yarn --frozen-lockfile && yarn build:node && yarn link && cd ../../../
+
+          cd ts/packages/anchor/
+          yarn docs
+
+      - name: Create TS docs PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -xeuo pipefail
+
+          DOCS_DIST="docs/src/.vuepress/dist"
+          DOCS_TMP="$RUNNER_TEMP/ts-docs"
+          BRANCH="ts-docs/$VERSION"
+
+          test -d "$DOCS_DIST"
+          mkdir -p "$DOCS_TMP"
+          cp -a "$DOCS_DIST"/. "$DOCS_TMP"/
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch -c "$BRANCH" origin/gh-pages
+
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp -a "$DOCS_TMP"/. .
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No TS docs changes to publish."
+          else
+            git commit -m "v$VERSION"
+            git push --set-upstream origin "$BRANCH"
+          fi

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -63,13 +63,13 @@ jobs:
 
       # I would love to automatically create a PR here, but GitHub does not allow triggering CI jobs
       # on automatically created PRs to prevent recursion
-      - name: Create release branch
+      - name: Create release bump branch
         env:
           VERSION: ${{ inputs.version }}
         run: |
           set -xeou pipefail
 
-          BRANCH="release/v$VERSION"
+          BRANCH="release-bump/$VERSION"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -30,7 +30,18 @@ jobs:
           set -xeuo pipefail
 
           echo "Publishing crates as a dry-run"
-          cargo release publish --workspace --allow-branch "*" --no-confirm
+          out_file=$(mktemp)
+          if cargo release publish --workspace --allow-branch "*" --no-confirm 2>&1 | tee "$out_file"; then
+            exit 0
+          fi
+          # cargo-release 1.1.1 exits non-zero with "no packages selected" when every
+          # workspace crate is skipped due to a previous publish. Treat that as success.
+          if grep -q "no packages selected" "$out_file" \
+             && grep -q "disabled due to previous publish" "$out_file"; then
+            echo "All crates already published at current versions; nothing to do."
+            exit 0
+          fi
+          exit 1
 
   publish-crates:
     name: Publish crates
@@ -64,7 +75,18 @@ jobs:
           set -xeuo pipefail
 
           echo "Publishing crates"
-          cargo release publish --workspace --allow-branch "*" --no-confirm --execute
+          out_file=$(mktemp)
+          if cargo release publish --workspace --allow-branch "*" --no-confirm --execute 2>&1 | tee "$out_file"; then
+            exit 0
+          fi
+          # cargo-release 1.1.1 exits non-zero with "no packages selected" when every
+          # workspace crate is skipped due to a previous publish. Treat that as success.
+          if grep -q "no packages selected" "$out_file" \
+             && grep -q "disabled due to previous publish" "$out_file"; then
+            echo "All crates already published at current versions; nothing to do."
+            exit 0
+          fi
+          exit 1
 
       - name: Check for crate artifacts
         id: crate-artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,7 +215,20 @@ jobs:
             exit 0
           fi
 
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* --title "$GITHUB_REF_NAME" "${publish_args[@]}"
+          # TODO: if we end up publishing pre-releases as well, we will need to update the parsing below
+          RELEASE_URL=$(echo $GITHUB_REF_NAME | sed 's/\./-/g' | sed 's/^v//')
+          RELEASE_CHANGELOG="$(echo $GITHUB_REF_NAME | sed 's/\.//g' | sed 's/^v//')---$(date '+%Y-%m-%d')"
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create $GITHUB_REF_NAME $DIST/*/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes "$(cat <<EOF
+          The $GITHUB_REF_NAME release is here.
+
+          Check out the release notes from [Anchor website](https://www.anchor-lang.com/docs/updates/release-notes/${RELEASE_URL}) or [GitHub](https://github.com/solana-foundation/anchor/blob/${GITHUB_REF_NAME}/docs/content/docs/updates/release-notes/${RELEASE_URL}.mdx).
+
+          For a list of notable changes with their associated PRs, see the [CHANGELOG](https://github.com/solana-foundation/anchor/blob/${GITHUB_REF_NAME}/CHANGELOG.md#${RELEASE_CHANGELOG}).
+          EOF
+          )" \
+            "${publish_args[@]}"
 
   publish-cli:
     name: Publish CLI onto npmjs

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -68,6 +68,24 @@ if [[ "$is_prerelease" -eq 0 ]]; then
     # Keep release notes and changelog the same
     git restore updates
     popd
+
+    # If the release notes are missing from the website, we should at the minimum create a placeholder linking to the github release notes
+    VERSION_URL=$(echo $version | sed 's/\./-/g')
+    VERSION_CHANGELOG=$(echo $version | sed 's/\.//g')
+    if [[ ! -f "docs/content/docs/updates/release-notes/${VERSION_URL}.mdx" ]]; then
+        cat <<EOF > "docs/content/docs/updates/release-notes/${VERSION_URL}.mdx"
+---
+title: $version
+description: Anchor - Release Notes $version
+---
+
+See the full 
+[CHANGELOG](https://github.com/solana-foundation/anchor/blob/v${version}/CHANGELOG.md#${VERSION_CHANGELOG}---$(date '+%Y-%m-%d')).
+EOF
+
+        # Insert the version into release notes meta, and sort the versions so the order is correct
+        jq --arg v "$VERSION_URL" '.pages |= (. + [$v] | sort_by(split("-") | map(tonumber)))' docs/content/docs/updates/release-notes/meta.json
+    fi
 fi
 
 # Potential for collisions in `package.json` files, handle those separately

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -73,8 +73,8 @@
     "ts-jest-resolver": "^2.0.0",
     "ts-node": "^9.0.0",
     "tslib": "^2.3.1",
-    "typedoc": "^0.22.10",
-    "typescript": "^5.5.4"
+    "typedoc": "^0.25.13",
+    "typescript": "^4.9.4"
   },
   "files": [
     "dist",

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1373,6 +1373,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz#f2cefb8b681aeb72b7cd50aebc00d509eba64d4c"
+  integrity sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1561,10 +1566,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+brace-expansion@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -2519,17 +2524,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 global-dirs@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -3419,10 +3413,10 @@ json5@2.x, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
-  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+jsonc-parser@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -3609,10 +3603,10 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-marked@^4.0.16:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.3.tgz#bd76a5eb510ff1d8421bc6c3b2f0b93488c15bea"
-  integrity sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 meow@^8.0.0:
   version "8.1.2"
@@ -3678,12 +3672,12 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz#6c9dffcf9927ff2a31e74b5af11adf8b9604b022"
-  integrity sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==
+minimatch@^9.0.3:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -4279,14 +4273,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
-  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
+shiki@^0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.7.tgz#c3c9e1853e9737845f1d2ef81b31bcfb07056d4e"
+  integrity sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==
   dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
 
 signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
@@ -4749,16 +4744,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc@^0.22.10:
-  version "0.22.18"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.18.tgz#1d000c33b66b88fd8cdfea14a26113a83b7e6591"
-  integrity sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==
+typedoc@^0.25.13:
+  version "0.25.13"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.13.tgz#9a98819e3b2d155a6d78589b46fa4c03768f0922"
+  integrity sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==
   dependencies:
-    glob "^8.0.3"
     lunr "^2.3.9"
-    marked "^4.0.16"
-    minimatch "^5.1.0"
-    shiki "^0.10.1"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.7"
 
 typescript@*:
   version "4.9.3"
@@ -4770,10 +4764,10 @@ typescript@=4.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
-typescript@^5.5.4:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+typescript@^4.9.4:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 universalify@^0.2.0:
   version "0.2.0"
@@ -4852,15 +4846,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vscode-oniguruma@^1.6.1:
+vscode-oniguruma@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
   integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
 
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Some additional improvements to the CI release process:
- Generate TS docs on their own branch - this still requires someone to remember to create the PR but I think this is a better alternative than allowing CI to do it / committing the changes directly automatically, as automatic actions like these do not trigger CI jobs, including the one that pushes to GitHub Pages.
- Building docs for the anchor TS package does not work with the versions as-is in `package.json` on my machine because the peer-dependency on `typescript` does not match what `typedoc` supports. Keeping `typescript` at `5.x` causes compilation errors due to typescript changes, therefore I've opted to have `typescript` be on 4.9 (and rest of our TS packages use 4.x as well) with upgrading `typedoc` to latest version that supports the 4.9 version of `typescript`.
- Slightly more consistent naming scheme, branches avoid the `v` prefix (to avoid conflicting with the tags), `release/` -> `release-bump/` to emphasize that it's meant to bump the versions only and is not the actual release branch
- `bump-version.sh` aims to create a changelog entry on the website so that the docs will always at least link to the GitHub changelog if we happen to forget to do so. We can probably improve this template a bit (e.g. how to upgrade to latest version), though I think this is a good start to make sure we don't forget this step.
- The GitHub release creation now uses a better default description to reduce one of the steps required part of each release.