### PR TITLE
feat(lang): rename realloc constraint to resize

### DIFF
--- a/lang/derive/accounts/src/lib.rs
+++ b/lang/derive/accounts/src/lib.rs
@@ -436,25 +436,25 @@ use {proc_macro::TokenStream, quote::ToTokens, syn::parse_macro_input};
 ///         </tr>
 ///         <tr>
 ///             <td>
-///                 <code>#[account(realloc = &lt;space&gt;, realloc::payer = &lt;target&gt;, realloc::zero = &lt;bool&gt;)]</code>
+///                 <code>#[account(resize = &lt;space&gt;, resize::payer = &lt;target&gt;, resize::zero = &lt;bool&gt;)]</code>
 ///             </td>
 ///             <td>
-///                 Used to <a href="https://docs.rs/solana-program/latest/solana_program/account_info/struct.AccountInfo.html#method.realloc" target = "_blank" rel = "noopener noreferrer">realloc</a>
+///                 Used to <a href="https://docs.rs/solana-program/latest/solana_program/account_info/struct.AccountInfo.html#method.resize" target = "_blank" rel = "noopener noreferrer">resize</a>
 ///                 program account space at the beginning of an instruction.
 ///                 <br><br>
 ///                 The account must be marked as <code>mut</code> and applied to either <code>Account</code> or <code>AccountLoader</code> types.
 ///                 <br><br>
-///                 If the change in account data length is additive, lamports will be transferred from the <code>realloc::payer</code> into the
+///                 If the change in account data length is additive, lamports will be transferred from the <code>resize::payer</code> into the
 ///                 program account in order to maintain rent exemption. Likewise, if the change is subtractive, lamports will be transferred from
-///                 the program account back into the <code>realloc::payer</code>.
+///                 the program account back into the <code>resize::payer</code>.
 ///                 <br><br>
-///                 The <code>realloc::zero</code> constraint is required in order to determine whether the new memory should be zero initialized after
-///                 reallocation. Please read the documentation on the <code>AccountInfo::realloc</code> function linked above to understand the
+///                 The <code>resize::zero</code> constraint is required in order to determine whether the new memory should be zero initialized after
+///                 resizing. Please read the documentation on the <code>AccountInfo::resize</code> function linked above to understand the
 ///                 caveats regarding compute units when providing <code>true</code> or <code>false</code> to this flag.
 ///                 <br><br>
-///                 The manual use of `AccountInfo::realloc` is discouraged in favor of the `realloc` constraint group due to the lack of native runtime checks
-///                 to prevent reallocation over the `MAX_PERMITTED_DATA_INCREASE` limit (which can unintentionally cause account data overwrite other accounts).
-///                 The constraint group also ensure account reallocation idempotency but checking and restricting duplicate account reallocation within a single ix.
+///                 The manual use of `AccountInfo::resize` is discouraged in favor of the `resize` constraint group due to the lack of native runtime checks
+///                 to prevent resize over the `MAX_PERMITTED_DATA_INCREASE` limit (which can unintentionally cause account data overwrite other accounts).
+///                 The constraint group also ensure account resize idempotency but checking and restricting duplicate account resize within a single ix.
 ///                 <br><br>
 ///                 Example:
 ///                 <pre>
@@ -466,9 +466,9 @@ use {proc_macro::TokenStream, quote::ToTokens, syn::parse_macro_input};
 ///         mut,
 ///         seeds = [b"example"],
 ///         bump,
-///         realloc = 8 + std::mem::size_of::&lt;MyType&gt;() + 100,
-///         realloc::payer = payer,
-///         realloc::zero = false,
+///         resize = 8 + std::mem::size_of::&lt;MyType&gt;() + 100,
+///         resize::payer = payer,
+///         resize::zero = false,
 ///     )]
 ///     pub acc: Account&lt;'info, MyType&gt;,
 ///     pub system_program: Program&lt;'info, System&gt;,

