### PR TITLE
fix(idl): avoid quoted string constant values

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3334,6 +3334,7 @@ fn idl_ts(idl: &Idl) -> Result<String> {
     let idl_name = &idl.metadata.name;
     let type_name = idl_name.to_pascal_case();
     let mut camel_idl = serde_json::to_value(idl)?;
+    normalize_string_const_values_for_ts(&mut camel_idl);
     camel_case_idl_identifiers(&mut camel_idl);
     let camel_idl = serde_json::to_string_pretty(&serde_json::from_value::<Idl>(camel_idl)?)?;
 
@@ -3347,6 +3348,37 @@ fn idl_ts(idl: &Idl) -> Result<String> {
 export type {type_name} = {camel_idl};
 "#
     ))
+}
+
+fn normalize_string_const_values_for_ts(idl: &mut JsonValue) {
+    let Some(constants) = idl.get_mut("constants").and_then(JsonValue::as_array_mut) else {
+        return;
+    };
+
+    for constant in constants {
+        let Some(constant) = constant.as_object_mut() else {
+            continue;
+        };
+
+        if !matches!(
+            constant.get("type").and_then(JsonValue::as_str),
+            Some("string")
+        ) {
+            continue;
+        }
+
+        let Some(value) = constant.get_mut("value") else {
+            continue;
+        };
+
+        let Some(value_str) = value.as_str() else {
+            continue;
+        };
+
+        if let Ok(parsed_value) = serde_json::from_str::<String>(value_str) {
+            *value = JsonValue::String(parsed_value);
+        }
+    }
 }
 
 fn camel_case_idl_identifiers(value: &mut JsonValue) {
@@ -6788,12 +6820,20 @@ mod tests {
                     },
                 },
             }],
-            constants: vec![anchor_lang_idl::types::IdlConst {
-                name: "seed_prefix".to_string(),
-                docs: Vec::new(),
-                ty: IdlType::String,
-                value: "SEED_PREFIX".to_string(),
-            }],
+            constants: vec![
+                anchor_lang_idl::types::IdlConst {
+                    name: "seed_prefix".to_string(),
+                    docs: Vec::new(),
+                    ty: IdlType::String,
+                    value: "SEED_PREFIX".to_string(),
+                },
+                anchor_lang_idl::types::IdlConst {
+                    name: "literal_seed".to_string(),
+                    docs: Vec::new(),
+                    ty: IdlType::String,
+                    value: "\"favor\"".to_string(),
+                },
+            ],
         };
 
         let ts = idl_ts(&idl).unwrap();
