### PR TITLE
fix(v2): validate associated token init account type

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -458,6 +458,18 @@ fn parse_associated_token_init(
         .iter()
         .filter(|nc| nc.namespace == "associated_token")
     {
+        let target = match nc.raw_key.as_str() {
+            "mint" => &mut mint,
+            "authority" => &mut authority,
+            "token_program" => &mut token_program,
+            _ => {
+                return Err(syn::Error::new(
+                    nc.value.span(),
+                    format!("unknown `associated_token` constraint `{}`", nc.raw_key),
+                ));
+            }
+        };
+
         let Some(ident) = expr_as_field_ident(&nc.value) else {
             return Err(syn::Error::new(
                 nc.value.span(),
@@ -475,12 +487,7 @@ fn parse_associated_token_init(
             ));
         }
 
-        match nc.raw_key.as_str() {
-            "mint" => mint = Some(ident),
-            "authority" => authority = Some(ident),
-            "token_program" => token_program = Some(ident),
-            _ => {}
-        }
+        *target = Some(ident);
     }
 
     if mint.is_none() && authority.is_none() && token_program.is_none() {
@@ -1123,8 +1130,10 @@ fn emit_associated_token_init_body(
 
             // SAFETY: this field has just been initialized by the associated
             // token program, and duplicate mutable accounts are rejected by
-            // the generated account bitvec check.
-            unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_after_init(__target, __program_id)? }
+            // the generated account bitvec check. ATA init is performed by
+            // external programs selected at runtime, so run the field type's
+            // full validation after the CPI.
+            unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target, __program_id)? }
         }
     })
 }

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -176,7 +176,7 @@ pub mod bad_discriminator {
 #[derive(Accounts)]
 pub struct Noop {}
 "#,
-        &["`#[discrim = N]` value must be an integer literal"],
+        &["`#[discrim = ...]` value must be an integer literal or byte array literal"],
     );
 }
 

--- a/tests-v2/programs/spl-ata/src/lib.rs
+++ b/tests-v2/programs/spl-ata/src/lib.rs
@@ -130,6 +130,13 @@ pub mod spl_ata_test {
         associated_token::create(cpi_ctx)?;
         Ok(())
     }
+
+    #[discrim = 14]
+    pub fn init_strict_ata_with_token_program(
+        _ctx: &mut Context<InitStrictAtaWithTokenProgram>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -240,6 +247,25 @@ pub struct InitInterfaceAtaWithTokenProgram {
         associated_token::token_program = token_program,
     )]
     pub token_account: InterfaceAccount<token_interface::TokenAccount>,
+    pub token_program: UncheckedAccount,
+    pub associated_token_program: Program<AssociatedToken>,
+    pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct InitStrictAtaWithTokenProgram {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<token_interface::Mint>,
+    pub authority: UncheckedAccount,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = mint,
+        associated_token::authority = authority,
+        associated_token::token_program = token_program,
+    )]
+    pub token_account: Account<TokenAccount>,
     pub token_program: UncheckedAccount,
     pub associated_token_program: Program<AssociatedToken>,
     pub system_program: Program<System>,

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -326,6 +326,38 @@ pub mod program_interface_duplicate_discriminator {
 }
 
 #[test]
+fn associated_token_rejects_unknown_constraint_key() {
+    compile_fail_case(
+        "associated_token_unknown_constraint_key",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct BadAta {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: UncheckedAccount,
+    pub authority: UncheckedAccount,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = mint,
+        associated_token::authority = authority,
+        associated_token::program = token_program,
+    )]
+    pub token_account: UncheckedAccount,
+    pub token_program: UncheckedAccount,
+    pub associated_token_program: UncheckedAccount,
+    pub system_program: UncheckedAccount,
+}
+"#,
+        &["unknown `associated_token` constraint `program`"],
+    );
+}
+
+#[test]
 fn declare_program_missing_idls_directory_fails_clearly() {
     compile_fail_case(
         "declare_program_missing_idls_directory",

--- a/tests-v2/tests/spl_ata.rs
+++ b/tests-v2/tests/spl_ata.rs
@@ -203,6 +203,26 @@ fn send_init_interface_ata_with_token_program(
     send_instruction(svm, program_id(), vec![6], metas, payer, &[]).map(|_| ())
 }
 
+fn send_init_strict_ata_with_token_program(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    mint: Pubkey,
+    owner: Pubkey,
+    ata: Pubkey,
+    token_program: Pubkey,
+) -> anyhow::Result<()> {
+    let metas = vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(owner, false),
+        AccountMeta::new(ata, false),
+        AccountMeta::new_readonly(token_program, false),
+        AccountMeta::new_readonly(ata_program_id(), false),
+        AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
+    ];
+    send_instruction(svm, program_id(), vec![14], metas, payer, &[]).map(|_| ())
+}
+
 fn send_init_ata_if_needed(
     svm: &mut LiteSVM,
     payer: &Keypair,
@@ -573,6 +593,35 @@ fn init_with_token_program_creates_token_2022_ata() {
         token_2022_program_id(),
     )
     .is_ok());
+}
+
+#[test]
+fn strict_ata_init_rejects_token_2022_program() {
+    let (mut svm, payer) = setup();
+    let mint_authority = keypair_for("spl-ata-strict-token-2022-mint-authority");
+    let owner = keypair_for("spl-ata-strict-token-2022-owner");
+    let mint = Keypair::new();
+    let ata = associated_token_address(&owner.pubkey(), &mint.pubkey(), &token_2022_program_id());
+
+    init_interface_mint_with_token_program(
+        &mut svm,
+        &payer,
+        &mint,
+        mint_authority.pubkey(),
+        token_2022_program_id(),
+    )
+    .expect("init token-2022 mint");
+
+    assert!(send_init_strict_ata_with_token_program(
+        &mut svm,
+        &payer,
+        mint.pubkey(),
+        owner.pubkey(),
+        ata,
+        token_2022_program_id(),
+    )
+    .is_err());
+    assert!(svm.get_account(&ata).is_none());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #4541

## Summary
- Run full account validation after v2 associated token account init instead of `load_mut_after_init`
- Prevent strict `Account<TokenAccount>` fields from accepting Token-2022 ATAs created through `associated_token::token_program`
- Reject unknown `associated_token::*` constraint keys instead of silently ignoring them

## Testing
- `cargo test --manifest-path tests-v2/Cargo.toml --test spl_ata strict_ata_init_rejects_token_2022_program`
- `cargo test --manifest-path tests-v2/Cargo.toml --test spl_ata init_with_token_program_creates_token_2022_ata`
- `cargo test --manifest-path tests-v2/Cargo.toml --test compile_fail associated_token_rejects_unknown_constraint_key`
- `cargo test --manifest-path tests-v2/Cargo.toml --test spl_ata`
- `cargo test -p anchor-derive-accounts-v2`
- `git diff --check`