### PR TITLE
client: avoid unwrap in log parser when regex doesn't match

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -837,13 +837,10 @@ fn parse_logs_response<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
                     // the next program ID, or else `execution.program()` will cause
                     // a panic during the next iteration.
                     if let Some(&next_log) = logs_iter.peek() {
-                        if next_log.ends_with("invoke [1]") {
-                            let next_instruction =
-                                regex.captures(next_log).unwrap().get(1).unwrap().as_str();
-                            // Within this if block, there will always be a regex match.
-                            // Therefore it's safe to unwrap and the captured program ID
-                            // at index 1 can also be safely unwrapped.
-                            execution.push(next_instruction.to_string());
+                        if let Some(caps) = regex.captures(next_log) {
+                            if let Some(next_instruction) = caps.get(1) {
+                                execution.push(next_instruction.as_str().to_string());
+                            }
                         }
                     };
                 }


### PR DESCRIPTION
Closes #4461. Lines ending in `"invoke [1]"` may not match the `Program ... invoke [N]` regex (program ID with non-base58 chars), and `unwrap()` panics anchor_client event listeners.