### PR TITLE
fix(docs): add space to distinguish between two headers

### DIFF
--- a/docs/content/docs/features/zero-copy.mdx
+++ b/docs/content/docs/features/zero-copy.mdx
@@ -43,6 +43,7 @@ Zero-copy (`AccountLoader<T>`) instead:
 - Arrays with many elements (orderbooks, event queues)
 - High-frequency operations
 - Compute-sensitive programs
+
  **Use regular Account\<T\> for:**
 - Small accounts (< 1KB)
 - Dynamic data structures (Vec, String, HashMap)


### PR DESCRIPTION
## Summary

Currently there is no visual separation between the two section headers (`Use zero-copy for:` and `Use regular Account<T> for:`) because the second header is rendered as a bullet point. This PR fixes that.

<img width="514" height="386" alt="Screenshot 2026-05-06 at 15 43 01" src="https://github.com/user-attachments/assets/9bd74235-a821-491d-9a79-b2366a79644d" />

## Branch Target

Just doc changes. So safe to target main.
