### PR TITLE
Chore: bump cargo-toml and make it a workspace dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - spl: Add missing auth account to `group_pointer_update` ([#4324](https://github.com/solana-foundation/anchor/pull/4324)).
 - lang: Support module constants in `max_len` attribute ([#3879](https://github.com/solana-foundation/anchor/pull/3879)).
 - spl: Deprecate broken `cpi_guard_enable/disable` functions ([#4465](https://github.com/solana-foundation/anchor/pull/4465)).
+- cli: Bump `cargo_toml` to allow parsing `resolver = "3"` ([#4515](https://github.com/solana-foundation/anchor/pull/4515)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,18 +982,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -1005,12 +1006,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.19.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4092,6 +4093,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6955,21 +6965,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.19.15",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -6979,6 +6992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -6998,23 +7020,9 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7039,10 +7047,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -7897,9 +7905,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ solana-sysvar = "3.1.1"
 solana-sysvar-id = "3.1.0"
 solana-transaction = "3.0.1"
 
+# Non solana crates
+cargo_toml = "0.22.3"
+
 [profile.release]
 lto = true
 

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -10,13 +10,17 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.32"
-cargo_toml = "0.19.2"
+cargo_toml.workspace = true
 cfg-if = "1.0.0"
 chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
-reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.11.9", default-features = false, features = [
+  "blocking",
+  "json",
+  "rustls-tls",
+] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,15 +18,18 @@ dev = []
 idl-localnet-testing = []
 
 [dependencies]
-anchor-cli-macros = { path = "cli-macros", version = "1.0.2"}
+anchor-cli-macros = { path = "cli-macros", version = "1.0.2" }
 anchor-client = { path = "../client", version = "1.0.2" }
 anchor-lang = { path = "../lang", version = "1.0.2" }
-anchor-lang-idl = { path = "../idl", version = "0.1.2", features = ["build", "convert"] }
+anchor-lang-idl = { path = "../idl", version = "0.1.2", features = [
+  "build",
+  "convert",
+] }
 anyhow = "1.0.32"
 base64 = "0.21"
 bincode = "1.3.3"
-cargo_metadata = "0.19.2"
-cargo_toml = "0.19.2"
+cargo_metadata = "0.23.1"
+cargo_toml.workspace = true
 chrono = "0.4.19"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
@@ -37,7 +40,11 @@ heck = "0.4.0"
 pathdiff = "0.2.0"
 portpicker = "0.1.1"
 regex = "1.8.3"
-reqwest = { version = "0.11.4", default-features = false, features = ["multipart", "blocking", "rustls-tls"] }
+reqwest = { version = "0.11.4", default-features = false, features = [
+  "multipart",
+  "blocking",
+  "rustls-tls",
+] }
 semver = "1.0.4"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1"
 bs58 = "0.5"
 
 # `idl-build` feature only
-cargo_toml = { version = "0.19", optional = true }
+cargo_toml = { workspace = true, optional = true }
 heck = "0.3"
 # `Span::local_file` required by the `idl-build` feature was stabilized in `1.0.100`
 proc-macro2 = { version = "1.0.100", features = ["span-locations"] }


### PR DESCRIPTION
## Summary

The current `cargo_toml` version was outdated and rejects resolver v3. Bumping fixes that issue. Also made it a workspace dep (can move more stuff to workspace in the future)