### PR TITLE
Add Zizmor and >= medium vuln changes for the actions. 

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -3,7 +3,7 @@ description: "Setup Solana"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Solana Tool Suite
       id: cache-solana
       with:
@@ -11,7 +11,7 @@ runs:
           ~/.cache/solana/
           ~/.local/share/solana/
         key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_VERSION }}
-    - uses: nick-fields/retry@v2
+    - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:
         retry_wait_seconds: 300

--- a/.github/actions/setup-surfpool/action.yaml
+++ b/.github/actions/setup-surfpool/action.yaml
@@ -3,17 +3,18 @@ description: "Installs and caches the Surfpool CLI"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Surfpool Binary
       id: cache-surfpool
       with:
         path: ~/.local/bin/surfpool
         key: surfpool-${{ runner.os }}-v${{ env.SURFPOOL_CLI_VERSION }}
 
+    # zizmor: literal hardcoded path, no user input — safe to write to GITHUB_PATH
     - shell: bash
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH # zizmor: ignore[github-env]
 
-    - uses: nick-fields/retry@v2
+    - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
       if: steps.cache-surfpool.outputs.cache-hit != 'true'
       with:
         retry_wait_seconds: 300

--- a/.github/actions/setup-ts/action.yaml
+++ b/.github/actions/setup-ts/action.yaml
@@ -3,17 +3,17 @@ description: "Setup ts"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Typescript node_modules
       id: cache-typescript-node-modules
       with:
         path: |
           ./ts/node_modules/
         key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/yarn.lock') }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Typescript Dist
       id: cache-typescript-dist
       with:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,7 +5,8 @@ runs:
   steps:
     - run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev
       shell: bash
-    - run: echo "ANCHOR_VERSION=$(cat ./VERSION)" >> $GITHUB_ENV
+    # zizmor: value comes from ./VERSION (tracked repo file, not user input) — safe to write to GITHUB_ENV
+    - run: echo "ANCHOR_VERSION=$(cat ./VERSION)" >> $GITHUB_ENV # zizmor: ignore[github-env]
       shell: bash
     - run: git submodule update --init --recursive --depth 1
       shell: bash

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -68,6 +70,8 @@ jobs:
       - name: Prepare
         id: prepare
         shell: bash