--- a/lang/error/src/lib.rs
+++ b/lang/error/src/lib.rs
@@ -271,12 +271,12 @@ pub enum ErrorCode {
     /// 3015 - The given public key does not match the required sysvar
     #[msg("The given public key does not match the required sysvar")]
     AccountSysvarMismatch,
-    /// 3016 - The account reallocation exceeds the MAX_PERMITTED_DATA_INCREASE limit
-    #[msg("The account reallocation exceeds the MAX_PERMITTED_DATA_INCREASE limit")]
-    AccountReallocExceedsLimit,
-    /// 3017 - The account was duplicated for more than one reallocation
-    #[msg("The account was duplicated for more than one reallocation")]
-    AccountDuplicateReallocs,
+    /// 3016 - The account resize exceeds the MAX_PERMITTED_DATA_INCREASE limit
+    #[msg("The account resize exceeds the MAX_PERMITTED_DATA_INCREASE limit")]
+    AccountResizeExceedsLimit,
+    /// 3017 - The account was duplicated for more than one resize
+    #[msg("The account was duplicated for more than one resize")]
+    AccountDuplicateResizes,
 
     // Miscellaneous
     /// 4100 - The declared program id does not match actual program id

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -351,7 +351,7 @@ where
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/account_info.rs
+++ b/lang/src/accounts/account_info.rs
@@ -17,7 +17,7 @@ impl<'info, B> Accounts<'info, B> for AccountInfo<'info> {
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -230,7 +230,7 @@ impl<'info, B, T: ZeroCopy + Owner> Accounts<'info, B> for AccountLoader<'info, 
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/boxed.rs
+++ b/lang/src/accounts/boxed.rs
@@ -27,9 +27,9 @@ impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Box<T> {
         accounts: &mut &'info [AccountInfo<'info>],
         ix_data: &[u8],
         bumps: &mut B,
-        reallocs: &mut BTreeSet<Pubkey>,
+        resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
-        T::try_accounts(program_id, accounts, ix_data, bumps, reallocs).map(Box::new)
+        T::try_accounts(program_id, accounts, ix_data, bumps, resizes).map(Box::new)
     }
 }
 

--- a/lang/src/accounts/interface.rs
+++ b/lang/src/accounts/interface.rs
@@ -111,7 +111,7 @@ impl<'info, B, T: CheckId> Accounts<'info, B> for Interface<'info, T> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -260,7 +260,7 @@ impl<'info, B, T: AccountSerialize + AccountDeserialize + CheckOwner + Clone> Ac
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -277,7 +277,7 @@ where
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -43,7 +43,7 @@ pub enum MigrationInner<From, To> {
 /// instruction exits. On exit, the account must be in the migrated state or an error will
 /// be returned.
 ///
-/// This type is typically used with the `realloc` constraint to resize the account
+/// This type is typically used with the `resize` constraint to resize the account
 /// during migration.
 ///
 /// Checks:
@@ -142,9 +142,9 @@ pub enum MigrationInner<From, To> {
 ///     pub payer: Signer<'info>,
 ///     #[account(
 ///         mut,
-///         realloc = 8 + AccountV2::INIT_SPACE,
-///         realloc::payer = payer,
-///         realloc::zero = false
+///         resize = 8 + AccountV2::INIT_SPACE,
+///         resize::payer = payer,
+///         resize::zero = false
 ///     )]
 ///     pub my_account: Migration<'info, AccountV1, AccountV2>,
 ///     pub system_program: Program<'info, System>,
@@ -341,7 +341,7 @@ where
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/option.rs
+++ b/lang/src/accounts/option.rs
@@ -23,7 +23,7 @@ impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Option<T> {
         accounts: &mut &'info [AccountInfo<'info>],
         ix_data: &[u8],
         bumps: &mut B,
-        reallocs: &mut BTreeSet<Pubkey>,
+        resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return if cfg!(feature = "allow-missing-optionals") {
@@ -49,7 +49,7 @@ impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Option<T> {
             // If the program_id doesn't equal the account key, we default to
             // the try_accounts implementation for the inner type and then wrap that with
             // Some. This should handle all possible valid cases.
-            T::try_accounts(program_id, accounts, ix_data, bumps, reallocs).map(Some)
+            T::try_accounts(program_id, accounts, ix_data, bumps, resizes).map(Some)
         }
     }
 }

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -180,7 +180,7 @@ impl<'info, B, T: Id> Accounts<'info, B> for Program<'info, T> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());
@@ -198,7 +198,7 @@ impl<'info, B> Accounts<'info, B> for Program<'info, ()> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -62,7 +62,7 @@ impl<'info, B> Accounts<'info, B> for Signer<'info> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -36,7 +36,7 @@ impl<'info, B> Accounts<'info, B> for SystemAccount<'info> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/sysvar.rs
+++ b/lang/src/accounts/sysvar.rs
@@ -76,7 +76,7 @@ impl<'info, B, T: SolanaSysvarSerialize> Accounts<'info, B> for Sysvar<'info, T>
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/unchecked_account.rs
+++ b/lang/src/accounts/unchecked_account.rs
@@ -27,7 +27,7 @@ impl<'info, B> Accounts<'info, B> for UncheckedAccount<'info> {
         accounts: &mut &'info [AccountInfo<'info>],
         _ix_data: &[u8],
         _bumps: &mut B,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -208,7 +208,7 @@ pub trait Accounts<'info, B>: ToAccountMetas + ToAccountInfos<'info> + Sized {
         accounts: &mut &'info [AccountInfo<'info>],
         ix_data: &[u8],
         bumps: &mut B,