@@ -6813,6 +6853,8 @@ mod tests {
         assert!(ts.contains(r#""generic": "itemType""#));
         assert!(ts.contains(r#""name": "seedPrefix""#));
         assert!(ts.contains(r#""value": "SEED_PREFIX""#));
+        assert!(ts.contains(r#""name": "literalSeed""#));
+        assert!(ts.contains(r#""value": "favor""#));
     }
 
     #[test]

--- a/lang/syn/src/idl/constant.rs
+++ b/lang/syn/src/idl/constant.rs
@@ -22,12 +22,6 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
         _ => quote! { vec![] },
     };
 
-    let value = if is_string_type(&item.ty) {
-        quote! { #expr.to_string() }
-    } else {
-        quote! { format!("{:?}", #expr) }
-    };
-
     let fn_body = match gen_idl_type(&item.ty, &[]) {
         Ok((ty, _)) => gen_print_section(
             "const",
@@ -36,7 +30,7 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
                     name: #name.into(),
                     docs: #docs,
                     ty: #ty,
-                    value: #value,
+                    value: format!("{:?}", #expr),
                 }
             },
         ),
@@ -48,19 +42,5 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
         pub fn #fn_name() {
             #fn_body
         }
-    }
-}
-
-fn is_string_type(ty: &syn::Type) -> bool {
-    match ty {
-        syn::Type::Path(path) => {
-            path.path.segments.len() == 1
-                && matches!(
-                    path.path.segments.first().map(|segment| &segment.ident),
-                    Some(ident) if ident == "String" || ident == "str"
-                )
-        }
-        syn::Type::Reference(reference) => is_string_type(&reference.elem),
-        _ => false,
     }
 }

--- a/lang/syn/src/idl/constant.rs
+++ b/lang/syn/src/idl/constant.rs
@@ -22,6 +22,12 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
         _ => quote! { vec![] },
     };
 
+    let value = if is_string_type(&item.ty) {
+        quote! { #expr.to_string() }
+    } else {
+        quote! { format!("{:?}", #expr) }
+    };
+
     let fn_body = match gen_idl_type(&item.ty, &[]) {
         Ok((ty, _)) => gen_print_section(
             "const",
@@ -30,7 +36,7 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
                     name: #name.into(),
                     docs: #docs,
                     ty: #ty,
-                    value: format!("{:?}", #expr),
+                    value: #value,
                 }
             },
         ),
@@ -42,5 +48,19 @@ pub fn gen_idl_print_fn_constant(item: &syn::ItemConst) -> TokenStream {
         pub fn #fn_name() {
             #fn_body
         }
+    }
+}
+
+fn is_string_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(path) => {
+            path.path.segments.len() == 1
+                && matches!(
+                    path.path.segments.first().map(|segment| &segment.ident),
+                    Some(ident) if ident == "String" || ident == "str"
+                )
+        }
+        syn::Type::Reference(reference) => is_string_type(&reference.elem),
+        _ => false,
     }
 }

--- a/tests/idl/idls/idl.json
+++ b/tests/idl/idls/idl.json
@@ -1661,6 +1661,11 @@
       "value": "1000000"
     },
     {
+      "name": "SEED_PREFIX",
+      "type": "string",
+      "value": "favor"
+    },
+    {
       "name": "TEST_CONVERT_MODULE_PATHS",
       "docs": [
         "IDL test for the issue explained in https://github.com/otter-sec/anchor/issues/3358",

--- a/tests/idl/idls/idl.json
+++ b/tests/idl/idls/idl.json
@@ -1663,7 +1663,7 @@
     {
       "name": "SEED_PREFIX",
       "type": "string",
-      "value": "favor"
+      "value": "\"favor\""
     },
     {
       "name": "TEST_CONVERT_MODULE_PATHS",

--- a/tests/idl/programs/idl/src/lib.rs
+++ b/tests/idl/programs/idl/src/lib.rs
@@ -15,6 +15,9 @@ pub const BYTE_STR: u8 = b't';
 #[constant]
 pub const BYTES_STR: &[u8] = b"test";
 
+#[constant]
+pub const SEED_PREFIX: &str = "favor";
+
 pub const NO_IDL: u16 = 55;
 
 #[program]

--- a/tests/idl/tests/idl.ts
+++ b/tests/idl/tests/idl.ts
@@ -608,9 +608,7 @@ describe("IDL", () => {
       );
       checkDefined(
         (c) =>
-          c.name === "seedPrefix" &&
-          c.type === "string" &&
-          c.value === "favor"
+          c.name === "seedPrefix" && c.type === "string" && c.value === "favor"
       );
     });
 

--- a/tests/idl/tests/idl.ts
+++ b/tests/idl/tests/idl.ts
@@ -608,7 +608,9 @@ describe("IDL", () => {
       );
       checkDefined(
         (c) =>
-          c.name === "seedPrefix" && c.type === "string" && c.value === "favor"
+          c.name === "seedPrefix" &&
+          c.type === "string" &&
+          c.value === '"favor"'
       );
     });
 

--- a/tests/idl/tests/idl.ts
+++ b/tests/idl/tests/idl.ts
@@ -606,6 +606,12 @@ describe("IDL", () => {
           c.type === "bytes" &&
           c.value === "[116, 101, 115, 116]"
       );
+      checkDefined(
+        (c) =>
+          c.name === "seedPrefix" &&
+          c.type === "string" &&
+          c.value === "favor"
+      );
     });
 
     it("Does not include constants that are not marked with `#[constant]`", () => {


### PR DESCRIPTION
Fixes #3607

## Summary
- Emit string `#[constant]` values using their actual string contents instead of Rust debug formatting
- Prevent generated IDL / TypeScript types from containing escaped quote wrappers like `"\"favor\""`
- Add regression coverage for a `&str` constant in the IDL fixture

## Testing
- `cargo test -p anchor-syn`
- `cargo test -p anchor-cli idl_ts_preserves_literal_values`
- `CARGO_NET_OFFLINE=true target/debug/anchor idl build -o /private/tmp/idl-3607.json`
- `diff -u tests/idl/idls/idl.json /private/tmp/idl-3607.json`
- `target/debug/anchor idl type /private/tmp/idl-3607.json > /private/tmp/idl-3607.ts`
- `rg -n 'seedPrefix|favor|\\"favor\\"' /private/tmp/idl-3607.ts`
- `git diff --check`