### PR TITLE
feat(ts): re-implement verifiedBuild using OtterSec registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- ts: Re-implement `verifiedBuild` using the OtterSec registry (`verify.osec.io`), replacing the defunct `apr.dev` API ([#4435](https://github.com/solana-foundation/anchor/issues/4435)).
+- ts: Re-implement `verifiedBuild` using the OtterSec registry (`verify.osec.io`), replacing the defunct `apr.dev` API ([#4522](https://github.com/solana-foundation/anchor/pull/4522)).
 - ts: Add `decodeIdlAccountRaw` ([#4375](https://github.com/solana-foundation/anchor/pull/4375)).
 - cli: Add `--stdout` flag to the `expand` command ([#4400](https://github.com/solana-foundation/anchor/pull/4400)).
 - client: Add versioned tx support ([#4207](https://github.com/solana-foundation/anchor/pull/4207)).
@@ -186,7 +186,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - spl: Update SPL dependencies to latest compatible versions ([#3860](https://github.com/solana-foundation/anchor/pull/3860)).
 - cli: Replace `anchor verify` to use `solana-verify` under the hood, adding automatic installation via AVM, local path support, and future-proof argument passing ([#3768](https://github.com/solana-foundation/anchor/pull/3768)).
-- cli: Upload IDL by default with an option to skip ((#3863)[https://github.com/solana-foundation/anchor/pull/3863]).
+- cli: Upload IDL by default with an option to skip ([#3863](https://github.com/solana-foundation/anchor/pull/3863)).
 - lang: remove Solang ([#3824](https://github.com/solana-foundation/anchor/pull/3824)).
 - cli: remove `anchor publish` command ([#3795](https://github.com/solana-foundation/anchor/pull/3795)).
 
@@ -478,7 +478,7 @@ See the [Anchor 0.30 release notes](https://www.anchor-lang.com/release-notes/0.
 - spl: Fix not being able to deserialize newer token 2022 extensions ([#2876](https://github.com/solana-foundation/anchor/pull/2876)).
 - client: Fix erroneous Cluster websocket ports ([#2690](https://github.com/solana-foundation/anchor/pull/2690)).
 - spl: Remove `solana-program` dependency ([#2900](https://github.com/solana-foundation/anchor/pull/2900)).
-- spl: Make `TokenAccount` and ` Mint` `Copy` ([#2904](https://github.com/solana-foundation/anchor/pull/2904)).
+- spl: Make `TokenAccount` and `Mint` `Copy` ([#2904](https://github.com/solana-foundation/anchor/pull/2904)).
 - ts: Add missing errors ([#2906](https://github.com/solana-foundation/anchor/pull/2906)).
 
 ### Breaking
@@ -823,9 +823,9 @@ See the [Anchor 0.29 release notes](https://www.anchor-lang.com/release-notes/0.
 - lang: Require doc comments when using AccountInfo or UncheckedAccount types ([#1452](https://github.com/solana-foundation/anchor/pull/1452)).
 - lang: add [`error!`](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.error.html) and [`err!`](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.err.html) macro and `Result` type ([#1462](https://github.com/solana-foundation/anchor/pull/1462)).
   This change will break most programs. Do the following to upgrade:
-  _ change all `ProgramResult`'s to `Result<()>`
+  _change all `ProgramResult`'s to `Result<()>`
   _ change `#[error]` to `#[error_code]`
-  _ change all `Err(MyError::SomeError.into())` to `Err(error!(MyError::SomeError))` and all `Err(ProgramError::SomeProgramError)` to `Err(ProgramError::SomeProgramError.into())` or `Err(Error::from(ProgramError::SomeProgramError).with_source(source!()))` to provide file and line source of the error (`with_source` is most useful with `ProgramError`s. `error!` already adds source information for custom and anchor internal errors).
+  _change all `Err(MyError::SomeError.into())` to `Err(error!(MyError::SomeError))` and all `Err(ProgramError::SomeProgramError)` to `Err(ProgramError::SomeProgramError.into())` or `Err(Error::from(ProgramError::SomeProgramError).with_source(source!()))` to provide file and line source of the error (`with_source` is most useful with `ProgramError`s. `error!` already adds source information for custom and anchor internal errors).
   _ change all `solana_program::program::invoke()` to `solana_program::program::invoke().map_err(Into::into)` and `solana_program::program::invoke_signed()` to `solana_program::program::invoke_signed().map_err(Into::into)`
 
 ## [0.21.0] - 2022-02-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- ts: Re-implement `verifiedBuild` using the OtterSec registry (`verify.osec.io`), replacing the defunct `apr.dev` API ([#4435](https://github.com/solana-foundation/anchor/issues/4435)).
 - ts: Add `decodeIdlAccountRaw` ([#4375](https://github.com/solana-foundation/anchor/pull/4375)).
 - cli: Add `--stdout` flag to the `expand` command ([#4400](https://github.com/solana-foundation/anchor/pull/4400)).
 - client: Add versioned tx support ([#4207](https://github.com/solana-foundation/anchor/pull/4207)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - spl: Update SPL dependencies to latest compatible versions ([#3860](https://github.com/solana-foundation/anchor/pull/3860)).
 - cli: Replace `anchor verify` to use `solana-verify` under the hood, adding automatic installation via AVM, local path support, and future-proof argument passing ([#3768](https://github.com/solana-foundation/anchor/pull/3768)).
-- cli: Upload IDL by default with an option to skip ([#3863](https://github.com/solana-foundation/anchor/pull/3863)).
+- cli: Upload IDL by default with an option to skip ((#3863)[https://github.com/solana-foundation/anchor/pull/3863]).
 - lang: remove Solang ([#3824](https://github.com/solana-foundation/anchor/pull/3824)).
 - cli: remove `anchor publish` command ([#3795](https://github.com/solana-foundation/anchor/pull/3795)).
 
@@ -478,7 +478,7 @@ See the [Anchor 0.30 release notes](https://www.anchor-lang.com/release-notes/0.
 - spl: Fix not being able to deserialize newer token 2022 extensions ([#2876](https://github.com/solana-foundation/anchor/pull/2876)).
 - client: Fix erroneous Cluster websocket ports ([#2690](https://github.com/solana-foundation/anchor/pull/2690)).
 - spl: Remove `solana-program` dependency ([#2900](https://github.com/solana-foundation/anchor/pull/2900)).
-- spl: Make `TokenAccount` and `Mint` `Copy` ([#2904](https://github.com/solana-foundation/anchor/pull/2904)).
+- spl: Make `TokenAccount` and ` Mint` `Copy` ([#2904](https://github.com/solana-foundation/anchor/pull/2904)).
 - ts: Add missing errors ([#2906](https://github.com/solana-foundation/anchor/pull/2906)).
 
 ### Breaking
@@ -823,9 +823,9 @@ See the [Anchor 0.29 release notes](https://www.anchor-lang.com/release-notes/0.
 - lang: Require doc comments when using AccountInfo or UncheckedAccount types ([#1452](https://github.com/solana-foundation/anchor/pull/1452)).
 - lang: add [`error!`](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.error.html) and [`err!`](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.err.html) macro and `Result` type ([#1462](https://github.com/solana-foundation/anchor/pull/1462)).
   This change will break most programs. Do the following to upgrade:
-  _change all `ProgramResult`'s to `Result<()>`
+  _ change all `ProgramResult`'s to `Result<()>`
   _ change `#[error]` to `#[error_code]`
-  _change all `Err(MyError::SomeError.into())` to `Err(error!(MyError::SomeError))` and all `Err(ProgramError::SomeProgramError)` to `Err(ProgramError::SomeProgramError.into())` or `Err(Error::from(ProgramError::SomeProgramError).with_source(source!()))` to provide file and line source of the error (`with_source` is most useful with `ProgramError`s. `error!` already adds source information for custom and anchor internal errors).
+  _ change all `Err(MyError::SomeError.into())` to `Err(error!(MyError::SomeError))` and all `Err(ProgramError::SomeProgramError)` to `Err(ProgramError::SomeProgramError.into())` or `Err(Error::from(ProgramError::SomeProgramError).with_source(source!()))` to provide file and line source of the error (`with_source` is most useful with `ProgramError`s. `error!` already adds source information for custom and anchor internal errors).
   _ change all `solana_program::program::invoke()` to `solana_program::program::invoke().map_err(Into::into)` and `solana_program::program::invoke_signed()` to `solana_program::program::invoke_signed().map_err(Into::into)`
 
 ## [0.21.0] - 2022-02-07

--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,1 @@
+ts: Re-implement 

--- a/Untitled
+++ b/Untitled
@@ -1,1 +1,0 @@
-ts: Re-implement 

--- a/ts/packages/anchor/src/utils/registry.ts
+++ b/ts/packages/anchor/src/utils/registry.ts
@@ -1,6 +1,32 @@
 import BN from "bn.js";
+import fetch from "cross-fetch";
 import * as borsh from "@anchor-lang/borsh";
 import { Connection, PublicKey } from "@solana/web3.js";
+
+const OSEC_REGISTRY_URL = "https://verify.osec.io";
+
+export type VerifiedBuild = {
+  is_verified: boolean;
+  on_chain_hash: string;
+  executable_hash: string;
+  repo_url: string;
+  commit: string;
+  last_verified_at: string;
+  signer: string;
+  is_frozen: boolean;
+};
+
+/** Returns verified build info from the OtterSec registry, or null if unverified. */
+export async function verifiedBuild(
+  programId: PublicKey
+): Promise<VerifiedBuild | null> {
+  const resp = await fetch(
+    `${OSEC_REGISTRY_URL}/status/${programId.toString()}`
+  );
+  if (!resp.ok) return null;
+  const build = (await resp.json()) as VerifiedBuild;
+  return build.is_verified ? build : null;
+}
 
 /**
  * Returns the program data account for this program, containing the

--- a/ts/packages/anchor/src/utils/registry.ts
+++ b/ts/packages/anchor/src/utils/registry.ts
@@ -7,25 +7,31 @@ const OSEC_REGISTRY_URL = "https://verify.osec.io";
 
 export type VerifiedBuild = {
   is_verified: boolean;
+  message?: string;
   on_chain_hash: string;
   executable_hash: string;
   repo_url: string;
-  commit: string;
   last_verified_at: string;
-  signer: string;
-  is_frozen: boolean;
+  // present in some registry responses but not guaranteed by the documented API
+  commit?: string;
+  signer?: string;
+  is_frozen?: boolean;
 };
 
-/** Returns verified build info from the OtterSec registry, or null if unverified. */
+/** Returns verified build info from the OtterSec registry, or null if unverified or the request fails. */
 export async function verifiedBuild(
   programId: PublicKey
 ): Promise<VerifiedBuild | null> {
-  const resp = await fetch(
-    `${OSEC_REGISTRY_URL}/status/${programId.toString()}`
-  );
-  if (!resp.ok) return null;
-  const build = (await resp.json()) as VerifiedBuild;
-  return build.is_verified ? build : null;
+  try {
+    const resp = await fetch(
+      `${OSEC_REGISTRY_URL}/status/${programId.toString()}`
+    );
+    if (!resp.ok) return null;
+    const build = (await resp.json()) as VerifiedBuild;
+    return build.is_verified ? build : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/ts/packages/anchor/src/utils/registry.ts
+++ b/ts/packages/anchor/src/utils/registry.ts
@@ -7,24 +7,23 @@ const OSEC_REGISTRY_URL = "https://verify.osec.io";
 
 export type VerifiedBuild = {
   is_verified: boolean;
-  message?: string;
+  message: string;
   on_chain_hash: string;
   executable_hash: string;
   repo_url: string;
-  last_verified_at: string;
-  // present in some registry responses but not guaranteed by the documented API
-  commit?: string;
-  signer?: string;
-  is_frozen?: boolean;
+  commit: string;
+  last_verified_at: string | null;
+  is_frozen: boolean;
+  is_closed: boolean;
 };
 
 /** Returns verified build info from the OtterSec registry, or null if unverified or the request fails. */
 export async function verifiedBuild(
-  programId: PublicKey
+  programId: PublicKey,
 ): Promise<VerifiedBuild | null> {
   try {
     const resp = await fetch(
-      `${OSEC_REGISTRY_URL}/status/${programId.toString()}`
+      `${OSEC_REGISTRY_URL}/status/${programId.toString()}`,
     );
     if (!resp.ok) return null;
     const build = (await resp.json()) as VerifiedBuild;
@@ -40,7 +39,7 @@ export async function verifiedBuild(
  */
 export async function fetchData(
   connection: Connection,
-  programId: PublicKey
+  programId: PublicKey,
 ): Promise<ProgramData> {
   const accountInfo = await connection.getAccountInfo(programId);
   if (accountInfo === null) {
@@ -48,13 +47,13 @@ export async function fetchData(
   }
   const { program } = decodeUpgradeableLoaderState(accountInfo.data);
   const programdataAccountInfo = await connection.getAccountInfo(
-    program.programdataAddress
+    program.programdataAddress,
   );
   if (programdataAccountInfo === null) {
     throw new Error("program data account not found");
   }
   const { programData } = decodeUpgradeableLoaderState(
-    programdataAccountInfo.data
+    programdataAccountInfo.data,
   );
   return programData;
 }
@@ -64,7 +63,7 @@ const UPGRADEABLE_LOADER_STATE_LAYOUT = borsh.rustEnum(
     borsh.struct([], "uninitialized"),
     borsh.struct(
       [borsh.option(borsh.publicKey(), "authorityAddress")],
-      "buffer"
+      "buffer",
     ),
     borsh.struct([borsh.publicKey("programdataAddress")], "program"),
     borsh.struct(
@@ -72,11 +71,11 @@ const UPGRADEABLE_LOADER_STATE_LAYOUT = borsh.rustEnum(
         borsh.u64("slot"),
         borsh.option(borsh.publicKey(), "upgradeAuthorityAddress"),
       ],
-      "programData"
+      "programData",
     ),
   ],
   undefined,
-  borsh.u32()
+  borsh.u32(),
 );
 
 export function decodeUpgradeableLoaderState(data: Buffer): any {

--- a/ts/packages/anchor/src/utils/registry.ts
+++ b/ts/packages/anchor/src/utils/registry.ts
@@ -19,11 +19,11 @@ export type VerifiedBuild = {
 
 /** Returns verified build info from the OtterSec registry, or null if unverified or the request fails. */
 export async function verifiedBuild(
-  programId: PublicKey,
+  programId: PublicKey
 ): Promise<VerifiedBuild | null> {
   try {
     const resp = await fetch(
-      `${OSEC_REGISTRY_URL}/status/${programId.toString()}`,
+      `${OSEC_REGISTRY_URL}/status/${programId.toString()}`
     );
     if (!resp.ok) return null;
     const build = (await resp.json()) as VerifiedBuild;
@@ -39,7 +39,7 @@ export async function verifiedBuild(
  */
 export async function fetchData(
   connection: Connection,
-  programId: PublicKey,
+  programId: PublicKey
 ): Promise<ProgramData> {
   const accountInfo = await connection.getAccountInfo(programId);
   if (accountInfo === null) {
@@ -47,13 +47,13 @@ export async function fetchData(
   }
   const { program } = decodeUpgradeableLoaderState(accountInfo.data);
   const programdataAccountInfo = await connection.getAccountInfo(
-    program.programdataAddress,
+    program.programdataAddress
   );
   if (programdataAccountInfo === null) {
     throw new Error("program data account not found");
   }
   const { programData } = decodeUpgradeableLoaderState(
-    programdataAccountInfo.data,
+    programdataAccountInfo.data
   );
   return programData;
 }
@@ -63,7 +63,7 @@ const UPGRADEABLE_LOADER_STATE_LAYOUT = borsh.rustEnum(
     borsh.struct([], "uninitialized"),
     borsh.struct(
       [borsh.option(borsh.publicKey(), "authorityAddress")],
-      "buffer",
+      "buffer"
     ),
     borsh.struct([borsh.publicKey("programdataAddress")], "program"),
     borsh.struct(
@@ -71,11 +71,11 @@ const UPGRADEABLE_LOADER_STATE_LAYOUT = borsh.rustEnum(
         borsh.u64("slot"),
         borsh.option(borsh.publicKey(), "upgradeAuthorityAddress"),
       ],
-      "programData",
+      "programData"
     ),
   ],
   undefined,
-  borsh.u32(),
+  borsh.u32()
 );
 
 export function decodeUpgradeableLoaderState(data: Buffer): any {


### PR DESCRIPTION
Closes #4435

### Problem

`verifiedBuild` was removed in #4425 because it pointed at `api.apr.dev`, which is defunct.

### Changes

- Re-implements `verifiedBuild(programId)` in `ts/packages/anchor/src/utils/registry.ts` using the OtterSec registry (`https://verify.osec.io/status/{programId}`)
- Exports a `VerifiedBuild` type matching the `/status/{programId}` response shape
- Returns `null` when the program is not verified or the request fails

### API comparison

| | Old (`apr.dev`) | New (`verify.osec.io`) |
|---|---|---|
| Staleness check | slot number comparison | `is_verified` flag (registry re-checks every 24h) |
| Signature | `verifiedBuild(connection, programId, limit?)` | `verifiedBuild(programId)` |
| `Connection` needed | Yes (to fetch on-chain slot) | No |