### PR TITLE
Fix v2 init owner override

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -978,6 +978,18 @@ fn emit_init_body(
         Some(expr) => quote! { #expr },
         None => quote! { <#field_ty as anchor_lang_v2::Space>::INIT_SPACE },
     };
+    let owner = match attrs.owner.as_ref() {
+        Some(expr) => quote! { #expr },
+        None => quote! { *__program_id },
+    };
+    let owner_check = attrs.owner.as_ref().map(|_| {
+        quote! {
+            fn __anchor_assert_foreign_owner_init<
+                T: anchor_lang_v2::ForeignOwnerInit,
+            >() {}
+            __anchor_assert_foreign_owner_init::<#field_ty>();
+        }
+    });
 
     // Init params come from namespaced constraints that name init-time
     // inputs (e.g. `mint::authority = x`). Runtime-only constraints —
@@ -1047,6 +1059,8 @@ fn emit_init_body(
     quote! {
         let __payer = #payer.account();
         #seeds_arg
+        #owner_check
+        let __owner = #owner;
         let __init_params = {
             type __P<'__a> = <#field_ty as anchor_lang_v2::AccountInitialize>::Params<'__a>;
             let mut __p = <__P as Default>::default();
@@ -1054,7 +1068,7 @@ fn emit_init_body(
             __p
         };
         <#field_ty as anchor_lang_v2::AccountInitialize>::create_and_initialize(
-            __payer, &__target, #space, __program_id, &__init_params, __seeds,
+            __payer, &__target, #space, &__owner, &__init_params, __seeds,
         )?
     }
 }

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{accounts::view_wrapper_traits, AnchorAccount},
+    crate::{accounts::view_wrapper_traits, AccountInitialize, AnchorAccount, ForeignOwnerInit},
     pinocchio::{account::AccountView, address::Address},
     solana_program_error::ProgramError,
 };
@@ -31,6 +31,28 @@ impl AnchorAccount for UncheckedAccount {
         Err(ProgramError::InvalidArgument)
     }
 }
+
+impl AccountInitialize for UncheckedAccount {
+    type Params<'a> = ();
+
+    #[inline(always)]
+    fn create_and_initialize<'a>(
+        payer: &AccountView,
+        account: &AccountView,
+        space: usize,
+        owner: &Address,
+        _params: &(),
+        signer_seeds: Option<&[&[u8]]>,
+    ) -> Result<Self, ProgramError> {
+        match signer_seeds {
+            Some(seeds) => crate::create_account_signed(payer, account, space, owner, seeds)?,
+            None => crate::create_account(payer, account, space, owner)?,
+        }
+        Self::load(*account, owner)
+    }
+}
+
+impl ForeignOwnerInit for UncheckedAccount {}
 
 view_wrapper_traits!(UncheckedAccount);
 

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -508,6 +508,15 @@ pub trait AccountInitialize: Sized {
     ) -> Result<Self, ProgramError>;
 }
 