+        env:
+          DIST: ${{ inputs.dist }}
         run: |
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             version="dry-run"
@@ -77,8 +81,8 @@ jobs:
           ext=""
           [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
 
-          mkdir ${{ inputs.dist }}
-          mv "target/${{ matrix.target }}/release/anchor$ext" ${{ inputs.dist }}/anchor-$version-${{ matrix.target }}$ext
+          mkdir "$DIST"
+          mv "target/${{ matrix.target }}/release/anchor$ext" "$DIST/anchor-$version-${{ matrix.target }}$ext"
 
           echo "version=$version" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/global-lint.yaml
+++ b/.github/workflows/global-lint.yaml
@@ -4,13 +4,19 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: {}
+
 # Manually run cspell locally via:
 #    make spellcheck
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       # Pinned version of the v7.2.0 tag, which is a lightweight and hence mutable tag
       - uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d
         with:

--- a/.github/workflows/nightly-attested-binaries.yaml
+++ b/.github/workflows/nightly-attested-binaries.yaml
@@ -17,15 +17,14 @@ concurrency:
   group: nightly-attested-binaries
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  id-token: write
-  attestations: write
-
 jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     strategy:
       fail-fast: false
@@ -48,6 +47,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -158,6 +158,8 @@ jobs:
     name: Upload to cloud bucket
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -295,21 +297,21 @@ jobs:
           fs.writeFileSync(path.join(uploadRoot, "latest-prefix.txt"), `${latestPrefix}\n`);
           NODE
 
-      ## Setting up teleport for the AWS login.     
+      ## Setting up teleport for the AWS login.
       - name: Set up Teleport
-        uses: teleport-actions/setup@v1
+        uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1
         with:
           version: ${{ env.TELEPORT_VERSION }}
           enterprise: true
 
       - name: Create tbot-config.yaml file
         run: |
-          cat <<'EOF' > ${{ runner.temp }}/tbot-config.yaml
+          cat <<EOF > "${RUNNER_TEMP}/tbot-config.yaml"
           version: v2
-          proxy_server: ${{ env.TELEPORT_PROXY }}
+          proxy_server: ${TELEPORT_PROXY}
           onboarding:
             join_method: github
-            token: ${{ env.TELEPORT_BOT_TOKEN_NAME }}
+            token: ${TELEPORT_BOT_TOKEN_NAME}
             certificate-ttl: 15m
           oneshot: true
           storage:
@@ -320,22 +322,24 @@ jobs:
               allow_reissue: true
               destination:
                 type: directory
-                path: ${{ runner.temp }}/aws-integration/machine-id
+                path: ${RUNNER_TEMP}/aws-integration/machine-id
           EOF
 
       # Perform authentication using Teleport Machine ID for AWS integration
       - name: Execute Teleport Machine ID Auth
         run: |
-          tbot start -c ${{ runner.temp }}/tbot-config.yaml --oneshot
-          tsh -i ${{ runner.temp }}/aws-integration/machine-id/identity --proxy ${{ env.TELEPORT_PROXY }} login
+          tbot start -c "${RUNNER_TEMP}/tbot-config.yaml" --oneshot
+          tsh -i "${RUNNER_TEMP}/aws-integration/machine-id/identity" --proxy "${TELEPORT_PROXY}" login
       - name: Upload binaries to cloud bucket
+        env:
+          S3_BUCKET: ${{ vars.RELEASES_S3_BUCKET }}
         run: |
           set -euo pipefail
 
           tsh apps login aws-integration-ops-prod
           tsh aws sts get-caller-identity
 
-          bucket="${{ vars.RELEASES_S3_BUCKET }}"
+          bucket="${S3_BUCKET}"
           build_prefix=$(cat s3-upload/build-prefix.txt)
           latest_prefix=$(cat s3-upload/latest-prefix.txt)
 

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   no-caching-tests:
     name: Reusable

--- a/.github/workflows/no-unpinned-docker.yaml
+++ b/.github/workflows/no-unpinned-docker.yaml
@@ -5,11 +5,17 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: chmod 755 ./docker/check-docker-pin.sh
       - run: ./docker/check-docker-pin.sh

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -13,17 +13,17 @@ on:
         default: true
         type: boolean
 
-permissions:
-  contents: write
-
 jobs:
   prepare-release-bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Force fetch upstream tags
         run: git fetch --tags --force
@@ -66,6 +66,7 @@ jobs:
       - name: Create release bump branch
         env:
           VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -xeou pipefail
 
@@ -73,6 +74,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
 
           git checkout -b "$BRANCH"
           git add -A
@@ -85,11 +87,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-release-bump
     if: ${{ inputs.create_ts_docs_pr }}
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Force fetch upstream tags
         run: git fetch --tags --force
@@ -131,6 +136,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
 
           git switch -c "$BRANCH" origin/gh-pages
 

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -56,6 +58,8 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:

--- a/.github/workflows/publish-npmjs.yaml
+++ b/.github/workflows/publish-npmjs.yaml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -43,6 +45,8 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -19,6 +19,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
   DIST: dist-dry-run
 
@@ -26,12 +28,16 @@ jobs:
   publish-crates-dryrun:
     name: Publish crates (dry-run)
     uses: ./.github/workflows/publish-crates.yaml
+    permissions:
+      contents: read
     with:
       dry_run: true
 
   publish-npmjs-dryrun:
     name: Publish npmjs packages (dry-run)
     uses: ./.github/workflows/publish-npmjs.yaml
+    permissions:
+      contents: read
     with:
       dry_run: true
 
@@ -42,6 +48,10 @@ jobs:
   build-cli-dryrun:
     name: Build binaries (dry-run)
     uses: ./.github/workflows/build-cli.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     with:
       dry_run: true
       dist: dist-dry-run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Force fetch upstream tags
         run: git fetch --tags --force
@@ -106,18 +107,24 @@ jobs:
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     uses: ./.github/workflows/publish-crates.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     with:
       dry_run: false
-    secrets: inherit
 
   publish-npmjs:
     name: Publish npmjs packages
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     uses: ./.github/workflows/publish-npmjs.yaml
+    permissions:
+      contents: read
+      id-token: write
     with:
       dry_run: false
-    secrets: inherit
 
   publish-dockerhub:
     name: Publish Docker image to Dockerhub
@@ -135,6 +142,8 @@ jobs:
       IMAGE_NAME: solanafoundation/anchor
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -181,6 +190,10 @@ jobs:
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     uses: ./.github/workflows/build-cli.yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     with:
       dry_run: false
       dist: dist-${{ github.ref_name }}
@@ -189,9 +202,13 @@ jobs:
     name: Upload binaries to release
     runs-on: ubuntu-latest
     needs: [verify-tag, build-cli]
+    permissions:
+      contents: write
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -242,6 +259,8 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -21,6 +21,9 @@ on:
       surfpool_cli_version:
         required: true
         type: string
+permissions:
+  contents: read
+
 env:
   CACHE: ${{ inputs.cache }}
   SOLANA_VERSION: ${{ inputs.solana_version }}
@@ -41,12 +44,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-cargo-build
@@ -78,9 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -94,7 +101,7 @@ jobs:
         if: env.CARGO_PROFILE != 'debug'
 
       - run: chmod +x ~/.cargo/bin/anchor
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/anchor
@@ -107,8 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -119,7 +128,7 @@ jobs:
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: basic-0 cache
         id: cache-basic-0
@@ -127,7 +136,7 @@ jobs:
           path: ./examples/tutorial/basic-0/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: basic-1 cache
         id: cache-basic-1
@@ -135,7 +144,7 @@ jobs:
           path: ./examples/tutorial/basic-1/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: basic-2 cache
         id: cache-basic-2
@@ -143,7 +152,7 @@ jobs:
           path: ./examples/tutorial/basic-2/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: basic-3 cache
         id: cache-basic-3
@@ -151,7 +160,7 @@ jobs:
           path: ./examples/tutorial/basic-3/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: basic-4 cache
         id: cache-basic-4
@@ -182,18 +191,20 @@ jobs:
           - path: tests/composite/
             name: composite.so
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +rwx ~/.cargo/bin/anchor
 
       - run: cd ${{ matrix.node.path }} && anchor build --skip-lint --ignore-keys
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.node.name }}
           path: ${{ matrix.node.path }}target/deploy/${{ matrix.node.name }}
