### PR TITLE
fix(ts): surface swallowed cause from accounts-resolver retry loop

### DIFF
--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -48,6 +48,11 @@ export type CustomAccountResolver<IDL extends Idl> = (params: {
 // Populates a given accounts context with PDAs and common missing accounts.
 export class AccountsResolver<IDL extends Idl> {
   private _accountStore: AccountStore<IDL>;
+  // Last error swallowed during a PDA / relations resolution attempt. Surfaced
+  // when resolution ultimately fails so the caller sees the underlying cause
+  // (e.g. a `seeds = [..., arg]` referencing an instruction-arg name that
+  // doesn't match the one declared in `#[instruction(...)]`).
+  private _lastResolutionError?: unknown;
 
   constructor(
     private _args: any[],
@@ -74,6 +79,7 @@ export class AccountsResolver<IDL extends Idl> {
   //       in parallel because there can be dependencies between
   //       addresses. That is, one PDA can be used as a seed in another.
   public async resolve() {
+    this._lastResolutionError = undefined;
     this.resolveEventCpi(this._idlIx.accounts);
     this.resolveConst(this._idlIx.accounts);
 
@@ -106,13 +112,26 @@ export class AccountsResolver<IDL extends Idl> {
         const resolvableAccs = this._idlIx.accounts.filter(
           this.isResolvable.bind(this)
         );
-        const unresolvedAccs = this.getUnresolvedAccounts(resolvableAccs);
-        throw new Error(
-          [
-            `Reached maximum depth for account resolution.`,
-            `Unresolved accounts: ${this.formatAccountPaths(unresolvedAccs)}`,
-          ].join(" ")
-        );
+        const unresolvedPaths = this.getUnresolvedAccounts(resolvableAccs);
+        const unresolvedAccs = this.formatAccountPaths(unresolvedPaths);
+
+        const parts = [
+          `Reached maximum depth for account resolution.`,
+          `Unresolved accounts: ${unresolvedAccs}`,
+        ];
+        if (this._lastResolutionError !== undefined) {
+          const causeMsg =
+            this._lastResolutionError instanceof Error
+              ? this._lastResolutionError.message
+              : String(this._lastResolutionError);
+          parts.push(`Last error encountered while resolving: ${causeMsg}`);
+        }
+        const err = new Error(parts.join(" "));
+        if (this._lastResolutionError !== undefined) {
+          (err as Error & { cause?: unknown }).cause =
+            this._lastResolutionError;
+        }
+        throw err;
       }
     }
   }
@@ -385,7 +404,9 @@ export class AccountsResolver<IDL extends Idl> {
       );
 
       this.set([...path, name], pubkey);
-    } catch {}
+    } catch (err) {
+      this._lastResolutionError = err;
+    }
     return false;
   }
 
@@ -403,7 +424,9 @@ export class AccountsResolver<IDL extends Idl> {
         });
         this.set([...path, name], accountData[name]);
       }
