### PR TITLE
test(v2): cover duplicate remaining accounts

### DIFF
--- a/bench/programs/multisig/anchor-v2/src/lib.rs
+++ b/bench/programs/multisig/anchor-v2/src/lib.rs
@@ -16,7 +16,7 @@ pub mod multisig_v2 {
 
     #[discrim = 0]
     pub fn create(ctx: &mut Context<Create>, threshold: u8) -> Result<()> {
-        let remaining = ctx.remaining_accounts();
+        let remaining = ctx.remaining_accounts()?;
         ctx.accounts.create_multisig(threshold, &remaining)?;
         ctx.accounts.config.bump = ctx.bumps.config;
         Ok(())
@@ -34,7 +34,7 @@ pub mod multisig_v2 {
 
     #[discrim = 3]
     pub fn execute_transfer(ctx: &mut Context<ExecuteTransfer>, amount: u64) -> Result<()> {
-        let remaining = ctx.remaining_accounts();
+        let remaining = ctx.remaining_accounts()?;
         ctx.accounts.verify_and_transfer(amount, ctx.bumps.vault, &remaining)
     }
 }

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -132,3 +132,7 @@ required-features = ["testing"]
 [[test]]
 name = "miri_wrapper_accounts"
 required-features = ["testing"]
+
+[[test]]
+name = "remaining_accounts_mut_check"
+required-features = ["testing"]

--- a/lang-v2/src/context.rs
+++ b/lang-v2/src/context.rs
@@ -1,6 +1,7 @@
 use {
     crate::cursor::AccountCursor,
     pinocchio::{account::AccountView, address::Address},
+    solana_program_error::ProgramError,
 };
 
 /// Instruction-scoped context passed to every handler. Holds the
@@ -29,10 +30,21 @@ pub struct Context<'a, T: Bumps> {
     /// zero once the remaining region is walked.
     remaining_num: u8,
 
+    /// Mutable-account mask covering the declared region (from
+    /// `T::MUT_MASK`). Used by [`Self::remaining_accounts`] to
+    /// re-check each trailing account against declared mut slots —
+    /// without this, a trailing account whose dup index points at a
+    /// mut declared account would silently alias it (bug 3: the
+    /// `HEADER_SIZE`-only check in `run_handler` can't see dups that
+    /// only surface during the trailing walk).
+    mut_mask: &'static [u64; 4],
+
     /// Cache of the parsed remaining accounts. Populated lazily on the
-    /// first call to [`Self::remaining_accounts`]; subsequent calls
-    /// return a clone of the cached vec so the caller receives an
-    /// owned value (avoiding borrow conflicts with `self.accounts`).
+    /// first successful call to [`Self::remaining_accounts`]; subsequent
+    /// calls return a clone of the cached vec. On failure the cache is
+    /// left unset so a retry re-executes the walk (a program is unlikely
+    /// to retry past a `ConstraintDuplicateMutableAccount` error, but we
+    /// avoid caching stale state regardless).
     remaining_cache: Option<alloc::vec::Vec<AccountView>>,
 }
 
@@ -44,6 +56,7 @@ impl<'a, T: Bumps> Context<'a, T> {
         bumps: T::Bumps,
         cursor: &'a mut AccountCursor,
         remaining_num: u8,
+        mut_mask: &'static [u64; 4],
     ) -> Self {
         Self {
             program_id,
@@ -51,6 +64,7 @@ impl<'a, T: Bumps> Context<'a, T> {
             bumps,
             cursor,
             remaining_num,
+            mut_mask,
             remaining_cache: None,
         }
     }
@@ -59,7 +73,20 @@ impl<'a, T: Bumps> Context<'a, T> {
     /// owned `Vec<AccountView>`. First call walks the cursor and caches;
     /// subsequent calls clone the cache. Owned vec avoids borrow conflicts
     /// with `self.accounts` / `self.bumps`.
-    pub fn remaining_accounts(&mut self) -> alloc::vec::Vec<AccountView> {
+    ///
+    /// After each cursor advance, re-tests the cursor's duplicate bitvec
+    /// against `T::MUT_MASK`. If a trailing account's dup index resolves
+    /// to a declared mut slot, returns
+    /// `ConstraintDuplicateMutableAccount`. The `HEADER_SIZE`-only check
+    /// in `run_handler` only sees duplicates that existed at the end of
+    /// the declared walk; trailing-region dups can only be caught here.
+    ///
+    /// `MUT_MASK` is sized per declared field, so bits set for trailing
+    /// indices (past `HEADER_SIZE`) are naturally zero — the intersect
+    /// only fires when a trailing slot's bit overlaps with a declared
+    /// mut slot's bit, which by construction means the runtime resolved
+    /// the trailing slot as a dup of that declared mut account.
+    pub fn remaining_accounts(&mut self) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
         if self.remaining_cache.is_none() {
             let mut v = alloc::vec::Vec::with_capacity(self.remaining_num as usize);
             for _ in 0..self.remaining_num {
@@ -67,10 +94,21 @@ impl<'a, T: Bumps> Context<'a, T> {
                 // remaining region and `remaining_num` is the exact
                 // number of accounts to walk.
                 v.push(unsafe { self.cursor.next() });
+                // If this advance materialized a dup whose earlier
+                // slot is a declared mut account, reject. `duplicates`
+                // is `Some` iff at least one dup has ever been seen
+                // (possibly during the `HEADER_SIZE` walk — but that
+                // case is already handled in `run_handler`, so any
+                // overlap here means a trailing account caused it).
+                if let Some(dups) = self.cursor.duplicates() {
+                    if dups.intersects(self.mut_mask) {
+                        return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
+                    }
+                }
             }
             self.remaining_cache = Some(v);
         }
-        self.remaining_cache.as_ref().unwrap().clone()
+        Ok(self.remaining_cache.as_ref().unwrap().clone())
     }
 }
 

--- a/lang-v2/src/context.rs
+++ b/lang-v2/src/context.rs
@@ -39,13 +39,14 @@ pub struct Context<'a, T: Bumps> {
     /// only surface during the trailing walk).
     mut_mask: &'static [u64; 4],
 
-    /// Cache of the parsed remaining accounts. Populated lazily on the
-    /// first successful call to [`Self::remaining_accounts`]; subsequent
-    /// calls return a clone of the cached vec. On failure the cache is
-    /// left unset so a retry re-executes the walk (a program is unlikely
-    /// to retry past a `ConstraintDuplicateMutableAccount` error, but we
-    /// avoid caching stale state regardless).
-    remaining_cache: Option<alloc::vec::Vec<AccountView>>,
+    /// Cached outcome of the remaining-accounts walk. `None` until the
+    /// first call to [`Self::remaining_accounts`]; then stores whichever
+    /// `Result` that walk produced. Subsequent calls replay the cache
+    /// (clone of the vec on success, clone of the error on failure) so
+    /// the cursor is advanced exactly once per instruction — retrying
+    /// after an error must not call `cursor.next()` again, which would
+    /// walk past the remaining region.
+    remaining_cache: Option<Result<alloc::vec::Vec<AccountView>, ProgramError>>,
 }
 
 impl<'a, T: Bumps> Context<'a, T> {
@@ -70,9 +71,12 @@ impl<'a, T: Bumps> Context<'a, T> {
     }
 
     /// Returns trailing accounts beyond the declared `T` fields as an
-    /// owned `Vec<AccountView>`. First call walks the cursor and caches;
-    /// subsequent calls clone the cache. Owned vec avoids borrow conflicts
-    /// with `self.accounts` / `self.bumps`.
+    /// owned `Vec<AccountView>`. First call walks the cursor and caches
+    /// the resulting `Result`; subsequent calls replay the cache (clone
+    /// of the vec on success, clone of the error on failure). Caching
+    /// the error is important: the walk advances an unsafe cursor, and
+    /// a handler that calls this again after an error must not trigger
+    /// another `cursor.next()` loop.
     ///
     /// After each cursor advance, re-tests the cursor's duplicate bitvec
     /// against `T::MUT_MASK`. If a trailing account's dup index resolves
@@ -88,27 +92,29 @@ impl<'a, T: Bumps> Context<'a, T> {
     /// the trailing slot as a dup of that declared mut account.
     pub fn remaining_accounts(&mut self) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
         if self.remaining_cache.is_none() {
-            let mut v = alloc::vec::Vec::with_capacity(self.remaining_num as usize);
-            for _ in 0..self.remaining_num {
-                // SAFETY: cursor is positioned at the start of the
-                // remaining region and `remaining_num` is the exact
-                // number of accounts to walk.
-                v.push(unsafe { self.cursor.next() });
-                // If this advance materialized a dup whose earlier
-                // slot is a declared mut account, reject. `duplicates`
-                // is `Some` iff at least one dup has ever been seen
-                // (possibly during the `HEADER_SIZE` walk — but that
-                // case is already handled in `run_handler`, so any
-                // overlap here means a trailing account caused it).
-                if let Some(dups) = self.cursor.duplicates() {
-                    if dups.intersects(self.mut_mask) {
-                        return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
-                    }
+            self.remaining_cache = Some(self.walk_remaining());
+        }
+        match self.remaining_cache.as_ref().unwrap() {
+            Ok(v) => Ok(v.clone()),
+            Err(e) => Err(e.clone()),
+        }
+    }
+
+    fn walk_remaining(&mut self) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
+        let mut v = alloc::vec::Vec::with_capacity(self.remaining_num as usize);
+        for _ in 0..self.remaining_num {
+            // SAFETY: cursor is positioned at the start of the remaining
+            // region and `remaining_num` is the exact number of accounts
+            // to walk. Walking stops on the first mut-alias error so we
+            // never advance past the remaining region.
+            v.push(unsafe { self.cursor.next() });
+            if let Some(dups) = self.cursor.duplicates() {
+                if dups.intersects(self.mut_mask) {
+                    return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
                 }
             }
-            self.remaining_cache = Some(v);
         }
-        Ok(self.remaining_cache.as_ref().unwrap().clone())
+        Ok(v)
     }
 }
 

--- a/lang-v2/src/context.rs
+++ b/lang-v2/src/context.rs
@@ -20,15 +20,12 @@ pub struct Context<'a, T: Bumps> {
     /// pass them in as arguments.
     pub bumps: T::Bumps,
 
-    /// Cursor into the serialized input buffer, positioned at the
+    /// Holds either a cursor into the serialized input buffer, pointing to the
     /// *start* of the remaining-accounts region (after `try_accounts`
     /// has consumed exactly `T::HEADER_SIZE` declared accounts). Used
     /// by [`Self::remaining_accounts`] for on-demand walking.
-    cursor: &'a mut AccountCursor,
-
-    /// Number of accounts after the declared region. Decremented to
-    /// zero once the remaining region is walked.
-    remaining_num: u8,
+    /// After `remaining_accounts` is called this holds a cache of the result.
+    remaining_accounts: RemainingAccounts<'a>,
 
     /// Mutable-account mask covering the declared region (from
     /// `T::MUT_MASK`). Used by [`Self::remaining_accounts`] to
@@ -38,15 +35,24 @@ pub struct Context<'a, T: Bumps> {
     /// `HEADER_SIZE`-only check in `run_handler` can't see dups that
     /// only surface during the trailing walk).
     mut_mask: &'static [u64; 4],
+}
 
-    /// Cached outcome of the remaining-accounts walk. `None` until the
-    /// first call to [`Self::remaining_accounts`]; then stores whichever
-    /// `Result` that walk produced. Subsequent calls replay the cache
-    /// (clone of the vec on success, clone of the error on failure) so
-    /// the cursor is advanced exactly once per instruction — retrying
-    /// after an error must not call `cursor.next()` again, which would
-    /// walk past the remaining region.
-    remaining_cache: Option<Result<alloc::vec::Vec<AccountView>, ProgramError>>,
+enum RemainingAccounts<'a> {
+    Unparsed {
+        /// Points to the `remaining-accounts` region
+        cursor: &'a mut AccountCursor,
+        /// Number of accounts remaining after the initially declared region
+        remaining: u8,
+    },
+    /// Cached result of walking `remaining-accounts`; will return an error if
+    /// duplicate mutable constraints are violated.
+    Cached(Result<alloc::vec::Vec<AccountView>, ProgramError>),
+}
+
+impl<'a> RemainingAccounts<'a> {
+    fn is_unparsed(&self) -> bool {
+        matches!(self, RemainingAccounts::Unparsed { .. })
+    }
 }
 
 impl<'a, T: Bumps> Context<'a, T> {
@@ -63,10 +69,11 @@ impl<'a, T: Bumps> Context<'a, T> {
             program_id,
             accounts,
             bumps,
-            cursor,
-            remaining_num,
+            remaining_accounts: RemainingAccounts::Unparsed {
+                cursor,
+                remaining: remaining_num,
+            },
             mut_mask,
-            remaining_cache: None,
         }
     }
 
@@ -91,24 +98,33 @@ impl<'a, T: Bumps> Context<'a, T> {
     /// mut slot's bit, which by construction means the runtime resolved
     /// the trailing slot as a dup of that declared mut account.
     pub fn remaining_accounts(&mut self) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
-        if self.remaining_cache.is_none() {
-            self.remaining_cache = Some(self.walk_remaining());
+        if self.remaining_accounts.is_unparsed() {
+            self.remaining_accounts = RemainingAccounts::Cached(self.walk_remaining());
         }
-        match self.remaining_cache.as_ref().unwrap() {
-            Ok(v) => Ok(v.clone()),
-            Err(e) => Err(e.clone()),
+
+        match &self.remaining_accounts {
+            RemainingAccounts::Cached(Ok(accs)) => Ok(accs.clone()),
+            RemainingAccounts::Cached(Err(err)) => Err(err.clone()),
+            RemainingAccounts::Unparsed { .. } => unreachable!(),
         }
     }
 
     fn walk_remaining(&mut self) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
-        let mut v = alloc::vec::Vec::with_capacity(self.remaining_num as usize);
-        for _ in 0..self.remaining_num {
+        let RemainingAccounts::Unparsed {
+            ref mut cursor,
+            remaining,
+        } = self.remaining_accounts
+        else {
+            unreachable!()
+        };
+        let mut v = alloc::vec::Vec::with_capacity(remaining as usize);
+        for _ in 0..remaining {
             // SAFETY: cursor is positioned at the start of the remaining
             // region and `remaining_num` is the exact number of accounts
             // to walk. Walking stops on the first mut-alias error so we
             // never advance past the remaining region.
-            v.push(unsafe { self.cursor.next() });
-            if let Some(dups) = self.cursor.duplicates() {
+            v.push(unsafe { cursor.next() });
+            if let Some(dups) = cursor.duplicates() {
                 if dups.intersects(self.mut_mask) {
                     return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
                 }

--- a/lang-v2/src/cursor.rs
+++ b/lang-v2/src/cursor.rs
@@ -82,6 +82,18 @@ impl AccountCursor {
         self.consumed
     }
 
+    /// Current duplicate-tracking bitvec. `None` if the cursor has not
+    /// yet yielded a duplicate account (lazy allocation — see
+    /// [`Self::next`]). Used by
+    /// [`Context::remaining_accounts`](crate::context::Context::remaining_accounts)
+    /// to re-check `MUT_MASK` after each trailing account is walked,
+    /// catching aliases of declared mut accounts that only surface past
+    /// `HEADER_SIZE`.
+    #[inline(always)]
+    pub fn duplicates(&self) -> Option<&AccountBitvec> {
+        self.duplicate.as_ref()
+    }
+
     /// Walk N accounts in a tight loop, storing views in the lookup array.
     /// Returns a slice of the walked views and the duplicate tracking bitvec.
     /// This avoids interleaving cursor math with validation logic, letting

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -85,7 +85,14 @@ pub fn run_handler<'a, T: TryAccounts>(
         T::try_accounts(program_id, views, duplicates, 0, ix_data)?
     };
     let remaining_num = (num_accounts - T::HEADER_SIZE) as u8;
-    let mut ctx = Context::new(program_id, ctx_accounts, bumps, cursor, remaining_num);
+    let mut ctx = Context::new(
+        program_id,
+        ctx_accounts,
+        bumps,
+        cursor,
+        remaining_num,
+        &T::MUT_MASK,
+    );
     handler(&mut ctx, ix_args)?;
     ctx.accounts.exit_accounts()?;
     Ok(())

--- a/lang-v2/tests/cursor_and_remaining_accounts.rs
+++ b/lang-v2/tests/cursor_and_remaining_accounts.rs
@@ -38,6 +38,11 @@ impl Bumps for DummyHeader {
     type Bumps = ();
 }
 
+/// No declared mut fields — these tests don't exercise the
+/// trailing-dup-vs-declared-mut check (that's covered by
+/// `remaining_accounts_mut_check.rs`).
+const EMPTY_MUT_MASK: &[u64; 4] = &[0, 0, 0, 0];
+
 fn unique_addr(i: u8) -> [u8; 32] {
     let mut a = [0u8; 32];
     a[0] = i + 1; // avoid [0;32] which collides with the System program id.
@@ -202,9 +207,10 @@ fn remaining_accounts_walks_trailing_region() {
         (),
         &mut cursor,
         /*remaining_num*/ 3,
+        EMPTY_MUT_MASK,
     );
 
-    let remaining = ctx.remaining_accounts();
+    let remaining = ctx.remaining_accounts().expect("walk");
     assert_eq!(remaining.len(), 3);
     assert_eq!(remaining[0].address().to_bytes(), unique_addr(2));
     assert_eq!(remaining[1].address().to_bytes(), unique_addr(3));
@@ -221,11 +227,11 @@ fn remaining_accounts_returns_empty_when_nothing_trails() {
 
     let program_id = Address::new_from_array([0x42; 32]);
     let mut ctx: Context<'_, DummyHeader> =
-        Context::new(&program_id, DummyHeader, (), &mut cursor, 0);
+        Context::new(&program_id, DummyHeader, (), &mut cursor, 0, EMPTY_MUT_MASK);
 
-    assert!(ctx.remaining_accounts().is_empty());
+    assert!(ctx.remaining_accounts().expect("walk").is_empty());
     // Second call on empty — still empty, no cache bookkeeping bug.
-    assert!(ctx.remaining_accounts().is_empty());
+    assert!(ctx.remaining_accounts().expect("walk").is_empty());
 }
 
 #[test]
@@ -247,10 +253,14 @@ fn remaining_accounts_caches_and_does_not_re_walk_cursor() {
         (),
         &mut cursor,
         /*remaining_num*/ 2,
+        EMPTY_MUT_MASK,
     );
 
-    let first = ctx.remaining_accounts();
-    let second = ctx.remaining_accounts();
+    // `remaining_accounts()` returns `Result<&Vec<_>, _>`; the borrow
+    // would conflict with a second call, so clone-out the first vec
+    // before re-borrowing `ctx`.
+    let first = ctx.remaining_accounts().cloned().expect("first walk");
+    let second = ctx.remaining_accounts().cloned().expect("second walk");
 
     // Structural equality via address, since AccountView is Copy and the
     // cache returns a clone each call.

--- a/lang-v2/tests/cursor_and_remaining_accounts.rs
+++ b/lang-v2/tests/cursor_and_remaining_accounts.rs
@@ -256,11 +256,8 @@ fn remaining_accounts_caches_and_does_not_re_walk_cursor() {
         EMPTY_MUT_MASK,
     );
 
-    // `remaining_accounts()` returns `Result<&Vec<_>, _>`; the borrow
-    // would conflict with a second call, so clone-out the first vec
-    // before re-borrowing `ctx`.
-    let first = ctx.remaining_accounts().cloned().expect("first walk");
-    let second = ctx.remaining_accounts().cloned().expect("second walk");
+    let first = ctx.remaining_accounts().expect("first walk");
+    let second = ctx.remaining_accounts().expect("second walk");
 
     // Structural equality via address, since AccountView is Copy and the
     // cache returns a clone each call.

--- a/lang-v2/tests/remaining_accounts_mut_check.rs
+++ b/lang-v2/tests/remaining_accounts_mut_check.rs
@@ -1,0 +1,227 @@
+//! Bug-3 fix: `Context::remaining_accounts()` re-checks `MUT_MASK`.
+//!
+//! ## The bug
+//!
+//! `run_handler` (`lang-v2/src/dispatch.rs`) performs exactly one
+//! `duplicates.intersects(&T::MUT_MASK)` test against the bitvec the
+//! `HEADER_SIZE` walk produced. `Context::remaining_accounts()` then
+//! calls `cursor.next()` for each trailing account. `cursor.next()`
+//! does detect dups and flips bits in the cursor's bitvec — but no
+//! re-test of `MUT_MASK` happens.
+//!
+//! Attack: supply `HEADER_SIZE + 1` accounts where the trailing slot
+//! aliases a declared mut slot. The handler's
+//! `ctx.remaining_accounts()[0]` now points at the same
+//! `RuntimeAccount` as `ctx.accounts.<mut_field>` without tripping
+//! `ConstraintDuplicateMutableAccount`.
+//!
+//! ## The fix
+//!
+//! `Context::remaining_accounts()` re-intersects the cursor's live
+//! bitvec against `MUT_MASK` after every `cursor.next()`. Because
+//! `MUT_MASK`'s bits only cover declared field indices (0..HEADER_SIZE
+//! for top-level structs), a trailing account's own index bit never
+//! collides with the mask — the test only fires when the cursor
+//! resolved a dup pointing at a declared mut slot.
+//!
+//! These tests drive `Context` directly (a `Bumps` impl for a
+//! stand-in accounts struct plus a fake `mut_mask`) rather than going
+//! through `#[derive(Accounts)]` — that keeps the test focused on
+//! the `Context::remaining_accounts` control flow and the cursor's
+//! bitvec exposure, which are the bits that actually changed.
+
+extern crate alloc;
+
+use {
+    anchor_lang_v2::{
+        testing::{AccountRecord, SbfInputBuffer},
+        AccountCursor, AccountView, Bumps, Context,
+    },
+    core::mem::MaybeUninit,
+    solana_address::Address,
+    solana_program_error::ProgramError,
+};
+
+/// Trivial accounts struct with no real declared fields — the test
+/// constructs `Context` by hand, so the generic bound is all we need.
+struct NoAccounts;
+impl Bumps for NoAccounts {
+    type Bumps = ();
+}
+
+const PROGRAM_ID: [u8; 32] = [0x42; 32];
+const MAX_ACCOUNTS: usize = 8;
+
+/// `ProgramError::Custom(2005)` — `ErrorCode::ConstraintDuplicateMutableAccount`
+/// (`lang-v2/src/lib.rs`).
+const DUP_MUT_ERROR: u32 = 2005;
+
+/// Build a fresh non-dup record with a distinct address.
+fn fresh(tag: u8) -> AccountRecord {
+    AccountRecord::NonDup {
+        address: [tag; 32],
+        owner: PROGRAM_ID,
+        lamports: 100,
+        is_signer: false,
+        is_writable: true,
+        executable: false,
+        data_len: 0,
+    }
+}
+
+/// Run one `Context::remaining_accounts()` invocation over a cursor
+/// built from `records`, treating the first `header_size` accounts as
+/// the declared region and the remainder as trailing. `mut_mask`
+/// bitmap covers the declared region (as `T::MUT_MASK` would).
+fn run_with(
+    records: &[AccountRecord],
+    header_size: usize,
+    mut_mask: &'static [u64; 4],
+) -> Result<alloc::vec::Vec<AccountView>, ProgramError> {
+    let mut buf = SbfInputBuffer::build(records);
+    let mut lookup: [MaybeUninit<AccountView>; MAX_ACCOUNTS] =
+        [const { MaybeUninit::uninit() }; MAX_ACCOUNTS];
+
+    let program_id = Address::new_from_array(PROGRAM_ID);
+    // SAFETY: buf outlives cursor; lookup is aligned + sized for MAX_ACCOUNTS.
+    let mut cursor =
+        unsafe { AccountCursor::new(buf.as_mut_ptr(), lookup.as_mut_ptr() as *mut AccountView) };
+
+    // Walk the declared region exactly as `run_handler` would. Check
+    // `MUT_MASK` once for parity with the dispatcher.
+    let (_views, dups) = unsafe { cursor.walk_n(header_size) };
+    if let Some(d) = dups {
+        if d.intersects(mut_mask) {
+            return Err(solana_program_error::ProgramError::Custom(DUP_MUT_ERROR));
+        }
+    }
+
+    let remaining_num = (records.len() - header_size) as u8;
+    let mut ctx: Context<NoAccounts> = Context::new(
+        &program_id,
+        NoAccounts,
+        (),
+        &mut cursor,
+        remaining_num,
+        mut_mask,
+    );
+    // Helper returns owned `Result<Vec, _>`; the API now hands back a
+    // borrow into the cache, which we clone out so the helper can drop
+    // its `Context` and return.
+    ctx.remaining_accounts().cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Bug reproducer + negative controls
+// ---------------------------------------------------------------------------
+
+/// MUT_MASK marking slot 0 as mut. Mirrors what `#[derive(Accounts)]`
+/// emits for `{ #[account(mut)] a: UncheckedAccount }`.
+const MUT_MASK_SLOT0: &[u64; 4] = &[0b1, 0, 0, 0];
+
+/// MUT_MASK marking slot 1 as mut (slot 0 is non-mut).
+const MUT_MASK_SLOT1: &[u64; 4] = &[0b10, 0, 0, 0];
+
+/// Empty MUT_MASK — no declared mut fields.
+const MUT_MASK_NONE: &[u64; 4] = &[0, 0, 0, 0];
+
+#[test]
+fn trailing_account_aliasing_declared_mut_is_rejected() {
+    // Layout: [ mut declared, trailing-dup-of-slot-0 ]
+    // Declared region has 1 slot, marked mut. Trailing slot's dup
+    // index resolves to slot 0 → alias of a mut declared account.
+    let records = [fresh(1), AccountRecord::Dup { index: 0 }];
+    let result = run_with(&records, /*header_size*/ 1, MUT_MASK_SLOT0);
+    match result {
+        Err(ProgramError::Custom(code)) if code == DUP_MUT_ERROR => {}
+        other => panic!(
+            "expected Err(ConstraintDuplicateMutableAccount), got {:?}",
+            other.map(|v| v.len())
+        ),
+    }
+}
+
+#[test]
+fn trailing_account_aliasing_non_mut_declared_is_allowed() {
+    // Declared region has 2 slots, only slot 1 is mut. Trailing slot
+    // dups slot 0 (non-mut) → must be allowed.
+    let records = [fresh(1), fresh(2), AccountRecord::Dup { index: 0 }];
+    let result = run_with(&records, /*header_size*/ 2, MUT_MASK_SLOT1);
+    match result {
+        Ok(v) => assert_eq!(v.len(), 1),
+        Err(e) => panic!("expected Ok, got Err({:?})", e),
+    }
+}
+
+#[test]
+fn two_trailing_dups_of_each_other_are_allowed() {
+    // Declared region has 1 slot, non-mut. Two trailing slots: the
+    // second dups the first trailing slot. Neither aliases a
+    // declared mut, so the mut-mask check must not fire.
+    let records = [fresh(1), fresh(2), AccountRecord::Dup { index: 1 }];
+    let result = run_with(&records, /*header_size*/ 1, MUT_MASK_NONE);
+    match result {
+        Ok(v) => assert_eq!(v.len(), 2),
+        Err(e) => panic!("expected Ok, got Err({:?})", e),
+    }
+}
+
+#[test]
+fn fresh_trailing_accounts_are_allowed() {
+    // Regression: all-fresh trailing accounts must pass even when
+    // slot 0 is declared mut.
+    let records = [fresh(1), fresh(2), fresh(3)];
+    let result = run_with(&records, /*header_size*/ 1, MUT_MASK_SLOT0);
+    match result {
+        Ok(v) => assert_eq!(v.len(), 2),
+        Err(e) => panic!("expected Ok, got Err({:?})", e),
+    }
+}
+
+#[test]
+fn trailing_account_aliasing_nested_mut_is_rejected() {
+    // Simulate `Parent { a: UncheckedAccount, inner: Nested<Inner> }`
+    // where `Inner { #[account(mut)] b }`. Parent's `MUT_MASK` has
+    // bit 1 set (slot 0 = parent's plain `a`; slot 1 = Inner's mut
+    // `b` after the nested-shift). A trailing account aliasing slot 1
+    // must still be caught — this is the "Nested children merge into
+    // the top-level mask" case.
+    let mut mask = [0u64; 4];
+    mask[0] = 0b10;
+    // Leaked to get 'static; test-only.
+    let mask_ref: &'static [u64; 4] = alloc::boxed::Box::leak(alloc::boxed::Box::new(mask));
+
+    let records = [fresh(1), fresh(2), AccountRecord::Dup { index: 1 }];
+    let result = run_with(&records, /*header_size*/ 2, mask_ref);
+    match result {
+        Err(ProgramError::Custom(code)) if code == DUP_MUT_ERROR => {}
+        other => panic!(
+            "expected Err(ConstraintDuplicateMutableAccount), got {:?}",
+            other.map(|v| v.len())
+        ),
+    }
+}
+
+#[test]
+fn remaining_accounts_result_is_cached_on_success() {
+    // Regression on the cache path: two successful calls must return
+    // equal-length vecs without re-walking the cursor (second walk
+    // would read past the end).
+    let records = [fresh(1), fresh(2), fresh(3)];
+    let mut buf = SbfInputBuffer::build(&records);
+    let mut lookup: [MaybeUninit<AccountView>; MAX_ACCOUNTS] =
+        [const { MaybeUninit::uninit() }; MAX_ACCOUNTS];
+    let program_id = Address::new_from_array(PROGRAM_ID);
+    let mut cursor =
+        unsafe { AccountCursor::new(buf.as_mut_ptr(), lookup.as_mut_ptr() as *mut AccountView) };
+    let (_views, _dups) = unsafe { cursor.walk_n(1) };
+    let mut ctx: Context<NoAccounts> =
+        Context::new(&program_id, NoAccounts, (), &mut cursor, 2, MUT_MASK_SLOT0);
+
+    // `remaining_accounts()` returns `Result<&Vec<_>, _>`; clone-out so
+    // the second call can re-borrow `ctx` mutably.
+    let first = ctx.remaining_accounts().cloned().expect("first call");
+    let second = ctx.remaining_accounts().cloned().expect("second call");
+    assert_eq!(first.len(), 2);
+    assert_eq!(second.len(), 2);
+}

--- a/lang-v2/tests/remaining_accounts_mut_check.rs
+++ b/lang-v2/tests/remaining_accounts_mut_check.rs
@@ -203,6 +203,36 @@ fn trailing_account_aliasing_nested_mut_is_rejected() {
 }
 
 #[test]
+fn remaining_accounts_error_is_cached_on_failure() {
+    // Before the fix, Err left `remaining_cache` unset, so a repeat
+    // call would re-enter the walk loop and call `cursor.next()` again
+    // — past the remaining region on an unsafe cursor. After the fix,
+    // the error is cached and replayed; the cursor advances exactly
+    // once per instruction regardless of how many times the handler
+    // calls `remaining_accounts()`.
+    let records = [fresh(1), AccountRecord::Dup { index: 0 }];
+    let mut buf = SbfInputBuffer::build(&records);
+    let mut lookup: [MaybeUninit<AccountView>; MAX_ACCOUNTS] =
+        [const { MaybeUninit::uninit() }; MAX_ACCOUNTS];
+    let program_id = Address::new_from_array(PROGRAM_ID);
+    let mut cursor =
+        unsafe { AccountCursor::new(buf.as_mut_ptr(), lookup.as_mut_ptr() as *mut AccountView) };
+    let (_views, _dups) = unsafe { cursor.walk_n(1) };
+    let mut ctx: Context<NoAccounts> =
+        Context::new(&program_id, NoAccounts, (), &mut cursor, 1, MUT_MASK_SLOT0);
+
+    for _ in 0..5 {
+        match ctx.remaining_accounts() {
+            Err(ProgramError::Custom(code)) => assert_eq!(code, DUP_MUT_ERROR),
+            other => panic!(
+                "expected cached Err(ConstraintDuplicateMutableAccount), got {:?}",
+                other.map(|v| v.len())
+            ),
+        }
+    }
+}
+
+#[test]
 fn remaining_accounts_result_is_cached_on_success() {
     // Regression on the cache path: two successful calls must return
     // equal-length vecs without re-walking the cursor (second walk

--- a/lang-v2/tests/remaining_accounts_mut_check.rs
+++ b/lang-v2/tests/remaining_accounts_mut_check.rs
@@ -105,10 +105,7 @@ fn run_with(
         remaining_num,
         mut_mask,
     );
-    // Helper returns owned `Result<Vec, _>`; the API now hands back a
-    // borrow into the cache, which we clone out so the helper can drop
-    // its `Context` and return.
-    ctx.remaining_accounts().cloned()
+    ctx.remaining_accounts()
 }
 
 // ---------------------------------------------------------------------------
@@ -248,10 +245,8 @@ fn remaining_accounts_result_is_cached_on_success() {
     let mut ctx: Context<NoAccounts> =
         Context::new(&program_id, NoAccounts, (), &mut cursor, 2, MUT_MASK_SLOT0);
 
-    // `remaining_accounts()` returns `Result<&Vec<_>, _>`; clone-out so
-    // the second call can re-borrow `ctx` mutably.
-    let first = ctx.remaining_accounts().cloned().expect("first call");
-    let second = ctx.remaining_accounts().cloned().expect("second call");
+    let first = ctx.remaining_accounts().expect("first call");
+    let second = ctx.remaining_accounts().expect("second call");
     assert_eq!(first.len(), 2);
     assert_eq!(second.len(), 2);
 }

--- a/tests-v2/programs/dispatch-remaining/src/lib.rs
+++ b/tests-v2/programs/dispatch-remaining/src/lib.rs
@@ -26,7 +26,7 @@ pub mod dispatch_remaining {
 
     #[discrim = 2]
     pub fn read_remaining_once(ctx: &mut Context<ReadRemaining>, expected_count: u8) -> Result<()> {
-        let remaining = ctx.remaining_accounts();
+        let remaining = ctx.remaining_accounts()?;
         if remaining.len() != expected_count as usize {
             return Err(ProgramError::InvalidArgument.into());
         }
@@ -39,8 +39,8 @@ pub mod dispatch_remaining {
 
     #[discrim = 3]
     pub fn read_remaining_twice(ctx: &mut Context<ReadRemaining>) -> Result<()> {
-        let first = ctx.remaining_accounts();
-        let second = ctx.remaining_accounts();
+        let first = ctx.remaining_accounts()?;
+        let second = ctx.remaining_accounts()?;
         if first.len() != 2 || second.len() != 2 {
             return Err(ProgramError::InvalidArgument.into());
         }
@@ -56,7 +56,7 @@ pub mod dispatch_remaining {
         value: u64,
     ) -> Result<()> {
         ctx.accounts.counter.value = value;
-        let remaining = ctx.remaining_accounts();
+        let remaining = ctx.remaining_accounts()?;
         if remaining.len() != 1 {
             return Err(ProgramError::InvalidArgument.into());
         }
@@ -67,6 +67,21 @@ pub mod dispatch_remaining {
     pub fn arg_echo(_ctx: &mut Context<ReadRemaining>, value: u64, tag: [u8; 4]) -> Result<()> {
         if value != 0x0102_0304_0506_0708 || tag != *b"echo" {
             return Err(ProgramError::InvalidInstructionData.into());
+        }
+        Ok(())
+    }
+
+    #[discrim = 6]
+    pub fn optional_mut_then_read_remaining(
+        ctx: &mut Context<OptionalMutThenReadRemaining>,
+        expected_count: u8,
+    ) -> Result<()> {
+        if let Some(counter) = ctx.accounts.counter.as_mut() {
+            counter.value = counter.value.saturating_add(1);
+        }
+        let remaining = ctx.remaining_accounts()?;
+        if remaining.len() != expected_count as usize {
+            return Err(ProgramError::InvalidArgument.into());
         }
         Ok(())
     }
@@ -102,4 +117,10 @@ pub struct ReadRemaining {
 pub struct MutateThenReadRemaining {
     #[account(mut)]
     pub counter: Account<Counter>,
+}
+
+#[derive(Accounts)]
+pub struct OptionalMutThenReadRemaining {
+    #[account(mut)]
+    pub counter: Option<Account<Counter>>,
 }

--- a/tests-v2/tests/dispatch_remaining.rs
+++ b/tests-v2/tests/dispatch_remaining.rs
@@ -22,6 +22,8 @@ fn counter_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"counter"], &program_id()).0
 }
 
+const DUPLICATE_MUT_ERROR: u32 = 2005;
+
 fn setup() -> (LiteSVM, Keypair) {
     let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let deploy_dir = test_dir.join("target/deploy");
@@ -72,6 +74,19 @@ fn counter_value(svm: &LiteSVM, counter: Pubkey) -> u64 {
     u64::from_le_bytes(account.data[8..16].try_into().unwrap())
 }
 
+#[track_caller]
+fn assert_custom_error(result: &TransactionResult, expected: u32) {
+    let failure = match result {
+        Ok(_) => panic!("expected transaction to fail with Custom({expected}), got success"),
+        Err(f) => f,
+    };
+    let rendered = format!("{:?}", failure.err);
+    assert!(
+        rendered.contains(&format!("Custom({expected})")),
+        "expected Custom({expected}), got: {rendered}",
+    );
+}
+
 #[test]
 fn too_few_declared_accounts_fails_before_handler() {
     let (mut svm, payer) = setup();
@@ -88,6 +103,126 @@ fn too_few_declared_accounts_fails_before_handler() {
         err.contains("NotEnoughAccountKeys") || err.contains("Custom("),
         "too few accounts should be rejected, got: {err}"
     );
+}
+
+#[test]
+fn remaining_duplicate_of_declared_mut_is_rejected() {
+    let (mut svm, payer) = setup();
+    let counter = initialize(&mut svm, &payer);
+    let data = dispatch_remaining::instruction::MutateThenReadRemaining { value: 123 }.data();
+
+    let result = call_raw(
+        &mut svm,
+        &payer,
+        data,
+        vec![
+            AccountMeta::new(counter, false),
+            AccountMeta::new(counter, false),
+        ],
+    );
+    assert_custom_error(&result, DUPLICATE_MUT_ERROR);
+}
+
+#[test]
+fn remaining_duplicate_of_declared_readonly_is_allowed() {
+    let (mut svm, payer) = setup();
+    let counter = initialize(&mut svm, &payer);
+    let data = dispatch_remaining::instruction::ReadRemainingOnce { expected_count: 1 }.data();
+
+    send_instruction(
+        &mut svm,
+        program_id(),
+        data,
+        vec![
+            AccountMeta::new_readonly(counter, false),
+            AccountMeta::new_readonly(counter, false),
+        ],
+        &payer,
+        &[],
+    )
+    .expect("readonly declared account may be duplicated through remaining accounts");
+}
+
+#[test]
+fn remaining_duplicate_of_trailing_account_is_allowed() {
+    let (mut svm, payer) = setup();
+    let counter = initialize(&mut svm, &payer);
+    let marker = Pubkey::new_unique();
+
+    send_instruction(
+        &mut svm,
+        program_id(),
+        vec![3],
+        vec![
+            AccountMeta::new_readonly(counter, false),
+            AccountMeta::new_readonly(marker, false),
+            AccountMeta::new_readonly(marker, false),
+        ],
+        &payer,
+        &[],
+    )
+    .expect("remaining accounts may duplicate each other when no declared mut slot aliases");
+}
+
+#[test]
+fn remaining_duplicate_of_optional_some_mut_is_rejected() {
+    let (mut svm, payer) = setup();
+    let counter = initialize(&mut svm, &payer);
+    let data =
+        dispatch_remaining::instruction::OptionalMutThenReadRemaining { expected_count: 1 }.data();
+
+    let result = call_raw(
+        &mut svm,
+        &payer,
+        data,
+        vec![
+            AccountMeta::new(counter, false),
+            AccountMeta::new(counter, false),
+        ],
+    );
+    assert_custom_error(&result, DUPLICATE_MUT_ERROR);
+}
+
+#[test]
+fn remaining_duplicate_of_optional_none_sentinel_is_allowed() {
+    let (mut svm, payer) = setup();
+    let data =
+        dispatch_remaining::instruction::OptionalMutThenReadRemaining { expected_count: 1 }.data();
+
+    send_instruction(
+        &mut svm,
+        program_id(),
+        data,
+        vec![
+            AccountMeta::new(program_id(), false),
+            AccountMeta::new(program_id(), false),
+        ],
+        &payer,
+        &[],
+    )
+    .expect("None sentinel should not count as an active optional mut account");
+}
+
+#[test]
+fn optional_some_mut_with_distinct_remaining_is_allowed() {
+    let (mut svm, payer) = setup();
+    let counter = initialize(&mut svm, &payer);
+    let marker = Pubkey::new_unique();
+    let data =
+        dispatch_remaining::instruction::OptionalMutThenReadRemaining { expected_count: 1 }.data();
+
+    send_instruction(
+        &mut svm,
+        program_id(),
+        data,
+        vec![
+            AccountMeta::new(counter, false),
+            AccountMeta::new_readonly(marker, false),
+        ],
+        &payer,
+        &[],
+    )
+    .expect("optional Some mut account should allow a distinct remaining account");
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #4441. Adds tests-v2 coverage for duplicate accounts discovered while walking remaining_accounts().

Coverage added:
- declared mut duplicated through remaining_accounts rejects
- declared readonly duplicated through remaining_accounts is allowed
- remaining accounts may duplicate each other when no declared mut slot aliases
- optional Some(mut) duplicated through remaining_accounts should reject
- optional None sentinel duplicate remains allowed
- optional Some(mut) with distinct remaining account remains allowed

Current result on this branch:
- cargo test -p tests-v2 --test dispatch_remaining -- --nocapture
- 13 passed, 1 failed
- failing test: remaining_duplicate_of_optional_some_mut_is_rejected, which exposes the optional-mut gap discussed in review