### PR TITLE
fix: reserve event cpi discriminator in dispatch

### DIFF
--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -78,15 +78,16 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             accounts: &'info [AccountInfo<'info>],
             data: &'info [u8],
         ) -> anchor_lang::Result<()> {
-            #(#global_ixs)*
-
             // Legacy IDL instructions have been removed in favor of Program Metadata
             // No IDL instructions are injected into programs anymore
 
-            // Dispatch Event CPI instruction
+            // Dispatch the Event CPI instruction before user instructions so a
+            // custom discriminator cannot shadow the reserved event-CPI tag.
             if data.starts_with(anchor_lang::event::EVENT_IX_TAG_LE) {
                 return #event_cpi_handler;
             }
+
+            #(#global_ixs)*
 
             #fallback_fn
         }

--- a/tests/events/programs/events/src/lib.rs
+++ b/tests/events/programs/events/src/lib.rs
@@ -31,6 +31,11 @@ pub mod events {
         });
         Ok(())
     }
+
+    #[instruction(discriminator = 0xe4)]
+    pub fn event_cpi_shadow_probe(_ctx: Context<EventCpiShadowProbe>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -42,6 +47,9 @@ pub struct TestEvent {}
 #[event_cpi]
 #[derive(Accounts)]
 pub struct TestEventCpi {}
+
+#[derive(Accounts)]
+pub struct EventCpiShadowProbe {}
 
 #[event]
 pub struct MyEvent {

--- a/tests/events/tests/events.ts
+++ b/tests/events/tests/events.ts
@@ -118,5 +118,18 @@ describe("Events", () => {
 
       throw new Error("Was able to invoke the self-CPI instruction");
     });
+
+    it("Allows short custom discriminator overlapping event CPI tag", async () => {
+      const tx = new anchor.web3.Transaction();
+      tx.add(
+        new anchor.web3.TransactionInstruction({
+          programId: program.programId,
+          keys: [],
+          data: Buffer.from([0xe4]),
+        })
+      );
+
+      await program.provider.sendAndConfirm(tx, [], confirmOptions);
+    });
   });
 });


### PR DESCRIPTION
Fixes #4272

## Summary

- Dispatches the reserved event-CPI tag before user instruction discriminators.
- Prevents a custom short discriminator like `[0xe4]` from shadowing the full event-CPI tag.
- Adds a regression test showing that the overlapping short custom discriminator still dispatches normally when sent by itself.

## Testing

- `rustfmt --check lang/syn/src/codegen/program/dispatch.rs tests/events/programs/events/src/lib.rs`
- `git diff --check`
- `cargo test -p anchor-syn`
- `cargo test --manifest-path tests/events/programs/events/Cargo.toml`
- `cargo test -p tests-v2 event_cpi`
- `PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/v20.19.0/bin:$PATH" ../../target/debug/anchor test --skip-lint` from `tests/events`

Full `tests/events` result: `5 passing`