### PR TITLE
fix(avm): handle missing rate limit reset header

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -668,22 +668,33 @@ fn fetch_versions_with_client(
             .collect();
         Ok(versions)
     } else {
-        let reset_time = github_rate_limit_reset_time(response.headers());
-        Err(anyhow!(
-            "GitHub API rate limit exceeded. Try again after {} UTC.",
-            reset_time
-        ))
+        Err(
+            if let Some(reset_time) = github_rate_limit_reset_time(response.headers()) {
+                anyhow!(
+                    "GitHub API rate limit exceeded. Try again after {} UTC.",
+                    reset_time
+                )
+            } else {
+                anyhow!("GitHub API rate limit exceeded. Try again later.",)
+            },
+        )
     }
 }
 
-fn github_rate_limit_reset_time(headers: &reqwest::header::HeaderMap) -> String {
-    headers
-        .get("X-RateLimit-Reset")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<i64>().ok())
-        .and_then(|timestamp| Utc.timestamp_opt(timestamp, 0).single())
-        .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+fn github_rate_limit_reset_time(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let timestamp = headers
+        .get("X-RateLimit-Reset")?
+        .to_str()
+        .ok()?
+        .parse::<i64>()
+        .ok()?;
+
+    Some(
+        Utc.timestamp_opt(timestamp, 0)
+            .single()?
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string(),
+    )
 }
 
 /// Print available versions and flags indicating installed, current and latest
@@ -980,25 +991,22 @@ mod tests {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert("X-RateLimit-Reset", "1715706000".parse().unwrap());
         assert_eq!(
-            github_rate_limit_reset_time(&headers),
-            "2024-05-14 17:00:00"
+            github_rate_limit_reset_time(&headers).as_deref(),
+            Some("2024-05-14 17:00:00")
         );
 
-        assert_eq!(
-            github_rate_limit_reset_time(&reqwest::header::HeaderMap::new()),
-            "unknown"
-        );
+        assert!(github_rate_limit_reset_time(&reqwest::header::HeaderMap::new()).is_none());
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert("X-RateLimit-Reset", "unknown".parse().unwrap());
-        assert_eq!(github_rate_limit_reset_time(&headers), "unknown");
+        assert!(github_rate_limit_reset_time(&headers).is_none());
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             "X-RateLimit-Reset",
             reqwest::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
-        assert_eq!(github_rate_limit_reset_time(&headers), "unknown");
+        assert!(github_rate_limit_reset_time(&headers).is_none());
     }
 
     #[test]

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -668,20 +668,22 @@ fn fetch_versions_with_client(
             .collect();
         Ok(versions)
     } else {
-        let reset_time_header = response
-            .headers()
-            .get("X-RateLimit-Reset")
-            .map_or("unknown", |v| v.to_str().unwrap());
-        let t = Utc.timestamp_opt(reset_time_header.parse::<i64>().unwrap(), 0);
-        let reset_time = t
-            .single()
-            .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
-            .unwrap_or_else(|| "unknown".to_string());
+        let reset_time = github_rate_limit_reset_time(response.headers());
         Err(anyhow!(
             "GitHub API rate limit exceeded. Try again after {} UTC.",
             reset_time
         ))
     }
+}
+
+fn github_rate_limit_reset_time(headers: &reqwest::header::HeaderMap) -> String {
+    headers
+        .get("X-RateLimit-Reset")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<i64>().ok())
+        .and_then(|timestamp| Utc.timestamp_opt(timestamp, 0).single())
+        .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Print available versions and flags indicating installed, current and latest
@@ -971,6 +973,32 @@ mod tests {
         // Should ignore this file because it's not anchor- prefixed
         fs::File::create(AVM_HOME.join("bin").join("garbage").as_path()).unwrap();
         assert_eq!(read_installed_versions().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_github_rate_limit_reset_time() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("X-RateLimit-Reset", "1715706000".parse().unwrap());
+        assert_eq!(
+            github_rate_limit_reset_time(&headers),
+            "2024-05-14 17:00:00"
+        );
+
+        assert_eq!(
+            github_rate_limit_reset_time(&reqwest::header::HeaderMap::new()),
+            "unknown"
+        );
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("X-RateLimit-Reset", "unknown".parse().unwrap());
+        assert_eq!(github_rate_limit_reset_time(&headers), "unknown");
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "X-RateLimit-Reset",
+            reqwest::header::HeaderValue::from_bytes(b"\xff").unwrap(),
+        );
+        assert_eq!(github_rate_limit_reset_time(&headers), "unknown");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Avoid panicking while formatting GitHub API rate limit errors in AVM. The reset header is now parsed defensively, so missing, invalid, or non-UTF-8 `X-RateLimit-Reset` values fall back to `unknown` while preserving the existing error message.

## Branch Target

This does not contain breaking changes and should target `master`.