### PR TITLE
tests: Fix `ido-pool` flakiness

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -457,7 +457,9 @@ jobs:
             path: tests/zero-copy
           - cmd: cd tests/chat && anchor test --skip-lint
             path: tests/chat
-          - cmd: cd tests/ido-pool && anchor test --skip-lint
+          # Use `solana-test-validator` instead of `surfpool` to fix flakiness
+          # and increase code coverage
+          - cmd: cd tests/ido-pool && anchor test --skip-lint --validator legacy
             path: tests/ido-pool
           # - cmd: cd tests/cfo && anchor run test-with-build && cd deps/stake && git checkout Cargo.lock && cd ../swap && git checkout Cargo.lock
           #   path: tests/cfo

--- a/tests/ido-pool/Anchor.toml
+++ b/tests/ido-pool/Anchor.toml
@@ -7,8 +7,3 @@ ido_pool = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]
-
-[surfpool]
-block_production_mode = "clock"


### PR DESCRIPTION
### Problem

[The `ido-pool` tests](https://github.com/solana-foundation/anchor/tree/832e210ec4c13f197817425b0c32a93d83d9c2fd/tests/ido-pool) have been flaky for a while. (e.g. [CI run from 7 hours ago](https://github.com/solana-foundation/anchor/actions/runs/25551633336/job/75001080910))

### Summary of changes

Fix `ido-pool` flakiness by using `solana-test-validator` via the `--validator legacy` option.

This is an alternative to https://github.com/solana-foundation/anchor/pull/4454, which uses `surfpool`-only features.

An additional benefit of this PR over the other approach is that it also increases code coverage, as we currently do not have any tests that use `solana-test-validator` even though we do support it still.