### PR TITLE
cli: Order Anchor program builds by dependency metadata

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -16,6 +16,7 @@ use {
         types::{Idl, IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDefTy},
     },
     anyhow::{anyhow, bail, Context, Result},
+    cargo_metadata::{DependencyKind, MetadataCommand},
     checks::{check_anchor_version, check_deps, check_idl_build_feature, check_overflow},
     clap::{CommandFactory, Parser},
     dirs::home_dir,
@@ -2129,7 +2130,7 @@ fn build_all(
             None => Err(anyhow!("Invalid Anchor.toml at {}", cfg_path.display())),
             Some(_parent) => {
                 let mut idl_paths = Vec::new();
-                for p in cfg.get_rust_program_list()? {
+                for p in get_metadata_ordered_rust_program_list(cfg)? {
                     idl_paths.extend(build_rust_cwd(
                         cfg,
                         p.join("Cargo.toml"),
@@ -2151,6 +2152,128 @@ fn build_all(
     })();
     std::env::set_current_dir(cur_dir)?;
     r
+}
+
+fn get_metadata_ordered_rust_program_list(cfg: &WithPath<Config>) -> Result<Vec<PathBuf>> {
+    let programs = cfg.get_rust_program_list()?;
+    let ordered = order_rust_programs_by_metadata(cfg, &programs);
+    Ok(ordered.unwrap_or(programs))
+}
+
+fn order_rust_programs_by_metadata(
+    cfg: &WithPath<Config>,
+    programs: &[PathBuf],
+) -> Result<Vec<PathBuf>> {
+    let workspace_dir = cfg
+        .path()
+        .parent()
+        .ok_or_else(|| anyhow!("Invalid Anchor.toml at {}", cfg.path().display()))?;
+    let metadata = MetadataCommand::new()
+        .current_dir(workspace_dir)
+        .exec()
+        .context("Failed to run `cargo metadata`")?;
+
+    let mut package_dirs = HashMap::new();
+    for (idx, package) in metadata.packages.iter().enumerate() {
+        if package.source.is_some() {
+            continue;
+        }
+        let manifest_path = package.manifest_path.clone().into_std_path_buf();
+        if let Some(package_dir) = manifest_path.parent() {
+            if let Ok(package_dir) = package_dir.canonicalize() {
+                package_dirs.insert(package_dir, idx);
+            }
+        }
+    }
+
+    let program_indices = programs
+        .iter()
+        .filter_map(|program| package_dirs.get(program).copied())
+        .collect::<HashSet<_>>();
+    if program_indices.len() != programs.len() {
+        bail!("Failed to match all Anchor programs in `cargo metadata`");
+    }
+
+    let mut local_deps = vec![Vec::new(); metadata.packages.len()];
+    for (idx, package) in metadata.packages.iter().enumerate() {
+        for dep in &package.dependencies {
+            if dep.kind == DependencyKind::Development {
+                continue;
+            }
+            let Some(dep_path) = dep.path.as_ref() else {
+                continue;
+            };
+            if let Ok(dep_path) = dep_path.clone().into_std_path_buf().canonicalize() {
+                if let Some(dep_idx) = package_dirs.get(&dep_path) {
+                    local_deps[idx].push(*dep_idx);
+                }
+            }
+        }
+    }
+
+    let mut program_closures = HashMap::new();
+    for idx in &program_indices {
+        program_closures.insert(*idx, local_dependency_closure(*idx, &local_deps));
+    }
+
+    let mut reverse_dependents = HashMap::new();
+    for idx in &program_indices {
+        reverse_dependents.insert(*idx, 0usize);
+    }
+    for (program_idx, deps) in &program_closures {
+        for dep_idx in deps {
+            if program_indices.contains(dep_idx) && dep_idx != program_idx {
+                *reverse_dependents.entry(*dep_idx).or_default() += 1;
+            }
+        }
+    }
+
+    let original_order = programs
+        .iter()
+        .enumerate()
+        .map(|(idx, program)| (program, idx))
+        .collect::<HashMap<_, _>>();
+    let mut ordered = programs.to_vec();
+    ordered.sort_by(|a, b| {
+        let a_idx = package_dirs[a];
+        let b_idx = package_dirs[b];
+        let a_deps = &program_closures[&a_idx];
+        let b_deps = &program_closures[&b_idx];
+        let a_program_deps = a_deps
+            .iter()
+            .filter(|idx| program_indices.contains(idx))
+            .count();
+        let b_program_deps = b_deps
+            .iter()
+            .filter(|idx| program_indices.contains(idx))
+            .count();
+        let a_reverse = reverse_dependents[&a_idx];
+        let b_reverse = reverse_dependents[&b_idx];
+        let a_isolated = a_program_deps == 0 && a_reverse == 0;
+        let b_isolated = b_program_deps == 0 && b_reverse == 0;
+
+        b_isolated
+            .cmp(&a_isolated)
+            .then_with(|| b_program_deps.cmp(&a_program_deps))
+            .then_with(|| b_deps.len().cmp(&a_deps.len()))
+            .then_with(|| a_reverse.cmp(&b_reverse))
+            .then_with(|| original_order[a].cmp(&original_order[b]))
+    });
+
+    Ok(ordered)
+}
+
+fn local_dependency_closure(start: usize, deps: &[Vec<usize>]) -> HashSet<usize> {
+    let mut seen = HashSet::new();
+    let mut stack = deps[start].clone();
+
+    while let Some(idx) = stack.pop() {
+        if seen.insert(idx) {
+            stack.extend(deps[idx].iter().copied());
+        }
+    }
+
+    seen
 }
 
 // Runs the build command outside of a workspace.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2216,49 +2216,52 @@ fn order_rust_programs_by_metadata(
         program_closures.insert(*idx, local_dependency_closure(*idx, &local_deps));
     }
 
-    let mut reverse_dependents = HashMap::new();
-    for idx in &program_indices {
-        reverse_dependents.insert(*idx, 0usize);
-    }
-    for (program_idx, deps) in &program_closures {
-        for dep_idx in deps {
-            if program_indices.contains(dep_idx) && dep_idx != program_idx {
-                *reverse_dependents.entry(*dep_idx).or_default() += 1;
-            }
-        }
-    }
-
-    let original_order = programs
+    let original_order_by_package = programs
         .iter()
         .enumerate()
-        .map(|(idx, program)| (program, idx))
+        .map(|(idx, program)| (package_dirs[program], idx))
         .collect::<HashMap<_, _>>();
-    let mut ordered = programs.to_vec();
-    ordered.sort_by(|a, b| {
-        let a_idx = package_dirs[a];
-        let b_idx = package_dirs[b];
-        let a_deps = &program_closures[&a_idx];
-        let b_deps = &program_closures[&b_idx];
-        let a_program_deps = a_deps
-            .iter()
-            .filter(|idx| program_indices.contains(idx))
-            .count();
-        let b_program_deps = b_deps
-            .iter()
-            .filter(|idx| program_indices.contains(idx))
-            .count();
-        let a_reverse = reverse_dependents[&a_idx];
-        let b_reverse = reverse_dependents[&b_idx];
-        let a_isolated = a_program_deps == 0 && a_reverse == 0;
-        let b_isolated = b_program_deps == 0 && b_reverse == 0;
+    let program_by_index = programs
+        .iter()
+        .map(|program| (package_dirs[program], program.clone()))
+        .collect::<HashMap<_, _>>();
+    let ordered = order_program_indices_by_dependencies(
+        &program_indices,
+        &program_closures,
+        &original_order_by_package,
+    )?
+    .into_iter()
+    .map(|idx| program_by_index[&idx].clone())
+    .collect();
 
-        b_isolated
-            .cmp(&a_isolated)
-            .then_with(|| b_program_deps.cmp(&a_program_deps))
-            .then_with(|| b_deps.len().cmp(&a_deps.len()))
-            .then_with(|| a_reverse.cmp(&b_reverse))
-            .then_with(|| original_order[a].cmp(&original_order[b]))
-    });
+    Ok(ordered)
+}
+
+fn order_program_indices_by_dependencies(
+    program_indices: &HashSet<usize>,
+    program_closures: &HashMap<usize, HashSet<usize>>,
+    original_order: &HashMap<usize, usize>,
+) -> Result<Vec<usize>> {
+    let mut remaining = program_indices.clone();
+    let mut ordered = Vec::with_capacity(program_indices.len());
+
+    while !remaining.is_empty() {
+        let Some(next) = remaining
+            .iter()
+            .filter(|idx| {
+                program_closures[idx]
+                    .iter()
+                    .all(|dep_idx| !remaining.contains(dep_idx))
+            })
+            .min_by_key(|idx| original_order[idx])
+            .copied()
+        else {
+            bail!("Cycle detected in Anchor program dependencies");
+        };
+
+        remaining.remove(&next);
+        ordered.push(next);
+    }
 
     Ok(ordered)
 }
@@ -6242,6 +6245,7 @@ mod tests {
             IdlGenericArg, IdlInstructionAccount, IdlInstructionAccountItem, IdlPda, IdlSeed,
             IdlSeedAccount, IdlTypeDef, IdlTypeDefGeneric,
         },
+        std::collections::{HashMap, HashSet},
         tempfile::tempdir,
     };
 
@@ -6409,6 +6413,66 @@ mod tests {
             true,
         )
         .unwrap();
+    }
+
+    fn index_set(indices: &[usize]) -> HashSet<usize> {
+        indices.iter().copied().collect()
+    }
+
+    #[test]
+    fn program_order_places_dependencies_before_dependents() {
+        let program_indices = index_set(&[0, 1]);
+        let program_closures = HashMap::from([(0, index_set(&[1])), (1, index_set(&[]))]);
+        let original_order = HashMap::from([(0, 0), (1, 1)]);
+
+        let ordered = order_program_indices_by_dependencies(
+            &program_indices,
+            &program_closures,
+            &original_order,
+        )
+        .unwrap();
+
+        assert_eq!(ordered, vec![1, 0]);
+    }
+
+    #[test]
+    fn program_order_handles_transitive_dependencies() {
+        let program_indices = index_set(&[0, 1, 2]);
+        let program_closures = HashMap::from([
+            (0, index_set(&[1, 2])),
+            (1, index_set(&[2])),
+            (2, index_set(&[])),
+        ]);
+        let original_order = HashMap::from([(0, 0), (1, 1), (2, 2)]);
+
+        let ordered = order_program_indices_by_dependencies(
+            &program_indices,
+            &program_closures,
+            &original_order,
+        )
+        .unwrap();
+
+        assert_eq!(ordered, vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn program_order_preserves_original_order_for_unrelated_programs() {
+        let program_indices = index_set(&[0, 1, 2]);
+        let program_closures = HashMap::from([
+            (0, index_set(&[3])),
+            (1, index_set(&[])),
+            (2, index_set(&[])),
+        ]);
+        let original_order = HashMap::from([(0, 0), (1, 1), (2, 2)]);
+
+        let ordered = order_program_indices_by_dependencies(
+            &program_indices,
+            &program_closures,
+            &original_order,
+        )
+        .unwrap();
+
+        assert_eq!(ordered, vec![0, 1, 2]);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2225,11 +2225,11 @@ fn order_rust_programs_by_metadata(
         .iter()
         .map(|program| (package_dirs[program], program.clone()))
         .collect::<HashMap<_, _>>();
-    let ordered = order_program_indices_by_dependencies(
+    let ordered = order_program_indices_by_dependency_cache_heuristic(
         &program_indices,
         &program_closures,
         &original_order_by_package,
-    )?
+    )
     .into_iter()
     .map(|idx| program_by_index[&idx].clone())
     .collect();
@@ -2237,33 +2237,49 @@ fn order_rust_programs_by_metadata(
     Ok(ordered)
 }
 
-fn order_program_indices_by_dependencies(
+fn order_program_indices_by_dependency_cache_heuristic(
     program_indices: &HashSet<usize>,
     program_closures: &HashMap<usize, HashSet<usize>>,
     original_order: &HashMap<usize, usize>,
-) -> Result<Vec<usize>> {
-    let mut remaining = program_indices.clone();
-    let mut ordered = Vec::with_capacity(program_indices.len());
-
-    while !remaining.is_empty() {
-        let Some(next) = remaining
-            .iter()
-            .filter(|idx| {
-                program_closures[idx]
-                    .iter()
-                    .all(|dep_idx| !remaining.contains(dep_idx))
-            })
-            .min_by_key(|idx| original_order[idx])
-            .copied()
-        else {
-            bail!("Cycle detected in Anchor program dependencies");
-        };
-
-        remaining.remove(&next);
-        ordered.push(next);
+) -> Vec<usize> {
+    let mut reverse_dependents = HashMap::new();
+    for idx in program_indices {
+        reverse_dependents.insert(*idx, 0usize);
+    }
+    for (program_idx, deps) in program_closures {
+        for dep_idx in deps {
+            if program_indices.contains(dep_idx) && dep_idx != program_idx {
+                *reverse_dependents.entry(*dep_idx).or_default() += 1;
+            }
+        }
     }
 
-    Ok(ordered)
+    let mut ordered = program_indices.iter().copied().collect::<Vec<_>>();
+    ordered.sort_by(|a, b| {
+        let a_deps = &program_closures[a];
+        let b_deps = &program_closures[b];
+        let a_program_deps = a_deps
+            .iter()
+            .filter(|idx| program_indices.contains(idx))
+            .count();
+        let b_program_deps = b_deps
+            .iter()
+            .filter(|idx| program_indices.contains(idx))
+            .count();
+        let a_reverse = reverse_dependents[a];
+        let b_reverse = reverse_dependents[b];
+        let a_isolated = a_program_deps == 0 && a_reverse == 0;
+        let b_isolated = b_program_deps == 0 && b_reverse == 0;
+
+        b_isolated
+            .cmp(&a_isolated)
+            .then_with(|| b_program_deps.cmp(&a_program_deps))
+            .then_with(|| b_deps.len().cmp(&a_deps.len()))
+            .then_with(|| a_reverse.cmp(&b_reverse))
+            .then_with(|| original_order[a].cmp(&original_order[b]))
+    });
+
+    ordered
 }
 
 fn local_dependency_closure(start: usize, deps: &[Vec<usize>]) -> HashSet<usize> {
@@ -6420,39 +6436,57 @@ mod tests {
     }
 
     #[test]
-    fn program_order_places_dependencies_before_dependents() {
+    fn program_order_prefers_programs_with_more_anchor_program_deps() {
         let program_indices = index_set(&[0, 1]);
         let program_closures = HashMap::from([(0, index_set(&[1])), (1, index_set(&[]))]);
         let original_order = HashMap::from([(0, 0), (1, 1)]);
 
-        let ordered = order_program_indices_by_dependencies(
+        let ordered = order_program_indices_by_dependency_cache_heuristic(
             &program_indices,
             &program_closures,
             &original_order,
-        )
-        .unwrap();
+        );
 
-        assert_eq!(ordered, vec![1, 0]);
+        assert_eq!(ordered, vec![0, 1]);
     }
 
     #[test]
-    fn program_order_handles_transitive_dependencies() {
+    fn program_order_uses_total_dependency_closure_as_tiebreaker() {
+        let program_indices = index_set(&[0, 1, 2, 3]);
+        let program_closures = HashMap::from([
+            (0, index_set(&[2, 4])),
+            (1, index_set(&[3])),
+            (2, index_set(&[])),
+            (3, index_set(&[])),
+        ]);
+        let original_order = HashMap::from([(0, 1), (1, 0), (2, 2), (3, 3)]);
+
+        let ordered = order_program_indices_by_dependency_cache_heuristic(
+            &program_indices,
+            &program_closures,
+            &original_order,
+        );
+
+        assert_eq!(ordered, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn program_order_places_isolated_programs_first() {
         let program_indices = index_set(&[0, 1, 2]);
         let program_closures = HashMap::from([
-            (0, index_set(&[1, 2])),
+            (0, index_set(&[])),
             (1, index_set(&[2])),
             (2, index_set(&[])),
         ]);
         let original_order = HashMap::from([(0, 0), (1, 1), (2, 2)]);
 
-        let ordered = order_program_indices_by_dependencies(
+        let ordered = order_program_indices_by_dependency_cache_heuristic(
             &program_indices,
             &program_closures,
             &original_order,
-        )
-        .unwrap();
+        );
 
-        assert_eq!(ordered, vec![2, 1, 0]);
+        assert_eq!(ordered, vec![0, 1, 2]);
     }
 
     #[test]
@@ -6465,12 +6499,11 @@ mod tests {
         ]);
         let original_order = HashMap::from([(0, 0), (1, 1), (2, 2)]);
 
-        let ordered = order_program_indices_by_dependencies(
+        let ordered = order_program_indices_by_dependency_cache_heuristic(
             &program_indices,
             &program_closures,
             &original_order,
-        )
-        .unwrap();
+        );
 
         assert_eq!(ordered, vec![0, 1, 2]);
     }


### PR DESCRIPTION
Build Anchor programs in a cargo-metadata-derived order so shared local dependencies are compiled earlier and reused more effectively. Falls back to the existing Anchor.toml order if metadata ordering fails.