### PR TITLE
feat(ts): add explicit borsh option values

### DIFF
--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -221,13 +221,19 @@ class InstructionFormatter {
       );
     }
     if ("option" in idlField.type) {
-      return data === null
-        ? "null"
-        : this.formatIdlData(
-            { name: "", type: idlField.type.option },
-            data,
-            types
-          );
+      if (data === null) {
+        return "null";
+      }
+
+      const isSome = borsh.isSome(data);
+      const value = isSome ? data.value : data;
+      const formatted = this.formatIdlData(
+        { name: "", type: idlField.type.option },
+        value as Object,
+        types
+      );
+
+      return isSome ? `Some(${formatted})` : formatted;
     }
     if ("defined" in idlField.type) {
       if (!types) {

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -1,4 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
+import { type Option as BorshOption } from "@anchor-lang/borsh";
 import BN from "bn.js";
 import {
   Idl,
@@ -138,7 +139,7 @@ export type DecodeType<T extends IdlType, Defined> = IdlType extends T
   : T extends { defined: { name: keyof Defined } }
   ? Defined[T["defined"]["name"]]
   : T extends { option: IdlType }
-  ? DecodeType<T["option"], Defined> | null
+  ? BorshOption<DecodeType<T["option"], Defined>>
   : T extends { coption: IdlType }
   ? DecodeType<T["coption"], Defined> | null
   : T extends { vec: IdlType }

--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as borsh from "@anchor-lang/borsh";
 import { BorshCoder } from "../src";
 import { Idl, IdlType } from "../src/idl";
 import { toInstruction } from "../src/program/common";
@@ -52,5 +53,64 @@ describe("coder.instructions", () => {
     const decoded = coder.instruction.decode(encoded);
 
     assert.deepStrictEqual(decoded?.data[idlIx.args[0].name], expected);
+  });
+
+  test("Can encode and decode nested option instruction arguments", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "nestedOption",
+          discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+          accounts: [],
+          args: [
+            {
+              name: "arg",
+              type: {
+                option: {
+                  option: "u8",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const idlIx = idl.instructions[0];
+    const discriminator = idlIx.discriminator;
+
+    const none = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, null)
+    );
+    const someNone = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, borsh.some(null))
+    );
+    const someSome = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, borsh.some(borsh.some(1)))
+    );
+
+    assert.deepStrictEqual([...none], [...discriminator, 0]);
+    assert.deepStrictEqual([...someNone], [...discriminator, 1, 0]);
+    assert.deepStrictEqual([...someSome], [...discriminator, 1, 1, 1]);
+
+    assert.deepStrictEqual(coder.instruction.decode(none)?.data["arg"], null);
+    assert.deepStrictEqual(
+      coder.instruction.decode(someNone)?.data["arg"],
+      borsh.some(null)
+    );
+    assert.deepStrictEqual(
+      coder.instruction.decode(someSome)?.data["arg"],
+      borsh.some(borsh.some(1))
+    );
   });
 });

--- a/ts/packages/borsh/src/index.ts
+++ b/ts/packages/borsh/src/index.ts
@@ -129,7 +129,29 @@ export function publicKey(property?: string): Layout<PublicKey> {
   );
 }
 
-class OptionLayout<T> extends LayoutCls<T | null> {
+const OPTION_SOME: unique symbol = Symbol.for(
+  "@anchor-lang/borsh.option.some"
+) as never;
+
+export type Some<T> = {
+  readonly [OPTION_SOME]: true;
+  readonly value: T;
+};
+
+export type Option<T> = Some<T> | T | null;
+
+export function some<T>(value: T): Some<T> {
+  return {
+    [OPTION_SOME]: true,
+    value,
+  };
+}
+
+export function isSome<T>(src: unknown): src is Some<T> {
+  return typeof src === "object" && src !== null && OPTION_SOME in src;
+}
+
+class OptionLayout<T> extends LayoutCls<Option<T>> {
   layout: Layout<T>;
   discriminator: Layout<number>;
 
@@ -139,7 +161,11 @@ class OptionLayout<T> extends LayoutCls<T | null> {
     this.discriminator = u8();
   }
 
-  encode(src: T | null, b: Buffer, offset = 0): number {
+  encode(src: Option<T> | undefined, b: Buffer, offset = 0): number {
+    if (isSome(src)) {
+      this.discriminator.encode(1, b, offset);
+      return this.layout.encode(src.value, b, offset + 1) + 1;
+    }
     if (src === null || src === undefined) {
       return this.discriminator.encode(0, b, offset);
     }
@@ -147,12 +173,12 @@ class OptionLayout<T> extends LayoutCls<T | null> {
     return this.layout.encode(src, b, offset + 1) + 1;
   }
 
-  decode(b: Buffer, offset = 0): T | null {
+  decode(b: Buffer, offset = 0): Some<T> | null {
     const discriminator = this.discriminator.decode(b, offset);
     if (discriminator === 0) {
       return null;
     } else if (discriminator === 1) {
-      return this.layout.decode(b, offset + 1);
+      return some(this.layout.decode(b, offset + 1));
     }
     throw new Error("Invalid option " + this.property);
   }
@@ -171,7 +197,7 @@ class OptionLayout<T> extends LayoutCls<T | null> {
 export function option<T>(
   layout: Layout<T>,
   property?: string
-): Layout<T | null> {
+): Layout<Option<T>> {
   return new OptionLayout<T>(layout, property);
 }
 


### PR DESCRIPTION
Adds an explicit TypeScript representation for Borsh `Some` values so nested options can be encoded and decoded without losing outer option state.

Follow-up to the discussion in [#4584](https://github.com/otter-sec/anchor/pull/4584#issuecomment-4544988531), where the v1 patch was closed because changing decode semantics there would be a small breaking change and the nested option behavior is better handled as an `anchor-next` API improvement.

This introduces `borsh.some(value)` and `borsh.isSome(value)` helpers and updates option decoding to preserve `Some(...)` instead of collapsing present values into raw values.

## Behavior

For `Option<Option<T>>`:

- outer `None` decodes as `null`
- `Some(None)` decodes as `borsh.some(null)`
- `Some(Some(value))` decodes as `borsh.some(borsh.some(value))`

Plain values are still accepted when encoding simple options, so existing `Option<T>` encode usage remains ergonomic.

## Testing

- `yarn build` in `ts/packages/borsh`
- `yarn build:node` in `ts/packages/anchor`
- `yarn test --runInBand` in `ts/packages/anchor`
- Prettier check for touched TS files