### PR TITLE
docs: Fixed grammatical error => "refer" to "refers"

### DIFF
--- a/docs/content/docs/basics/cpi.mdx
+++ b/docs/content/docs/basics/cpi.mdx
@@ -5,7 +5,7 @@ description:
   enable composability between different Solana programs.
 ---
 
-Cross Program Invocations (CPI) refer to the process of one program invoking
+Cross Program Invocations (CPI) refers to the process of one program invoking
 instructions of another program, which enables the composability of Solana
 programs.
 


### PR DESCRIPTION

##Problem: There was a grammatical error in the doc where the subject CPI is singular but a plural verb was used, "refer" instead of "refers".


## Summary Of Changes 
Fixed the grammatical error where:
The subject is "Cross Program Invocation" (singular, not plural), and

The abbreviation CPI also stands for this singular term.

Therefore, the verb must agree: "refers" (not "refer").

Describe the change and why it is needed.

["refer"  => "refers"]

## Branch Target
Targets `master` branch - this is a non-breaking documentation fix correcting a grammatical error.

[[If this contains breaking changes, it should target the `anchor-next` branch.]]
