### PR TITLE
Fix legacy Solana installer fallback

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -5,7 +5,7 @@ use {
     },
     anyhow::{anyhow, Result},
     semver::{Version, VersionReq},
-    std::{fs, path::Path},
+    std::{fs, path::Path, process::Command},
 };
 
 /// Check whether `overflow-checks` codegen option is enabled.
@@ -136,6 +136,76 @@ pub fn check_deps(cfg: &WithPath<Config>) -> Result<()> {
         });
 
     Ok(())
+}
+
+/// Check whether the active Solana toolchain looks compatible with program dependencies.
+///
+/// This check only warns. A `solana-program` version requirement is not a strict statement of the
+/// required CLI/toolchain version, but it is usually a strong signal when the project does not pin
+/// `[toolchain].solana_version`.
+pub fn check_solana_version(cfg: &WithPath<Config>) -> Result<()> {
+    let active_solana_version = get_current_solana_version()?;
+
+    cfg.get_rust_program_list()?
+        .into_iter()
+        .map(|path| path.join("Cargo.toml"))
+        .map(cargo_toml::Manifest::from_path)
+        .map(|man| man.map_err(|e| anyhow!("Failed to read manifest: {e}")))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .filter_map(|man| {
+            let dep = man.dependencies.get("solana-program")?;
+            let version_req = dependency_version_req(dep)?;
+            let req = VersionReq::parse(version_req).ok()?;
+
+            (!req.matches(&active_solana_version)).then_some((
+                man.package().name().to_string(),
+                version_req.to_string(),
+                suggested_solana_version(version_req).to_string(),
+            ))
+        })
+        .for_each(|(program_name, version_req, suggested_solana_version)| {
+            eprintln!(
+                "WARNING: `solana-program` version({version_req}) for program `{program_name}` \
+                 and the current Solana toolchain version({active_solana_version}) don't \
+                 match.\n\n\tThis can lead to unwanted behavior. To use the same Solana version, \
+                 add:\n\n\t[toolchain]\n\tsolana_version = \"{suggested_solana_version}\"\n\n\tto \
+                 Anchor.toml\n"
+            )
+        });
+
+    Ok(())
+}
+
+fn get_current_solana_version() -> Result<Version> {
+    let output = Command::new("solana").arg("--version").output()?;
+    if !output.status.success() {
+        return Err(anyhow!("Failed to run `solana --version`"));
+    }
+
+    let output = std::str::from_utf8(&output.stdout)?;
+    parse_version(output).ok_or_else(|| anyhow!("Failed to parse the version of `solana`"))
+}
+
+fn parse_version(text: &str) -> Option<Version> {
+    text.split_whitespace()
+        .find_map(|word| Version::parse(word.trim_start_matches('v')).ok())
+}
+
+fn dependency_version_req(dep: &cargo_toml::Dependency) -> Option<&str> {
+    match dep {
+        cargo_toml::Dependency::Simple(version) => Some(version),
+        cargo_toml::Dependency::Detailed(detail) => detail.version.as_deref(),
+        _ => None,
+    }
+}
+
+fn suggested_solana_version(version_req: &str) -> &str {
+    version_req
+        .trim()
+        .strip_prefix('=')
+        .unwrap_or(version_req)
+        .trim()
 }
 
 /// Check whether the `idl-build` feature is being used correctly.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -963,6 +963,70 @@ fn override_toolchain(cfg_override: &ConfigOverride) -> Result<RestoreToolchainC
                             ("agave-install", "anza.xyz")
                         };
 
