### PR TITLE
fix(syn): bind bump byte for init + seeds expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Fallback to a priority fee of 0 on localnet ([#4259](https://github.com/solana-foundation/anchor/pull/4259/)).
 - lang: Support module constants in `max_len` attribute ([#3879](https://github.com/solana-foundation/anchor/pull/3879)).
 - spl: Deprecate broken `cpi_guard_enable/disable` functions ([#4465](https://github.com/solana-foundation/anchor/pull/4465)).
+- lang/syn: Fix compile error with `init` and a runtime seeds expression ([#4495](https://github.com/solana-foundation/anchor/pull/4495)).
 
 ### Breaking
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -591,8 +591,9 @@ fn generate_constraint_init_group(
                         __bumps.#field = #bump_tok;
 
                         // Build signer seeds at runtime = seeds + bump
+                        let __bump_bytes: [u8; 1] = [__bump];
                         let mut __signer_seeds_vec: ::std::vec::Vec<&[u8]> = __seeds_slice.to_vec();
-                        __signer_seeds_vec.push(&[__bump][..]);
+                        __signer_seeds_vec.push(&__bump_bytes[..]);
                         let __signer_seeds = __signer_seeds_vec;
 
                         if #field.key() != __pda_address {

--- a/lang/tests/seeds_compile.rs
+++ b/lang/tests/seeds_compile.rs
@@ -51,6 +51,38 @@ pub struct ExprSeeds<'info> {
     user: Signer<'info>,
 }
 
+#[derive(Accounts)]
+pub struct InitExprSeeds<'info> {
+    // Test init + seeds generated with a runtime slice
+    #[account(
+        init,
+        payer = user,
+        space = 8,
+        seeds = pda_seeds(user.key()),
+        bump
+    )]
+    pda: Account<'info, Dummy>,
+    #[account(mut)]
+    user: Signer<'info>,
+    system_program: Program<'info, System>,
+}
+
+#[cfg(feature = "init-if-needed")]
+#[derive(Accounts)]
+pub struct InitIfNeededExprSeeds<'info> {
+    #[account(
+        init_if_needed,
+        payer = user,
+        space = 8,
+        seeds = pda_seeds(user.key()),
+        bump
+    )]
+    pda: Account<'info, Dummy>,
+    #[account(mut)]
+    user: Signer<'info>,
+    system_program: Program<'info, System>,
+}
+
 /// Dummy account so the structs derive cleanly
 #[account]
 pub struct Dummy {}


### PR DESCRIPTION
Binding this array to a variable instead of a temporary resolves a lifetime issue, allowing this to compile.