-        reallocs: &mut BTreeSet<Pubkey>,
+        resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self>;
 }
 

--- a/lang/src/vec.rs
+++ b/lang/src/vec.rs
@@ -30,10 +30,10 @@ impl<'info, B, T: Accounts<'info, B>> Accounts<'info, B> for Vec<T> {
         accounts: &mut &'info [AccountInfo<'info>],
         ix_data: &[u8],
         bumps: &mut B,
-        reallocs: &mut BTreeSet<Pubkey>,
+        resizes: &mut BTreeSet<Pubkey>,
     ) -> Result<Self> {
         let mut vec: Vec<T> = Vec::new();
-        T::try_accounts(program_id, accounts, ix_data, bumps, reallocs)
+        T::try_accounts(program_id, accounts, ix_data, bumps, resizes)
             .map(|item| vec.push(item))?;
         Ok(vec)
     }
@@ -65,10 +65,10 @@ mod tests {
         let account2 =
             AccountInfo::new(&key, true, true, &mut lamports2, &mut data2, &owner, false);
         let mut bumps = TestBumps::default();
-        let mut reallocs = std::collections::BTreeSet::new();
+        let mut resizes = std::collections::BTreeSet::new();
         let mut accounts = &[account1, account2][..];
         let parsed_accounts =
-            Vec::<Test>::try_accounts(&program_id, &mut accounts, &[], &mut bumps, &mut reallocs)
+            Vec::<Test>::try_accounts(&program_id, &mut accounts, &[], &mut bumps, &mut resizes)
                 .unwrap();
 
         assert_eq!(accounts.len(), parsed_accounts.len());
@@ -79,9 +79,9 @@ mod tests {
     fn test_accounts_trait_for_vec_empty() {
         let program_id = Pubkey::default();
         let mut bumps = TestBumps::default();
-        let mut reallocs = std::collections::BTreeSet::new();
+        let mut resizes = std::collections::BTreeSet::new();
         let mut accounts = &[][..];
-        Vec::<Test>::try_accounts(&program_id, &mut accounts, &[], &mut bumps, &mut reallocs)
+        Vec::<Test>::try_accounts(&program_id, &mut accounts, &[], &mut bumps, &mut resizes)
             .unwrap();
     }
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -100,7 +100,7 @@ pub fn linearize(c_group: &ConstraintGroup) -> Vec<Constraint> {
         associated_token,
         token_account,
         mint,
-        realloc,
+        resize,
     } = c_group.clone();
 
     let mut constraints = Vec::new();
@@ -111,8 +111,8 @@ pub fn linearize(c_group: &ConstraintGroup) -> Vec<Constraint> {
     if let Some(c) = init {
         constraints.push(Constraint::Init(c));
     }
-    if let Some(c) = realloc {
-        constraints.push(Constraint::Realloc(c));
+    if let Some(c) = resize {
+        constraints.push(Constraint::Resize(c));
     }
     if let Some(c) = seeds {
         constraints.push(Constraint::Seeds(c));
@@ -177,7 +177,7 @@ fn generate_constraint(
         Constraint::AssociatedToken(c) => generate_constraint_associated_token(f, c, accs),
         Constraint::TokenAccount(c) => generate_constraint_token_account(f, c, accs),
         Constraint::Mint(c) => generate_constraint_mint(f, c, accs),
-        Constraint::Realloc(c) => generate_constraint_realloc(f, c, accs),
+        Constraint::Resize(c) => generate_constraint_resize(f, c, accs),
     }
 }
 
@@ -428,9 +428,9 @@ pub fn generate_constraint_rent_exempt(
     }
 }
 
-fn generate_constraint_realloc(
+fn generate_constraint_resize(
     f: &Field,
-    c: &ConstraintReallocGroup,
+    c: &ConstraintResizeGroup,
     accs: &AccountsStruct,
 ) -> proc_macro2::TokenStream {
     let field = &f.ident;
@@ -444,11 +444,11 @@ fn generate_constraint_realloc(
         optional_check_scope.generate_check(quote! {system_program});
 
     quote! {
-        // Blocks duplicate account reallocs in a single instruction to prevent accidental account overwrites
+        // Blocks duplicate account resizes in a single instruction to prevent accidental account overwrites
         // and to ensure the calculation of the change in bytes is based on account size at program entry
         // which inheritantly guarantee idempotency.
-        if __reallocs.contains(&#field.key()) {
-            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountDuplicateReallocs).with_account_name(#account_name));
+        if __resizes.contains(&#field.key()) {
+            return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountDuplicateResizes).with_account_name(#account_name));
         }
 
         let __anchor_rent = anchor_lang::prelude::Rent::get()?;
@@ -464,7 +464,7 @@ fn generate_constraint_realloc(
             if __delta_space > 0 {
                 #system_program_optional_check
                 if ::std::convert::TryInto::<usize>::try_into(__delta_space).unwrap() > anchor_lang::solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE {
-                    return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountReallocExceedsLimit).with_account_name(#account_name));
+                    return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountResizeExceedsLimit).with_account_name(#account_name));
                 }
 
                 if __new_rent_minimum > __field_info.lamports() {
@@ -486,7 +486,7 @@ fn generate_constraint_realloc(
             }
 
             __field_info.resize(#new_space)?;
-            __reallocs.insert(#field.key());
+            __resizes.insert(#field.key());
         }
     }
 }

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -29,7 +29,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     quote! {
                         #[cfg(feature = "anchor-debug")]
                         ::anchor_lang::solana_program::log::sol_log(stringify!(#name));
-                        let #name: #ty = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, &mut __bumps.#name, __reallocs)?;
+                        let #name: #ty = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, &mut __bumps.#name, __resizes)?;
                     }
                 }
                 AccountField::Field(f) => {
@@ -84,7 +84,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         quote! {
                             #[cfg(feature = "anchor-debug")]
                             ::anchor_lang::solana_program::log::sol_log(stringify!(#typed_name));
-                            let #typed_name = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, __bumps, __reallocs)
+                            let #typed_name = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, __bumps, __resizes)
                                 .map_err(|e| e.with_account_name(#name))?;
                             #warning
                         }
@@ -252,7 +252,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                 __accounts: &mut &#trait_generics [anchor_lang::solana_program::account_info::AccountInfo<#trait_generics>],
                 __ix_data: &[u8],
                 __bumps: &mut #bumps_struct_name,
-                __reallocs: &mut std::collections::BTreeSet<anchor_lang::solana_program::pubkey::Pubkey>,
+                __resizes: &mut std::collections::BTreeSet<anchor_lang::solana_program::pubkey::Pubkey>,
             ) -> anchor_lang::Result<Self> {
                 // Deserialize instruction, if declared.
                 #ix_de

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -113,7 +113,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     // Bump collector.
                     let mut __bumps = <#accounts_struct_name as anchor_lang::Bumps>::Bumps::default();
 
-                    let mut __reallocs = std::collections::BTreeSet::new();
+                    let mut __resizes = std::collections::BTreeSet::new();
 
                     // Deserialize accounts.
                     let mut __remaining_accounts = __accounts;
@@ -122,7 +122,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         &mut __remaining_accounts,
                         __ix_data,
                         &mut __bumps,
-                        &mut __reallocs,
+                        &mut __resizes,
                     )?;
 
                     unsafe fn __shrink_lifetime<'from, 'to, T>(value: &'from mut T) -> &'to mut T {

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -751,7 +751,7 @@ pub struct ConstraintGroup {
     pub associated_token: Option<ConstraintAssociatedToken>,
     pub token_account: Option<ConstraintTokenAccountGroup>,
     pub mint: Option<ConstraintTokenMintGroup>,
-    pub realloc: Option<ConstraintReallocGroup>,
+    pub resize: Option<ConstraintResizeGroup>,
 }
 
 impl ConstraintGroup {
@@ -804,7 +804,7 @@ pub enum Constraint {
     Address(ConstraintAddress),
     TokenAccount(ConstraintTokenAccountGroup),
     Mint(ConstraintTokenMintGroup),
-    Realloc(ConstraintReallocGroup),
+    Resize(ConstraintResizeGroup),
 }
 
 // Constraint token is a single keyword in a `#[account(<TOKEN>)]` attribute.
@@ -838,9 +838,9 @@ pub enum ConstraintToken {
     MintTokenProgram(Context<ConstraintTokenProgram>),
     Bump(Context<ConstraintTokenBump>),
     ProgramSeed(Context<ConstraintProgramSeed>),
-    Realloc(Context<ConstraintRealloc>),
-    ReallocPayer(Context<ConstraintReallocPayer>),
-    ReallocZero(Context<ConstraintReallocZero>),
+    Resize(Context<ConstraintResize>),
+    ResizePayer(Context<ConstraintResizePayer>),
+    ResizeZero(Context<ConstraintResizeZero>),
     // extensions
     ExtensionGroupPointerAuthority(Context<ConstraintExtensionAuthority>),
     ExtensionGroupPointerGroupAddress(Context<ConstraintExtensionGroupPointerGroupAddress>),
@@ -885,24 +885,24 @@ pub struct ConstraintMut {
 pub struct ConstraintDup {}
 
 #[derive(Debug, Clone)]
-pub struct ConstraintReallocGroup {
+pub struct ConstraintResizeGroup {
     pub payer: Expr,
     pub space: Expr,
     pub zero: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstraintRealloc {
+pub struct ConstraintResize {
     pub space: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstraintReallocPayer {
+pub struct ConstraintResizePayer {
     pub target: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstraintReallocZero {
+pub struct ConstraintResizeZero {
     pub zero: Expr,
 }
 

--- a/lang/syn/src/parser/accounts/constraints.rs
+++ b/lang/syn/src/parser/accounts/constraints.rs
@@ -396,15 +396,22 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
             }
         }
         "realloc" => {
+            return Err(ParseError::new(
+                ident.span(),
+                "`realloc` has been renamed to `resize` (and `realloc::payer`/`realloc::zero` to \
+                 `resize::payer`/`resize::zero`) to match AccountInfo::resize in the Solana SDK",
+            ));
+        }
+        "resize" => {
             if stream.peek(Token![=]) {
                 stream.parse::<Token![=]>()?;
                 let span = ident
                     .span()
                     .join(stream.span())
                     .unwrap_or_else(|| ident.span());
-                ConstraintToken::Realloc(Context::new(
+                ConstraintToken::Resize(Context::new(
                     span,
-                    ConstraintRealloc {
+                    ConstraintResize {
                         space: stream.parse()?,
                     },
                 ))
@@ -420,23 +427,23 @@ pub fn parse_token(stream: ParseStream) -> ParseResult<ConstraintToken> {
                     .unwrap_or_else(|| ident.span());
 
                 match kw.as_str() {
-                    "payer" => ConstraintToken::ReallocPayer(Context::new(
+                    "payer" => ConstraintToken::ResizePayer(Context::new(
                         span,
-                        ConstraintReallocPayer {
+                        ConstraintResizePayer {
                             target: stream.parse()?,
                         },
                     )),
-                    "zero" => ConstraintToken::ReallocZero(Context::new(
+                    "zero" => ConstraintToken::ResizeZero(Context::new(
                         span,
-                        ConstraintReallocZero {
+                        ConstraintResizeZero {
                             zero: stream.parse()?,
                         },
                     )),
                     _ => {
                         return Err(ParseError::new(
                             ident.span(),
-                            "Invalid attribute. realloc::payer and realloc::zero are the only \
-                             valid attributes",
+                            "Invalid attribute. resize::payer and resize::zero are the only valid \
+                             attributes",
                         ))
                     }
                 }
@@ -584,9 +591,9 @@ pub struct ConstraintGroupBuilder<'ty> {
     pub extension_pausable_authority: Option<Context<ConstraintExtensionAuthority>>,
     pub bump: Option<Context<ConstraintTokenBump>>,
     pub program_seed: Option<Context<ConstraintProgramSeed>>,
-    pub realloc: Option<Context<ConstraintRealloc>>,
-    pub realloc_payer: Option<Context<ConstraintReallocPayer>>,
-    pub realloc_zero: Option<Context<ConstraintReallocZero>>,
+    pub resize: Option<Context<ConstraintResize>>,
+    pub resize_payer: Option<Context<ConstraintResizePayer>>,
+    pub resize_zero: Option<Context<ConstraintResizeZero>>,
     pub dup: Option<Context<ConstraintDup>>,
 }
 
@@ -631,9 +638,9 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_pausable_authority: None,
             bump: None,
             program_seed: None,
-            realloc: None,
-            realloc_payer: None,
-            realloc_zero: None,
+            resize: None,
+            resize_payer: None,
+            resize_zero: None,
             dup: None,
         }
     }
@@ -730,18 +737,18 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             }
         }
 
-        // Realloc.
-        if let Some(r) = &self.realloc {
-            if self.realloc_payer.is_none() {
+        // Resize.
+        if let Some(r) = &self.resize {
+            if self.resize_payer.is_none() {
                 return Err(ParseError::new(
                     r.span(),
-                    "realloc::payer must be provided when using realloc",
+                    "resize::payer must be provided when using resize",
                 ));
             }
-            if self.realloc_zero.is_none() {
+            if self.resize_zero.is_none() {
                 return Err(ParseError::new(
                     r.span(),
-                    "realloc::zero must be provided when using realloc",
+                    "resize::zero must be provided when using resize",
                 ));
             }
         }
@@ -849,9 +856,9 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             extension_pausable_authority,
             bump,
             program_seed,
-            realloc,
-            realloc_payer,
-            realloc_zero,
+            resize,
+            resize_payer,
+            resize_zero,
             dup,
         } = self;
 
@@ -1112,18 +1119,18 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
                     })
                 })
                 .transpose()?,
-            realloc: realloc.as_ref().map(|r| ConstraintReallocGroup {
+            resize: resize.as_ref().map(|r| ConstraintResizeGroup {
                 #[allow(
                     clippy::unwrap_used,
-                    reason = "realloc payer guaranteed when realloc constraint present"
+                    reason = "resize payer guaranteed when resize constraint present"
                 )]
-                payer: into_inner!(realloc_payer).unwrap().target,
+                payer: into_inner!(resize_payer).unwrap().target,
                 space: r.space.clone(),
                 #[allow(
                     clippy::unwrap_used,
-                    reason = "realloc zero guaranteed when realloc constraint present"
+                    reason = "resize zero guaranteed when resize constraint present"
                 )]
-                zero: into_inner!(realloc_zero).unwrap().zero,
+                zero: into_inner!(resize_zero).unwrap().zero,
             }),
             zeroed: into_inner!(zeroed),
             mutable: into_inner!(mutable),
@@ -1173,9 +1180,9 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
             ConstraintToken::MintTokenProgram(c) => self.add_mint_token_program(c),
             ConstraintToken::Bump(c) => self.add_bump(c),
             ConstraintToken::ProgramSeed(c) => self.add_program_seed(c),
-            ConstraintToken::Realloc(c) => self.add_realloc(c),
-            ConstraintToken::ReallocPayer(c) => self.add_realloc_payer(c),
-            ConstraintToken::ReallocZero(c) => self.add_realloc_zero(c),
+            ConstraintToken::Resize(c) => self.add_resize(c),
+            ConstraintToken::ResizePayer(c) => self.add_resize_payer(c),
+            ConstraintToken::ResizeZero(c) => self.add_resize_zero(c),
             ConstraintToken::ExtensionGroupPointerAuthority(c) => {
                 self.add_extension_group_pointer_authority(c)
             }
@@ -1303,7 +1310,7 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         Ok(())
     }
 
-    fn add_realloc(&mut self, c: Context<ConstraintRealloc>) -> ParseResult<()> {
+    fn add_resize(&mut self, c: Context<ConstraintResize>) -> ParseResult<()> {
         if !matches!(self.f_ty, Some(Ty::Account(_)))
             && !matches!(self.f_ty, Some(Ty::LazyAccount(_)))
             && !matches!(self.f_ty, Some(Ty::AccountLoader(_)))
@@ -1311,47 +1318,47 @@ impl<'ty> ConstraintGroupBuilder<'ty> {
         {
             return Err(ParseError::new(
                 c.span(),
-                "realloc must be on an Account, LazyAccount, AccountLoader, or Migration",
+                "resize must be on an Account, LazyAccount, AccountLoader, or Migration",
             ));
         }
         if self.mutable.is_none() {
             return Err(ParseError::new(
                 c.span(),
-                "mut must be provided before realloc",
+                "mut must be provided before resize",
             ));
         }
-        if self.realloc.is_some() {
-            return Err(ParseError::new(c.span(), "realloc already provided"));
+        if self.resize.is_some() {
+            return Err(ParseError::new(c.span(), "resize already provided"));
         }
-        self.realloc.replace(c);
+        self.resize.replace(c);
         Ok(())
     }
 
-    fn add_realloc_payer(&mut self, c: Context<ConstraintReallocPayer>) -> ParseResult<()> {
-        if self.realloc.is_none() {
+    fn add_resize_payer(&mut self, c: Context<ConstraintResizePayer>) -> ParseResult<()> {
+        if self.resize.is_none() {
             return Err(ParseError::new(
                 c.span(),
-                "realloc must be provided before realloc::payer",
+                "resize must be provided before resize::payer",
             ));
         }
-        if self.realloc_payer.is_some() {
-            return Err(ParseError::new(c.span(), "realloc::payer already provided"));
+        if self.resize_payer.is_some() {
+            return Err(ParseError::new(c.span(), "resize::payer already provided"));
         }
-        self.realloc_payer.replace(c);
+        self.resize_payer.replace(c);
         Ok(())
     }
 
-    fn add_realloc_zero(&mut self, c: Context<ConstraintReallocZero>) -> ParseResult<()> {
-        if self.realloc.is_none() {
+    fn add_resize_zero(&mut self, c: Context<ConstraintResizeZero>) -> ParseResult<()> {
+        if self.resize.is_none() {
             return Err(ParseError::new(
                 c.span(),
-                "realloc must be provided before realloc::zero",
+                "resize must be provided before resize::zero",
             ));
         }
-        if self.realloc_zero.is_some() {
-            return Err(ParseError::new(c.span(), "realloc::zero already provided"));
+        if self.resize_zero.is_some() {
+            return Err(ParseError::new(c.span(), "resize::zero already provided"));
         }
-        self.realloc_zero.replace(c);
+        self.resize_zero.replace(c);
         Ok(())
     }
 

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -269,14 +269,14 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         }
     }
 
-    // REALLOC
-    let mut required_realloc = false;
-    let realloc_fields: Vec<&Field> = fields
+    // RESIZE
+    let mut required_resize = false;
+    let resize_fields: Vec<&Field> = fields
         .iter()
         .filter_map(|f| match f {
-            AccountField::Field(field) if field.constraints.realloc.is_some() => {
+            AccountField::Field(field) if field.constraints.resize.is_some() => {
                 if !field.is_optional {
-                    required_realloc = true
+                    required_resize = true
                 }
                 Some(field)
             }
@@ -284,29 +284,29 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         })
         .collect();
 
-    if !realloc_fields.is_empty() {
-        // realloc needs system program.
+    if !resize_fields.is_empty() {
+        // resize needs system program.
         if !fields
             .iter()
-            .any(|f| f.ident() == "system_program" && !(required_realloc && f.is_optional()))
+            .any(|f| f.ident() == "system_program" && !(required_resize && f.is_optional()))
         {
             #[allow(
                 clippy::indexing_slicing,
-                reason = "guarded by !realloc_fields.is_empty() above"
+                reason = "guarded by !resize_fields.is_empty() above"
             )]
             return Err(ParseError::new(
-                realloc_fields[0].ident.span(),
-                message("realloc", "system_program", required_realloc),
+                resize_fields[0].ident.span(),
+                message("resize", "system_program", required_resize),
             ));
         }
 
-        for field in realloc_fields {
-            // Get allocator for realloc-ed account
+        for field in resize_fields {
+            // Get allocator for resized account
             #[allow(
                 clippy::unwrap_used,
-                reason = "realloc_fields only contains fields with realloc constraint set"
+                reason = "resize_fields only contains fields with resize constraint set"
             )]
-            let associated_payer_name = match field.constraints.realloc.clone().unwrap().payer {
+            let associated_payer_name = match field.constraints.resize.clone().unwrap().payer {
                 // composite allocator, check not supported
                 Expr::Field(_) => continue,
                 // method call, check not supported
@@ -325,21 +325,20 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
                     if !associated_payer_field.constraints.is_mutable() {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "the realloc::payer specified for an realloc constraint must be \
-                             mutable.",
+                            "the resize::payer specified for a resize constraint must be mutable.",
                         ));
-                    } else if associated_payer_field.is_optional && required_realloc {
+                    } else if associated_payer_field.is_optional && required_resize {
                         return Err(ParseError::new(
                             field.ident.span(),
-                            "the realloc::payer specified for a required realloc constraint must \
-                             be required.",
+                            "the resize::payer specified for a required resize constraint must be \
+                             required.",
                         ));
                     }
                 }
                 _ => {
                     return Err(ParseError::new(
                         field.ident.span(),
-                        "the realloc::payer specified does not exist.",
+                        "the resize::payer specified does not exist.",
                     ));
                 }
             }

--- a/tests/optional/programs/optional/src/context.rs
+++ b/tests/optional/programs/optional/src/context.rs
@@ -30,11 +30,11 @@ pub struct Update<'info> {
 pub struct Realloc<'info> {
     #[account(mut)]
     pub payer: Option<Signer<'info>>,
-    #[account(mut, realloc = new_size as usize, realloc::payer = payer, realloc::zero = false)]
+    #[account(mut, resize = new_size as usize, resize::payer = payer, resize::zero = false)]
     pub optional_pda: Option<Account<'info, DataPda>>,
     pub required: Account<'info, DataAccount>,
     pub system_program: Option<Program<'info, System>>,
-    #[account(mut, signer, realloc = new_size as usize, realloc::payer = payer, realloc::zero = true)]
+    #[account(mut, signer, resize = new_size as usize, resize::payer = payer, resize::zero = true)]
     pub optional_account: Option<Account<'info, DataAccount>>,
 }
 

--- a/tests/realloc/programs/realloc/src/lib.rs
+++ b/tests/realloc/programs/realloc/src/lib.rs
@@ -12,7 +12,7 @@ pub mod realloc {
         Ok(())
     }
 
-    pub fn realloc(ctx: Context<Realloc>, len: u16) -> Result<()> {
+    pub fn realloc(ctx: Context<Resize>, len: u16) -> Result<()> {
         ctx.accounts
             .sample
             .data
@@ -20,7 +20,7 @@ pub mod realloc {
         Ok(())
     }
 
-    pub fn realloc2(ctx: Context<Realloc2>, len: u16) -> Result<()> {
+    pub fn realloc2(ctx: Context<Resize2>, len: u16) -> Result<()> {
         ctx.accounts
             .sample1
             .data
@@ -53,7 +53,7 @@ pub struct Initialize<'info> {
 
 #[derive(Accounts)]
 #[instruction(len: u16)]
-pub struct Realloc<'info> {
+pub struct Resize<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
@@ -61,9 +61,9 @@ pub struct Realloc<'info> {
         mut,
         seeds = [b"sample"],
         bump = sample.bump,
-        realloc = Sample::space(len as usize),
-        realloc::payer = authority,
-        realloc::zero = false,
+        resize = Sample::space(len as usize),
+        resize::payer = authority,
+        resize::zero = false,
     )]
     pub sample: Account<'info, Sample>,
 
@@ -72,7 +72,7 @@ pub struct Realloc<'info> {
 
 #[derive(Accounts)]
 #[instruction(len: u16)]
-pub struct Realloc2<'info> {
+pub struct Resize2<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
@@ -80,9 +80,9 @@ pub struct Realloc2<'info> {
         mut,
         seeds = [b"sample"],
         bump = sample1.bump,
-        realloc = Sample::space(len as usize),
-        realloc::payer = authority,
-        realloc::zero = false,
+        resize = Sample::space(len as usize),
+        resize::payer = authority,
+        resize::zero = false,
     )]
     pub sample1: Account<'info, Sample>,
 
@@ -90,9 +90,9 @@ pub struct Realloc2<'info> {
         mut,
         seeds = [b"sample"],
         bump = sample2.bump,
-        realloc = Sample::space((len + 10) as usize),
-        realloc::payer = authority,
-        realloc::zero = false,
+        resize = Sample::space((len + 10) as usize),
+        resize::payer = authority,
+        resize::zero = false,
         dup, // Allow duplicate accounts
     )]
     pub sample2: Account<'info, Sample>,

--- a/tests/realloc/tests/realloc.ts
+++ b/tests/realloc/tests/realloc.ts
@@ -42,7 +42,7 @@ describe("realloc", () => {
       assert.isTrue(e instanceof AnchorError);
       const err: AnchorError = e;
       const errMsg =
-        "The account reallocation exceeds the MAX_PERMITTED_DATA_INCREASE limit";
+        "The account resize exceeds the MAX_PERMITTED_DATA_INCREASE limit";
       assert.strictEqual(err.error.errorMessage, errMsg);
       assert.strictEqual(err.error.errorCode.number, 3016);
     }
@@ -81,8 +81,7 @@ describe("realloc", () => {
     } catch (e) {
       assert.isTrue(e instanceof AnchorError);
       const err: AnchorError = e;
-      const errMsg =
-        "The account was duplicated for more than one reallocation";
+      const errMsg = "The account was duplicated for more than one resize";
       assert.strictEqual(err.error.errorMessage, errMsg);
       assert.strictEqual(err.error.errorCode.number, 3017);
     }


### PR DESCRIPTION
closes #4526

the Solana SDK renamed `AccountInfo::realloc` to `AccountInfo::resize`. the generated code in anchor was already calling `.resize()` internally — this PR syncs the constraint keyword itself to match.

**before:**
```rust
#[account(
    mut,
    realloc = 8 + std::mem::size_of::<MyType>(),
    realloc::payer = payer,
    realloc::zero = false,
)]
pub my_account: Account<'info, MyType>,
```

**after:**
```rust
#[account(
    mut,
    resize = 8 + std::mem::size_of::<MyType>(),
    resize::payer = payer,
    resize::zero = false,
)]
pub my_account: Account<'info, MyType>,
```

**what changed:**
- constraint keyword `realloc` → `resize` (and sub-keys `realloc::payer`, `realloc::zero`)
- all internal types renamed (`ConstraintReallocGroup` → `ConstraintResizeGroup`, etc.)
- error codes renamed (`AccountReallocExceedsLimit` → `AccountResizeExceedsLimit`, `AccountDuplicateReallocs` → `AccountDuplicateResizes`)
- the `Accounts` trait `try_accounts` parameter renamed from `reallocs` to `resizes`
- docs and test program updated

**breaking change:** any program using the `realloc` constraint needs to rename to `resize`.