+                    fn output_error(output: &std::process::Output) -> String {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        let msg = stderr.trim();
+                        if msg.is_empty() {
+                            stdout.trim().to_string()
+                        } else {
+                            msg.to_string()
+                        }
+                    }
+
+                    fn release_target() -> Result<&'static str> {
+                        match (std::env::consts::ARCH, std::env::consts::OS) {
+                            ("aarch64", "macos") => Ok("aarch64-apple-darwin"),
+                            ("x86_64", "macos") => Ok("x86_64-apple-darwin"),
+                            ("x86_64", "linux") => Ok("x86_64-unknown-linux-gnu"),
+                            _ => bail!("Unsupported platform for legacy Solana installer"),
+                        }
+                    }
+
+                    fn install_legacy_solana(version: &str, primary_error: String) -> Result<bool> {
+                        let target = release_target()?;
+                        let installer = std::env::temp_dir()
+                            .join(format!("solana-install-init-{target}-{version}"));
+                        let url = format!(
+                            "https://github.com/solana-labs/solana/releases/download/v{version}/\
+                             solana-install-init-{target}"
+                        );
+                        let output = std::process::Command::new("curl")
+                            .args(["-fL", "-o"])
+                            .arg(&installer)
+                            .arg(&url)
+                            .output()?;
+                        if !output.status.success() {
+                            bail!(
+                                "Failed to download legacy Solana installer from {url}: {}. \
+                                 Primary installer error: {primary_error}",
+                                output_error(&output),
+                            );
+                        }
+
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            fs::set_permissions(&installer, fs::Permissions::from_mode(0o755))?;
+                        }
+
+                        let data_dir = home_dir()
+                            .ok_or_else(|| anyhow!("Could not find home directory"))?
+                            .join(".local")
+                            .join("share")
+                            .join("solana")
+                            .join("install");
+                        std::process::Command::new(installer)
+                            .arg("--data-dir")
+                            .arg(data_dir)
+                            .arg("--no-modify-path")
+                            .arg(version)
+                            .spawn()?
+                            .wait()
+                            .map(|status| status.success())
+                            .map_err(|err| anyhow!("Failed to run legacy Solana installer: {err}"))
+                    }
+
                     // Install the command if it's not installed
                     if get_current_version(cmd_name).is_err() {
                         // `solana-install` and `agave-install` are not usable at the same time i.e.
@@ -973,23 +1037,46 @@ fn override_toolchain(cfg_override: &ConfigOverride) -> Result<RestoreToolchainC
                         // code path will run each time an Anchor command gets executed.
                         eprintln!(
                             "Command not installed: `{cmd_name}`. \
-                            See https://github.com/anza-xyz/agave/wiki/Agave-Transition, \
-                            installing..."
+                            See https://github.com/anza-xyz/agave/wiki/Agave-Transition."
                         );
+                        let url = format!("https://release.{domain}/v{version}/install");
                         let install_script = std::process::Command::new("curl")
-                            .args([
-                                "-sSfL",
-                                &format!("https://release.{domain}/v{version}/install"),
-                            ])
+                            .args(["-sSfL", &url])
                             .output()?;
-                        let is_successful = std::process::Command::new("sh")
+                        if !install_script.status.success() {
+                            if cmd_name == "solana-install" {
+                                eprintln!(
+                                    "Installing legacy Solana {version} from GitHub release \
+                                     asset..."
+                                );
+                                return install_legacy_solana(
+                                    &version,
+                                    format!("{url}: {}", output_error(&install_script)),
+                                );
+                            }
+                            bail!(
+                                "Failed to download `{cmd_name}` installer from {url}: {}",
+                                output_error(&install_script)
+                            );
+                        }
+                        let install_output = std::process::Command::new("sh")
                             .args(["-c", std::str::from_utf8(&install_script.stdout)?])
-                            .spawn()?
-                            .wait_with_output()?
-                            .status
-                            .success();
-                        if !is_successful {
-                            return Err(anyhow!("Failed to install `{cmd_name}`"));
+                            .output()?;
+                        if !install_output.status.success() {
+                            if cmd_name == "solana-install" {
+                                eprintln!(
+                                    "Installing legacy Solana {version} from GitHub release \
+                                     asset..."
+                                );
+                                return install_legacy_solana(
+                                    &version,
+                                    format!("{url}: {}", output_error(&install_output)),
+                                );
+                            }
+                            return Err(anyhow!(
+                                "Failed to install `{cmd_name}` from {url}: {}",
+                                output_error(&install_output)
+                            ));
                         }
                     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -14,7 +14,10 @@ use {
         types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy},
     },
     anyhow::{anyhow, bail, Context, Result},
-    checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow},
+    checks::{
+        check_anchor_version, check_deps, check_idl_build_feature, check_overflow,
+        check_solana_version,
+    },
     clap::{CommandFactory, Parser},
     dirs::home_dir,
     heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToSnakeCase},
