### PR TITLE
Support init with foreign owner in v2 (#4557)

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1029,6 +1029,16 @@ fn emit_init_body(
         quote! { let __seeds: Option<&[&[u8]]> = None; }
     };
 
+    // Owner of the new account. Defaults to the currently-executing program;
+    // `#[account(init, owner = expr)]` lets users init accounts owned by a
+    // foreign program (e.g. when CPI'ing into another program that expects
+    // to own the account afterward). When set, we also skip the post-init
+    // owner equality check (see process_constraints) — it's tautological.
+    let owner_arg = match attrs.owner.as_ref() {
+        Some(owner_expr) => quote! { &#owner_expr },
+        None => quote! { __program_id },
+    };
+
     quote! {
         let __payer = #payer.account();
         #seeds_arg
@@ -1039,7 +1049,7 @@ fn emit_init_body(
             __p
         };
         <#field_ty as anchor_lang_v2::AccountInitialize>::create_and_initialize(
-            __payer, &__target, #space, __program_id, &__init_params, __seeds,
+            __payer, &__target, #space, #owner_arg, &__init_params, __seeds,
         )?
     }
 }
@@ -1627,17 +1637,25 @@ pub fn parse_field(
     }
 
     // owner
+    //
+    // Skipped on plain `init`: the freshly-created account is owned by the
+    // exact `owner` expression we just passed to `create_and_initialize`,
+    // so re-checking is a no-op. `init_if_needed` still emits the check —
+    // the "already exists" branch skips the create CPI and must verify the
+    // existing account's owner matches.
     if let Some(ref owner_expr) = attrs.owner {
-        let err = if let Some(ref e) = attrs.owner_error {
-            quote! { core::convert::Into::into(#e) }
-        } else {
-            quote! { anchor_lang_v2::ErrorCode::ConstraintOwner.into() }
-        };
-        constraints.push(quote! {
-            if !#field_name.account().owned_by(&#owner_expr) {
-                return Err(#err);
-            }
-        });
+        if !attrs.is_init {
+            let err = if let Some(ref e) = attrs.owner_error {
+                quote! { core::convert::Into::into(#e) }
+            } else {
+                quote! { anchor_lang_v2::ErrorCode::ConstraintOwner.into() }
+            };
+            constraints.push(quote! {
+                if !#field_name.account().owned_by(&#owner_expr) {
+                    return Err(#err);
+                }
+            });
+        }
     }
 
     // constraint(s) — emitted in the order they appeared in the attribute.

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{accounts::view_wrapper_traits, AnchorAccount},
+    crate::{accounts::view_wrapper_traits, AccountInitialize, AnchorAccount},
     pinocchio::{account::AccountView, address::Address},
     solana_program_error::ProgramError,
 };
@@ -25,6 +25,32 @@ impl AnchorAccount for UncheckedAccount {
     #[inline(always)]
     fn account(&self) -> &AccountView {
         &self.view
+    }
+}
+
+/// Init for `UncheckedAccount`: creates a zero-initialized account at
+/// `view.address()` with the requested space, owned by `program_id`, then
+/// returns the loaded view. Intended for the "init then CPI into a foreign
+/// program that owns the account" pattern — pair with
+/// `#[account(init, owner = foreign::ID, ...)]` so the new account is
+/// handed off owned by the right program.
+impl AccountInitialize for UncheckedAccount {
+    type Params<'a> = ();
+
+    #[inline(always)]
+    fn create_and_initialize<'a>(
+        payer: &AccountView,
+        account: &AccountView,
+        space: usize,
+        program_id: &Address,
+        _params: &(),
+        signer_seeds: Option<&[&[u8]]>,
+    ) -> Result<Self, ProgramError> {
+        match signer_seeds {
+            Some(seeds) => crate::create_account_signed(payer, account, space, program_id, seeds)?,
+            None => crate::create_account(payer, account, space, program_id)?,
+        }
+        Ok(Self { view: *account })
     }
 }
 

--- a/tests-v2/programs/constraints/src/lib.rs
+++ b/tests-v2/programs/constraints/src/lib.rs
@@ -183,6 +183,18 @@ pub mod constraints {
     pub fn check_address_into_ref(_ctx: &mut Context<CheckAddressIntoRef>) -> Result<()> {
         Ok(())
     }
+
+    /// `init` + `owner = <foreign program>` on an `UncheckedAccount`.
+    /// Mirrors the marginfi/Solend pattern: create an account that another
+    /// program will own. The derive must pass `OTHER_PROGRAM` (not
+    /// `__program_id`) as the owner argument to the system program's
+    /// `CreateAccount` CPI, and must skip the post-init owner check —
+    /// otherwise constraint validation would reject the freshly-created
+    /// account.
+    #[discrim = 19]
+    pub fn init_foreign_owned(_ctx: &mut Context<InitForeignOwned>) -> Result<()> {
+        Ok(())
+    }
 }
 
 // -- Accounts structs --------------------------------------------------------
@@ -353,6 +365,29 @@ pub struct CheckAddressInto {
 pub struct CheckAddressIntoRef {
     #[account(address = pinned_address_ref())]
     pub pinned: UncheckedAccount,
+}
+
+// 19. init + owner = <foreign program>
+//
+// The new account is a fresh PDA derived from `[b"foreign"]` under THIS
+// program's id (we're the only one that can sign for it via seeds), but
+// once created it's owned by `OTHER_PROGRAM`. `UncheckedAccount` is the
+// right wrapper — a typed `Account<T>` would refuse to load because the
+// foreign owner can't pass the wrapper's owner/disc checks.
+#[derive(Accounts)]
+pub struct InitForeignOwned {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        seeds = [b"foreign"],
+        bump,
+        space = 64,
+        owner = OTHER_PROGRAM,
+    )]
+    pub foreign: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
 #[derive(Accounts)]

--- a/tests-v2/tests/constraints.rs
+++ b/tests-v2/tests/constraints.rs
@@ -870,3 +870,52 @@ fn signer_on_unchecked_rejected_when_not_signed() {
     // `ConstraintSigner` -> `ProgramError::MissingRequiredSignature`.
     assert_err_contains(&result, "MissingRequiredSignature");
 }
+
+// ---- 19. init + owner = <foreign program> --------------------------------
+//
+// Reproduction of the issue: `#[account(init, owner = OTHER_PROGRAM, ...)]`
+// on an `UncheckedAccount` must create the account owned by `OTHER_PROGRAM`
+// (not by the executing program). Before the fix the derive hardcoded
+// `__program_id` as the new account's owner and then the post-init owner
+// check failed because `OTHER_PROGRAM != __program_id`.
+
+fn foreign_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"foreign"], &program_id()).0
+}
+
+#[test]
+fn init_with_foreign_owner_creates_account_owned_by_foreign_program() {
+    let (mut svm, payer, _) = setup();
+    let foreign = foreign_pda();
+
+    // Sanity: account doesn't exist yet.
+    assert!(svm
+        .get_account(&foreign)
+        .map(|a| a.data.is_empty() && a.lamports == 0)
+        .unwrap_or(true));
+
+    call(
+        &mut svm,
+        &payer,
+        19,
+        vec![
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new(foreign, false),
+            AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
+        ],
+        &[],
+    )
+    .expect("init_foreign_owned");
+
+    let created = svm
+        .get_account(&foreign)
+        .expect("account exists after init");
+    assert_eq!(
+        created.owner,
+        other_program(),
+        "freshly-init'd account must be owned by the foreign program, \
+         not by the executing program — got {:?}",
+        created.owner,
+    );
+    assert_eq!(created.data.len(), 64, "space = 64 must be honored");
+}