@@ -205,37 +216,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: optional.so
           path: tests/optional/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: events.so
           path: tests/events/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: basic_4.so
           path: examples/tutorial/basic-4/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: basic_2.so
           path: examples/tutorial/basic-2/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: composite.so
           path: tests/composite/target/deploy/
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache client/example target
         id: cache-test-target
@@ -253,13 +266,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -267,13 +282,13 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache tests/bpf-upgradeable-state target
         id: cache-test-target
@@ -302,10 +317,10 @@ jobs:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 30
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
   #     - uses: ./.github/actions/setup/
   #     - uses: ./.github/actions/setup-ts/
-  #     - uses: actions/cache@v3
+  #     - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
   #       name: Cache Solana Tool Suite
   #       id: cache-solana
   #       with:
@@ -324,13 +339,13 @@ jobs:
   #       shell: bash
   #     - run: solana config set --url localhost
   #       shell: bash
-  #     - uses: actions/download-artifact@v4
+  #     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
   #       with:
   #         name: ${{ env.ANCHOR_BINARY_NAME }}
   #         path: ~/.cargo/bin/
   #     - run: chmod +x ~/.cargo/bin/anchor
 
-  #     - uses: actions/cache@v3
+  #     - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
   #       name: Cache tests/misc target
   #       id: cache-test-target
   #       with:
@@ -353,13 +368,15 @@ jobs:
       matrix:
         template: [mocha, jest, rust, mollusk, litesvm]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -367,7 +384,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -511,13 +528,15 @@ jobs:
             path: tests/test-instruction-validation
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -525,13 +544,13 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: ${{ env.CACHE != 'false' }}
         name: Cache ${{ matrix.node.path }} target
         id: cache-test-target

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -11,6 +11,9 @@ on:
       - "docs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SOLANA_VERSION: "3.1.10"
   NODE_VERSION: "20"
@@ -23,10 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         name: Cache Cargo home
         with:
           path: |
@@ -36,7 +41,7 @@ jobs:
           key: cargo-home-${{ runner.os }}-template-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-home-${{ runner.os }}-template-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         name: Cache cargo target
         with:
           path: ./target/
@@ -45,7 +50,7 @@ jobs:
 
       - run: cargo install --path cli --locked --debug --force --target-dir ./target
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: anchor-cli
           path: ~/.cargo/bin/anchor
@@ -65,12 +70,14 @@ jobs:
         template: [single, multiple]
         test_template: [rust, mollusk, litesvm]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: anchor-cli
           path: ~/.cargo/bin/
@@ -86,7 +93,7 @@ jobs:
       # template-files diff, so a partial restore from a prior commit is
       # always a hit. Per-cell key avoids cross-pollination; different
       # test templates pull different dev-deps.
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/my_program/target/
           key: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-${{ github.sha }}
@@ -136,12 +143,14 @@ jobs:
         language: [typescript, javascript]
         package_manager: [npm, yarn, pnpm, bun]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -153,13 +162,13 @@ jobs:
       #   - pnpm: pnpm/action-setup adds the binary to PATH
       #   - bun:  oven-sh/setup-bun does the same
       - if: matrix.package_manager == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - if: matrix.package_manager == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: anchor-cli
           path: ~/.cargo/bin/
@@ -172,12 +181,12 @@ jobs:
       # init. Caching keys are per-cell so e.g. `mocha+ts+npm` doesn't pull
       # `jest+js+pnpm`'s lockfile artifacts. `restore-keys` lets a stale
       # commit's cache hit when the SHA-suffixed primary key misses.
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/my_program/target/
           key: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-${{ github.sha }}
           restore-keys: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/my_program/node_modules/
           key: template-nm-${{ runner.os }}-${{ matrix.test_template }}-${{ matrix.language }}-${{ matrix.package_manager }}-${{ github.sha }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,9 @@ on:
     paths-ignore:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Reusable

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+# brew install zizmor && zizmor .github/workflows/
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          min-severity: medium


### PR DESCRIPTION
## Summary

Adds a blocking Zizmor workflow that runs static analysis on all GitHub Actions workflows for every PR. Fixes all findings: scopes permissions to job level across all workflows, pins all third-party actions to commit SHAs, removes secrets: inherit where unused, adds persist-credentials: false to all checkouts, and fixes template injection issues by moving context expressions into env vars.

https://github.com/zizmorcore/zizmor

## Branch Target

If this contains breaking changes, it should target the `anchor-next` branch.
