### PR TITLE
fix(v2): reject unchecked close and realloc constraints

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -614,6 +614,58 @@ pub fn extract_option_inner(ty: &Type) -> Option<&Type> {
     None
 }
 
+fn extract_box_inner(ty: &Type) -> Option<&Type> {
+    if let Type::Path(tp) = ty {
+        if let Some(seg) = tp.path.segments.last() {
+            if seg.ident == "Box" {
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        return Some(inner);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn transparent_account_inner(mut ty: &Type) -> &Type {
+    loop {
+        if let Some(inner) = extract_option_inner(ty) {
+            ty = inner;
+            continue;
+        }
+        if let Some(inner) = extract_box_inner(ty) {
+            ty = inner;
+            continue;
+        }
+        return ty;
+    }
+}
+
+fn validate_unchecked_account_constraints(ty: &Type, attrs: &AccountAttrs) -> syn::Result<()> {
+    let ty = transparent_account_inner(ty);
+
+    if field_ty_str(ty) != "UncheckedAccount" {
+        return Ok(());
+    }
+
+    if attrs.close.is_some() {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "`close` cannot be used on `UncheckedAccount`",
+        ));
+    }
+    if attrs.realloc.is_some() {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "`realloc` cannot be used on `UncheckedAccount`",
+        ));
+    }
+
+    Ok(())
+}
+
 pub struct AccountField {
     pub name: Ident,
     /// The field's original `syn::Type` — used by `impl_accounts` to build
@@ -1142,6 +1194,7 @@ pub fn parse_field(
     let associated_token = parse_associated_token_init(&attrs, field_names)?;
 
     let option_inner = extract_option_inner(field_ty);
+    validate_unchecked_account_constraints(field_ty, &attrs)?;
     let is_optional = option_inner.is_some();
     // Fresh-keypair init (no seeds) — caller signs the tx. Distinct from
     // `Signer`-type fields, which the IDL picks up through

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -537,6 +537,38 @@ pub struct Close {
 }
 
 #[test]
+fn close_on_optional_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "close_on_optional_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod close_on_optional_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn close(ctx: &mut Context<Close>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close {
+    #[account(mut, close = receiver)]
+    pub data: Option<UncheckedAccount>,
+    #[account(mut)]
+    pub receiver: UncheckedAccount,
+}
+"#,
+        &["`close` cannot be used on `UncheckedAccount`"],
+    );
+}
+
+#[test]
 fn realloc_on_unchecked_account_does_not_compile() {
     compile_fail_case(
         "realloc_on_unchecked_account",
@@ -560,6 +592,70 @@ pub mod realloc_on_unchecked_account {
 pub struct Resize {
     #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
     pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc` cannot be used on `UncheckedAccount`"],
+    );
+}
+
+#[test]
+fn realloc_on_boxed_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "realloc_on_boxed_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod realloc_on_boxed_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn resize(ctx: &mut Context<Resize>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Resize {
+    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: Box<UncheckedAccount>,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc` cannot be used on `UncheckedAccount`"],
+    );
+}
+
+#[test]
+fn realloc_on_optional_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "realloc_on_optional_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod realloc_on_optional_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn resize(ctx: &mut Context<Resize>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Resize {
+    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: Option<UncheckedAccount>,
     #[account(mut)]
     pub payer: Signer,
 }

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -471,3 +471,99 @@ pub struct Bad {
         &["the trait bound", "__AnchorIxArgCoerce"],
     );
 }
+
+#[test]
+fn close_on_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "close_on_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod close_on_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn close(ctx: &mut Context<Close>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close {
+    #[account(mut, close = receiver)]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub receiver: UncheckedAccount,
+}
+"#,
+        &["`close` cannot be used on `UncheckedAccount`"],
+    );
+}
+
+#[test]
+fn close_on_boxed_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "close_on_boxed_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod close_on_boxed_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn close(ctx: &mut Context<Close>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close {
+    #[account(mut, close = receiver)]
+    pub data: Box<UncheckedAccount>,
+    #[account(mut)]
+    pub receiver: UncheckedAccount,
+}
+"#,
+        &["`close` cannot be used on `UncheckedAccount`"],
+    );
+}
+
+#[test]
+fn realloc_on_unchecked_account_does_not_compile() {
+    compile_fail_case(
+        "realloc_on_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod realloc_on_unchecked_account {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn resize(ctx: &mut Context<Resize>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Resize {
+    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc` cannot be used on `UncheckedAccount`"],
+    );
+}


### PR DESCRIPTION
fixes  #4567 
## Summary

Reject `close` and `realloc` constraints on `UncheckedAccount` in the v2 `Accounts` derive...

This matches the intended safety behavior from v1, where these constraints are only valid on account types that safely support close/realloc handling. The validation also unwraps transparent wrappers like `Option<T>` and `Box<T>`, so `Option<UncheckedAccount>` and `Box<UncheckedAccount>` cannot bypass the restriction.

## Changes

- Added v2 derive validation for `close` on `UncheckedAccount`
- Added v2 derive validation for `realloc` on `UncheckedAccount`
- Added compile-fail tests for:
  - `close` on `UncheckedAccount`
  - `close` on `Box<UncheckedAccount>`
  - `realloc` on `UncheckedAccount`

## Testing

- `cargo test --manifest-path tests-v2/Cargo.toml --test compile_fail unchecked_account`
- `cargo test -p anchor-derive-accounts-v2`
- `git diff --check`

Note: full `cargo test --manifest-path tests-v2/Cargo.toml --test compile_fail` currently has an unrelated existing failure in `program_interface_cpi_rejects_optional_accounts_clearly`