### PR TITLE
fix(declare-program): handle numeric instruction suffixes

### DIFF
--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -4,6 +4,7 @@ use {
         IdlInstructionAccounts, IdlRepr, IdlSerialization, IdlType, IdlTypeDef, IdlTypeDefGeneric,
         IdlTypeDefTy,
     },
+    heck::{CamelCase, SnakeCase},
     proc_macro2::Literal,
     quote::{format_ident, quote},
 };
@@ -31,7 +32,7 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
     let re_exports = idl
         .instructions
         .iter()
-        .map(|ix| format_ident!("__{}_accounts_{}", prefix, ix.name))
+        .map(|ix| format_ident!("{}", gen_accounts_mod_name(prefix, &ix.name)))
         .map(|ident| quote! { pub use super::internal::#ident::*; });
 
     quote! {
@@ -39,6 +40,14 @@ pub fn gen_accounts_common(idl: &Idl, prefix: &str) -> proc_macro2::TokenStream 
             #(#re_exports)*
         }
     }
+}
+
+fn gen_accounts_mod_name(prefix: &str, name: &str) -> String {
+    format!(
+        "__{}_accounts_{}",
+        prefix,
+        name.to_camel_case().to_snake_case()
+    )
 }
 
 pub fn convert_idl_type_to_syn_type(ty: &IdlType) -> syn::Type {
@@ -1091,6 +1100,18 @@ mod tests {
         let result = gen_discriminator(&disc);
         let expected = quote! { [1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8] };
         assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_gen_accounts_mod_name_matches_generated_accounts() {
+        assert_eq!(
+            gen_accounts_mod_name("cpi_client", "initialize_with_token_2022"),
+            "__cpi_client_accounts_initialize_with_token2022"
+        );
+        assert_eq!(
+            gen_accounts_mod_name("client", "initialize_with_token_2022"),
+            "__client_accounts_initialize_with_token2022"
+        );
     }
 
     #[test]

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -114,6 +114,26 @@
       "args": []
     },
     {
+      "name": "initialize_with_token_2022",
+      "discriminator": [
+        37,
+        190,
+        126,
+        222,
+        44,
+        154,
+        171,
+        17
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "test_compilation_packed_account",
       "discriminator": [
         56,

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -119,6 +119,12 @@ pub mod external {
         Ok(())
     }
 
+    // Regression test for `declare_program!` codegen with numeric suffixes.
+    // https://github.com/otter-sec/anchor/issues/4281
+    pub fn initialize_with_token_2022(_ctx: Context<TestCompilation>) -> Result<()> {
+        Ok(())
+    }
+
     // Test optional accounts parsing
     pub fn update_with_optional(ctx: Context<UpdateWithOptional>, value: u32) -> Result<()> {
         ctx.accounts.my_account.field = value;


### PR DESCRIPTION
Fixes #4281

## Summary

Fixes `declare_program!` account module re-exports for instruction names that contain an underscore before a numeric suffix, such as `initialize_with_token_2022`.

Previously, generated internal account modules normalized the instruction name through CamelCase and then snake_case, while the public client/CPI account re-exports used the raw IDL instruction name. That could make the re-export look for `__cpi_client_accounts_initialize_with_token_2022` even though the generated module was named `__cpi_client_accounts_initialize_with_token2022`.

## Changes

- Normalize `declare_program!` client/CPI account re-export module names the same way as generated account modules.
- Add a regression test for `initialize_with_token_2022`.
- Add the matching instruction to the `declare-program` fixture IDL.

## Testing

- `cargo +nightly fmt --check -p anchor-attribute-program`
- `cargo test -p anchor-attribute-program test_gen_accounts_mod_name_matches_generated_accounts`
- `cargo check -p declare-program --features cpi`
- `cargo check -p external`
- `cargo clippy -p anchor-attribute-program --all-targets -- -D warnings`
- `git diff --check`

Note: full workspace `cargo +nightly fmt --check` currently fails on an unrelated pre-existing import ordering diff in `lang/src/lib.rs`, which this PR does not touch...