### PR TITLE
fix(v2): Anchor 'a on empty CPI accounts structs

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -882,13 +882,43 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 quote! { self.#n }
             })
             .collect();
+        // An empty Accounts struct would otherwise emit `pub struct Foo<'a> {}`,
+        // which fails E0392 because nothing on `Self` references `'a`. Anchor
+        // the lifetime via a `PhantomData<&'a ()>` field — kept hidden — and
+        // expose a no-arg `new()` / `Default` so callers don't need to spell
+        // out the marker. Non-empty structs already bind `'a` through their
+        // `CpiHandle<'a>` fields and skip the extra field entirely.
+        let (extra_field, ctor_impl) = if fields.is_empty() {
+            (
+                quote! {
+                    #[doc(hidden)]
+                    pub _phantom: ::core::marker::PhantomData<&'a ()>,
+                },
+                quote! {
+                    impl<'a> #name<'a> {
+                        #[inline]
+                        pub const fn new() -> Self {
+                            Self { _phantom: ::core::marker::PhantomData }
+                        }
+                    }
+                    impl<'a> ::core::default::Default for #name<'a> {
+                        #[inline]
+                        fn default() -> Self { Self::new() }
+                    }
+                },
+            )
+        } else {
+            (quote! {}, quote! {})
+        };
         quote! {
             pub mod #cpi_mod_name {
                 extern crate alloc;
                 use super::*;
                 pub struct #name<'a> {
                     #(#cpi_field_decls,)*
+                    #extra_field
                 }
+                #ctor_impl
                 impl<'a> anchor_lang_v2::ToCpiAccounts<'a> for #name<'a> {
                     fn to_instruction_accounts(
                         &self,

--- a/tests-v2/programs/callee/src/lib.rs
+++ b/tests-v2/programs/callee/src/lib.rs
@@ -25,6 +25,13 @@ pub mod callee {
         Ok(())
     }
 
+    /// Zero-account handler — drives the empty-fields branch of the cpi
+    /// accounts codegen, where `'a` has no `CpiHandle` field to anchor it
+    /// and would otherwise fail E0392.
+    pub fn empty(_ctx: &mut Context<Empty>) -> Result<()> {
+        Ok(())
+    }
+
     /// Drives all four `InstructionAccount::{writable_signer, writable,
     /// readonly_signer, readonly}` ctor branches of the auto-generated
     /// `ToCpiAccounts` impl.
@@ -62,6 +69,11 @@ pub struct SetData {
     #[account(address = data.authority)]
     pub authority: Signer,
 }
+
+/// Empty Accounts struct — exercises the `'a`-anchoring `PhantomData`
+/// fallback in the auto-generated `__cpi_accounts_empty` module.
+#[derive(Accounts)]
+pub struct Empty {}
 
 /// Mixes one of each writable/signer combination so the cpi-accounts
 /// codegen has to emit each `InstructionAccount` ctor variant.

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -33,7 +33,8 @@ pub mod caller {
             data: ctx.accounts.callee_data.cpi_handle_mut(),
             authority: ctx.accounts.authority.cpi_handle(),
         };
-        let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
+        let cpi_ctx =
+            CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
         callee::cpi::set_data(cpi_ctx, value)?;
         Ok(())
     }
@@ -45,8 +46,22 @@ pub mod caller {
             data: ctx.accounts.callee_data.cpi_handle_mut(),
             authority: ctx.accounts.authority.cpi_handle(),
         };
-        let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
+        let cpi_ctx =
+            CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
         callee::cpi::noop(cpi_ctx)?;
+        Ok(())
+    }
+
+    /// CPIs into the zero-account `empty` handler. Constructs the
+    /// auto-generated `cpi::accounts::Empty` via its `new()` ctor — the
+    /// only viable route since the lifetime-anchoring `_phantom` field
+    /// is hidden.
+    pub fn proxy_empty(ctx: &mut Context<ProxyEmpty>) -> Result<()> {
+        let cpi_ctx = CpiContext::new(
+            ctx.accounts.callee_program.address(),
+            callee::cpi::accounts::Empty::new(),
+        );
+        callee::cpi::empty(cpi_ctx)?;
         Ok(())
     }
 
@@ -60,7 +75,8 @@ pub mod caller {
             authority: ctx.accounts.authority.cpi_handle(),
             spectator: ctx.accounts.spectator.cpi_handle(),
         };
-        let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
+        let cpi_ctx =
+            CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
         callee::cpi::touch(cpi_ctx, delta)?;
         Ok(())
     }
@@ -74,6 +90,11 @@ pub struct ProxySetData {
     #[account(mut)]
     pub callee_data: Account<CalleeData>,
     pub authority: Signer,
+    pub callee_program: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct ProxyEmpty {
     pub callee_program: UncheckedAccount,
 }
 

--- a/tests-v2/tests/cpi.rs
+++ b/tests-v2/tests/cpi.rs
@@ -70,6 +70,28 @@ fn init_data_account(
     data_pda
 }
 
+/// Regression: an Accounts struct with zero fields used to fail E0392
+/// in the auto-generated CPI module ("lifetime parameter `'a` is never
+/// used"). The `_phantom: PhantomData<&'a ()>` field anchors `'a` on
+/// `Self`; this test confirms the resulting `cpi::accounts::Empty::new()`
+/// constructor flows through a real CPI call.
+#[test]
+fn test_cpi_empty_accounts() {
+    let (mut svm, payer) = setup();
+
+    let proxy_empty = caller::instruction::ProxyEmpty {}.data();
+    let proxy_metas = vec![AccountMeta::new_readonly(callee_id(), false)];
+    send_instruction(
+        &mut svm,
+        caller_id(),
+        proxy_empty,
+        proxy_metas,
+        &payer,
+        &[],
+    )
+    .expect("caller::proxy_empty should succeed");
+}
+
 #[test]
 fn test_direct_set_data() {
     let (mut svm, payer) = setup();


### PR DESCRIPTION
Empty instruction accounts would produce an error while generating equivalent CPI structs due to the lack of lifetime fields, add PhantomData to fix this
