### PR TITLE
fix(lang/syn): Use first type alias when encountering duplicates

### DIFF
--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -528,10 +528,12 @@ pub fn gen_idl_type(
                                 .map(|s| s.ident.to_string())
                                 .chain(ctx.enums().map(|e| e.ident.to_string()))
                                 .collect();
-                            let type_aliases: HashMap<String, String> = ctx
-                                .type_aliases()
-                                .map(|ty| (ty.ident.to_string(), ty.to_token_stream().to_string()))
-                                .collect();
+                            let mut type_aliases: HashMap<String, String> = HashMap::new();
+                            for ty in ctx.type_aliases() {
+                                type_aliases
+                                    .entry(ty.ident.to_string())
+                                    .or_insert_with(|| ty.to_token_stream().to_string());
+                            }
                             CachedCrateData {
                                 defined_names,
                                 type_aliases,


### PR DESCRIPTION
#4325 introduced a slight behaviour change; when there are multiple duplicate type aliases, the hashmap collect will result in the last one being used, whereas previously the first one was used. This restores the original behaviour.