### PR TITLE
fix(ts): encode undefined option args as null

### DIFF
--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -7,6 +7,7 @@ import {
   handleDefinedFields,
   Idl,
   IdlField,
+  IdlGenericArg,
   IdlType,
   IdlTypeDef,
   IdlAccount,
@@ -67,22 +68,339 @@ export class BorshInstructionCoder implements InstructionCoder {
           }.`
         );
       }
-      const missing = encoder.args
-        .map((a) => a.name)
-        .filter((name) => !ix.hasOwnProperty(name));
-      if (missing.length > 0) {
-        throw new Error(
-          `Invalid arguments for instruction "${ixName}": missing field${
-            missing.length > 1 ? "s" : ""
-          } ${missing.map((m) => `\`${m}\``).join(", ")}.`
-        );
-      }
     }
 
-    const len = encoder.layout.encode(ix, buffer);
+    const requiredMissing = encoder.args
+      .filter(
+        (arg) => !BorshInstructionCoder.isOption(arg.type, this.idl.types)
+      )
+      .map((arg) => arg.name)
+      .filter((name) => !ix.hasOwnProperty(name));
+    if (requiredMissing.length > 0) {
+      throw new Error(
+        `Invalid arguments for instruction "${ixName}": missing field${
+          requiredMissing.length > 1 ? "s" : ""
+        } ${requiredMissing.map((m) => `\`${m}\``).join(", ")}.`
+      );
+    }
+
+    const ixWithDefinedOptions = BorshInstructionCoder.convertUndefinedOptions(
+      encoder.args,
+      ix,
+      this.idl.types
+    );
+    const len = encoder.layout.encode(ixWithDefinedOptions, buffer);
     const data = buffer.slice(0, len);
 
     return Buffer.concat([Buffer.from(encoder.discriminator), data]);
+  }
+
+  private static isOption(
+    idlType: IdlType,
+    types: IdlTypeDef[] = [],
+    visited = new Set<string>()
+  ): boolean {
+    if (typeof idlType !== "object") {
+      return false;
+    }
+    if ("option" in idlType) {
+      return true;
+    }
+    if ("defined" in idlType) {
+      const definedName = idlType.defined.name;
+      if (visited.has(definedName)) {
+        return false;
+      }
+
+      const typeDef = types.find((t) => t.name === definedName);
+      if (typeDef?.type.kind !== "type") {
+        return false;
+      }
+
+      const alias = BorshInstructionCoder.resolveGenericType(
+        typeDef.type.alias,
+        typeDef,
+        idlType.defined.generics
+      );
+      return BorshInstructionCoder.isOption(
+        alias,
+        types,
+        new Set([...visited, definedName])
+      );
+    }
+
+    return false;
+  }
+
+  private static convertUndefinedOptions(
+    args: IdlField[],
+    ix: any,
+    types: IdlTypeDef[] = []
+  ): any {
+    const converted = { ...ix };
+    args.forEach((arg) => {
+      converted[arg.name] = BorshInstructionCoder.convertUndefinedOption(
+        arg.type,
+        ix[arg.name],
+        types
+      );
+    });
+    return converted;
+  }
+
+  private static convertUndefinedOption(
+    idlType: IdlType,
+    value: any,
+    types: IdlTypeDef[]
+  ): any {
+    if (typeof idlType === "string") {
+      return value;
+    }
+
+    if ("option" in idlType) {
+      if (value === undefined) {
+        return null;
+      }
+      if (value === null) {
+        return null;
+      }
+      return BorshInstructionCoder.convertUndefinedOption(
+        idlType.option,
+        value,
+        types
+      );
+    }
+
+    if ("vec" in idlType) {
+      return Array.isArray(value)
+        ? value.map((item) =>
+            BorshInstructionCoder.convertUndefinedOption(
+              idlType.vec,
+              item,
+              types
+            )
+          )
+        : value;
+    }
+
+    if ("array" in idlType) {
+      return Array.isArray(value)
+        ? value.map((item) =>
+            BorshInstructionCoder.convertUndefinedOption(
+              idlType.array[0],
+              item,
+              types
+            )
+          )
+        : value;
+    }
+
+    if ("defined" in idlType) {
+      const typeDef = types.find((t) => t.name === idlType.defined.name);
+      if (!typeDef) {
+        return value;
+      }
+      const genericArgs = idlType.defined.generics;
+      return BorshInstructionCoder.convertUndefinedOptionDefined(
+        typeDef,
+        value,
+        types,
+        genericArgs
+      );
+    }
+
+    return value;
+  }
+
+  private static convertUndefinedOptionDefined(
+    typeDef: IdlTypeDef,
+    value: any,
+    types: IdlTypeDef[],
+    genericArgs?: IdlGenericArg[]
+  ): any {
+    if (typeDef.type.kind === "type") {
+      const alias = BorshInstructionCoder.resolveGenericType(
+        typeDef.type.alias,
+        typeDef,
+        genericArgs
+      );
+      return BorshInstructionCoder.convertUndefinedOption(alias, value, types);
+    }
+
+    if (value === null || value === undefined || typeof value !== "object") {
+      return value;
+    }
+
+    switch (typeDef.type.kind) {
+      case "struct": {
+        return handleDefinedFields(
+          typeDef.type.fields,
+          () => value,
+          (fields) => {
+            const converted = { ...value };
+            fields.forEach((field) => {
+              const fieldType = BorshInstructionCoder.resolveGenericType(
+                field.type,
+                typeDef,
+                genericArgs
+              );
+              converted[field.name] =
+                BorshInstructionCoder.convertUndefinedOption(
+                  fieldType,
+                  value[field.name],
+                  types
+                );
+            });
+            return converted;
+          },
+          (fields) => {
+            const converted = Array.isArray(value) ? [...value] : { ...value };
+            fields.forEach((field, index) => {
+              const fieldType = BorshInstructionCoder.resolveGenericType(
+                field,
+                typeDef,
+                genericArgs
+              );
+              converted[index] = BorshInstructionCoder.convertUndefinedOption(
+                fieldType,
+                value[index],
+                types
+              );
+            });
+            return converted;
+          }
+        );
+      }
+      case "enum": {
+        const variantName = Object.keys(value)[0];
+        const variant = typeDef.type.variants.find(
+          (v) => v.name === variantName
+        );
+        if (!variant) {
+          return value;
+        }
+
+        return {
+          ...value,
+          [variantName]: handleDefinedFields(
+            variant.fields,
+            () => value[variantName],
+            (fields) => {
+              const converted = { ...value[variantName] };
+              fields.forEach((field) => {
+                const fieldType = BorshInstructionCoder.resolveGenericType(
+                  field.type,
+                  typeDef,
+                  genericArgs
+                );
+                converted[field.name] =
+                  BorshInstructionCoder.convertUndefinedOption(
+                    fieldType,
+                    value[variantName][field.name],
+                    types
+                  );
+              });
+              return converted;
+            },
+            (fields) => {
+              const converted = Array.isArray(value[variantName])
+                ? [...value[variantName]]
+                : { ...value[variantName] };
+              fields.forEach((field, index) => {
+                const fieldType = BorshInstructionCoder.resolveGenericType(
+                  field,
+                  typeDef,
+                  genericArgs
+                );
+                converted[index] = BorshInstructionCoder.convertUndefinedOption(
+                  fieldType,
+                  value[variantName][index],
+                  types
+                );
+              });
+              return converted;
+            }
+          ),
+        };
+      }
+    }
+  }
+
+  private static resolveGenericType(
+    idlType: IdlType,
+    typeDef: IdlTypeDef,
+    genericArgs?: IdlGenericArg[]
+  ): IdlType {
+    if (!genericArgs || typeof idlType !== "object") {
+      return idlType;
+    }
+
+    if ("generic" in idlType) {
+      const genericIndex = typeDef.generics?.findIndex(
+        (generic) => generic.kind === "type" && generic.name === idlType.generic
+      );
+      if (genericIndex === undefined || genericIndex < 0) {
+        return idlType;
+      }
+
+      const genericArg = genericArgs[genericIndex];
+      return genericArg?.kind === "type" ? genericArg.type : idlType;
+    }
+
+    if ("option" in idlType) {
+      return {
+        option: BorshInstructionCoder.resolveGenericType(
+          idlType.option,
+          typeDef,
+          genericArgs
+        ),
+      };
+    }
+
+    if ("vec" in idlType) {
+      return {
+        vec: BorshInstructionCoder.resolveGenericType(
+          idlType.vec,
+          typeDef,
+          genericArgs
+        ),
+      };
+    }
+
+    if ("array" in idlType) {
+      return {
+        array: [
+          BorshInstructionCoder.resolveGenericType(
+            idlType.array[0],
+            typeDef,
+            genericArgs
+          ),
+          idlType.array[1],
+        ],
+      };
+    }
+
+    if ("defined" in idlType) {
+      return {
+        defined: {
+          ...idlType.defined,
+          generics: idlType.defined.generics?.map((genericArg) =>
+            genericArg.kind === "type"
+              ? {
+                  ...genericArg,
+                  type: BorshInstructionCoder.resolveGenericType(
+                    genericArg.type,
+                    typeDef,
+                    genericArgs
+                  ),
+                }
+              : genericArg
+          ),
+        },
+      };
+    }
+
+    return idlType;
   }
 
   /**

--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import BN from "bn.js";
 import { BorshCoder } from "../src";
 import { Idl, IdlType } from "../src/idl";
 import { toInstruction } from "../src/program/common";
@@ -131,5 +132,533 @@ describe("coder.instructions", () => {
         coder.instruction.encode("noArgs", {} as object)
       );
     });
+  });
+
+  test("encodes undefined option instruction arguments as null", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                option: "u64",
+              },
+            },
+            {
+              name: "someArg2",
+              type: {
+                option: "u64",
+              },
+            },
+          ],
+        },
+      ],
+      types: [],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+    const ix = toInstruction(idlIx, true, undefined, new BN(0x3030));
+
+    const encoded = coder.instruction.encode(idlIx.name, ix);
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idlIx.discriminator,
+        1, // required bool
+        0, // someArg: None
+        1, // someArg2: Some
+        0x30,
+        0x30,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+    assert.ok(decoded?.data["someArg2"].eq(new BN(0x3030)));
+  });
+
+  test("allows missing option instruction arguments", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                option: "u64",
+              },
+            },
+          ],
+        },
+      ],
+      types: [],
+    };
+
+    const coder = new BorshCoder(idl);
+    const encoded = coder.instruction.encode("initialize", { required: true });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idl.instructions[0].discriminator,
+        1, // required bool
+        0, // someArg: None
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+  });
+
+  test("encodes undefined aliased option instruction arguments as null", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                defined: {
+                  name: "MaybeU64",
+                },
+              },
+            },
+            {
+              name: "someArg2",
+              type: {
+                defined: {
+                  name: "MaybeU64",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "MaybeU64",
+          type: {
+            kind: "type",
+            alias: {
+              option: "u64",
+            },
+          },
+        },
+      ],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+    const ix = toInstruction(idlIx, true, undefined, new BN(0x3030));
+
+    const encoded = coder.instruction.encode(idlIx.name, ix);
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idlIx.discriminator,
+        1, // required bool
+        0, // someArg: None
+        1, // someArg2: Some
+        0x30,
+        0x30,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+    assert.ok(decoded?.data["someArg2"].eq(new BN(0x3030)));
+  });
+
+  test("allows missing aliased option instruction arguments", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                defined: {
+                  name: "MaybeU64",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "MaybeU64",
+          type: {
+            kind: "type",
+            alias: {
+              option: "u64",
+            },
+          },
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const encoded = coder.instruction.encode("initialize", { required: true });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idl.instructions[0].discriminator,
+        1, // required bool
+        0, // someArg: None
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+  });
+
+  test("encodes undefined generic aliased option instruction arguments as null", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                defined: {
+                  name: "Identity",
+                  generics: [{ kind: "type", type: { option: "u64" } }],
+                },
+              },
+            },
+            {
+              name: "someArg2",
+              type: {
+                defined: {
+                  name: "Identity",
+                  generics: [{ kind: "type", type: { option: "u64" } }],
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "Identity",
+          generics: [{ kind: "type", name: "T" }],
+          type: {
+            kind: "type",
+            alias: {
+              generic: "T",
+            },
+          },
+        },
+      ],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+    const ix = toInstruction(idlIx, true, undefined, new BN(0x3030));
+
+    const encoded = coder.instruction.encode(idlIx.name, ix);
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idlIx.discriminator,
+        1, // required bool
+        0, // someArg: None
+        1, // someArg2: Some
+        0x30,
+        0x30,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+    assert.ok(decoded?.data["someArg2"].eq(new BN(0x3030)));
+  });
+
+  test("allows missing generic aliased option instruction arguments", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "required",
+              type: "bool",
+            },
+            {
+              name: "someArg",
+              type: {
+                defined: {
+                  name: "Identity",
+                  generics: [{ kind: "type", type: { option: "u64" } }],
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "Identity",
+          generics: [{ kind: "type", name: "T" }],
+          type: {
+            kind: "type",
+            alias: {
+              generic: "T",
+            },
+          },
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const encoded = coder.instruction.encode("initialize", { required: true });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idl.instructions[0].discriminator,
+        1, // required bool
+        0, // someArg: None
+      ]
+    );
+    assert.strictEqual(decoded?.data["someArg"], null);
+  });
+
+  test("encodes undefined options inside generic defined structs as null", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "wrapper",
+              type: {
+                defined: {
+                  name: "Wrapper",
+                  generics: [{ kind: "type", type: { option: "u64" } }],
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "Wrapper",
+          generics: [{ kind: "type", name: "T" }],
+          type: {
+            kind: "struct",
+            fields: [
+              { name: "someArg", type: { generic: "T" } },
+              { name: "someArg2", type: { generic: "T" } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+
+    const encoded = coder.instruction.encode(idlIx.name, {
+      wrapper: { someArg: undefined, someArg2: new BN(0x3030) },
+    });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idlIx.discriminator,
+        0, // wrapper.someArg: None
+        1, // wrapper.someArg2: Some
+        0x30,
+        0x30,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    );
+    assert.strictEqual(decoded?.data["wrapper"].someArg, null);
+    assert.ok(decoded?.data["wrapper"].someArg2.eq(new BN(0x3030)));
+  });
+
+  test("encodes undefined options inside generic defined enums as null", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "wrapper",
+              type: {
+                defined: {
+                  name: "WrapperEnum",
+                  generics: [{ kind: "type", type: { option: "u64" } }],
+                },
+              },
+            },
+          ],
+        },
+      ],
+      types: [
+        {
+          name: "WrapperEnum",
+          generics: [{ kind: "type", name: "T" }],
+          type: {
+            kind: "enum",
+            variants: [
+              {
+                name: "Fields",
+                fields: [
+                  { name: "someArg", type: { generic: "T" } },
+                  { name: "someArg2", type: { generic: "T" } },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+
+    const encoded = coder.instruction.encode(idlIx.name, {
+      wrapper: { Fields: { someArg: undefined, someArg2: new BN(0x3030) } },
+    });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(
+      [...encoded],
+      [
+        ...idlIx.discriminator,
+        0, // WrapperEnum::Fields discriminator
+        0, // wrapper.Fields.someArg: None
+        1, // wrapper.Fields.someArg2: Some
+        0x30,
+        0x30,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    );
+    assert.strictEqual(decoded?.data["wrapper"].Fields.someArg, null);
+    assert.ok(decoded?.data["wrapper"].Fields.someArg2.eq(new BN(0x3030)));
   });
 });


### PR DESCRIPTION
Fixes #1637

## Summary

- Normalizes `undefined` instruction args to `null` when the IDL type is `option`.
- Prevents `buffer-layout` from skipping undefined optional fields during instruction encoding.
- Handles nested option fields inside defined structs/enums as well.
- Keeps non-option fields unchanged.

## Testing

- `yarn prettier src/coder/borsh/instruction.ts tests/coder-instructions.spec.ts --check`
- `yarn build:node`
- `yarn jest tests/coder-instructions.spec.ts --runInBand`
- `yarn test --runInBand`
- `git diff --check`