### PR TITLE
cli: pass extra validator args from config

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1388,6 +1388,9 @@ pub struct _Validator {
     // Deactivate one or more features.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivate_feature: Option<Vec<String>>,
+    // Extra arguments to pass through to solana-test-validator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_args: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -1425,6 +1428,8 @@ pub struct Validator {
     pub warp_slot: Option<Slot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivate_feature: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_args: Option<Vec<String>>,
 }
 
 impl From<_Validator> for Validator {
@@ -1452,6 +1457,7 @@ impl From<_Validator> for Validator {
             ticks_per_slot: _validator.ticks_per_slot,
             warp_slot: _validator.warp_slot,
             deactivate_feature: _validator.deactivate_feature,
+            extra_args: _validator.extra_args,
         }
     }
 }
@@ -1477,6 +1483,7 @@ impl From<Validator> for _Validator {
             ticks_per_slot: validator.ticks_per_slot,
             warp_slot: validator.warp_slot,
             deactivate_feature: validator.deactivate_feature,
+            extra_args: validator.extra_args,
         }
     }
 }
@@ -1572,6 +1579,15 @@ impl Merge for _Validator {
             deactivate_feature: other
                 .deactivate_feature
                 .or_else(|| self.deactivate_feature.take()),
+            extra_args: match self.extra_args.take() {
+                None => other.extra_args,
+                Some(mut args) => {
+                    if let Some(other_args) = other.extra_args {
+                        args.extend(other_args);
+                    }
+                    Some(args)
+                }
+            },
         };
     }
 }
@@ -1866,6 +1882,45 @@ go = { enable = true, path = "go-client" }
             reparsed.clients.go.as_ref().and_then(|g| g.path()),
             Some("go-client"),
         );
+    }
+
+    #[test]
+    fn test_validator_extra_args_round_trips() {
+        let toml = BASE_CONFIG.to_owned()
+            + r#"
+[test.validator]
+extra_args = [
+    "--rpc-pubsub-enable-block-subscription",
+    "--geyser-plugin-config",
+    "geyser.json",
+]
+"#;
+        let config = Config::from_str(&toml).unwrap();
+        let extra_args = config
+            .test_validator
+            .as_ref()
+            .and_then(|test| test.validator.as_ref())
+            .and_then(|validator| validator.extra_args.as_ref())
+            .unwrap();
+
+        assert_eq!(
+            extra_args,
+            &vec![
+                "--rpc-pubsub-enable-block-subscription".to_string(),
+                "--geyser-plugin-config".to_string(),
+                "geyser.json".to_string(),
+            ]
+        );
+
+        let serialized = config.to_string();
+        let reparsed = Config::from_str(&serialized).unwrap();
+        let reparsed_extra_args = reparsed
+            .test_validator
+            .as_ref()
+            .and_then(|test| test.validator.as_ref())
+            .and_then(|validator| validator.extra_args.as_ref())
+            .unwrap();
+        assert_eq!(reparsed_extra_args, extra_args);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4376,6 +4376,12 @@ fn validator_flags(
                     // these validator flags.
                     continue;
                 };
+                if key == "extra_args" {
+                    for arg in value.as_array().unwrap() {
+                        flags.push(arg.as_str().unwrap().to_string());
+                    }
+                    continue;
+                }
                 if key == "account" {
                     for entry in value.as_array().unwrap() {
                         // Push the account flag for each array entry


### PR DESCRIPTION
## Summary
- add [test.validator].extra_args as a raw solana-test-validator passthrough
- append extra args verbatim during validator flag construction
- cover TOML parse/serialization roundtrip for the new field

Closes #1840

## Test
- cargo test -p anchor-cli test_validator_extra_args_round_trips