-    } catch {}
+    } catch (err) {
+      this._lastResolutionError = err;
+    }
   }
 
   private async parseProgramId(

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -48,11 +48,10 @@ export type CustomAccountResolver<IDL extends Idl> = (params: {
 // Populates a given accounts context with PDAs and common missing accounts.
 export class AccountsResolver<IDL extends Idl> {
   private _accountStore: AccountStore<IDL>;
-  // Last error swallowed during a PDA / relations resolution attempt. Surfaced
-  // when resolution ultimately fails so the caller sees the underlying cause
-  // (e.g. a `seeds = [..., arg]` referencing an instruction-arg name that
-  // doesn't match the one declared in `#[instruction(...)]`).
-  private _lastResolutionError?: unknown;
+  // Errors swallowed during PDA / relations resolution, keyed by account path.
+  // Only errors for accounts that are still unresolved at max depth are surfaced
+  // so a stale failure from an account that later resolved is not reported.
+  private _resolutionErrors = new Map<string, unknown>();
 
   constructor(
     private _args: any[],
@@ -79,7 +78,7 @@ export class AccountsResolver<IDL extends Idl> {
   //       in parallel because there can be dependencies between
   //       addresses. That is, one PDA can be used as a seed in another.
   public async resolve() {
-    this._lastResolutionError = undefined;
+    this._resolutionErrors.clear();
     this.resolveEventCpi(this._idlIx.accounts);
     this.resolveConst(this._idlIx.accounts);
 
@@ -119,17 +118,26 @@ export class AccountsResolver<IDL extends Idl> {
           `Reached maximum depth for account resolution.`,
           `Unresolved accounts: ${unresolvedAccs}`,
         ];
-        if (this._lastResolutionError !== undefined) {
-          const causeMsg =
-            this._lastResolutionError instanceof Error
-              ? this._lastResolutionError.message
-              : String(this._lastResolutionError);
-          parts.push(`Last error encountered while resolving: ${causeMsg}`);
+        const relevantErrors = unresolvedPaths
+          .map((path) => ({
+            path: this.pathKey(path),
+            error: this._resolutionErrors.get(this.pathKey(path)),
+          }))
+          .filter(
+            (entry): entry is { path: string; error: unknown } =>
+              entry.error !== undefined
+          );
+
+        if (relevantErrors.length > 0) {
+          const causeMsgs = this.formatResolutionErrorDetails(relevantErrors);
+          parts.push(
+            `Errors encountered while resolving: ${causeMsgs.join("; ")}`
+          );
         }
         const err = new Error(parts.join(" "));
-        if (this._lastResolutionError !== undefined) {
-          (err as Error & { cause?: unknown }).cause =
-            this._lastResolutionError;
+        const cause = this.resolutionCause(relevantErrors);
+        if (cause !== undefined) {
+          (err as Error & { cause?: unknown }).cause = cause;
         }
         throw err;
       }
@@ -138,6 +146,32 @@ export class AccountsResolver<IDL extends Idl> {
 
   private getUnresolvedAccounts(accs: IdlInstructionAccountItem[]) {
     return this.getPaths(accs).filter((path) => !this.get(path));
+  }
+
+  private formatResolutionErrorDetails(
+    relevantErrors: { path: string; error: unknown }[]
+  ): string[] {
+    return relevantErrors.map(({ path, error }) => {
+      const msg = error instanceof Error ? error.message : String(error);
+      return `\`${path}\`: ${msg}`;
+    });
+  }
+
+  private resolutionCause(
+    relevantErrors: { path: string; error: unknown }[]
+  ): unknown | undefined {
+    if (relevantErrors.length === 0) {
+      return undefined;
+    }
+    if (relevantErrors.length === 1) {
+      return relevantErrors[0].error;
+    }
+
+    return new Error(this.formatResolutionErrorDetails(relevantErrors).join("; "));
+  }
+
+  private pathKey(path: string[]): string {
+    return path.join(".");
   }
 
   private formatAccountPaths(paths: string[][]): string {
@@ -404,8 +438,9 @@ export class AccountsResolver<IDL extends Idl> {
       );
 
       this.set([...path, name], pubkey);
+      this._resolutionErrors.delete(this.pathKey([...path, name]));
     } catch (err) {
-      this._lastResolutionError = err;
+      this._resolutionErrors.set(this.pathKey([...path, name]), err);
     }
     return false;
   }
@@ -423,9 +458,10 @@ export class AccountsResolver<IDL extends Idl> {
           publicKey: accountKey,
         });
         this.set([...path, name], accountData[name]);
+        this._resolutionErrors.delete(this.pathKey([...path, name]));
       }
     } catch (err) {
-      this._lastResolutionError = err;
+      this._resolutionErrors.set(this.pathKey([...path, name]), err);
     }
   }
 

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -167,7 +167,9 @@ export class AccountsResolver<IDL extends Idl> {
       return relevantErrors[0].error;
     }
 
-    return new Error(this.formatResolutionErrorDetails(relevantErrors).join("; "));
+    return new Error(
+      this.formatResolutionErrorDetails(relevantErrors).join("; ")
+    );
   }
 
   private pathKey(path: string[]): string {

--- a/ts/packages/anchor/tests/accounts-resolver.spec.ts
+++ b/ts/packages/anchor/tests/accounts-resolver.spec.ts
@@ -59,11 +59,176 @@ describe("AccountsResolver", () => {
     // ...but it must now also carry the root cause both in the message and
     // on `.cause` so the user can see what really went wrong.
     expect(err.message).toMatch(
-      /Unable to find argument for seed: different_name/
+      /Errors encountered while resolving: `pda`: Unable to find argument for seed: different_name/
     );
     expect(err.cause).toBeInstanceOf(Error);
     expect((err.cause as Error).message).toMatch(
       /Unable to find argument for seed: different_name/
     );
+  });
+
+  it("only surfaces stored errors for unresolved accounts that failed", async () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: { name: "test", version: "0.0.0", spec: "0.1.0" },
+      instructions: [
+        {
+          name: "doThing",
+          discriminator: [0, 0, 0, 0, 0, 0, 0, 0],
+          args: [{ name: "my_param", type: "u64" }],
+          accounts: [
+            {
+              name: "pdaWaiting",
+              pda: {
+                seeds: [{ kind: "account", path: "missingSeed" }],
+              },
+            },
+            {
+              name: "badPda",
+              pda: {
+                seeds: [{ kind: "arg", path: "different_name" }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolver = new AccountsResolver(
+      [1],
+      {},
+      {} as any,
+      new PublicKey("Test111111111111111111111111111111111111111"),
+      idl.instructions[0] as any,
+      {} as any,
+      []
+    );
+
+    let caught: unknown;
+    try {
+      await resolver.resolve();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error;
+    expect(err.message).toMatch(/`badPda`: Unable to find argument for seed/);
+    expect(err.message).not.toMatch(/`pdaWaiting`:/);
+  });
+
+  it("includes every account error in cause when multiple accounts fail", async () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: { name: "test", version: "0.0.0", spec: "0.1.0" },
+      instructions: [
+        {
+          name: "doThing",
+          discriminator: [0, 0, 0, 0, 0, 0, 0, 0],
+          args: [{ name: "my_param", type: "u64" }],
+          accounts: [
+            {
+              name: "badPda1",
+              pda: {
+                seeds: [{ kind: "arg", path: "missing_one" }],
+              },
+            },
+            {
+              name: "badPda2",
+              pda: {
+                seeds: [{ kind: "arg", path: "missing_two" }],
+              },
+            },
+            {
+              name: "badPda3",
+              pda: {
+                seeds: [{ kind: "arg", path: "missing_three" }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolver = new AccountsResolver(
+      [1],
+      {},
+      {} as any,
+      new PublicKey("Test111111111111111111111111111111111111111"),
+      idl.instructions[0] as any,
+      {} as any,
+      []
+    );
+
+    let caught: unknown;
+    try {
+      await resolver.resolve();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error & { cause?: unknown };
+    expect(err.message).toMatch(
+      /Errors encountered while resolving: `badPda1`: Unable to find argument for seed: missing_one; `badPda2`: Unable to find argument for seed: missing_two; `badPda3`: Unable to find argument for seed: missing_three/
+    );
+    expect(err.cause).toBeInstanceOf(Error);
+    expect((err.cause as Error).message).toBe(
+      "`badPda1`: Unable to find argument for seed: missing_one; `badPda2`: Unable to find argument for seed: missing_two; `badPda3`: Unable to find argument for seed: missing_three"
+    );
+  });
+
+  it("does not surface errors for accounts that resolved successfully", async () => {
+    const providedSeed = new PublicKey(
+      "SysvarC1ock11111111111111111111111111111111"
+    );
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: { name: "test", version: "0.0.0", spec: "0.1.0" },
+      instructions: [
+        {
+          name: "doThing",
+          discriminator: [0, 0, 0, 0, 0, 0, 0, 0],
+          args: [{ name: "my_param", type: "u64" }],
+          accounts: [
+            {
+              name: "resolvedPda",
+              pda: {
+                seeds: [{ kind: "account", path: "providedSeed" }],
+              },
+            },
+            {
+              name: "badPda",
+              pda: {
+                seeds: [{ kind: "arg", path: "different_name" }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolver = new AccountsResolver(
+      [1],
+      { providedSeed },
+      {} as any,
+      new PublicKey("Test111111111111111111111111111111111111111"),
+      idl.instructions[0] as any,
+      {} as any,
+      []
+    );
+
+    let caught: unknown;
+    try {
+      await resolver.resolve();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error;
+    expect(err.message).toMatch(/Unresolved accounts: `badPda`/);
+    expect(err.message).not.toMatch(/`resolvedPda`/);
+    expect(err.message).toMatch(/`badPda`: Unable to find argument for seed/);
   });
 });

--- a/ts/packages/anchor/tests/accounts-resolver.spec.ts
+++ b/ts/packages/anchor/tests/accounts-resolver.spec.ts
@@ -1,0 +1,69 @@
+import { PublicKey } from "@solana/web3.js";
+
+import { AccountsResolver } from "../src/program/accounts-resolver";
+import { Idl } from "../src";
+
+// When a PDA seed references an instruction argument whose name doesn't match
+// the function's parameter name (and therefore isn't present in the IDL
+// `instructions[].args` list), `AccountsResolver.resolve()` used to swallow
+// the underlying `Unable to find argument for seed` error inside an empty
+// `catch {}` block and then surface only a generic
+// `Reached maximum depth for account resolution` message after 16 unsuccessful
+// passes. That made the real root cause invisible to users.
+describe("AccountsResolver", () => {
+  it("surfaces the underlying error when a seed references an unknown arg", async () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: { name: "test", version: "0.0.0", spec: "0.1.0" },
+      instructions: [
+        {
+          name: "doThing",
+          discriminator: [0, 0, 0, 0, 0, 0, 0, 0],
+          // The instruction declares an arg named `my_param`, but the PDA
+          // seed below references `different_name` — simulating the
+          // `#[instruction(different_name)]` / fn-signature mismatch
+          args: [{ name: "my_param", type: "u64" }],
+          accounts: [
+            {
+              name: "pda",
+              pda: {
+                seeds: [{ kind: "arg", path: "different_name" }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolver = new AccountsResolver(
+      [1], // _args
+      {}, // _accounts (none pre-set)
+      {} as any, // _provider (unused on the failing path)
+      new PublicKey("Test111111111111111111111111111111111111111"),
+      idl.instructions[0] as any,
+      {} as any, // accountNamespace (unused on the failing path)
+      [] // idlTypes
+    );
+
+    let caught: unknown;
+    try {
+      await resolver.resolve();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as Error & { cause?: unknown };
+    // The thrown error must still indicate that resolution gave up...
+    expect(err.message).toMatch(/maximum depth/i);
+    // ...but it must now also carry the root cause both in the message and
+    // on `.cause` so the user can see what really went wrong.
+    expect(err.message).toMatch(
+      /Unable to find argument for seed: different_name/
+    );
+    expect(err.cause).toBeInstanceOf(Error);
+    expect((err.cause as Error).message).toMatch(
+      /Unable to find argument for seed: different_name/
+    );
+  });
+});


### PR DESCRIPTION
Closes #3453 