### PR TITLE
V2: Remove `idl-build` from Anchor crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,6 @@ dependencies = [
  "bytemuck",
  "pinocchio",
  "pinocchio-system",
- "serde_json",
  "sha2 0.10.9",
  "solana-address 2.6.0",
  "solana-define-syscall 5.0.0",

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,19 @@ coverage-v2-host:
 	# Second pass: the other v2 crates under default features.
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report -p anchor-spl-v2 -p tests-v2
-	# Third pass: lang-v2 + spl-v2 with --features idl-build so the
-	# IDL-emission branches in derive/src/idl.rs and the program-level IDL
-	# assembler run. `--no-report` accumulates profile data across passes;
-	# the merged report is assembled by the final `llvm-cov report` below.
+	# Third pass: the test programs that declare a local `idl-build` feature,
+	# run with `--features idl-build` so the IDL-emission code paths fire —
+	# derive-emitted `IdlAccountType` impls, `__idl_accounts()` /
+	# `__idl_register_deps()` / `__idl_errors()` fns, and the
+	# `__anchor_private_print_idl_*` test bodies. After the IDL redesign the
+	# `idl-build` feature lives only in end-user crates; lang-v2 and spl-v2
+	# ship the supporting trait + helpers unconditionally and have no
+	# feature of their own. `--no-report` accumulates profile data across
+	# passes; the merged report is assembled by the final `llvm-cov report`
+	# below.
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report --features idl-build \
-		-p anchor-lang-v2 -p anchor-spl-v2
+		-p constraints -p derives-test -p accounts-test -p spl-test
 	cargo llvm-cov report \
 		--lcov \
 		--output-path $(COVERAGE_DIR)/host.lcov \
@@ -142,8 +148,9 @@ coverage-v2-merge: $(COVERAGE_DIR)/sbf.lcov $(COVERAGE_DIR)/host.lcov
 		--ignore-errors unused \
 		--ignore-errors empty
 	# Self-merge to collapse duplicate `SF:` blocks. Host coverage runs
-	# three `cargo llvm-cov --no-report` passes (default features, + spl
-	# + tests-v2, + idl-build), plus the SBF pass. Ubuntu's lcov 1.x
+	# three `cargo llvm-cov --no-report` passes (lang-v2 testing, spl-v2 +
+	# tests-v2 default, test programs + idl-build), plus the SBF pass.
+	# Ubuntu's lcov 1.x
 	# concatenates records from each pass rather than merging them,
 	# yielding 4x duplicate `SF:` entries per file in the combined
 	# output. lcov 2.x merges on read, so this step is a no-op locally

--- a/bench/programs/helloworld/anchor-v2/Cargo.toml
+++ b/bench/programs/helloworld/anchor-v2/Cargo.toml
@@ -15,7 +15,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint", "dep:borsh"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 profile = ["anchor-v2-testing/profile"]
 
 [dependencies]

--- a/bench/programs/multisig/anchor-v2/Cargo.toml
+++ b/bench/programs/multisig/anchor-v2/Cargo.toml
@@ -15,7 +15,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint", "dep:borsh"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 profile = ["anchor-v2-testing/profile"]
 
 [dependencies]

--- a/bench/programs/nested/anchor-v2/Cargo.toml
+++ b/bench/programs/nested/anchor-v2/Cargo.toml
@@ -15,7 +15,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint", "dep:borsh"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 profile = ["anchor-v2-testing/profile"]
 
 [dependencies]

--- a/bench/programs/prop-amm/anchor-v2/Cargo.toml
+++ b/bench/programs/prop-amm/anchor-v2/Cargo.toml
@@ -15,7 +15,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint", "dep:borsh"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 # Switch tests to `anchor_v2_testing::svm()` so the SBF register-trace
 # callback fires. `anchor debugger` (loose mode) auto-detects this
 # feature and passes `--features profile` to cargo test.

--- a/bench/programs/vault/anchor-v2/Cargo.toml
+++ b/bench/programs/vault/anchor-v2/Cargo.toml
@@ -15,7 +15,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint", "dep:borsh"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 profile = ["anchor-v2-testing/profile"]
 
 [dependencies]

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -283,7 +283,7 @@ default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 {2}
 
 [dependencies]

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [features]
 default = ["alloc", "guardrails", "account-resize"]
 alloc = ["pinocchio/alloc"]
-idl-build = ["dep:serde_json"]
 # Opt-in v1-compat shims for users porting anchor-lang code. Currently
 # exposes `debug!` — a `msg!`-shaped macro that accepts any Rust format
 # string (`{:?}`, `{:x}`, dynamic width, …) via `alloc::format!`. Default-off
@@ -61,10 +60,6 @@ solana-program-log = { version = "1.1", features = ["macro"], optional = true }
 borsh = "1.5.7"
 bytemuck = { version = "1", features = ["derive"] }
 wincode = { version = "0.5", features = ["derive"] }
-# Only pulled in under `idl-build`; the program-level IDL assembler uses it
-# to structurally split type defs into `accounts[]` + `types[]` entries
-# instead of doing byte-level surgery. Not shipped in production BPF binaries.
-serde_json = { version = "1", optional = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = "5.0"
@@ -74,7 +69,16 @@ sha2 = "0.10"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(target_os, values("solana"))']
+# `feature = "idl-build"` is emitted by the derive macros in code that
+# expands inside the *user crate*, where it's a real local feature. It
+# never resolves against lang-v2's own features (lang-v2 has none by
+# this name on purpose — IDL infrastructure is unconditional). Register
+# it here so rustc doesn't warn when compiling lang-v2's integration
+# tests, which apply those derives in a crate without the feature.
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("idl-build"))',
+]
 
 # Integration tests that exercise `unsafe` paths via the `testing`
 # scaffold. Gated behind the `testing` feature so the mock types never

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -332,6 +332,10 @@ pub fn build_accounts_emission(fields: &[AccountsJsonField<'_>]) -> TokenStream2
         .collect();
 
     quote! {
+        /// **Opaque / unstable.** Returns the IDL JSON for this Accounts
+        /// struct's account list. Implementation detail of the IDL build
+        /// pipeline; do not rely on the shape or call this directly.
+        #[doc(hidden)]
         pub fn __idl_accounts() -> anchor_lang_v2::__alloc::string::String {
             let __parts: anchor_lang_v2::__alloc::vec::Vec<
                 anchor_lang_v2::__alloc::string::String

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -395,31 +395,50 @@ pub enum TypeKind {
     BytemuckRepr,
 }
 
-/// Build IDL type definition JSON from struct fields. `docs` is the list of
-/// `#[doc = "..."]` lines scraped from the struct-level attrs; each named
-/// field also contributes its own `docs` array from its own attrs.
+/// Pre-split IDL type strings emitted by the derive at macro-expansion time.
+///
+/// The runtime print test no longer parses JSON — it concatenates these
+/// strings directly. Eliminating runtime `serde_json` is what lets the
+/// `idl-build` feature/cfg disappear from `lang-v2` entirely.
+pub struct IdlTypeStrings {
+    /// `{"name":"X","discriminator":[…]}` for the program-level
+    /// `accounts[]` array (spec:137-140). `None` when the discriminator
+    /// is empty — i.e. plain `#[derive(IdlType)]` types that only
+    /// contribute to `types[]`.
+    pub account_entry: Option<String>,
+    /// `IdlTypeDef` JSON (spec:176-188) — `name`, optional `docs`, the
+    /// `serialization` / `repr` pair, and the inner `type` object. Never
+    /// carries `discriminator`; that field belongs only on the
+    /// accounts entry.
+    pub type_def: String,
+}
+
+/// Build pre-split IDL type strings from struct fields.
 ///
 /// `kind` selects the `serialization` / `repr` metadata emitted onto the
 /// type definition. Zero-copy `#[account]` / default `#[event]` pass
 /// `TypeKind::BytemuckRepr`; their borsh-mode counterparts pass
 /// `TypeKind::Borsh` (the default, which suppresses both fields).
-pub fn build_type_json(
+pub fn build_type_strings(
     name: &str,
     disc: &[u8],
     docs: &[String],
     fields: &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>,
     kind: TypeKind,
-) -> String {
-    let mut out = build_type_header(name, disc, docs, kind);
+) -> IdlTypeStrings {
+    let mut type_def_obj = build_type_def_header(name, docs, kind);
     let field_values: Vec<Value> = fields.iter().map(named_field_value).collect();
-    out.insert(
+    type_def_obj.insert(
         "type".into(),
         json!({ "kind": "struct", "fields": field_values }),
     );
-    Value::Object(out).to_string()
+    IdlTypeStrings {
+        account_entry: build_account_entry(name, disc),
+        type_def: Value::Object(type_def_obj).to_string(),
+    }
 }
 
-/// Build IDL type definition JSON from enum variants. Matches the spec's
+/// Build pre-split IDL type strings from enum variants. Matches the spec's
 /// `IdlTypeDefTy::Enum { variants }` shape (idl/spec/src/lib.rs:237-248).
 /// Each variant is emitted as `{"name": ..., "fields"?: ...}` where `fields`
 /// is either a named-field object array (struct-like variants), a tuple of
@@ -428,15 +447,15 @@ pub fn build_type_json(
 ///
 /// Only `TypeKind::Borsh` is really meaningful for enums today — bytemuck
 /// enums are rare. We accept the same `kind` parameter for shape symmetry
-/// with `build_type_json`.
-pub fn build_enum_type_json(
+/// with `build_type_strings`.
+pub fn build_enum_type_strings(
     name: &str,
     disc: &[u8],
     docs: &[String],
     variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
     kind: TypeKind,
-) -> String {
-    let mut out = build_type_header(name, disc, docs, kind);
+) -> IdlTypeStrings {
+    let mut type_def_obj = build_type_def_header(name, docs, kind);
     let variant_values: Vec<Value> = variants
         .iter()
         .map(|v| {
@@ -460,26 +479,44 @@ pub fn build_enum_type_json(
             Value::Object(obj)
         })
         .collect();
-    out.insert(
+    type_def_obj.insert(
         "type".into(),
         json!({ "kind": "enum", "variants": variant_values }),
     );
-    Value::Object(out).to_string()
+    IdlTypeStrings {
+        account_entry: build_account_entry(name, disc),
+        type_def: Value::Object(type_def_obj).to_string(),
+    }
 }
 
-/// Shared header construction for struct and enum type definitions. Emits
-/// `name`, `discriminator`, optional `docs`, and the `serialization` / `repr`
-/// pair derived from `kind`. The caller appends the `type` object matching
-/// `IdlTypeDefTy::{Struct, Enum, Type}`.
-fn build_type_header(
+/// Compose the program-level `accounts[]` entry. Returns `None` when the
+/// discriminator is empty (plain `IdlType` types that don't appear in
+/// `accounts[]`).
+fn build_account_entry(name: &str, disc: &[u8]) -> Option<String> {
+    if disc.is_empty() {
+        return None;
+    }
+    Some(
+        json!({
+            "name": name,
+            "discriminator": disc_json_value(disc),
+        })
+        .to_string(),
+    )
+}
+
+/// Shared header construction for the `IdlTypeDef` payload. Emits
+/// `name`, optional `docs`, and the `serialization` / `repr` pair derived
+/// from `kind`. The caller appends the `type` object matching
+/// `IdlTypeDefTy::{Struct, Enum, Type}`. Notably *no* `discriminator` —
+/// that field only belongs on the accounts entry.
+fn build_type_def_header(
     name: &str,
-    disc: &[u8],
     docs: &[String],
     kind: TypeKind,
 ) -> serde_json::Map<String, Value> {
     let mut out = serde_json::Map::new();
     out.insert("name".into(), Value::String(name.to_owned()));
-    out.insert("discriminator".into(), disc_json_value(disc));
     if !docs.is_empty() {
         out.insert("docs".into(), docs_value(docs));
     }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1015,12 +1015,18 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
             /// Walks each account field's `IdlAccountType::__register_idl_deps`
             /// so nested user-defined types (plain `#[derive(IdlType)]`
             /// structs, `#[account]` data types, `#[event]` payload types,
-            /// etc.) transitively register into the IDL's `types[]` array.
+            /// etc.) transitively register into the IDL's program-level
+            /// `accounts[]` and `types[]` arrays. The walker pushes
+            /// `__IDL_ACCOUNT_ENTRY` and `__IDL_TYPE_DEF` strings into the
+            /// caller-provided buffers; the program-level print test joins
+            /// each with commas to assemble the final IDL JSON without
+            /// invoking a JSON parser at runtime.
             pub fn __idl_register_deps(
+                accounts: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
             ) {
                 #(
-                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(types);
+                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
                 )*
             }
         }
@@ -1066,10 +1072,10 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         idl::TypeKind::BytemuckRepr
     };
-    let idl_type_json = if let Fields::Named(named) = fields {
-        idl::build_type_json(&name_str, disc_bytes, &struct_docs, &named.named, type_kind)
+    let idl_type_strings = if let Fields::Named(named) = fields {
+        idl::build_type_strings(&name_str, disc_bytes, &struct_docs, &named.named, type_kind)
     } else {
-        idl::build_type_json(
+        idl::build_type_strings(
             &name_str,
             disc_bytes,
             &struct_docs,
@@ -1077,6 +1083,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
             type_kind,
         )
     };
+    let idl_account_entry = match idl_type_strings.account_entry {
+        Some(s) => quote! { Some(#s) },
+        None => quote! { None },
+    };
+    let idl_type_def = idl_type_strings.type_def;
 
     // Named-field types for the transitive IDL dep walk. `__register_idl_deps`
     // fans out through each field type so nested user structs land in the
@@ -1223,15 +1234,20 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
         #account_deserialize_impl
         #[cfg(feature = "idl-build")]
         impl anchor_lang_v2::IdlAccountType for #name {
-            const __IDL_TYPE: Option<&'static str> = Some(#idl_type_json);
+            const __IDL_ACCOUNT_ENTRY: Option<&'static str> = #idl_account_entry;
+            const __IDL_TYPE_DEF: Option<&'static str> = Some(#idl_type_def);
             fn __register_idl_deps(
+                accounts: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
             ) {
-                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE {
+                if let Some(a) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_ACCOUNT_ENTRY {
+                    accounts.push(a);
+                }
+                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE_DEF {
                     types.push(t);
                 }
                 #(
-                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(types);
+                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
                 )*
             }
         }
@@ -1300,10 +1316,10 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     // `IdlType` is layout-agnostic — users opt into Pod separately via
     // their own `bytemuck::Pod` derive if they need zero-copy. Forcing a
     // `"bytemuck"` tag here would lie in the IDL for non-Pod types.
-    let (idl_type_json, field_tys) = match &input.data {
+    let (idl_type_strings, field_tys) = match &input.data {
         Data::Struct(data) => {
-            let idl_json = match &data.fields {
-                Fields::Named(named) => idl::build_type_json(
+            let strings = match &data.fields {
+                Fields::Named(named) => idl::build_type_strings(
                     &name_str,
                     &empty_disc,
                     &docs,
@@ -1316,7 +1332,7 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
                 // variants get `IdlDefinedFields::Tuple` — so tuple structs
                 // fall through to struct-with-empty-fields. Users needing
                 // tuple shapes should prefer named fields.
-                _ => idl::build_type_json(
+                _ => idl::build_type_strings(
                     &name_str,
                     &empty_disc,
                     &docs,
@@ -1332,10 +1348,10 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
                 Fields::Unnamed(unnamed) => unnamed.unnamed.iter().map(|f| &f.ty).collect(),
                 Fields::Unit => Vec::new(),
             };
-            (idl_json, field_tys)
+            (strings, field_tys)
         }
         Data::Enum(data) => {
-            let idl_json = idl::build_enum_type_json(
+            let strings = idl::build_enum_type_strings(
                 &name_str,
                 &empty_disc,
                 &docs,
@@ -1354,7 +1370,7 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
                     Fields::Unit => Vec::new(),
                 })
                 .collect();
-            (idl_json, field_tys)
+            (strings, field_tys)
         }
         Data::Union(_) => {
             return syn::Error::new(
@@ -1365,6 +1381,11 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             .into();
         }
     };
+    // Plain `IdlType` types never carry a discriminator and never appear in
+    // `accounts[]`; only `__IDL_TYPE_DEF` is `Some`. The builder enforces
+    // this via the empty-disc → `account_entry: None` rule.
+    debug_assert!(idl_type_strings.account_entry.is_none());
+    let idl_type_def = idl_type_strings.type_def;
 
     // Thread any generic / lifetime params from the input type through
     // the impl so `#[derive(IdlType)] struct Foo<'a>` lowers to
@@ -1376,15 +1397,19 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #[cfg(feature = "idl-build")]
         impl #impl_generics anchor_lang_v2::IdlAccountType for #name #ty_generics #where_clause {
-            const __IDL_TYPE: Option<&'static str> = Some(#idl_type_json);
+            const __IDL_TYPE_DEF: Option<&'static str> = Some(#idl_type_def);
             fn __register_idl_deps(
+                accounts: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
             ) {
-                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE {
+                // `IdlType` plain types never push to `accounts[]` —
+                // `__IDL_ACCOUNT_ENTRY` defaults to `None`. We only
+                // contribute to `types[]` and recurse for transitive deps.
+                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE_DEF {
                     types.push(t);
                 }
                 #(
-                    <#field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(types);
+                    <#field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
                 )*
             }
         }
@@ -2142,77 +2167,45 @@ fn impl_program(module: &ItemMod) -> TokenStream2 {
                     ),*
                 ];
 
-                // Collect types from all accounts structs via the transitive
-                // dep walker. `__register_idl_deps` on each field type pushes
-                // the field's `__IDL_TYPE` (if any) and recursively walks its
-                // own fields — so a plain `#[derive(IdlType)] struct Inner`
-                // embedded in an `#[account]` data type lands in `types[]`
-                // too. View wrappers (Signer, Program<T>, Sysvar<T>, …) use
-                // the trait's default no-op `__register_idl_deps`, so they
-                // contribute nothing.
+                // Collect accounts + types from every Accounts struct field
+                // via the transitive dep walker, plus from every handler's
+                // ix arg types. `__register_idl_deps` pushes pre-split
+                // strings — `__IDL_ACCOUNT_ENTRY` into the accounts buffer,
+                // `__IDL_TYPE_DEF` into the types buffer — so the print
+                // test just dedupes + joins. No runtime JSON parsing.
                 //
-                // Also walk every handler's **ix arg types** — a user
-                // struct referenced only as a `#[program]` fn argument
-                // (e.g. `args: MixedArgs<'_>`) otherwise lands in
+                // View wrappers (Signer, Program<T>, Sysvar<T>, …) use
+                // the trait's default no-op `__register_idl_deps`, so they
+                // contribute nothing. Primitive / collection / `&T`
+                // blanket impls are no-op forwarders (`idl_build.rs`),
+                // so only user-derived `#[account]` / `#[event]` /
+                // `IdlType` structs contribute.
+                //
+                // Walking ix arg types matters because a user struct
+                // referenced only as a `#[program]` fn argument (e.g.
+                // `args: MixedArgs<'_>`) otherwise lands in
                 // `instructions[].args` as a bare `{defined:{name:...}}`
-                // reference with no matching `types[]` entry. Primitive /
-                // collection / `&T` blanket impls are no-op forwarders
-                // (`idl_build.rs`), so only user-derived `IdlType` structs
-                // contribute.
-                let mut all_types: Vec<&str> = Vec::new();
-                #(#idl_accounts_types::__idl_register_deps(&mut all_types);)*
+                // reference with no matching `types[]` entry.
+                let mut accounts_entries: Vec<&'static str> = Vec::new();
+                let mut types_entries: Vec<&'static str> = Vec::new();
+                #(
+                    #idl_accounts_types::__idl_register_deps(
+                        &mut accounts_entries,
+                        &mut types_entries,
+                    );
+                )*
                 #(
                     #(
-                        <#ix_arg_types_per_handler as anchor_lang_v2::IdlAccountType>::__register_idl_deps(&mut all_types);
+                        <#ix_arg_types_per_handler as anchor_lang_v2::IdlAccountType>::__register_idl_deps(
+                            &mut accounts_entries,
+                            &mut types_entries,
+                        );
                     )*
                 )*
-                all_types.sort();
-                all_types.dedup();
-
-                // Split each __IDL_TYPE into an `IdlAccount`
-                // (name + discriminator, spec:137-140) and an
-                // `IdlTypeDef` (everything else, spec:176-188). Each
-                // input string is a full type def:
-                //
-                //   {"name":"X","discriminator":[...][,"docs":[...]]
-                //    [,"serialization":"...","repr":{...}],
-                //    "type":{"kind":"struct","fields":[...]}}
-                //
-                // We parse each one as structured JSON, pluck off
-                // `name` + `discriminator` for the accounts entry, drop
-                // `discriminator` for the types entry, and skip
-                // `IdlType`-registered plain types (empty discriminator)
-                // from `accounts[]` entirely.
-                let mut accounts_entries = Vec::new();
-                let mut types_entries = Vec::new();
-                for ty in &all_types {
-                    let Ok(mut parsed) =
-                        anchor_lang_v2::__serde_json::from_str::<
-                            anchor_lang_v2::__serde_json::Value,
-                        >(ty)
-                    else {
-                        continue;
-                    };
-                    let Some(obj) = parsed.as_object_mut() else { continue; };
-                    let Some(name) = obj.get("name").cloned() else { continue; };
-                    let disc = obj.remove("discriminator");
-                    let disc_is_empty = matches!(
-                        &disc,
-                        Some(anchor_lang_v2::__serde_json::Value::Array(a)) if a.is_empty()
-                    );
-                    if let Some(disc_v) = disc {
-                        if !disc_is_empty {
-                            let acct = anchor_lang_v2::__serde_json::json!({
-                                "name": name,
-                                "discriminator": disc_v,
-                            });
-                            accounts_entries.push(acct.to_string());
-                        }
-                    }
-                    // `parsed` is now `{name, docs?, serialization?, repr?, type}` —
-                    // exactly the `IdlTypeDef` shape (spec:176-188).
-                    types_entries.push(parsed.to_string());
-                }
+                accounts_entries.sort();
+                accounts_entries.dedup();
+                types_entries.sort();
+                types_entries.dedup();
 
                 let crate_name = env!("CARGO_CRATE_NAME").replace('-', "_");
                 // Pull `description` / `repository` from the program crate's
@@ -2347,10 +2340,10 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
         EventMode::Bytemuck => idl::TypeKind::BytemuckRepr,
     };
     let struct_docs = idl::extract_doc_lines(attrs);
-    let type_def_json = if let Fields::Named(named) = fields {
-        idl::build_type_json(&name_str, disc_bytes, &struct_docs, &named.named, type_kind)
+    let event_type_strings = if let Fields::Named(named) = fields {
+        idl::build_type_strings(&name_str, disc_bytes, &struct_docs, &named.named, type_kind)
     } else {
-        idl::build_type_json(
+        idl::build_type_strings(
             &name_str,
             disc_bytes,
             &struct_docs,
@@ -2358,6 +2351,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
             type_kind,
         )
     };
+    let event_type_def = event_type_strings.type_def;
     let event_disc_json = idl::disc_json(disc_bytes);
     let event_header_json = format!(
         "{{\"event\":{{\"name\":\"{}\",\"discriminator\":{}}},\"types\":[",
@@ -2386,9 +2380,20 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(all(test, feature = "idl-build"))]
         #[test]
         fn #idl_fn_name() {
+            // Events don't appear in the program-level `accounts[]` array
+            // (the event's own discriminator lives in `event_header_json`
+            // below), so the accounts buffer here is a sink that's never
+            // serialized — we still pass it because `__register_idl_deps`
+            // takes both buffers, and a nested `#[account]` data type
+            // referenced from an event payload would push into it.
+            let mut __accounts: anchor_lang_v2::__alloc::vec::Vec<&'static str> =
+                anchor_lang_v2::__alloc::vec::Vec::new();
             let mut __types: anchor_lang_v2::__alloc::vec::Vec<&'static str> =
                 anchor_lang_v2::__alloc::vec::Vec::new();
-            <#name as anchor_lang_v2::IdlAccountType>::__register_idl_deps(&mut __types);
+            <#name as anchor_lang_v2::IdlAccountType>::__register_idl_deps(
+                &mut __accounts,
+                &mut __types,
+            );
             __types.sort();
             __types.dedup();
             let mut __payload = anchor_lang_v2::__alloc::string::String::from(#event_header_json);
@@ -2405,21 +2410,23 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
     // Emit the `IdlAccountType` impl for the event itself. Walks field
-    // types for transitive dep registration. Same shape as the `#[account]`
-    // impl — the only difference is that `#[event]` + `#[account]` both
-    // carry their own discriminator embedded in `type_def_json`.
+    // types for transitive dep registration. Events don't surface in the
+    // program-level `accounts[]` array — `__IDL_ACCOUNT_ENTRY` defaults
+    // to `None`. Their discriminator lives in `event_header_json` (the
+    // `--- IDL begin event ---` payload prefix), not in `__IDL_TYPE_DEF`.
     let idl_account_type_impl = quote! {
         #[cfg(feature = "idl-build")]
         impl anchor_lang_v2::IdlAccountType for #name {
-            const __IDL_TYPE: Option<&'static str> = Some(#type_def_json);
+            const __IDL_TYPE_DEF: Option<&'static str> = Some(#event_type_def);
             fn __register_idl_deps(
+                accounts: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut ::anchor_lang_v2::__alloc::vec::Vec<&'static str>,
             ) {
-                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE {
+                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE_DEF {
                     types.push(t);
                 }
                 #(
-                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(types);
+                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
                 )*
             }
         }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1007,20 +1007,19 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         }
 
         #[cfg(feature = "idl-build")]
+        #[doc(hidden)]
         impl #name {
             // Runtime-assembled accounts JSON: reads per-wrapper signer /
             // address trait consts, splices in compile-time flags.
             #idl_accounts_fn
 
-            /// Walks each account field's `IdlAccountType::__register_idl_deps`
-            /// so nested user-defined types (plain `#[derive(IdlType)]`
-            /// structs, `#[account]` data types, `#[event]` payload types,
-            /// etc.) transitively register into the IDL's program-level
-            /// `accounts[]` and `types[]` arrays. The walker pushes
-            /// `__IDL_ACCOUNT_ENTRY` and `__IDL_TYPE_DEF` strings into the
-            /// caller-provided buffers; the program-level print test joins
-            /// each with commas to assemble the final IDL JSON without
-            /// invoking a JSON parser at runtime.
+            /// **Opaque / unstable.** Walks each account field's
+            /// [`IdlAccountType::__register_idl_deps`] so nested
+            /// user-defined types (plain `#[derive(IdlType)]` structs,
+            /// `#[account]` data types, `#[event]` payload types, etc.)
+            /// transitively register into the IDL's program-level
+            /// `accounts[]` and `types[]` arrays.
+            #[doc(hidden)]
             pub fn __idl_register_deps(
                 accounts: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
@@ -1233,6 +1232,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         #account_deserialize_impl
         #[cfg(feature = "idl-build")]
+        #[doc(hidden)]
         impl anchor_lang_v2::IdlAccountType for #name {
             const __IDL_ACCOUNT_ENTRY: Option<&'static str> = #idl_account_entry;
             const __IDL_TYPE_DEF: Option<&'static str> = Some(#idl_type_def);
@@ -1396,6 +1396,7 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         #[cfg(feature = "idl-build")]
+        #[doc(hidden)]
         impl #impl_generics anchor_lang_v2::IdlAccountType for #name #ty_generics #where_clause {
             const __IDL_TYPE_DEF: Option<&'static str> = Some(#idl_type_def);
             fn __register_idl_deps(
@@ -2416,6 +2417,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
     // `--- IDL begin event ---` payload prefix), not in `__IDL_TYPE_DEF`.
     let idl_account_type_impl = quote! {
         #[cfg(feature = "idl-build")]
+        #[doc(hidden)]
         impl anchor_lang_v2::IdlAccountType for #name {
             const __IDL_TYPE_DEF: Option<&'static str> = Some(#event_type_def);
             fn __register_idl_deps(

--- a/lang-v2/src/accounts/borsh_account.rs
+++ b/lang-v2/src/accounts/borsh_account.rs
@@ -289,6 +289,7 @@ impl<T: BorshDeserialize + BorshSerialize + Owner + Discriminator> Discriminator
     const DISCRIMINATOR: &'static [u8] = T::DISCRIMINATOR;
 }
 
+#[doc(hidden)]
 impl<T> crate::IdlAccountType for BorshAccount<T>
 where
     T: BorshDeserialize + BorshSerialize + Owner + Discriminator + crate::IdlAccountType,

--- a/lang-v2/src/accounts/borsh_account.rs
+++ b/lang-v2/src/accounts/borsh_account.rs
@@ -294,9 +294,13 @@ impl<T> crate::IdlAccountType for BorshAccount<T>
 where
     T: BorshDeserialize + BorshSerialize + Owner + Discriminator + crate::IdlAccountType,
 {
-    const __IDL_TYPE: Option<&'static str> = T::__IDL_TYPE;
-    fn __register_idl_deps(types: &mut ::alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
+    const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;
+    fn __register_idl_deps(
+        accounts: &mut ::alloc::vec::Vec<&'static str>,
+        types: &mut ::alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 

--- a/lang-v2/src/accounts/borsh_account.rs
+++ b/lang-v2/src/accounts/borsh_account.rs
@@ -289,7 +289,6 @@ impl<T: BorshDeserialize + BorshSerialize + Owner + Discriminator> Discriminator
     const DISCRIMINATOR: &'static [u8] = T::DISCRIMINATOR;
 }
 
-#[cfg(feature = "idl-build")]
 impl<T> crate::IdlAccountType for BorshAccount<T>
 where
     T: BorshDeserialize + BorshSerialize + Owner + Discriminator + crate::IdlAccountType,

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -49,9 +49,13 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
 
 #[cfg(feature = "idl-build")]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Box<T> {
-    const __IDL_TYPE: Option<&'static str> = T::__IDL_TYPE;
-    fn __register_idl_deps(types: &mut ::alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
+    const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;
+    fn __register_idl_deps(
+        accounts: &mut ::alloc::vec::Vec<&'static str>,
+        types: &mut ::alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -47,7 +47,6 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
     }
 }
 
-#[cfg(feature = "idl-build")]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Box<T> {
     const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
     const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -47,6 +47,7 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
     }
 }
 
+#[doc(hidden)]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Box<T> {
     const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
     const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;

--- a/lang-v2/src/accounts/program.rs
+++ b/lang-v2/src/accounts/program.rs
@@ -70,7 +70,6 @@ impl<T: Id> AsRef<Address> for Program<T> {
     }
 }
 
-#[cfg(feature = "idl-build")]
 impl<T: Id> crate::IdlAccountType for Program<T> {
     // `Id::IDL_ADDRESS` defaults to `""`; convert empty → None so unknown
     // program markers elide the `address` field instead of emitting a bogus

--- a/lang-v2/src/accounts/program.rs
+++ b/lang-v2/src/accounts/program.rs
@@ -70,6 +70,7 @@ impl<T: Id> AsRef<Address> for Program<T> {
     }
 }
 
+#[doc(hidden)]
 impl<T: Id> crate::IdlAccountType for Program<T> {
     // `Id::IDL_ADDRESS` defaults to `""`; convert empty → None so unknown
     // program markers elide the `address` field instead of emitting a bogus

--- a/lang-v2/src/accounts/signer.rs
+++ b/lang-v2/src/accounts/signer.rs
@@ -63,6 +63,7 @@ impl AnchorAccount for Signer {
 
 view_wrapper_traits!(Signer);
 
+#[doc(hidden)]
 impl crate::IdlAccountType for Signer {
     const __IDL_IS_SIGNER: bool = true;
 }

--- a/lang-v2/src/accounts/signer.rs
+++ b/lang-v2/src/accounts/signer.rs
@@ -63,7 +63,6 @@ impl AnchorAccount for Signer {
 
 view_wrapper_traits!(Signer);
 
-#[cfg(feature = "idl-build")]
 impl crate::IdlAccountType for Signer {
     const __IDL_IS_SIGNER: bool = true;
 }

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -784,7 +784,6 @@ where
     }
 }
 
-#[cfg(feature = "idl-build")]
 impl<H, T> crate::IdlAccountType for Slab<H, T>
 where
     H: Pod + Zeroable + SlabSchema + crate::IdlAccountType,

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -789,9 +789,13 @@ impl<H, T> crate::IdlAccountType for Slab<H, T>
 where
     H: Pod + Zeroable + SlabSchema + crate::IdlAccountType,
 {
-    const __IDL_TYPE: Option<&'static str> = H::__IDL_TYPE;
-    fn __register_idl_deps(types: &mut ::alloc::vec::Vec<&'static str>) {
-        H::__register_idl_deps(types);
+    const __IDL_ACCOUNT_ENTRY: Option<&'static str> = H::__IDL_ACCOUNT_ENTRY;
+    const __IDL_TYPE_DEF: Option<&'static str> = H::__IDL_TYPE_DEF;
+    fn __register_idl_deps(
+        accounts: &mut ::alloc::vec::Vec<&'static str>,
+        types: &mut ::alloc::vec::Vec<&'static str>,
+    ) {
+        H::__register_idl_deps(accounts, types);
     }
 }
 

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -784,6 +784,7 @@ where
     }
 }
 
+#[doc(hidden)]
 impl<H, T> crate::IdlAccountType for Slab<H, T>
 where
     H: Pod + Zeroable + SlabSchema + crate::IdlAccountType,

--- a/lang-v2/src/accounts/system_account.rs
+++ b/lang-v2/src/accounts/system_account.rs
@@ -33,4 +33,5 @@ impl AnchorAccount for SystemAccount {
 
 view_wrapper_traits!(SystemAccount);
 
+#[doc(hidden)]
 impl crate::IdlAccountType for SystemAccount {}

--- a/lang-v2/src/accounts/system_account.rs
+++ b/lang-v2/src/accounts/system_account.rs
@@ -33,5 +33,4 @@ impl AnchorAccount for SystemAccount {
 
 view_wrapper_traits!(SystemAccount);
 
-#[cfg(feature = "idl-build")]
 impl crate::IdlAccountType for SystemAccount {}

--- a/lang-v2/src/accounts/sysvar.rs
+++ b/lang-v2/src/accounts/sysvar.rs
@@ -97,6 +97,7 @@ impl<T: PinocchioSysvar + SysvarId + Copy> AsRef<AccountView> for Sysvar<T> {
     }
 }
 
+#[doc(hidden)]
 impl<T: PinocchioSysvar + SysvarId + Copy> crate::IdlAccountType for Sysvar<T> {
     const __IDL_ADDRESS: Option<&'static str> = if T::IDL_ADDRESS.is_empty() {
         None

--- a/lang-v2/src/accounts/sysvar.rs
+++ b/lang-v2/src/accounts/sysvar.rs
@@ -16,31 +16,26 @@ pub trait SysvarId {
     const SYSVAR_ID: Address;
     /// Well-known base58 address for IDL emission. Empty string → no
     /// `address` emission at the `Program<T>` / `Sysvar<T>` IDL site.
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "";
 }
 
 impl SysvarId for pinocchio::sysvars::clock::Clock {
     const SYSVAR_ID: Address = pinocchio::sysvars::clock::CLOCK_ID;
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "SysvarC1ock11111111111111111111111111111111";
 }
 
 impl<T: Deref<Target = [u8]>> SysvarId for pinocchio::sysvars::instructions::Instructions<T> {
     const SYSVAR_ID: Address = pinocchio::sysvars::instructions::INSTRUCTIONS_ID;
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "Sysvar1nstructions1111111111111111111111111";
 }
 
 impl SysvarId for pinocchio::sysvars::rent::Rent {
     const SYSVAR_ID: Address = pinocchio::sysvars::rent::RENT_ID;
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "SysvarRent111111111111111111111111111111111";
 }
 
 impl<T: Deref<Target = [u8]>> SysvarId for pinocchio::sysvars::slot_hashes::SlotHashes<T> {
     const SYSVAR_ID: Address = pinocchio::sysvars::slot_hashes::SLOTHASHES_ID;
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "SysvarS1otHashes111111111111111111111111111";
 }
 
@@ -102,7 +97,6 @@ impl<T: PinocchioSysvar + SysvarId + Copy> AsRef<AccountView> for Sysvar<T> {
     }
 }
 
-#[cfg(feature = "idl-build")]
 impl<T: PinocchioSysvar + SysvarId + Copy> crate::IdlAccountType for Sysvar<T> {
     const __IDL_ADDRESS: Option<&'static str> = if T::IDL_ADDRESS.is_empty() {
         None

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -30,4 +30,5 @@ impl AnchorAccount for UncheckedAccount {
 
 view_wrapper_traits!(UncheckedAccount);
 
+#[doc(hidden)]
 impl crate::IdlAccountType for UncheckedAccount {}

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -30,5 +30,4 @@ impl AnchorAccount for UncheckedAccount {
 
 view_wrapper_traits!(UncheckedAccount);
 
-#[cfg(feature = "idl-build")]
 impl crate::IdlAccountType for UncheckedAccount {}

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -5,44 +5,61 @@
 //! sysvar/signer/program/unchecked from IDL types). Data-bearing wrappers
 //! (`Box<T>`, `Account<T>`, `BorshAccount<T>`, `Slab<H, T>`, `Nested<T>`)
 //! delegate to the inner type. User `#[account]`/`#[event]`/`#[derive(IdlType)]`
-//! structs get auto-generated impls with `__IDL_TYPE = Some(<JSON>)` and
-//! recursive `__register_idl_deps`.
+//! structs get auto-generated impls with both `__IDL_ACCOUNT_ENTRY` and
+//! `__IDL_TYPE_DEF` set at macro-expansion time.
 //!
-//! Only present under `idl-build` cfg; compiles out for on-chain builds.
+//! The trait + helpers are unconditionally compiled — empty default-method
+//! impls cost nothing in BPF. End-user crates opt into IDL emission via
+//! their own local `idl-build` feature; the macro emissions in
+//! `anchor-derive-accounts-v2` are gated on that user-side feature.
 //!
-//! This module is exposed only for IDL generation;
-//! it is NOT part of the stable API and is subject to change.
+//! This module is exposed only for IDL generation; it is NOT part of the
+//! stable API and is subject to change.
 
 extern crate alloc;
 
 /// Contributes (or elides) a user-defined type to the generated IDL.
 ///
-/// `__IDL_TYPE = None` → framework wrapper, nothing added to `types[]`.
-/// `__IDL_TYPE = Some(json)` → contributes a types entry.
-/// `__IDL_IS_SIGNER` / `__IDL_ADDRESS` surface per-wrapper metadata in
-/// `instructions[i].accounts[j]` JSON (`Signer`, `Program<T>`, `Sysvar<T>`).
+/// **Opaque / unstable.** Do not access these consts or call
+/// `__register_idl_deps` directly — they are implementation details of the
+/// `anchor idl build` pipeline and will change without notice.
 ///
-/// `__register_idl_deps` handles transitive type registration: user structs
-/// push their type def and recurse into fields. Primitives/collections
-/// default to no-op; wrappers delegate to the inner type.
-#[diagnostic::on_unimplemented(
-    message = "Ensure that `{Self}` has an `#[account]` attribute"
-)]
+/// `__IDL_ACCOUNT_ENTRY` populates the IDL's program-level `accounts[]`
+/// array (spec:137-140). `__IDL_TYPE_DEF` populates `types[]` (spec:176-188).
+/// Plain `#[derive(IdlType)]` types set only the latter — they don't appear
+/// in `accounts[]`. View wrappers (`Signer`, `Program<T>`, `Sysvar<T>`,
+/// `UncheckedAccount`, …) leave both at `None` and surface per-wrapper
+/// metadata via `__IDL_IS_SIGNER` / `__IDL_ADDRESS`.
+///
+/// `__register_idl_deps` handles transitive type registration: a user struct
+/// pushes its own pair of strings, then recurses into field types so a
+/// nested `#[derive(IdlType)] struct Inner` referenced from an `#[account]`
+/// data type lands in `types[]` too.
+#[diagnostic::on_unimplemented(message = "Ensure that `{Self}` has an `#[account]` attribute")]
 pub trait IdlAccountType {
-    const __IDL_TYPE: Option<&'static str> = None;
+    /// `{"name":"X","discriminator":[…]}` for the program-level `accounts[]`.
+    /// `None` for types that don't appear there (`IdlType` plain types,
+    /// view wrappers, primitives, collections).
+    const __IDL_ACCOUNT_ENTRY: Option<&'static str> = None;
+    /// `IdlTypeDef` JSON for the program-level `types[]`. `None` for
+    /// view wrappers, primitives, and collection forwarders.
+    const __IDL_TYPE_DEF: Option<&'static str> = None;
     const __IDL_IS_SIGNER: bool = false;
     const __IDL_ADDRESS: Option<&'static str> = None;
 
-    /// Register this type's `__IDL_TYPE` (if any) and recursively register
-    /// any user-defined types its fields reference. Default: no-op.
+    /// Push this type's accounts/types entries (if any) and recursively
+    /// register every user-defined type its fields reference. Default: no-op.
     ///
-    /// Implementers that carry their own type def push it here; delegating
-    /// wrappers (`Box<T>`, `BorshAccount<T>`, `Slab<H, T>`, `Nested<T>`)
-    /// forward to their inner type; collection impls (`Vec<T>`, `Option<T>`,
-    /// `[T; N]`) forward to the element type. Primitive impls (bool, u*,
-    /// i*, f*, String, Address, etc.) use the default no-op — they never
-    /// appear in `types[]`.
-    fn __register_idl_deps(_types: &mut alloc::vec::Vec<&'static str>) {}
+    /// Wrappers (`Box<T>`, `BorshAccount<T>`, `Slab<H, T>`, `Nested<T>`)
+    /// forward to the inner type; collection impls (`Vec<T>`, `Option<T>`,
+    /// `[T; N]`, `[T]`, `&T`, `PodVec<T, N>`) forward to the element type.
+    /// Primitive impls (bool, u*, i*, f*, String, Address, etc.) use the
+    /// default no-op — they never appear in `types[]`.
+    fn __register_idl_deps(
+        _accounts: &mut alloc::vec::Vec<&'static str>,
+        _types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -97,8 +114,11 @@ impl_idl_account_type_noop!(
 );
 
 impl<T: IdlAccountType> IdlAccountType for alloc::vec::Vec<T> {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 
@@ -106,28 +126,40 @@ impl<T: IdlAccountType> IdlAccountType for alloc::vec::Vec<T> {
 // carry borrowed slice fields (e.g. `MixedArgs<'a> { values: &'a [u64] }`),
 // which wincode supports as a zero-copy ix arg.
 impl<T: IdlAccountType> IdlAccountType for [T] {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 
 // `&T` — forward to `T` so a field typed as `&'a Inner` pulls `Inner`'s
 // type def into the IDL's `types[]`.
 impl<T: IdlAccountType + ?Sized> IdlAccountType for &T {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 
 impl<T: IdlAccountType> IdlAccountType for Option<T> {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 
 impl<T: IdlAccountType, const N: usize> IdlAccountType for [T; N] {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 
@@ -138,8 +170,11 @@ impl<T, const MAX: usize> IdlAccountType for crate::pod::PodVec<T, MAX>
 where
     T: bytemuck::Pod + IdlAccountType,
 {
-    fn __register_idl_deps(types: &mut alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    fn __register_idl_deps(
+        accounts: &mut alloc::vec::Vec<&'static str>,
+        types: &mut alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }
 

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -74,6 +74,7 @@ pub trait IdlAccountType {
 macro_rules! impl_idl_account_type_noop {
     ($($t:ty),* $(,)?) => {
         $(
+            #[doc(hidden)]
             impl IdlAccountType for $t {}
         )*
     };
@@ -113,6 +114,7 @@ impl_idl_account_type_noop!(
     crate::pod::PodI128,
 );
 
+#[doc(hidden)]
 impl<T: IdlAccountType> IdlAccountType for alloc::vec::Vec<T> {
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
@@ -125,6 +127,7 @@ impl<T: IdlAccountType> IdlAccountType for alloc::vec::Vec<T> {
 // Borrowed slice `&[T]` — surfaces on `#[derive(IdlType)]` structs that
 // carry borrowed slice fields (e.g. `MixedArgs<'a> { values: &'a [u64] }`),
 // which wincode supports as a zero-copy ix arg.
+#[doc(hidden)]
 impl<T: IdlAccountType> IdlAccountType for [T] {
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
@@ -136,6 +139,7 @@ impl<T: IdlAccountType> IdlAccountType for [T] {
 
 // `&T` — forward to `T` so a field typed as `&'a Inner` pulls `Inner`'s
 // type def into the IDL's `types[]`.
+#[doc(hidden)]
 impl<T: IdlAccountType + ?Sized> IdlAccountType for &T {
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
@@ -145,6 +149,7 @@ impl<T: IdlAccountType + ?Sized> IdlAccountType for &T {
     }
 }
 
+#[doc(hidden)]
 impl<T: IdlAccountType> IdlAccountType for Option<T> {
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
@@ -154,6 +159,7 @@ impl<T: IdlAccountType> IdlAccountType for Option<T> {
     }
 }
 
+#[doc(hidden)]
 impl<T: IdlAccountType, const N: usize> IdlAccountType for [T; N] {
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
@@ -166,6 +172,7 @@ impl<T: IdlAccountType, const N: usize> IdlAccountType for [T; N] {
 // `PodVec<T, MAX>` — the zero-copy bounded-capacity analog of `Vec<T>`.
 // Forward `__register_idl_deps` so a `#[account]` zero-copy type holding
 // a `PodVec<Inner, 16>` still pulls `Inner` into the IDL's `types[]`.
+#[doc(hidden)]
 impl<T, const MAX: usize> IdlAccountType for crate::pod::PodVec<T, MAX>
 where
     T: bytemuck::Pod + IdlAccountType,

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -14,7 +14,6 @@ pub mod cursor;
 mod dispatch;
 pub mod event;
 pub mod hash;
-#[cfg(feature = "idl-build")]
 #[doc(hidden)]
 pub mod idl_build;
 pub mod loader;
@@ -113,10 +112,20 @@ pub const BORSH_CONFIG: wincode::config::Configuration<
 > = wincode::config::Configuration::new();
 
 /// `#[derive(IdlType)]` — register a plain struct in the IDL's `types[]`
-/// array. Always exported; the emitted impl body is itself
-/// `#[cfg(feature = "idl-build")]`, so non-IDL builds pay nothing.
+/// array.
+///
+/// **Opaque / unstable.** Apply this derive on user types you want to
+/// surface in the generated IDL; do not call any of the emitted associated
+/// items directly — they are implementation details of the `anchor idl
+/// build` pipeline and will change without notice. The emitted impl body
+/// is gated on the **end-user crate's** local `idl-build` feature, so
+/// non-IDL builds pay nothing.
 pub use anchor_derive_accounts_v2::IdlType;
-#[cfg(feature = "idl-build")]
+/// **Opaque / unstable.** Re-exported so derive-emitted code in user
+/// crates can name the trait. Do not implement this trait by hand or call
+/// its associated items — they are implementation details of the IDL
+/// build pipeline and will change without notice. See [`idl_build`] for
+/// the trait definition.
 pub use idl_build::IdlAccountType;
 // ---------------------------------------------------------------------------
 // Client-side types — for building instructions off-chain (tests, CPI, SDK)

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -112,20 +112,12 @@ pub const BORSH_CONFIG: wincode::config::Configuration<
     u8,
 > = wincode::config::Configuration::new();
 
-/// Internal: only used by `#[cfg(feature = "idl-build")]` codegen from the
-/// derive macros to split type-def JSON in `__anchor_private_print_idl_program`.
-/// Not part of the stable API — hence the `__` prefix.
-#[cfg(feature = "idl-build")]
-#[doc(hidden)]
-pub use serde_json as __serde_json;
-
 /// `#[derive(IdlType)]` — register a plain struct in the IDL's `types[]`
 /// array. Always exported; the emitted impl body is itself
 /// `#[cfg(feature = "idl-build")]`, so non-IDL builds pay nothing.
 pub use anchor_derive_accounts_v2::IdlType;
 #[cfg(feature = "idl-build")]
 pub use idl_build::IdlAccountType;
-
 // ---------------------------------------------------------------------------
 // Client-side types — for building instructions off-chain (tests, CPI, SDK)
 // ---------------------------------------------------------------------------

--- a/lang-v2/src/prelude.rs
+++ b/lang-v2/src/prelude.rs
@@ -1,7 +1,5 @@
 //! Prelude: import everything you need with `use anchor_lang_v2::prelude::*;`
 
-#[cfg(feature = "idl-build")]
-pub use crate::IdlAccountType;
 pub use crate::{
     access_control,
     account,
@@ -83,7 +81,7 @@ pub use crate::{
 // Re-export pinocchio sysvar types and trait for use with Sysvar<T>
 pub use pinocchio::sysvars::Sysvar as PinocchioSysvar;
 pub use {
-    crate::IdlType,
+    crate::{IdlAccountType, IdlType},
     pinocchio::{
         account::AccountView,
         address::Address,

--- a/lang-v2/src/programs.rs
+++ b/lang-v2/src/programs.rs
@@ -12,7 +12,6 @@ impl Id for System {
         const ADDR: Address = Address::from_str_const("11111111111111111111111111111111");
         ADDR
     }
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "11111111111111111111111111111111";
 }
 
@@ -23,7 +22,6 @@ impl Id for Token {
             Address::from_str_const("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
         ADDR
     }
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 }
 
@@ -34,7 +32,6 @@ impl Id for Token2022 {
             Address::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
         ADDR
     }
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 }
 
@@ -45,7 +42,6 @@ impl Id for AssociatedToken {
             Address::from_str_const("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
         ADDR
     }
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 }
 
@@ -56,6 +52,5 @@ impl Id for Memo {
             Address::from_str_const("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
         ADDR
     }
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
 }

--- a/lang-v2/src/programs.rs
+++ b/lang-v2/src/programs.rs
@@ -1,8 +1,8 @@
 //! Well-known program marker types for use with `Program<T>`.
 //!
 //! IDs are const-evaluated via `from_str_const` (base58 decoded at compile
-//! time). Each marker exposes `IDL_ADDRESS` (gated behind `idl-build`)
-//! forwarded through `IdlAccountType::__IDL_ADDRESS` at emission time.
+//! time). Each marker exposes `IDL_ADDRESS`, forwarded through `IdlAccountType::__IDL_ADDRESS`
+//! at emission time.
 
 use {crate::Id, pinocchio::address::Address};
 

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -365,8 +365,12 @@ impl<T> core::ops::DerefMut for Nested<T> {
 
 #[cfg(feature = "idl-build")]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Nested<T> {
-    const __IDL_TYPE: Option<&'static str> = T::__IDL_TYPE;
-    fn __register_idl_deps(types: &mut ::alloc::vec::Vec<&'static str>) {
-        T::__register_idl_deps(types);
+    const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
+    const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;
+    fn __register_idl_deps(
+        accounts: &mut ::alloc::vec::Vec<&'static str>,
+        types: &mut ::alloc::vec::Vec<&'static str>,
+    ) {
+        T::__register_idl_deps(accounts, types);
     }
 }

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -362,6 +362,7 @@ impl<T> core::ops::DerefMut for Nested<T> {
     }
 }
 
+#[doc(hidden)]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Nested<T> {
     const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
     const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -196,7 +196,6 @@ pub trait Id {
     /// signals "no address to advertise in the IDL" — consumed by
     /// `IdlAccountType::__IDL_ADDRESS` on `Program<T>` and converted to
     /// `None` there.
-    #[cfg(feature = "idl-build")]
     const IDL_ADDRESS: &'static str = "";
 }
 
@@ -363,7 +362,6 @@ impl<T> core::ops::DerefMut for Nested<T> {
     }
 }
 
-#[cfg(feature = "idl-build")]
 impl<T: crate::IdlAccountType> crate::IdlAccountType for Nested<T> {
     const __IDL_ACCOUNT_ENTRY: Option<&'static str> = T::__IDL_ACCOUNT_ENTRY;
     const __IDL_TYPE_DEF: Option<&'static str> = T::__IDL_TYPE_DEF;

--- a/spl-v2/Cargo.toml
+++ b/spl-v2/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [features]
 default = []
-idl-build = ["anchor-lang-v2/idl-build"]
 
 [dependencies]
 anchor-lang-v2 = { path = "../lang-v2", version = "2.0.0" }

--- a/spl-v2/src/mint.rs
+++ b/spl-v2/src/mint.rs
@@ -42,6 +42,7 @@ unsafe impl Zeroable for Mint {}
 // layout is known to any SPL-aware client. Default `__IDL_TYPE = None` keeps
 // it out of the user's IDL `types[]` array (matches v1's `impl_idl_build!`
 // behavior for this type).
+#[doc(hidden)]
 impl anchor_lang_v2::IdlAccountType for Mint {}
 
 // On-chain size — SPL Token program requires 82 bytes. Used by

--- a/spl-v2/src/mint.rs
+++ b/spl-v2/src/mint.rs
@@ -42,7 +42,6 @@ unsafe impl Zeroable for Mint {}
 // layout is known to any SPL-aware client. Default `__IDL_TYPE = None` keeps
 // it out of the user's IDL `types[]` array (matches v1's `impl_idl_build!`
 // behavior for this type).
-#[cfg(feature = "idl-build")]
 impl anchor_lang_v2::IdlAccountType for Mint {}
 
 // On-chain size — SPL Token program requires 82 bytes. Used by

--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -61,6 +61,7 @@ unsafe impl Zeroable for TokenAccount {}
 // — its layout is known to any SPL-aware client. Default `__IDL_TYPE = None`
 // keeps it out of the user's IDL `types[]` array (matches v1's
 // `impl_idl_build!` behavior for this type).
+#[doc(hidden)]
 impl anchor_lang_v2::IdlAccountType for TokenAccount {}
 
 // On-chain size — SPL Token program requires 165 bytes. Used by

--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -61,7 +61,6 @@ unsafe impl Zeroable for TokenAccount {}
 // — its layout is known to any SPL-aware client. Default `__IDL_TYPE = None`
 // keeps it out of the user's IDL `types[]` array (matches v1's
 // `impl_idl_build!` behavior for this type).
-#[cfg(feature = "idl-build")]
 impl anchor_lang_v2::IdlAccountType for TokenAccount {}
 
 // On-chain size — SPL Token program requires 165 bytes. Used by

--- a/spl-v2/src/token_interface.rs
+++ b/spl-v2/src/token_interface.rs
@@ -125,8 +125,10 @@ impl anchor_lang_v2::Space for Interface<crate::Mint> {
 // IDL — keep interface types out of the user's types[] array
 // ---------------------------------------------------------------------------
 
+#[doc(hidden)]
 impl anchor_lang_v2::IdlAccountType for Interface<crate::TokenAccount> {}
 
+#[doc(hidden)]
 impl anchor_lang_v2::IdlAccountType for Interface<crate::Mint> {}
 
 // ---------------------------------------------------------------------------

--- a/spl-v2/src/token_interface.rs
+++ b/spl-v2/src/token_interface.rs
@@ -125,10 +125,8 @@ impl anchor_lang_v2::Space for Interface<crate::Mint> {
 // IDL — keep interface types out of the user's types[] array
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "idl-build")]
 impl anchor_lang_v2::IdlAccountType for Interface<crate::TokenAccount> {}
 
-#[cfg(feature = "idl-build")]
 impl anchor_lang_v2::IdlAccountType for Interface<crate::Mint> {}
 
 // ---------------------------------------------------------------------------

--- a/tests-v2/programs/accounts/Cargo.toml
+++ b/tests-v2/programs/accounts/Cargo.toml
@@ -14,7 +14,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 
 [dependencies]
 anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }

--- a/tests-v2/programs/constraints/Cargo.toml
+++ b/tests-v2/programs/constraints/Cargo.toml
@@ -13,7 +13,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 
 [dependencies]
 anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }

--- a/tests-v2/programs/constraints/src/lib.rs
+++ b/tests-v2/programs/constraints/src/lib.rs
@@ -431,7 +431,7 @@ pub struct InitIfNeededNoSeeds {
 // `seeds` / `seeds::program` are already covered structurally
 // by the `seeds` program fixture; adding a duplicate here would only
 // retest the shared `classify_seed` path.
-#[cfg(all(test, feature = "idl-build"))]
+#[cfg(test)]
 mod idl_tests {
     use {
         super::*,

--- a/tests-v2/programs/derives/Cargo.toml
+++ b/tests-v2/programs/derives/Cargo.toml
@@ -14,7 +14,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 no-idl = []
 no-log-ix-name = []
-idl-build = ["anchor-lang-v2/idl-build"]
+idl-build = []
 
 [dependencies]
 anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }

--- a/tests-v2/programs/spl/Cargo.toml
+++ b/tests-v2/programs/spl/Cargo.toml
@@ -14,10 +14,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 no-idl = []
 no-log-ix-name = []
-idl-build = [
-    "anchor-lang-v2/idl-build",
-    "anchor-spl-v2/idl-build",
-]
+idl-build = []
 
 [dependencies]
 anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
We now only have `idl-build` in the end user crate