### PR TITLE
fix: correct spelling in test files

### DIFF
--- a/tests/auction-house/programs/auction-house/src/lib.rs
+++ b/tests/auction-house/programs/auction-house/src/lib.rs
@@ -873,7 +873,7 @@ pub mod auction_house {
             &token_mint.key(),
         )?;
 
-        // make sure you cant get rugged
+        // make sure you can't get rugged
         if buyer_rec_acct.delegate.is_some() {
             return err!(ErrorCode::BuyerATACannotHaveDelegate);
         }

--- a/tests/cpi-returns/tests/cpi-return.ts
+++ b/tests/cpi-returns/tests/cpi-return.ts
@@ -219,7 +219,7 @@ describe("CPI return", () => {
     );
   });
 
-  it("cant call view on mutable instruction", async () => {
+  it("can't call view on mutable instruction", async () => {
     assert.equal(calleeProgram.views.initialize, undefined);
     try {
       await calleeProgram.methods


### PR DESCRIPTION
## Description
Fixed spelling errors in comments and test files.

⚠️ **Note:** Comment and test changes only. No functional code modified.

## Changes
- Fix 'cant' → 'can't'
- Fix 'dont' → 'don't'

## Impact
- Comment clarity improvement only
- No functional changes