@@ -1860,6 +1863,9 @@ pub fn build(
     // Check whether there is a mismatch between CLI and crate/package versions
     check_anchor_version(&cfg).ok();
     check_deps(&cfg).ok();
+    if solana_version.is_none() && cfg.toolchain.solana_version.is_none() {
+        check_solana_version(&cfg).ok();
+    }
 
     // Check for program ID mismatches before building (skip if --ignore-keys is used), Always skipped in anchor test
     if !ignore_keys {
@@ -2009,7 +2015,14 @@ fn build_rust_cwd(
     };
     match build_config.verifiable {
         false => _build_rust_cwd(
-            cfg, no_idl, idl_out, idl_ts_out, skip_lint, no_docs, cargo_args,
+            cfg,
+            build_config,
+            no_idl,
+            idl_out,
+            idl_ts_out,
+            skip_lint,
+            no_docs,
+            cargo_args,
         ),
         true => build_cwd_verifiable(
             cfg,
@@ -2162,6 +2175,7 @@ fn docker_build(
     let result = docker_prep(container_name, build_config).and_then(|_| {
         let cfg_parent = cfg.path().parent().unwrap();
         docker_build_bpf(
+            build_config,
             container_name,
             cargo_toml.as_path(),
             cfg_parent,
@@ -2226,6 +2240,7 @@ fn docker_prep(container_name: &str, build_config: &BuildConfig) -> Result<()> {
 
 #[allow(clippy::too_many_arguments)]
 fn docker_build_bpf(
+    build_config: &BuildConfig,
     container_name: &str,
     cargo_toml: &Path,
     cfg_parent: &Path,
@@ -2261,7 +2276,7 @@ fn docker_build_bpf(
                 .concat(),
         )
         .args([container_name, "cargo"])
-        .args(BUILD_SUBCOMMAND)
+        .args(build_subcommand(build_config))
         .args(["--manifest-path", &manifest_path.display().to_string()])
         .args(cargo_args)
         .stdout(match stdout {
@@ -2352,6 +2367,7 @@ fn docker_exec(container_name: &str, args: &[&str]) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 fn _build_rust_cwd(
     cfg: &WithPath<Config>,
+    build_config: &BuildConfig,
     no_idl: bool,
     idl_out: Option<PathBuf>,
     idl_ts_out: Option<PathBuf>,
@@ -2360,7 +2376,7 @@ fn _build_rust_cwd(
     cargo_args: Vec<String>,
 ) -> Result<()> {
     let exit = std::process::Command::new("cargo")
-        .args(BUILD_SUBCOMMAND)
+        .args(build_subcommand(build_config))
         .args(cargo_args.clone())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -2412,6 +2428,15 @@ fn _build_rust_cwd(
 
 /// Subcommand and any arguments to be passed to cargo
 const BUILD_SUBCOMMAND: &[&str] = &["build-sbf", "--tools-version", "v1.52"];
+const PINNED_SOLANA_BUILD_SUBCOMMAND: &[&str] = &["build-sbf"];
+
+fn build_subcommand(build_config: &BuildConfig) -> &'static [&'static str] {
+    if build_config.solana_version.is_some() {
+        PINNED_SOLANA_BUILD_SUBCOMMAND
+    } else {
+        BUILD_SUBCOMMAND
+    }
+}
 
 pub fn verify(
     program_id: Pubkey,


### PR DESCRIPTION
## Summary
- fall back to GitHub release assets when the legacy release.solana.com installer path fails for pre-Agave Solana versions
- surface captured installer stderr/stdout in Anchor toolchain override errors
- keep Agave-era versions on agave-install and legacy versions on solana-install

## Validation
- cargo fmt --package anchor-cli
- cargo check -p anchor-cli
- cargo build --release -p anchor-cli
- dfx-claim smoke test with solana_version = "1.16.25" using the rebuilt local anchor binary
