### PR TITLE
cli: add `--version --verbose` for tools version info

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -6,5 +6,19 @@ fn main() -> Result<()> {
         unreachable!();
     }
 
+    if is_version_request() {
+        print!("{}", anchor_cli::support_version_report());
+        return Ok(());
+    }
+
     anchor_cli::entry(Opts::parse())
+}
+
+fn is_version_request() -> bool {
+    let mut args = std::env::args_os().skip(1);
+    let Some(arg) = args.next() else {
+        return false;
+    };
+
+    (arg == "--version" || arg == "-V") && args.next().is_none()
 }

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,4 +1,4 @@
-use {anchor_cli::Opts, anyhow::Result, clap::Parser};
+use {anchor_cli::Opts, anyhow::Result, clap::Parser, std::ffi::OsString};
 
 fn main() -> Result<()> {
     #[cfg(not(windows))]
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
         unreachable!();
     }
 
-    if is_version_request() {
+    if is_verbose_version_request() {
         print!("{}", anchor_cli::support_version_report());
         return Ok(());
     }
@@ -14,11 +14,55 @@ fn main() -> Result<()> {
     anchor_cli::entry(Opts::parse())
 }
 
-fn is_version_request() -> bool {
-    let mut args = std::env::args_os().skip(1);
-    let Some(arg) = args.next() else {
-        return false;
-    };
+fn is_verbose_version_request() -> bool {
+    is_verbose_version_args(std::env::args_os().skip(1).collect())
+}
 
-    (arg == "--version" || arg == "-V") && args.next().is_none()
+fn is_verbose_version_args(args: Vec<OsString>) -> bool {
+    match args.as_slice() {
+        [arg] => arg == "-vV" || arg == "-Vv",
+        [first, second] => {
+            (is_version_arg(first) && is_verbose_arg(second))
+                || (is_verbose_arg(first) && is_version_arg(second))
+        }
+        _ => false,
+    }
+}
+
+fn is_version_arg(arg: &OsString) -> bool {
+    arg == "--version" || arg == "-V"
+}
+
+fn is_verbose_arg(arg: &OsString) -> bool {
+    arg == "--verbose" || arg == "-v"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn detects_verbose_version_requests() {
+        for input in [
+            &["-vV"][..],
+            &["-Vv"],
+            &["-v", "-V"],
+            &["-V", "-v"],
+            &["--verbose", "--version"],
+            &["--version", "--verbose"],
+        ] {
+            assert!(is_verbose_version_args(args(input)));
+        }
+    }
+
+    #[test]
+    fn ignores_regular_version_requests() {
+        for input in [&["-V"][..], &["--version"], &["version"], &[]] {
+            assert!(!is_verbose_version_args(args(input)));
+        }
+    }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -89,6 +89,71 @@ pub static AVM_HOME: LazyLock<PathBuf> = LazyLock::new(|| {
     }
 });
 
+pub fn support_version_report() -> String {
+    let mut lines = vec![format!("anchor-cli {VERSION}")];
+
+    lines.push(command_version_line("solana-cli", "solana"));
+    lines.push(command_version_line("cargo", "cargo"));
+    lines.push(format!("OS: {}", os_version()));
+
+    lines.join("\n") + "\n"
+}
+
+fn command_version_line(label: &str, command: &str) -> String {
+    match command_output(command, &["--version"]) {
+        Some(version) if version.starts_with(label) => version,
+        Some(version) => format!("{label} {version}"),
+        None => format!("{label} unavailable"),
+    }
+}
+
+fn command_output(command: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(command)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .and_then(|output| output.lines().next().map(str::trim).map(str::to_owned))
+        .filter(|line| !line.is_empty())
+}
+
+fn os_version() -> String {
+    if let Some(version) = macos_version() {
+        return version;
+    }
+    if let Some(version) = command_output("lsb_release", &["-ds"]) {
+        return version.trim_matches('"').to_owned();
+    }
+    if let Some(version) = linux_os_release() {
+        return version;
+    }
+    if let Some(version) = command_output("cmd", &["/C", "ver"]) {
+        return version;
+    }
+
+    std::env::consts::OS.to_owned()
+}
+
+fn macos_version() -> Option<String> {
+    let name = command_output("sw_vers", &["-productName"])?;
+    let version = command_output("sw_vers", &["-productVersion"])?;
+    let build = command_output("sw_vers", &["-buildVersion"])?;
+    Some(format!("{name} {version} {build}"))
+}
+
+fn linux_os_release() -> Option<String> {
+    fs::read_to_string("/etc/os-release")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+        .map(|value| value.trim_matches('"').to_owned())
+}
+
 #[derive(Debug, Parser, AbsolutePath)]
 #[clap(version = VERSION)]
 pub struct Opts {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -123,15 +123,22 @@ fn command_output(command: &str, args: &[&str]) -> Option<String> {
 }
 
 fn os_version() -> String {
+    #[cfg(target_os = "macos")]
     if let Some(version) = macos_version() {
         return version;
     }
-    if let Some(version) = command_output("lsb_release", &["-ds"]) {
-        return version.trim_matches('"').to_owned();
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(version) = command_output("lsb_release", &["-ds"]) {
+            return version.trim_matches('"').to_owned();
+        }
+        if let Some(version) = linux_os_release() {
+            return version;
+        }
     }
-    if let Some(version) = linux_os_release() {
-        return version;
-    }
+
+    #[cfg(target_os = "windows")]
     if let Some(version) = command_output("cmd", &["/C", "ver"]) {
         return version;
     }
@@ -139,6 +146,7 @@ fn os_version() -> String {
     std::env::consts::OS.to_owned()
 }
 
+#[cfg(target_os = "macos")]
 fn macos_version() -> Option<String> {
     let name = command_output("sw_vers", &["-productName"])?;
     let version = command_output("sw_vers", &["-productVersion"])?;
@@ -146,6 +154,7 @@ fn macos_version() -> Option<String> {
     Some(format!("{name} {version} {build}"))
 }
 
+#[cfg(target_os = "linux")]
 fn linux_os_release() -> Option<String> {
     fs::read_to_string("/etc/os-release")
         .ok()?


### PR DESCRIPTION
## Summary
- expand `anchor --version` / `anchor -V` to include Solana CLI, Cargo, and OS version info
- fall back to `unavailable` for missing external tools

Closes #3105

## Testing
- `cargo fmt --check --package anchor-cli`
- `cargo check -p anchor-cli`
- `cargo run -q -p anchor-cli -- --version`
- `cargo run -q -p anchor-cli -- -V`
- `git diff --check`