### PR TITLE
fix(ts): support nested option serialization

### DIFF
--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as borsh from "@anchor-lang/borsh";
 import { BorshCoder } from "../src";
 import { Idl, IdlType } from "../src/idl";
 import { toInstruction } from "../src/program/common";
@@ -52,5 +53,64 @@ describe("coder.instructions", () => {
     const decoded = coder.instruction.decode(encoded);
 
     assert.deepStrictEqual(decoded?.data[idlIx.args[0].name], expected);
+  });
+
+  test("Can encode nested option instruction arguments", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "nestedOption",
+          discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+          accounts: [],
+          args: [
+            {
+              name: "arg",
+              type: {
+                option: {
+                  option: "u8",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const idlIx = idl.instructions[0];
+    const discriminator = idlIx.discriminator;
+
+    const none = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, null)
+    );
+    const someNone = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, borsh.some(null))
+    );
+    const someSome = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, borsh.some(1))
+    );
+
+    assert.deepStrictEqual([...none], [...discriminator, 0]);
+    assert.deepStrictEqual([...someNone], [...discriminator, 1, 0]);
+    assert.deepStrictEqual([...someSome], [...discriminator, 1, 1, 1]);
+
+    assert.deepStrictEqual(coder.instruction.decode(none)?.data["arg"], null);
+    assert.deepStrictEqual(
+      coder.instruction.decode(someNone)?.data["arg"],
+      borsh.some(null)
+    );
+    assert.deepStrictEqual(
+      coder.instruction.decode(someSome)?.data["arg"],
+      borsh.some(1)
+    );
   });
 });

--- a/ts/packages/borsh/src/index.ts
+++ b/ts/packages/borsh/src/index.ts
@@ -127,7 +127,27 @@ export function publicKey(property?: string): Layout<PublicKey> {
   );
 }
 
-class OptionLayout<T> extends LayoutCls<T | null> {
+const OPTION_SOME: unique symbol = Symbol.for(
+  "@anchor-lang/borsh.option.some"
+) as never;
+
+export type Some<T> = {
+  readonly [OPTION_SOME]: true;
+  readonly value: T;
+};
+
+export function some<T>(value: T): Some<T> {
+  return {
+    [OPTION_SOME]: true,
+    value,
+  };
+}
+
+function isSome<T>(src: T | null | undefined | Some<T>): src is Some<T> {
+  return typeof src === "object" && src !== null && OPTION_SOME in src;
+}
+
+class OptionLayout<T> extends LayoutCls<T | null | Some<T>> {
   layout: Layout<T>;
   discriminator: Layout<number>;
 
@@ -137,7 +157,11 @@ class OptionLayout<T> extends LayoutCls<T | null> {
     this.discriminator = u8();
   }
 
-  encode(src: T | null, b: Buffer, offset = 0): number {
+  encode(src: T | null | Some<T>, b: Buffer, offset = 0): number {
+    if (isSome(src)) {
+      this.discriminator.encode(1, b, offset);
+      return this.layout.encode(src.value, b, offset + 1) + 1;
+    }
     if (src === null || src === undefined) {
       return this.discriminator.encode(0, b, offset);
     }
@@ -145,12 +169,13 @@ class OptionLayout<T> extends LayoutCls<T | null> {
     return this.layout.encode(src, b, offset + 1) + 1;
   }
 
-  decode(b: Buffer, offset = 0): T | null {
+  decode(b: Buffer, offset = 0): T | null | Some<T> {
     const discriminator = this.discriminator.decode(b, offset);
     if (discriminator === 0) {
       return null;
     } else if (discriminator === 1) {
-      return this.layout.decode(b, offset + 1);
+      const value = this.layout.decode(b, offset + 1);
+      return this.layout instanceof OptionLayout ? some(value) : value;
     }
     throw new Error("Invalid option " + this.property);
   }
@@ -169,7 +194,7 @@ class OptionLayout<T> extends LayoutCls<T | null> {
 export function option<T>(
   layout: Layout<T>,
   property?: string
-): Layout<T | null> {
+): Layout<T | null | Some<T>> {
   return new OptionLayout<T>(layout, property);
 }
 


### PR DESCRIPTION
Fixes #2435

## Summary

Adds an explicit `borsh.some(value)` helper so TypeScript clients can serialize nested options where the outer option is `Some` and the inner option is `None`.

Previously, `null` always encoded as `None`, so `Option<Option<T>>` could encode:

- `None`
- `Some(Some(value))`

but could not represent:

- `Some(None)`

With this change, callers can now encode `Some(None)` using:

```ts
borsh.some(null)
```

## Testing

- yarn build in ts/packages/borsh
- yarn jest tests/coder-instructions.spec.ts --runInBand
- yarn build:node in ts/packages/anchor
- yarn test --runInBand in ts/packages/anchor