### PR TITLE
fix(ts): preserve caller blockhash in sendAll and simulate

### DIFF
--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -218,30 +218,44 @@ export class AnchorProvider implements Provider {
     if (opts === undefined) {
       opts = this.opts;
     }
-    const recentBlockhash = (
-      await this.connection.getLatestBlockhash(opts.preflightCommitment)
-    ).blockhash;
-
-    let txs = txWithSigners.map((r) => {
-      if (isVersionedTransaction(r.tx)) {
-        let tx: VersionedTransaction = r.tx;
-        if (r.signers) {
-          tx.sign(r.signers);
-        }
-        return tx;
-      } else {
-        let tx: Transaction = r.tx;
-        let signers = r.signers ?? [];
-
-        tx.feePayer = tx.feePayer ?? this.wallet.publicKey;
-        tx.recentBlockhash = recentBlockhash;
-
-        signers.forEach((kp) => {
-          tx.partialSign(kp);
-        });
-        return tx;
+    // Lazily fetch one blockhash while preserving caller-provided values.
+    let blockhashPromise: Promise<string> | undefined;
+    const ensureBlockhash = () => {
+      if (!blockhashPromise) {
+        blockhashPromise = this.connection
+          .getLatestBlockhash(opts!.preflightCommitment)
+          .then((b) => b.blockhash);
       }
-    });
+      return blockhashPromise;
+    };
+
+    let txs = await Promise.all(
+      txWithSigners.map(async (r) => {
+        if (isVersionedTransaction(r.tx)) {
+          let tx: VersionedTransaction = r.tx;
+          if (r.signers) {
+            tx.sign(r.signers);
+          }
+          return tx;
+        } else {
+          let tx: Transaction = r.tx;
+          let signers = r.signers ?? [];
+
+          tx.feePayer = tx.feePayer ?? this.wallet.publicKey;
+          if (
+            !tx.recentBlockhash ||
+            tx.recentBlockhash === "11111111111111111111111111111111"
+          ) {
+            tx.recentBlockhash = await ensureBlockhash();
+          }
+
+          signers.forEach((kp) => {
+            tx.partialSign(kp);
+          });
+          return tx;
+        }
+      })
+    );
 
     const signedTxs = await this.wallet.signAllTransactions(txs);
 
@@ -304,12 +318,6 @@ export class AnchorProvider implements Provider {
     commitment?: Commitment,
     includeAccounts?: boolean | PublicKey[]
   ): Promise<SuccessfulTxSimulationResponse> {
-    let recentBlockhash = (
-      await this.connection.getLatestBlockhash(
-        commitment ?? this.connection.commitment
-      )
-    ).blockhash;
-
     let result: RpcResponseAndContext<SimulatedTransactionResponse>;
     if (isVersionedTransaction(tx)) {
       if (signers && signers.length > 0) {
@@ -322,7 +330,17 @@ export class AnchorProvider implements Provider {
       result = await this.connection.simulateTransaction(tx, { commitment });
     } else {
       tx.feePayer = tx.feePayer || this.wallet.publicKey;
-      tx.recentBlockhash = recentBlockhash;
+      // Preserve caller-provided blockhash (e.g. durable nonces) — see #3375.
+      if (
+        !tx.recentBlockhash ||
+        tx.recentBlockhash === "11111111111111111111111111111111"
+      ) {
+        tx.recentBlockhash = (
+          await this.connection.getLatestBlockhash(
+            commitment ?? this.connection.commitment
+          )
+        ).blockhash;
+      }
 
       if (signers && signers.length > 0) {
         tx = await this.wallet.signTransaction(tx);

--- a/ts/packages/anchor/tests/provider-blockhash.spec.ts
+++ b/ts/packages/anchor/tests/provider-blockhash.spec.ts
@@ -1,0 +1,141 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+
+import { AnchorProvider, Wallet } from "../src";
+
+// `AnchorProvider.sendAll` and `AnchorProvider.simulate` used to unconditionally
+// overwrite `tx.recentBlockhash` with a freshly-fetched value, which clobbered
+// caller-provided blockhashes (notably durable nonces). Both call sites now
+// only fetch / assign when the field is missing or set to the all-zeros
+// sentinel — matching the existing behavior of `sendAndConfirm`.
+
+const PRESET_BLOCKHASH = "GfVcyD5tT6Aua4yzGiVy5gM2y2qXmZRr5GnMaCu2FQVc";
+const FETCHED_BLOCKHASH = "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N";
+const STOP = new Error("__stop_after_blockhash_assignment__");
+
+function makeFixture() {
+  const walletKp = Keypair.generate();
+  let getLatestBlockhashCalls = 0;
+
+  const connection = {
+    commitment: "processed",
+    getLatestBlockhash: async () => {
+      getLatestBlockhashCalls++;
+      return { blockhash: FETCHED_BLOCKHASH, lastValidBlockHeight: 0 };
+    },
+    // Anchor's local `simulateTransaction` helper calls `_rpcRequest` after
+    // the provider has already assigned the blockhash. Reject to halt the
+    // flow before serialization / network access.
+    _rpcRequest: async () => {
+      throw STOP;
+    },
+    sendRawTransaction: async () => "fake-sig",
+    confirmTransaction: async () => ({ value: { err: null } }),
+  } as unknown as Connection;
+
+  const wallet: Wallet = {
+    publicKey: walletKp.publicKey,
+    signTransaction: async (tx: any) => tx,
+    // Reject after the sendAll loop has already mutated each tx — lets us
+    // inspect the post-mutation state without exercising serialize / RPC.
+    signAllTransactions: async () => {
+      throw STOP;
+    },
+    payer: walletKp,
+  } as any;
+
+  return {
+    provider: new AnchorProvider(connection, wallet),
+    getLatestBlockhashCalls: () => getLatestBlockhashCalls,
+  };
+}
+
+function legacyTx(blockhash?: string): Transaction {
+  const tx = new Transaction();
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: PublicKey.default,
+      toPubkey: PublicKey.default,
+      lamports: 1,
+    })
+  );
+  if (blockhash) tx.recentBlockhash = blockhash;
+  return tx;
+}
+
+describe("AnchorProvider blockhash handling (#3375)", () => {
+  describe("sendAll", () => {
+    it("preserves a caller-provided recentBlockhash", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const tx = legacyTx(PRESET_BLOCKHASH);
+
+      await expect(provider.sendAll([{ tx }])).rejects.toBe(STOP);
+
+      expect(tx.recentBlockhash).toBe(PRESET_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(0);
+    });
+
+    it("fetches and assigns only for txs missing a blockhash", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const txWith = legacyTx(PRESET_BLOCKHASH);
+      const txWithout = legacyTx();
+
+      await expect(
+        provider.sendAll([{ tx: txWith }, { tx: txWithout }])
+      ).rejects.toBe(STOP);
+
+      expect(txWith.recentBlockhash).toBe(PRESET_BLOCKHASH);
+      expect(txWithout.recentBlockhash).toBe(FETCHED_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(1);
+    });
+
+    it("reuses a single fetched blockhash across multiple missing txs", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const a = legacyTx();
+      const b = legacyTx();
+
+      await expect(provider.sendAll([{ tx: a }, { tx: b }])).rejects.toBe(STOP);
+
+      expect(a.recentBlockhash).toBe(FETCHED_BLOCKHASH);
+      expect(b.recentBlockhash).toBe(FETCHED_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(1);
+    });
+
+    it("treats the all-zeros sentinel as missing", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const tx = legacyTx("11111111111111111111111111111111");
+
+      await expect(provider.sendAll([{ tx }])).rejects.toBe(STOP);
+
+      expect(tx.recentBlockhash).toBe(FETCHED_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(1);
+    });
+  });
+
+  describe("simulate", () => {
+    it("preserves a caller-provided recentBlockhash", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const tx = legacyTx(PRESET_BLOCKHASH);
+
+      await expect(provider.simulate(tx)).rejects.toBe(STOP);
+
+      expect(tx.recentBlockhash).toBe(PRESET_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(0);
+    });
+
+    it("fetches a blockhash only when missing", async () => {
+      const { provider, getLatestBlockhashCalls } = makeFixture();
+      const tx = legacyTx();
+
+      await expect(provider.simulate(tx)).rejects.toBe(STOP);
+
+      expect(tx.recentBlockhash).toBe(FETCHED_BLOCKHASH);
+      expect(getLatestBlockhashCalls()).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`AnchorProvider.sendAll` and `AnchorProvider.simulate` unconditionally overwrote `tx.recentBlockhash` with a freshly-fetched value, clobbering caller-set blockhashes (notably durable nonces). Both call sites now guard the assignment with the same `!tx.recentBlockhash || === 11111111111111111111111111111111` check `sendAndConfirm` already uses. `sendAll` fetches lazily via a memoized promise so a batch of N legacy txs missing a blockhash still triggers one RPC, and skips the call entirely when every tx is preset.

Fixes [#3375](https://github.com/otter-sec/anchor/issues/3375)