### PR TITLE
fix(lang/syn): restore silent-fail behaviour for CrateContext::parse in IDL build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- lang: Restore silent-fail behaviour for `CrateContext::parse` in IDL build so that crates using modern Rust syntax (e.g. precise-capturing `+ use<T>`, Rust 1.82+) no longer break `--features idl-build` ([#4513](https://github.com/solana-foundation/anchor/issues/4513)).
 - client: Avoid panic in `parse_logs_response` when a program-emitted log line ends with `invoke [1]` ([#4461](https://github.com/solana-foundation/anchor/issues/4461)).
 - cli: Correctly honor `--skip-seed-phrase-validation` in `keygen recover` ([#4417](https://github.com/solana-foundation/anchor/pull/4417)).
 - spl: Fix wrong owner pubkey in CPI Guard enable/disable ([#4322](https://github.com/solana-foundation/anchor/pull/4322)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- lang: Restore silent-fail behaviour for `CrateContext::parse` in IDL build so that crates using modern Rust syntax (e.g. precise-capturing `+ use<T>`, Rust 1.82+) no longer break `--features idl-build` ([#4513](https://github.com/solana-foundation/anchor/issues/4513)).
+- lang: Avoid fatal errors in IDL building when modern Rust syntax is in use ([#4520](https://github.com/solana-foundation/anchor/pull/4520)).
 - client: Avoid panic in `parse_logs_response` when a program-emitted log line ends with `invoke [1]` ([#4461](https://github.com/solana-foundation/anchor/issues/4461)).
 - cli: Correctly honor `--skip-seed-phrase-validation` in `keygen recover` ([#4417](https://github.com/solana-foundation/anchor/pull/4417)).
 - spl: Fix wrong owner pubkey in CPI Guard enable/disable ([#4322](https://github.com/solana-foundation/anchor/pull/4322)).

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -509,20 +509,21 @@ pub fn gen_idl_type(
                     type_aliases: HashMap<String, String>,
                 }
 
-                static CRATE_DATA_CACHE: OnceLock<
-                    std::result::Result<CachedCrateData, anyhow::Error>,
-                > = OnceLock::new();
+                static CRATE_DATA_CACHE: OnceLock<Option<CachedCrateData>> = OnceLock::new();
 
                 // If no path was found, just return an empty path and let the find_path function handle it
                 let source_path = proc_macro2::Span::call_site()
                     .local_file()
                     .unwrap_or_default();
 
-                if let Ok(lib_path) = find_path("lib.rs", &source_path) {
+                'cache: {
+                    let Ok(lib_path) = find_path("lib.rs", &source_path) else {
+                        break 'cache;
+                    };
                     let name = path.path.segments.last().unwrap().ident.to_string();
 
                     let cache = CRATE_DATA_CACHE.get_or_init(|| {
-                        CrateContext::parse(&lib_path).map(|ctx| {
+                        CrateContext::parse(&lib_path).ok().map(|ctx| {
                             let defined_names: HashSet<String> = ctx
                                 .structs()
                                 .map(|s| s.ident.to_string())
@@ -541,14 +542,12 @@ pub fn gen_idl_type(
                         })
                     });
 
-                    let cache = match cache {
-                        Ok(data) => data,
-                        Err(e) => {
-                            return Err(syn::Error::new(
-                                path.span(),
-                                format!("Failed to parse crate: {e}"),
-                            ));
-                        }
+                    // If CrateContext::parse failed (e.g. the crate uses Rust syntax that
+                    // syn v1 cannot parse), fall through to "Defined in crate" below.
+                    // This restores the pre-#4325 silent-fail behaviour and prevents a
+                    // single unparseable file from poisoning every type lookup in the crate.
+                    let Some(cache) = cache else {
+                        break 'cache;
                     };
 
                     let alias_src = cache.type_aliases.get(&name).cloned();

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -509,6 +509,12 @@ pub fn gen_idl_type(
                     type_aliases: HashMap<String, String>,
                 }
 
+                // FIXME: migrate to syn 2.0. syn 1.x was last released in December 2022 and
+                // does not support Rust syntax stabilised after that date (e.g. precise-capturing
+                // `use<T>` syntax, C-string literals). Our MSRV has long since moved past what
+                // syn 1.x supports, so CrateContext::parse will silently fail on any project
+                // that uses modern Rust syntax. Upgrading to syn 2.0 would let us parse those
+                // files correctly and remove the None-on-failure workaround below.
                 static CRATE_DATA_CACHE: OnceLock<Option<CachedCrateData>> = OnceLock::new();
 
                 // If no path was found, just return an empty path and let the find_path function handle it

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -509,7 +509,7 @@ pub fn gen_idl_type(
                     type_aliases: HashMap<String, String>,
                 }
 
-                // FIXME: migrate to syn 2.0. syn 1.x was last released in December 2022 and
+                // FIXME(#4521): migrate to syn 2.0. syn 1.x was last released in December 2022 and
                 // does not support Rust syntax stabilised after that date (e.g. precise-capturing
                 // `use<T>` syntax, C-string literals). Our MSRV has long since moved past what
                 // syn 1.x supports, so CrateContext::parse will silently fail on any project


### PR DESCRIPTION
Fixes #4513.

## What changed

Two small changes in `lang/syn/src/idl/defined.rs` (`gen_idl_type`):

1. `OnceLock<Result<CachedCrateData, anyhow::Error>>` → `OnceLock<Option<CachedCrateData>>`
2. `.map(|ctx| …)` → `.ok().map(|ctx| …)` on the `CrateContext::parse` call
3. The hard-error `match` block → `let Some(cache) = cache else { break 'cache; }` which silently falls through to the existing "Defined in crate" path

## Root cause

PR #4325 introduced two behaviour changes that combined to cause the regression:

**1 — Silent failure became a hard error.**
Before #4325, a failed `CrateContext::parse` was swallowed by an `if let Ok(Ok(ctx)) = …` guard and execution fell through to "Defined in crate". After #4325 the failure is explicitly returned as a compile error.

**2 — The failure is cached in a `static OnceLock`.**
Because the cache is process-wide, the first `CrateContext::parse` failure permanently poisons every subsequent type lookup in the compilation, producing a cascade of errors across all structs.

`CrateContext::parse` uses **syn v1** (`syn = "1"`, last released December 2022) to parse every `.rs` file in the crate recursively. Any file that uses Rust syntax stabilised after that date causes `syn::parse_file` to fail. Confirmed triggers:

| Syntax | Stabilised | syn v1 error |
|---|---|---|
| `impl Trait + use<T>` (precise capturing, RFC 3617) | Rust 1.82 | `expected identifier` |
| `c"hello"` (C-string literals) | Rust 1.77 | panic in syn |

## Fix

Store `Option<CachedCrateData>` in the `OnceLock` instead of `Result<…, Error>`. A `None` means "parse failed — skip alias/external-type resolution and fall through to Defined-in-crate", which is exactly what happened before #4325. The `OnceLock` performance win from #4325 is fully preserved.

The longer-term fix would be upgrading anchor-syn from `syn = "1"` to `syn = "2"` (which handles all modern Rust syntax), but that is a larger change.

## Testing

```bash
# Reproducer: a crate with precise-capturing syntax in a helper module
# and a forward-referencing account struct.

# Without idl-build — passes on 1.0.2 before and after this fix
cargo check -p idl-forward-ref

# With idl-build — failed on 1.0.2, passes after this fix
cargo check -p idl-forward-ref --features idl-build
```

Errors produced by 1.0.2 before fix:
```
error: Failed to parse crate: expected identifier
error[E0599]: no function or associated item named `create_type` found for struct `State`
error[E0599]: no function or associated item named `insert_types` found for struct `State`
```