### PR TITLE
fix(cli): Deny `program-keypair` when deploying multiple programs

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -217,6 +217,12 @@ pub fn process_deploy(
                  deploy a specific program."
             ));
         }
+        if program_keypair.is_some() {
+            return Err(anyhow!(
+                "Cannot specify --program-keypair when deploying multiple programs. Use \
+                 --program-name to deploy a specific program."
+            ));
+        }
 
         // Delegate to deploy_workspace
         return deploy_workspace(


### PR DESCRIPTION
When using `anchor program deploy` to deploy a workspace, users may specify a `program-keypair`. As programs are deployed in a loop, this uses the same keypair for all programs, resulting in all but the last program being overwritten.