### PR DESCRIPTION
Closes #4557.

In v2, `#[account(init, owner = foreign::ID, ...)]` doesn't work — the derive hardcodes `__program_id` as the new account's owner in the `create_and_initialize` call, and then the post-init owner constraint check rejects the freshly-created account because its owner doesn't match the user-specified `owner` expr.

This blocks the marginfi/Solend pattern where you init an account that another program will own (e.g. so you can immediately CPI into the foreign program and have it set up that account's state).

## Changes

- `lang-v2/derive/src/parse.rs` — when `attrs.owner` is set in `emit_init_body`, pass `&#owner_expr` to `create_and_initialize` instead of `__program_id`. Matches v1's behavior (`lang/syn/src/codegen/accounts/constraints.rs:1076`).
- `lang-v2/derive/src/parse.rs` — skip the standalone owner equality check on plain `init`, since the freshly-created account is owned by the exact expr we just passed to `create_and_initialize`. `init_if_needed` keeps the check because the existing-account branch doesn't re-create.
- `lang-v2/src/accounts/unchecked_account.rs` — add `AccountInitialize` for `UncheckedAccount`. That's the right wrapper for this pattern; a typed `Account<T>` would refuse to load on a foreign owner anyway.
- `tests-v2/programs/constraints` + `tests-v2/tests/constraints.rs` — LiteSVM regression test asserting the new account's owner is the foreign program after init.

## Notes

- Existing v2 unit and macro-diagnostic tests pass locally. The LiteSVM integration test couldn't be exercised locally (missing SBF toolchain on my machine — existing tests fail with the same error), but the test is structured the same way as `init_if_needed_creates_then_reuses` next to it.
- Branched off `anchor-next` since v2 lives there.