+/// Marker for account wrappers that may be allocated with an explicit
+/// foreign owner through `#[account(init, owner = ...)]`.
+///
+/// Typed account wrappers intentionally do not implement this: their init
+/// paths stamp and load Anchor-owned data, so they must stay owned by the
+/// current program. `UncheckedAccount` is the escape hatch for allocating
+/// bytes that a foreign program will initialize or validate later.
+pub trait ForeignOwnerInit: AccountInitialize {}
+
 // ---------------------------------------------------------------------------
 // Extensible constraint system
 // ---------------------------------------------------------------------------

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -266,3 +266,69 @@ pub struct Bad {
         &["the payer specified for an init constraint must be mutable"],
     );
 }
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn init_owner_override_rejects_typed_accounts() {
+    fn case(name: &str, account_attr: &str, field_ty: &str) {
+        let source = format!(
+            r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+{account_attr}
+pub struct Data {{
+    pub value: u64,
+}}
+
+#[derive(Accounts)]
+pub struct Bad {{
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        owner = OTHER_PROGRAM,
+    )]
+    pub data: {field_ty},
+    pub system_program: Program<System>,
+}}
+"#
+        );
+        compile_fail_case(name, &source, &["ForeignOwnerInit", "is not implemented"]);
+    }
+
+    case(
+        "init_owner_override_account",
+        "#[account]",
+        "Account<Data>",
+    );
+    case(
+        "init_owner_override_boxed_account",
+        "#[account]",
+        "Box<Account<Data>>",
+    );
+    case(
+        "init_owner_override_interface_account",
+        "#[account]",
+        "InterfaceAccount<Data>",
+    );
+    case(
+        "init_owner_override_borsh_account",
+        "#[account(borsh)]",
+        "BorshAccount<Data>",
+    );
+    case(
+        "init_owner_override_boxed_borsh_account",
+        "#[account(borsh)]",
+        "Box<BorshAccount<Data>>",
+    );
+}

--- a/tests-v2/programs/constraints/src/lib.rs
+++ b/tests-v2/programs/constraints/src/lib.rs
@@ -201,6 +201,15 @@ pub mod constraints {
         ctx.accounts.data.value = ctx.accounts.data.value.wrapping_add(1);
         Ok(())
     }
+
+    /// `init` with an explicit `owner = ...` creates the account under
+    /// that owner instead of this program id.
+    #[discrim = 20]
+    pub fn init_foreign_owned_unchecked(
+        _ctx: &mut Context<InitForeignOwnedUnchecked>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 // -- Accounts structs --------------------------------------------------------
@@ -443,6 +452,25 @@ pub struct InitIfNeededNoSeeds {
     pub payer: Signer,
     #[account(init_if_needed, payer = payer)]
     pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+
+/// Regression fixture for `#[account(init, owner = ...)]` on unchecked
+/// accounts. The account is only allocated here; the foreign program owns
+/// any later initialization of its bytes.
+#[derive(Accounts)]
+pub struct InitForeignOwnedUnchecked {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 8,
+        owner = OTHER_PROGRAM,
+        seeds = [b"foreign"],
+        bump,
+    )]
+    pub foreign: UncheckedAccount,
     pub system_program: Program<System>,
 }
 

--- a/tests-v2/tests/constraints.rs
+++ b/tests-v2/tests/constraints.rs
@@ -68,6 +68,10 @@ fn maybe_explicit_bump_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"maybe-explicit"], &program_id()).0
 }
 
+fn foreign_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"foreign"], &program_id()).0
+}
+
 fn other_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"other"], &other_program()).0
 }
@@ -374,6 +378,29 @@ fn owner_custom_err_mismatch_surfaces_custom() {
         &[],
     );
     assert_custom(&result, ERR_BAD_OWNER);
+}
+
+#[test]
+fn init_with_owner_creates_foreign_owned_unchecked_account() {
+    let (mut svm, payer, _) = setup();
+    let foreign = foreign_pda();
+
+    call(
+        &mut svm,
+        &payer,
+        20,
+        vec![
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new(foreign, false),
+            AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
+        ],
+        &[],
+    )
+    .expect("init foreign-owned unchecked account");
+
+    let account = svm.get_account(&foreign).expect("created account");
+    assert_eq!(account.owner, other_program());
+    assert_eq!(account.data.len(), 8);
 }
 
 // ---- 7. constraint = expr --------------------------------------------------


### PR DESCRIPTION
## Summary
- honor explicit owner constraints when emitting v2 init/create code
- allow UncheckedAccount to be used with init so foreign-owned accounts can be allocated
- add a constraints regression that initializes a PDA owned by another program

Fixes #4557.

## Testing
- cargo test -p tests-v2 --test constraints init_with_owner_creates_foreign_owned_unchecked_account
- cargo test -p tests-v2 --test constraints