### PR TITLE
Inherit nightly upload workflow permissions

### DIFF
--- a/.github/workflows/nightly-attested-binaries.yaml
+++ b/.github/workflows/nightly-attested-binaries.yaml
@@ -158,8 +158,6 @@ jobs:
     name: Upload to cloud bucket
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: read
 
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
## Summary

- remove the upload job-level permissions block from the nightly attested binaries workflow
- let the upload job inherit the workflow-level `id-token: write` permission needed by Teleport Machine ID

## Validation

- git diff --check
- Ruby YAML parse of .github/workflows/nightly-attested-binaries.yaml
