### PR TITLE
fix: remove test_id test

### DIFF
--- a/lang/attribute/account/src/id.rs
+++ b/lang/attribute/account/src/id.rs
@@ -74,12 +74,6 @@ fn id_to_tokens(
         }
 
         #event_authority_and_bump
-
-        #[cfg(test)]
-        #[test]
-        fn test_id() {
-            assert!(check_id(&id()));
-        }
     });
 }
 


### PR DESCRIPTION
## Summary

When running `cargo test`, an unknown `test_id` unit test surfaces.

This PR removes the redundant `test_id` unit test in the `id_to_tokens` function.