### PR TITLE
Make Owner an associated constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang-v2",
  "bytemuck",
+ "foreign-borsh-account",
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
@@ -2707,6 +2708,14 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-borsh-account"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang-v2",
+ "wincode 0.5.4",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -9255,6 +9264,7 @@ dependencies = [
  "dispatch-remaining",
  "dup-mut",
  "event-cpi-test",
+ "foreign-borsh-account",
  "init-space-usability",
  "ix-macro",
  "litesvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "tests-v2/programs/dispatch-remaining",
     "tests-v2/programs/dup-mut",
     "tests-v2/programs/equivalence",
+    "tests-v2/programs/foreign-borsh-account",
     "tests-v2/programs/equivalence/metadata/spy",
     "tests-v2/programs/equivalence/metadata/v1",
     "tests-v2/programs/equivalence/metadata/v2",

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -131,5 +131,9 @@ name = "remaining_accounts_mut_check"
 required-features = ["testing"]
 
 [[test]]
+name = "program_invoke"
+required-features = ["testing"]
+
+[[test]]
 name = "to_cpi_accounts_derive"
 required-features = ["testing"]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1930,7 +1930,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
         #pod_impls
 
         impl anchor_lang_v2::Owner for #name {
-            fn owner(program_id: &anchor_lang_v2::Address) -> anchor_lang_v2::Address { *program_id }
+            const OWNER: anchor_lang_v2::Address = crate::ID;
         }
         impl anchor_lang_v2::Discriminator for #name {
             const DISCRIMINATOR: &'static [u8] = &[#(#disc_literals),*];
@@ -2724,9 +2724,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
             let ty_generics = &generics.ty_generics;
             quote! {
                 impl #impl_generics anchor_lang_v2::Owner for #ident #ty_generics {
-                    fn owner(_program_id: &anchor_lang_v2::Address) -> anchor_lang_v2::Address {
-                        ID
-                    }
+                    const OWNER: anchor_lang_v2::Address = ID;
                 }
 
                 impl #impl_generics anchor_lang_v2::Discriminator for #ident #ty_generics {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2725,6 +2725,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
             quote! {
                 impl #impl_generics anchor_lang_v2::Owner for #ident #ty_generics {
                     const OWNER: anchor_lang_v2::Address = ID;
+                    const SERIALIZE_ON_EXIT: bool = false;
                 }
 
                 impl #impl_generics anchor_lang_v2::Discriminator for #ident #ty_generics {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2725,7 +2725,6 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
             quote! {
                 impl #impl_generics anchor_lang_v2::Owner for #ident #ty_generics {
                     const OWNER: anchor_lang_v2::Address = ID;
-                    const SERIALIZE_ON_EXIT: bool = false;
                 }
 
                 impl #impl_generics anchor_lang_v2::Discriminator for #ident #ty_generics {

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1095,25 +1095,25 @@ fn emit_associated_token_init_body(
         {
             let mut __payer =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#payer_offset], __program_id)?;
+                    ::load(__views[#payer_offset])?;
             let mut __associated_token =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__target, __program_id)?;
+                    ::load(__target)?;
             let __authority =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#authority_offset], __program_id)?;
+                    ::load(__views[#authority_offset])?;
             let __mint =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#mint_offset], __program_id)?;
+                    ::load(__views[#mint_offset])?;
             let __system_program =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#system_program_offset], __program_id)?;
+                    ::load(__views[#system_program_offset])?;
             let __token_program =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#token_program_offset], __program_id)?;
+                    ::load(__views[#token_program_offset])?;
             let __associated_token_program =
                 <anchor_lang_v2::accounts::UncheckedAccount as anchor_lang_v2::AnchorAccount>
-                    ::load(__views[#associated_token_program_offset], __program_id)?;
+                    ::load(__views[#associated_token_program_offset])?;
 
             if !anchor_lang_v2::address_eq(
                 __system_program.account().address(),
@@ -1144,7 +1144,7 @@ fn emit_associated_token_init_body(
             // the generated account bitvec check. ATA init is performed by
             // external programs selected at runtime, so run the field type's
             // full validation after the CPI.
-            unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target, __program_id)? }
+            unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
         }
     })
 }
@@ -1346,9 +1346,7 @@ pub fn parse_field(
                     // SAFETY: the bitvec duplicate-account check below ensures
                     // no other mutable reference to this account's data exists.
                     Some(unsafe {
-                        <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(
-                            __target, __program_id,
-                        )?
+                        <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)?
                     })
                 } else {
                     Some({ #init_body_with_constraints })
@@ -1374,9 +1372,7 @@ pub fn parse_field(
                     // SAFETY: the bitvec duplicate-account check below ensures
                     // no other mutable reference to this account's data exists.
                     Some(unsafe {
-                        <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(
-                            __target, __program_id,
-                        )?
+                        <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)?
                     })
                 }
             }
@@ -1385,16 +1381,12 @@ pub fn parse_field(
                 // SAFETY: the bitvec duplicate-account check below ensures
                 // no other mutable reference to this account's data exists.
                 Some(unsafe {
-                    <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(
-                        __target, __program_id,
-                    )?
+                    <#inner_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)?
                 })
             }
         } else {
             quote! {
-                Some(<#inner_ty as anchor_lang_v2::AnchorAccount>::load(
-                    __target, __program_id,
-                )?)
+                Some(<#inner_ty as anchor_lang_v2::AnchorAccount>::load(__target)?)
             }
         };
         let init_if_needed_existed_binding = init_if_needed_existed.as_ref().map(|existed| {
@@ -1459,7 +1451,7 @@ pub fn parse_field(
                 if #existed {
                     // SAFETY: the bitvec duplicate-account check below ensures
                     // no other mutable reference to this account's data exists.
-                    unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target, __program_id)? }
+                    unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
                 } else {
                     // Create branch: run `AccountConstraint::init` for every
                     // runtime-only constraint AFTER the account's typed
@@ -1490,18 +1482,18 @@ pub fn parse_field(
                 }
                 // SAFETY: the bitvec duplicate-account check below ensures
                 // no other mutable reference to this account's data exists.
-                unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target, __program_id)? }
+                unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
             };
         }
     } else if attrs.is_mut {
         quote! {
             // SAFETY: the bitvec duplicate-account check below ensures no
             // other mutable reference to this account's data exists.
-            let mut #field_name = unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__views[#offset_expr], __program_id)? };
+            let mut #field_name = unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__views[#offset_expr])? };
         }
     } else {
         quote! {
-            let #field_name: #field_ty = anchor_lang_v2::AnchorAccount::load(__views[#offset_expr], __program_id)?;
+            let #field_name: #field_ty = anchor_lang_v2::AnchorAccount::load(__views[#offset_expr])?;
         }
     };
 

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -12,27 +12,24 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
     const IS_SIGNER: bool = T::IS_SIGNER;
     const MIN_DATA_LEN: usize = T::MIN_DATA_LEN;
 
-    fn load(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
-        T::load(view, program_id).map(Box::new)
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
+        T::load(view).map(Box::new)
     }
 
     /// # Safety
     ///
     /// See [`AnchorAccount::load_mut`] — caller must ensure no other live
     /// `&mut` to the same account data exists.
-    unsafe fn load_mut(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
-        T::load_mut(view, program_id).map(Box::new)
+    unsafe fn load_mut(view: AccountView) -> Result<Self, ProgramError> {
+        T::load_mut(view).map(Box::new)
     }
 
     /// # Safety
     ///
     /// See [`AnchorAccount::load_mut_after_init`] — caller must ensure no
     /// other live `&mut` to the same account data exists.
-    unsafe fn load_mut_after_init(
-        view: AccountView,
-        program_id: &Address,
-    ) -> Result<Self, ProgramError> {
-        T::load_mut_after_init(view, program_id).map(Box::new)
+    unsafe fn load_mut_after_init(view: AccountView) -> Result<Self, ProgramError> {
+        T::load_mut_after_init(view).map(Box::new)
     }
 
     fn account(&self) -> &AccountView {
@@ -105,12 +102,11 @@ impl<T: AccountInitialize> AccountInitialize for Box<T> {
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
+        owner: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<Self, ProgramError> {
-        T::create_and_initialize(payer, account, space, program_id, params, signer_seeds)
-            .map(Box::new)
+        T::create_and_initialize(payer, account, space, owner, params, signer_seeds).map(Box::new)
     }
 }
 

--- a/lang-v2/src/accounts/interface.rs
+++ b/lang-v2/src/accounts/interface.rs
@@ -23,7 +23,7 @@ impl<T: Ids> AnchorAccount for Interface<'_, T> {
     type Data = AccountView;
 
     #[inline(always)]
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         #[cfg(feature = "guardrails")]
         require!(view.executable(), ProgramError::InvalidAccountData);
         require!(

--- a/lang-v2/src/accounts/program.rs
+++ b/lang-v2/src/accounts/program.rs
@@ -31,7 +31,7 @@ impl<T: Id> Program<T> {
 impl<T: Id> AnchorAccount for Program<T> {
     type Data = AccountView;
     #[inline(always)]
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         #[cfg(feature = "guardrails")]
         require!(view.executable(), ProgramError::InvalidAccountData);
         let id = T::id();

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -157,10 +157,7 @@ where
         // could have mutated owner, discriminator, or payload in any
         // combination — without re-checking, we'd accept an account that
         // no longer validates as `T`.
-        require!(
-            self.view.owned_by(&T::owner(program_id)),
-            ProgramError::IllegalOwner
-        );
+        require!(self.view.owned_by(&T::OWNER), ProgramError::IllegalOwner);
         let mut view_mut = self.view;
         let data_ref = view_mut.try_borrow_mut()?;
         if data_ref.len() < DISC_LEN {
@@ -222,10 +219,7 @@ where
         // Hot path: a single owner check. The "uninitialized placeholder"
         // disambiguation lives in `cold_owner_error` (slab.rs) — see
         // the comment there for why this is safe.
-        require!(
-            view.owned_by(&T::owner(program_id)),
-            super::slab::cold_owner_error(&view)
-        );
+        require!(view.owned_by(&T::OWNER), super::slab::cold_owner_error(&view));
         if data.len() < DISC_LEN {
             return Err(ProgramError::AccountDataTooSmall);
         }

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -103,6 +103,7 @@ where
     /// called. Immutable / already-released borrows skip the commit.
     pub fn release_borrow(&mut self) -> Result<(), ProgramError> {
         Self::serialize_current_owner(
+            &self.view,
             &self.data,
             &mut self.borrow,
             &mut self.serialized_len,
@@ -112,17 +113,14 @@ where
         Ok(())
     }
 
-    fn should_serialize_for_owner(view: &AccountView) -> bool {
-        view.owned_by(&T::OWNER)
-    }
-
     fn serialize_current_owner(
+        view: &AccountView,
         data: &T,
         borrow: &mut SerializedAccountBorrow,
         serialized_len: &mut usize,
         serialize_on_exit: bool,
     ) -> Result<(), ProgramError> {
-        if !serialize_on_exit {
+        if !serialize_on_exit || !view.owned_by(&T::OWNER) {
             return Ok(());
         }
         if let SerializedAccountBorrow::Mutable { ref mut guard } = borrow {
@@ -171,7 +169,7 @@ where
         let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[DISC_LEN..])?;
         self.data = data;
         self.serialized_len = serialized_len;
-        self.serialize_on_exit = Self::should_serialize_for_owner(&self.view);
+        self.serialize_on_exit = T::SERIALIZE_ON_EXIT && self.view.owned_by(&T::OWNER);
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
         self.borrow = SerializedAccountBorrow::Mutable { guard };
         Ok(())
@@ -251,7 +249,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Immutable { _guard: guard },
             serialized_len,
-            serialize_on_exit: Self::should_serialize_for_owner(&view),
+            serialize_on_exit: T::SERIALIZE_ON_EXIT && view.owned_by(&T::OWNER),
             _serializer: PhantomData,
         })
     }
@@ -280,7 +278,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
-            serialize_on_exit: Self::should_serialize_for_owner(&view),
+            serialize_on_exit: T::SERIALIZE_ON_EXIT && view.owned_by(&T::OWNER),
             _serializer: PhantomData,
         })
     }
@@ -347,6 +345,7 @@ where
             self.reacquire_guard_only()?;
         }
         Self::serialize_current_owner(
+            &self.view,
             &self.data,
             &mut self.borrow,
             &mut self.serialized_len,

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -384,7 +384,12 @@ where
 {
     type Target = T;
     fn deref(&self) -> &T {
-        &self.data
+        match &self.borrow {
+            SerializedAccountBorrow::Mutable { .. } | SerializedAccountBorrow::Immutable { .. } => {
+                &self.data
+            }
+            SerializedAccountBorrow::Released => panic!("account borrow released (closed)"),
+        }
     }
 }
 

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -59,7 +59,6 @@ where
     data: T,
     borrow: SerializedAccountBorrow,
     serialized_len: usize,
-    serialize_on_exit: bool,
     _serializer: PhantomData<S>,
 }
 
@@ -102,27 +101,20 @@ where
     /// this, `exit()` becomes a no-op until `reacquire_borrow_mut()` is
     /// called. Immutable / already-released borrows skip the commit.
     pub fn release_borrow(&mut self) -> Result<(), ProgramError> {
-        Self::serialize_current_owner(
-            &self.view,
+        Self::serialize_mutable_borrow(
             &self.data,
             &mut self.borrow,
             &mut self.serialized_len,
-            self.serialize_on_exit,
         )?;
         self.borrow = SerializedAccountBorrow::Released;
         Ok(())
     }
 
-    fn serialize_current_owner(
-        view: &AccountView,
+    fn serialize_mutable_borrow(
         data: &T,
         borrow: &mut SerializedAccountBorrow,
         serialized_len: &mut usize,
-        serialize_on_exit: bool,
     ) -> Result<(), ProgramError> {
-        if !serialize_on_exit || !view.owned_by(&T::OWNER) {
-            return Ok(());
-        }
         if let SerializedAccountBorrow::Mutable { ref mut guard } = borrow {
             let payload_len = guard.len() - DISC_LEN;
             let mut payload = &mut guard[DISC_LEN..];
@@ -169,7 +161,6 @@ where
         let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[DISC_LEN..])?;
         self.data = data;
         self.serialized_len = serialized_len;
-        self.serialize_on_exit = T::SERIALIZE_ON_EXIT && self.view.owned_by(&T::OWNER);
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
         self.borrow = SerializedAccountBorrow::Mutable { guard };
         Ok(())
@@ -249,7 +240,6 @@ where
             data,
             borrow: SerializedAccountBorrow::Immutable { _guard: guard },
             serialized_len,
-            serialize_on_exit: T::SERIALIZE_ON_EXIT && view.owned_by(&T::OWNER),
             _serializer: PhantomData,
         })
     }
@@ -278,7 +268,6 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
-            serialize_on_exit: T::SERIALIZE_ON_EXIT && view.owned_by(&T::OWNER),
             _serializer: PhantomData,
         })
     }
@@ -344,12 +333,10 @@ where
             self.borrow = SerializedAccountBorrow::Released;
             self.reacquire_guard_only()?;
         }
-        Self::serialize_current_owner(
-            &self.view,
+        Self::serialize_mutable_borrow(
             &self.data,
             &mut self.borrow,
             &mut self.serialized_len,
-            self.serialize_on_exit,
         )?;
         Ok(())
     }
@@ -519,7 +506,6 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
-            serialize_on_exit: true,
             _serializer: PhantomData,
         })
     }

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -112,8 +112,8 @@ where
         Ok(())
     }
 
-    fn should_serialize_for_program(view: &AccountView, program_id: &Address) -> bool {
-        view.owned_by(program_id)
+    fn should_serialize_for_owner(view: &AccountView) -> bool {
+        view.owned_by(&T::OWNER)
     }
 
     fn serialize_current_owner(
@@ -152,7 +152,7 @@ where
     ///
     /// Returns `IllegalOwner` / `AccountDataTooSmall` /
     /// `InvalidAccountData` if the account no longer validates as `T`.
-    pub fn reacquire_borrow_mut(&mut self, program_id: &Address) -> Result<(), ProgramError> {
+    pub fn reacquire_borrow_mut(&mut self) -> Result<(), ProgramError> {
         // Re-run the load-time invariants. A CPI in the release window
         // could have mutated owner, discriminator, or payload in any
         // combination — without re-checking, we'd accept an account that
@@ -171,7 +171,7 @@ where
         let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[DISC_LEN..])?;
         self.data = data;
         self.serialized_len = serialized_len;
-        self.serialize_on_exit = Self::should_serialize_for_program(&self.view, program_id);
+        self.serialize_on_exit = Self::should_serialize_for_owner(&self.view);
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
         self.borrow = SerializedAccountBorrow::Mutable { guard };
         Ok(())
@@ -214,7 +214,6 @@ where
     fn validate_and_load(
         view: AccountView,
         data: &[u8],
-        program_id: &Address,
     ) -> Result<(T, usize), ProgramError> {
         // Hot path: a single owner check. The "uninitialized placeholder"
         // disambiguation lives in `cold_owner_error` (slab.rs) — see
@@ -240,9 +239,9 @@ where
     type Data = T;
     const MIN_DATA_LEN: usize = 8;
 
-    fn load(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         let data_ref = view.try_borrow()?;
-        let (data, serialized_len) = Self::validate_and_load(view, &data_ref, program_id)?;
+        let (data, serialized_len) = Self::validate_and_load(view, &data_ref)?;
         // SAFETY: AccountView's raw pointer is valid for the entire instruction
         // lifetime (Solana runtime guarantee). We hold the Ref to prevent
         // subsequent mutable borrows on the same account (duplicate detection).
@@ -252,7 +251,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Immutable { _guard: guard },
             serialized_len,
-            serialize_on_exit: Self::should_serialize_for_program(&view, program_id),
+            serialize_on_exit: Self::should_serialize_for_owner(&view),
             _serializer: PhantomData,
         })
     }
@@ -261,7 +260,7 @@ where
     ///
     /// See [`AnchorAccount::load_mut`] — caller must ensure no other live
     /// `&mut` to the same account data exists.
-    unsafe fn load_mut(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
+    unsafe fn load_mut(view: AccountView) -> Result<Self, ProgramError> {
         // Guardrail: catches "forgot `#[account(mut)]`" early with a clear
         // error. Under `default-features = false` the Solana runtime still
         // rejects the tx when we try to write, just with a less specific
@@ -272,7 +271,7 @@ where
         }
         let mut view_mut = view;
         let data_ref = view_mut.try_borrow_mut()?;
-        let (data, serialized_len) = Self::validate_and_load(view, &data_ref, program_id)?;
+        let (data, serialized_len) = Self::validate_and_load(view, &data_ref)?;
         // SAFETY: Same as load(). RefMut provides exclusive access and prevents
         // any other borrow on the same account.
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
@@ -281,7 +280,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
-            serialize_on_exit: Self::should_serialize_for_program(&view, program_id),
+            serialize_on_exit: Self::should_serialize_for_owner(&view),
             _serializer: PhantomData,
         })
     }
@@ -492,7 +491,7 @@ where
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
+        _owner: &Address,
         _params: &(),
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<Self, ProgramError> {
@@ -500,8 +499,8 @@ where
             .try_into()
             .map_err(|_| ProgramError::InvalidAccountData)?;
         match signer_seeds {
-            Some(seeds) => crate::create_account_signed(payer, account, space, program_id, seeds)?,
-            None => crate::create_account(payer, account, space, program_id)?,
+            Some(seeds) => crate::create_account_signed(payer, account, space, &T::OWNER, seeds)?,
+            None => crate::create_account(payer, account, space, &T::OWNER)?,
         }
         let mut view_mut = *account;
         let data_ref = view_mut.try_borrow_mut()?;

--- a/lang-v2/src/accounts/signer.rs
+++ b/lang-v2/src/accounts/signer.rs
@@ -21,7 +21,7 @@ impl AnchorAccount for Signer {
     const IS_SIGNER: bool = true;
 
     #[inline(always)]
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         require!(view.is_signer(), ProgramError::MissingRequiredSignature);
         Ok(Self { view })
     }
@@ -39,7 +39,7 @@ impl AnchorAccount for Signer {
     ///
     /// Returns `ConstraintSigner` if either flag is unset.
     #[inline(always)]
-    unsafe fn load_mut(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    unsafe fn load_mut(view: AccountView) -> Result<Self, ProgramError> {
         // SAFETY: view.account_ptr() points at a valid RuntimeAccount header.
         // Byte `+1` and `+2` are always in bounds within the 88-byte header.
         // The read is byte-aligned (offset 1 into a u16) but SBF allows

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -938,9 +938,7 @@ mod tests {
     }
 
     impl Owner for Counter {
-        fn owner(program_id: &Address) -> Address {
-            *program_id
-        }
+        const OWNER: Address = Address::new_from_array(PROGRAM_ID);
     }
 
     impl Discriminator for Counter {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -67,14 +67,14 @@ where
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
+        _owner: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<Self, ProgramError> {
-        H::create_and_initialize(payer, account, space, program_id, params, signer_seeds)?;
+        H::create_and_initialize(payer, account, space, params, signer_seeds)?;
         // SAFETY: `create_and_initialize` just created this account; no other
         // mutable reference to its data can exist yet.
-        unsafe { <Self as AnchorAccount>::load_mut_after_init(*account, program_id) }
+        unsafe { <Self as AnchorAccount>::load_mut_after_init(*account) }
     }
 }
 
@@ -249,13 +249,13 @@ where
     }
 
     #[inline(always)]
-    fn from_ref(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
+    fn from_ref(view: AccountView) -> Result<Self, ProgramError> {
         Self::assert_header_alignment();
         // SAFETY: AccountView's data pointer is valid for the instruction lifetime
         // (Solana runtime guarantee). Duplicate mutable accounts are rejected at
         // deserialization, so no aliasing can occur.
         let data = unsafe { view.borrow_unchecked() };
-        H::validate(&view, data, program_id)?;
+        H::validate(&view, data)?;
         if data.len() < Self::ITEMS_OFFSET {
             return Err(ProgramError::AccountDataTooSmall);
         }
@@ -661,8 +661,8 @@ where
     const MIN_DATA_LEN: usize = Slab::<H, T>::MIN_DATA_LEN;
 
     #[inline(always)]
-    fn load(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
-        Self::from_ref(view, program_id)
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
+        Self::from_ref(view)
     }
 
     /// # Safety
@@ -670,13 +670,13 @@ where
     /// See [`AnchorAccount::load_mut`] — caller must ensure no other live
     /// `&mut` to the same account data exists.
     #[inline(always)]
-    unsafe fn load_mut(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
+    unsafe fn load_mut(view: AccountView) -> Result<Self, ProgramError> {
         // Reuses the post-init primitive for construction, then layers full
         // validation on top.
-        let slab = Self::load_mut_after_init(view, program_id)?;
+        let slab = Self::load_mut_after_init(view)?;
         // SAFETY: build_mutable succeeded, so the data pointer is valid.
         let data: &[u8] = unsafe { slab.view.borrow_unchecked() };
-        H::validate(&slab.view, data, program_id)?;
+        H::validate(&slab.view, data)?;
         if data.len() < Self::ITEMS_OFFSET {
             return Err(ProgramError::AccountDataTooSmall);
         }
@@ -692,10 +692,7 @@ where
     /// See [`AnchorAccount::load_mut`] — no other live `&mut` to the
     /// same account data.
     #[inline(always)]
-    unsafe fn load_mut_after_init(
-        view: AccountView,
-        _program_id: &Address,
-    ) -> Result<Self, ProgramError> {
+    unsafe fn load_mut_after_init(view: AccountView) -> Result<Self, ProgramError> {
         // Guardrail: catches "forgot `#[account(mut)]`" early with a clear
         // error. Under `default-features = false` the Solana runtime still
         // rejects the tx when we try to write, just with a less specific
@@ -960,10 +957,9 @@ mod tests {
     fn read_only_load_blocks_try_borrow_mut_on_copy() {
         let mut buf = AccountBuffer::<256>::new();
         setup(&mut buf, false);
-        let pid = Address::new_from_array(PROGRAM_ID);
         let view = unsafe { buf.view() };
 
-        let acct = CounterAccount::load(view, &pid).unwrap();
+        let acct = CounterAccount::load(view).unwrap();
         assert_eq!(acct.value, 42);
 
         let mut view_copy = view;
@@ -980,10 +976,9 @@ mod tests {
     fn read_only_load_allows_try_borrow_on_copy() {
         let mut buf = AccountBuffer::<256>::new();
         setup(&mut buf, false);
-        let pid = Address::new_from_array(PROGRAM_ID);
         let view = unsafe { buf.view() };
 
-        let acct = CounterAccount::load(view, &pid).unwrap();
+        let acct = CounterAccount::load(view).unwrap();
 
         let view_copy = view;
         assert!(
@@ -998,11 +993,10 @@ mod tests {
     fn mut_load_blocks_all_borrows_on_copy() {
         let mut buf = AccountBuffer::<256>::new();
         setup(&mut buf, true);
-        let pid = Address::new_from_array(PROGRAM_ID);
         let view = unsafe { buf.view() };
 
         // SAFETY: this is the only live wrapper over `view`'s data.
-        let mut acct = unsafe { CounterAccount::load_mut(view, &pid).unwrap() };
+        let mut acct = unsafe { CounterAccount::load_mut(view).unwrap() };
         acct.value = 99;
 
         let mut view_copy = view;

--- a/lang-v2/src/accounts/slab_hooks.rs
+++ b/lang-v2/src/accounts/slab_hooks.rs
@@ -7,7 +7,7 @@
 
 use {
     crate::{require, require_eq, Discriminator, Owner},
-    pinocchio::{account::AccountView, address::Address},
+    pinocchio::account::AccountView,
     solana_program_error::ProgramError,
 };
 
@@ -27,7 +27,7 @@ pub trait SlabSchema {
     /// Minimum account data length that can contain `Self` at `DATA_OFFSET`.
     const MIN_DATA_LEN: usize;
 
-    fn validate(view: &AccountView, data: &[u8], program_id: &Address) -> Result<(), ProgramError>;
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError>;
 }
 
 impl<T: Owner + Discriminator> SlabSchema for T {
@@ -38,7 +38,7 @@ impl<T: Owner + Discriminator> SlabSchema for T {
     };
 
     #[inline(always)]
-    fn validate(view: &AccountView, data: &[u8], program_id: &Address) -> Result<(), ProgramError> {
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
         require!(view.owned_by(&T::OWNER), super::slab::cold_owner_error(view));
         let disc = T::DISCRIMINATOR;
         if data.len() < Self::MIN_DATA_LEN {
@@ -62,7 +62,6 @@ pub trait SlabInit {
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError>;
@@ -76,14 +75,13 @@ impl<T: Owner + Discriminator> SlabInit for T {
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
         _params: &(),
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError> {
         let disc = T::DISCRIMINATOR;
         match signer_seeds {
-            Some(seeds) => crate::create_account_signed(payer, account, space, program_id, seeds)?,
-            None => crate::create_account(payer, account, space, program_id)?,
+            Some(seeds) => crate::create_account_signed(payer, account, space, &T::OWNER, seeds)?,
+            None => crate::create_account(payer, account, space, &T::OWNER)?,
         }
         let mut account_view = *account;
         let data = unsafe { account_view.borrow_unchecked_mut() };

--- a/lang-v2/src/accounts/slab_hooks.rs
+++ b/lang-v2/src/accounts/slab_hooks.rs
@@ -39,10 +39,7 @@ impl<T: Owner + Discriminator> SlabSchema for T {
 
     #[inline(always)]
     fn validate(view: &AccountView, data: &[u8], program_id: &Address) -> Result<(), ProgramError> {
-        require!(
-            view.owned_by(&T::owner(program_id)),
-            super::slab::cold_owner_error(view)
-        );
+        require!(view.owned_by(&T::OWNER), super::slab::cold_owner_error(view));
         let disc = T::DISCRIMINATOR;
         if data.len() < Self::MIN_DATA_LEN {
             return Err(ProgramError::AccountDataTooSmall);

--- a/lang-v2/src/accounts/system_account.rs
+++ b/lang-v2/src/accounts/system_account.rs
@@ -19,7 +19,7 @@ impl SystemAccount {
 impl AnchorAccount for SystemAccount {
     type Data = AccountView;
     #[inline(always)]
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         require!(view.owned_by(&System::id()), ProgramError::IllegalOwner);
         Ok(Self { view })
     }

--- a/lang-v2/src/accounts/sysvar.rs
+++ b/lang-v2/src/accounts/sysvar.rs
@@ -58,7 +58,7 @@ pub struct Sysvar<T: PinocchioSysvar + SysvarId + Copy> {
 impl<T: PinocchioSysvar + SysvarId + Copy> AnchorAccount for Sysvar<T> {
     type Data = T;
 
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         // Same chunked-compare rationale as `Program<T>::load`. See lib.rs.
         let id = T::SYSVAR_ID;
         require!(

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -19,7 +19,7 @@ impl UncheckedAccount {
 impl AnchorAccount for UncheckedAccount {
     type Data = AccountView;
     #[inline(always)]
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self, ProgramError> {
+    fn load(view: AccountView) -> Result<Self, ProgramError> {
         Ok(Self { view })
     }
     #[inline(always)]
@@ -48,7 +48,7 @@ impl AccountInitialize for UncheckedAccount {
             Some(seeds) => crate::create_account_signed(payer, account, space, owner, seeds)?,
             None => crate::create_account(payer, account, space, owner)?,
         }
-        Self::load(*account, owner)
+        Self::load(*account)
     }
 }
 

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -78,7 +78,7 @@ pub fn run_handler<'a, T: TryAccounts, R>(
         return Err(crate::ErrorCode::AccountNotEnoughKeys.into());
     }
     let (ctx_accounts, bumps, ix_args) = {
-        let mut loader = AccountLoader::new(program_id, cursor);
+        let mut loader = AccountLoader::new(cursor);
         let (views, duplicates) = loader.walk_n(T::HEADER_SIZE);
         // Single AND+test across the whole struct tree — replaces the
         // per-mut-field `__duplicates.get()` checks the derive used to

--- a/lang-v2/src/loader.rs
+++ b/lang-v2/src/loader.rs
@@ -3,28 +3,27 @@ use {
         cursor::{AccountBitvec, AccountCursor},
         AnchorAccount,
     },
-    pinocchio::{account::AccountView, address::Address},
+    pinocchio::account::AccountView,
     solana_program_error::ProgramError,
 };
 
 /// Sequential account loader for `#[derive(Accounts)]`.
 ///
-/// Thin wrapper around an [`AccountCursor`] and a borrowed `program_id`.
-/// The dispatcher bulk-walks the declared account region with [`Self::walk_n`],
-/// and specialized init paths can still walk individual accounts through
-/// `next_view` / `load_next` / `next_mut`.
+/// Thin wrapper around an [`AccountCursor`]. The dispatcher bulk-walks the
+/// declared account region with [`Self::walk_n`], and specialized init paths
+/// can still walk individual accounts through `next_view` / `load_next` /
+/// `next_mut`.
 ///
 /// Bounds checking is done before the declared-region walk: the dispatcher has
 /// already verified `num_accounts >= T::HEADER_SIZE`.
 pub struct AccountLoader<'a> {
-    program_id: &'a Address,
     cursor: &'a mut AccountCursor,
 }
 
 impl<'a> AccountLoader<'a> {
     #[inline(always)]
-    pub fn new(program_id: &'a Address, cursor: &'a mut AccountCursor) -> Self {
-        Self { program_id, cursor }
+    pub fn new(cursor: &'a mut AccountCursor) -> Self {
+        Self { cursor }
     }
 
     #[inline(always)]
@@ -58,7 +57,7 @@ impl<'a> AccountLoader<'a> {
     #[inline(always)]
     pub fn load_next<T: AnchorAccount>(&mut self) -> Result<T, ProgramError> {
         let view = unsafe { self.cursor.next() };
-        T::load(view, self.program_id)
+        T::load(view)
     }
 
     /// Walk + `T::load_mut()` the next account.
@@ -70,6 +69,6 @@ impl<'a> AccountLoader<'a> {
     #[inline(always)]
     pub unsafe fn next_mut<T: AnchorAccount>(&mut self) -> Result<T, ProgramError> {
         let view = self.cursor.next();
-        T::load_mut(view, self.program_id)
+        T::load_mut(view)
     }
 }

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -472,16 +472,16 @@ impl<T: AsRef<AccountView>> Lamports for T {}
 /// Declares which program owns accounts of this data type.
 ///
 /// For your own program's types, `#[account]` generates this automatically
-/// returning `*program_id` (no `declare_id!` needed).
+/// from the program's declared ID.
 ///
 /// External crates implement this with their program's address:
 /// ```ignore
 /// impl Owner for TokenAccountData {
-///     fn owner(_program_id: &Address) -> Address { Token::id() }
+///     const OWNER: Address = Token::ID;
 /// }
 /// ```
 pub trait Owner {
-    fn owner(program_id: &Address) -> Address;
+    const OWNER: Address;
 }
 
 /// Declares the on-chain address for a program marker type.

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -472,10 +472,17 @@ impl<T: AsRef<AccountView>> Lamports for T {}
 /// ```ignore
 /// impl Owner for TokenAccountData {
 ///     const OWNER: Address = Token::ID;
+///     const SERIALIZE_ON_EXIT: bool = false;
 /// }
 /// ```
 pub trait Owner {
     const OWNER: Address;
+
+    /// Whether deserialized account wrappers should write in-memory changes
+    /// back on exit. Program-local account types use the default; foreign
+    /// account mirrors should opt out because the current program does not own
+    /// their data at runtime.
+    const SERIALIZE_ON_EXIT: bool = true;
 }
 
 /// Declares the on-chain address for a program marker type.

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -146,7 +146,7 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     /// check).
     const MIN_DATA_LEN: usize = 0;
 
-    fn load(view: AccountView, program_id: &Address) -> core::result::Result<Self, ProgramError>;
+    fn load(view: AccountView) -> core::result::Result<Self, ProgramError>;
 
     /// Load an account for mutable access.
     ///
@@ -162,14 +162,11 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     /// override to use `borrow_unchecked_mut` for write provenance.
     /// `Signer` overrides with a fused `is_signer` + `is_writable` check.
     #[inline(always)]
-    unsafe fn load_mut(
-        view: AccountView,
-        program_id: &Address,
-    ) -> core::result::Result<Self, ProgramError> {
+    unsafe fn load_mut(view: AccountView) -> core::result::Result<Self, ProgramError> {
         if !view.is_writable() {
             return Err(crate::ErrorCode::ConstraintMut.into());
         }
-        Self::load(view, program_id)
+        Self::load(view)
     }
 
     /// Like [`load_mut`], but called right after
@@ -183,11 +180,8 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     ///
     /// [`load_mut`]: Self::load_mut
     #[inline(always)]
-    unsafe fn load_mut_after_init(
-        view: AccountView,
-        program_id: &Address,
-    ) -> core::result::Result<Self, ProgramError> {
-        Self::load_mut(view, program_id)
+    unsafe fn load_mut_after_init(view: AccountView) -> core::result::Result<Self, ProgramError> {
+        Self::load_mut(view)
     }
 
     fn account(&self) -> &AccountView;
@@ -544,7 +538,7 @@ pub trait AccountInitialize: Sized {
         payer: &AccountView,
         account: &AccountView,
         space: usize,
-        program_id: &Address,
+        owner: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<Self, ProgramError>;

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -472,17 +472,10 @@ impl<T: AsRef<AccountView>> Lamports for T {}
 /// ```ignore
 /// impl Owner for TokenAccountData {
 ///     const OWNER: Address = Token::ID;
-///     const SERIALIZE_ON_EXIT: bool = false;
 /// }
 /// ```
 pub trait Owner {
     const OWNER: Address;
-
-    /// Whether deserialized account wrappers should write in-memory changes
-    /// back on exit. Program-local account types use the default; foreign
-    /// account mirrors should opt out because the current program does not own
-    /// their data at runtime.
-    const SERIALIZE_ON_EXIT: bool = true;
 }
 
 /// Declares the on-chain address for a program marker type.

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -32,10 +32,6 @@ use {
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
 
-fn program_id() -> Address {
-    Address::new_from_array(PROGRAM_ID)
-}
-
 #[derive(SchemaRead, SchemaWrite, Default)]
 struct Counter {
     value: u64,
@@ -72,9 +68,7 @@ struct ShortDiscBytes {
 }
 
 impl Owner for ShortDiscBytes {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for ShortDiscBytes {
@@ -88,9 +82,7 @@ struct LongDiscCounter {
 }
 
 impl Owner for LongDiscCounter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for LongDiscCounter {
@@ -158,7 +150,7 @@ fn signer_load_rejects_non_signer() {
         false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(Signer::load(view, &program_id()));
+    let err = expect_err(Signer::load(view));
     assert_eq!(err, ProgramError::MissingRequiredSignature);
 }
 
@@ -174,7 +166,7 @@ fn signer_load_accepts_signer() {
         false,
     );
     let view = unsafe { buf.view() };
-    let signer = Signer::load(view, &program_id()).unwrap();
+    let signer = Signer::load(view).unwrap();
     assert_eq!(signer.address().to_bytes(), [0x01; 32]);
 }
 
@@ -183,7 +175,7 @@ fn signer_load_mut_rejects_non_signer_non_writable() {
     let mut buf = AccountBuffer::<128>::new();
     buf.init([0x01; 32], SYSTEM_PROGRAM_ID, 0, false, false, false);
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { Signer::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { Signer::load_mut(view) });
     // Fused check: either flag missing maps to ConstraintSigner.
     assert_eq!(err, ErrorCode::ConstraintSigner.into());
 }
@@ -200,7 +192,7 @@ fn signer_load_mut_rejects_signer_without_writable() {
         false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { Signer::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { Signer::load_mut(view) });
     assert_eq!(err, ErrorCode::ConstraintSigner.into());
 }
 
@@ -216,7 +208,7 @@ fn signer_load_mut_rejects_writable_without_signer() {
         false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { Signer::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { Signer::load_mut(view) });
     assert_eq!(err, ErrorCode::ConstraintSigner.into());
 }
 
@@ -232,7 +224,7 @@ fn signer_load_mut_accepts_signer_and_writable() {
         false,
     );
     let view = unsafe { buf.view() };
-    let signer = unsafe { Signer::load_mut(view, &program_id()) }.unwrap();
+    let signer = unsafe { Signer::load_mut(view) }.unwrap();
     assert_eq!(signer.address().to_bytes(), [0x01; 32]);
 }
 
@@ -244,7 +236,7 @@ fn system_account_load_rejects_non_system_owner() {
     // Owner = [0x42; 32] (program_id), not the all-zero System program id.
     buf.init([0x01; 32], PROGRAM_ID, 0, false, false, false);
     let view = unsafe { buf.view() };
-    let err = expect_err(SystemAccount::load(view, &program_id()));
+    let err = expect_err(SystemAccount::load(view));
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
@@ -253,7 +245,7 @@ fn system_account_load_accepts_system_owner() {
     let mut buf = AccountBuffer::<128>::new();
     buf.init([0x01; 32], SYSTEM_PROGRAM_ID, 0, false, false, false);
     let view = unsafe { buf.view() };
-    let sa = SystemAccount::load(view, &program_id()).unwrap();
+    let sa = SystemAccount::load(view).unwrap();
     assert_eq!(sa.address().to_bytes(), [0x01; 32]);
 }
 
@@ -268,7 +260,7 @@ fn system_account_default_load_mut_rejects_non_writable() {
         [0x01; 32], PROGRAM_ID, 0, false, /*writable*/ false, false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { SystemAccount::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { SystemAccount::load_mut(view) });
     assert_eq!(err, ErrorCode::ConstraintMut.into());
 }
 
@@ -280,7 +272,7 @@ fn system_account_default_load_mut_rejects_writable_wrong_owner() {
         [0x01; 32], PROGRAM_ID, 0, false, /*writable*/ true, false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { SystemAccount::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { SystemAccount::load_mut(view) });
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
@@ -294,7 +286,7 @@ fn unchecked_account_load_accepts_anything() {
     let mut buf = AccountBuffer::<128>::new();
     buf.init([0xAB; 32], [0x99; 32], 0, false, false, false);
     let view = unsafe { buf.view() };
-    let ua = UncheckedAccount::load(view, &program_id()).unwrap();
+    let ua = UncheckedAccount::load(view).unwrap();
     assert_eq!(ua.address().to_bytes(), [0xAB; 32]);
 }
 
@@ -305,7 +297,7 @@ fn unchecked_account_default_load_mut_rejects_non_writable() {
         [0xAB; 32], [0x99; 32], 0, false, /*writable*/ false, false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { UncheckedAccount::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { UncheckedAccount::load_mut(view) });
     assert_eq!(err, ErrorCode::ConstraintMut.into());
 }
 
@@ -316,7 +308,7 @@ fn unchecked_account_load_mut_accepts_writable() {
         [0xAB; 32], [0x99; 32], 0, false, /*writable*/ true, false,
     );
     let view = unsafe { buf.view() };
-    let ua = unsafe { UncheckedAccount::load_mut(view, &program_id()) }.unwrap();
+    let ua = unsafe { UncheckedAccount::load_mut(view) }.unwrap();
     assert_eq!(ua.address().to_bytes(), [0xAB; 32]);
 }
 
@@ -330,7 +322,8 @@ fn unchecked_account_close_constraint_fails_at_runtime() {
 
     let views = [unsafe { data_buf.view() }, unsafe { receiver_buf.view() }];
     let (mut accounts, _, _) =
-        CloseUnchecked::try_accounts(&program_id(), &views, None, 0, &[]).unwrap();
+        CloseUnchecked::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
+            .unwrap();
 
     let err = expect_err(accounts.exit_accounts());
     assert_eq!(err, ProgramError::InvalidArgument);
@@ -346,7 +339,7 @@ fn program_load_rejects_wrong_address() {
         [0x01; 32], [0u8; 32], 0, false, false, /*executable*/ true,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(Program::<System>::load(view, &program_id()));
+    let err = expect_err(Program::<System>::load(view));
     assert_eq!(err, ProgramError::IncorrectProgramId);
 }
 
@@ -358,7 +351,7 @@ fn program_load_accepts_matching_system_address() {
         [0u8; 32], [0u8; 32], 0, false, false, /*executable*/ true,
     );
     let view = unsafe { buf.view() };
-    let p = Program::<System>::load(view, &program_id()).unwrap();
+    let p = Program::<System>::load(view).unwrap();
     assert_eq!(p.address().to_bytes(), [0u8; 32]);
 }
 
@@ -371,7 +364,7 @@ fn program_load_rejects_non_executable_under_guardrails() {
         [0u8; 32], [0u8; 32], 0, false, false, /*executable*/ false,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(Program::<System>::load(view, &program_id()));
+    let err = expect_err(Program::<System>::load(view));
     assert_eq!(err, ProgramError::InvalidAccountData);
 }
 
@@ -383,7 +376,7 @@ fn program_load_token_wrong_address_rejects() {
         [0x01; 32], [0u8; 32], 0, false, false, /*executable*/ true,
     );
     let view = unsafe { buf.view() };
-    let err = expect_err(Program::<Token>::load(view, &program_id()));
+    let err = expect_err(Program::<Token>::load(view));
     assert_eq!(err, ProgramError::IncorrectProgramId);
 }
 
@@ -396,10 +389,7 @@ fn sysvar_load_rejects_wrong_address() {
     let mut buf = AccountBuffer::<128>::new();
     buf.init([0x01; 32], [0u8; 32], 0, false, false, false);
     let view = unsafe { buf.view() };
-    let err = expect_err(Sysvar::<pinocchio::sysvars::clock::Clock>::load(
-        view,
-        &program_id(),
-    ));
+    let err = expect_err(Sysvar::<pinocchio::sysvars::clock::Clock>::load(view));
     assert_eq!(err, ProgramError::InvalidArgument);
 }
 
@@ -410,7 +400,7 @@ fn account_load_accepts_valid_owner_and_discriminator() {
     let mut buf = AccountBuffer::<128>::new();
     setup_pod_counter_buf(&mut buf, PROGRAM_ID, false, 17);
     let view = unsafe { buf.view() };
-    let acct = Account::<PodCounter>::load(view, &program_id()).unwrap();
+    let acct = Account::<PodCounter>::load(view).unwrap();
     assert_eq!(acct.value, 17);
 }
 
@@ -441,7 +431,7 @@ fn account_load_uses_short_discriminator_len_as_data_offset() {
     buf.write_data(&data);
 
     let view = unsafe { buf.view() };
-    let acct = Account::<ShortDiscBytes>::load(view, &program_id()).unwrap();
+    let acct = Account::<ShortDiscBytes>::load(view).unwrap();
     assert_eq!(acct.value, [1, 2, 3, 4]);
 }
 
@@ -471,7 +461,7 @@ fn account_load_uses_long_discriminator_len_as_data_offset() {
     buf.write_data(&data);
 
     let view = unsafe { buf.view() };
-    let acct = Account::<LongDiscCounter>::load(view, &program_id()).unwrap();
+    let acct = Account::<LongDiscCounter>::load(view).unwrap();
     assert_eq!(acct.value, 123);
 }
 
@@ -481,7 +471,7 @@ fn account_load_mut_rejects_non_writable() {
     let mut buf = AccountBuffer::<128>::new();
     setup_pod_counter_buf(&mut buf, PROGRAM_ID, false, 17);
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { Account::<PodCounter>::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { Account::<PodCounter>::load_mut(view) });
     assert_eq!(err, ProgramError::InvalidAccountData);
 }
 
@@ -494,7 +484,7 @@ fn account_deref_mut_panics_when_loaded_read_only() {
     let mut buf = AccountBuffer::<128>::new();
     setup_pod_counter_buf(&mut buf, PROGRAM_ID, false, 17);
     let view = unsafe { buf.view() };
-    let mut acct = Account::<PodCounter>::load(view, &program_id()).unwrap();
+    let mut acct = Account::<PodCounter>::load(view).unwrap();
     acct.value = 18;
 }
 
@@ -505,7 +495,7 @@ fn borsh_account_load_accepts_valid_owner_and_discriminator() {
     let mut buf = AccountBuffer::<128>::new();
     setup_borsh_counter_buf(&mut buf, PROGRAM_ID, false, 9);
     let view = unsafe { buf.view() };
-    let acct = BorshAccount::<Counter>::load(view, &program_id()).unwrap();
+    let acct = BorshAccount::<Counter>::load(view).unwrap();
     assert_eq!(acct.value, 9);
 }
 
@@ -515,7 +505,7 @@ fn borsh_account_load_mut_rejects_non_writable() {
     let mut buf = AccountBuffer::<128>::new();
     setup_borsh_counter_buf(&mut buf, PROGRAM_ID, false, 9);
     let view = unsafe { buf.view() };
-    let err = expect_err(unsafe { BorshAccount::<Counter>::load_mut(view, &program_id()) });
+    let err = expect_err(unsafe { BorshAccount::<Counter>::load_mut(view) });
     assert_eq!(err, ProgramError::InvalidAccountData);
 }
 
@@ -524,7 +514,7 @@ fn borsh_account_load_rejects_wrong_owner() {
     let mut buf = AccountBuffer::<128>::new();
     setup_borsh_counter_buf(&mut buf, [0x99; 32], true, 9);
     let view = unsafe { buf.view() };
-    let err = expect_err(BorshAccount::<Counter>::load(view, &program_id()));
+    let err = expect_err(BorshAccount::<Counter>::load(view));
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
@@ -533,7 +523,7 @@ fn borsh_account_load_mut_accepts_writable_account() {
     let mut buf = AccountBuffer::<128>::new();
     setup_borsh_counter_buf(&mut buf, PROGRAM_ID, true, 9);
     let view = unsafe { buf.view() };
-    let acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id()) }.unwrap();
+    let acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
     assert_eq!(acct.value, 9);
 }
 
@@ -543,6 +533,6 @@ fn borsh_account_deref_mut_panics_when_loaded_read_only() {
     let mut buf = AccountBuffer::<128>::new();
     setup_borsh_counter_buf(&mut buf, PROGRAM_ID, false, 9);
     let view = unsafe { buf.view() };
-    let mut acct = BorshAccount::<Counter>::load(view, &program_id()).unwrap();
+    let mut acct = BorshAccount::<Counter>::load(view).unwrap();
     acct.value = 10;
 }

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -42,9 +42,7 @@ struct Counter {
 }
 
 impl Owner for Counter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Counter {
@@ -59,9 +57,7 @@ struct PodCounter {
 }
 
 impl Owner for PodCounter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for PodCounter {

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -50,7 +50,6 @@ struct ForeignCounter {
 
 impl Owner for ForeignCounter {
     const OWNER: Address = Address::new_from_array(FOREIGN_PROGRAM_ID);
-    const SERIALIZE_ON_EXIT: bool = false;
 }
 
 impl Discriminator for ForeignCounter {
@@ -161,7 +160,7 @@ fn exit_writes_modified_in_memory_state_to_guard() {
 }
 
 #[test]
-fn exit_skips_serialization_for_foreign_owned_account() {
+fn exit_serializes_mutably_loaded_foreign_owned_account() {
     let mut buf = AccountBuffer::<256>::new();
     setup_foreign_counter_buf(&mut buf, 42);
 
@@ -175,11 +174,11 @@ fn exit_skips_serialization_for_foreign_owned_account() {
     }
 
     let bytes = read_data_bytes(&buf, 8, 8);
-    assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 42);
+    assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 999);
 }
 
 #[test]
-fn release_borrow_skips_serialization_for_foreign_owned_account() {
+fn release_borrow_serializes_mutably_loaded_foreign_owned_account() {
     let mut buf = AccountBuffer::<256>::new();
     setup_foreign_counter_buf(&mut buf, 42);
 
@@ -193,7 +192,7 @@ fn release_borrow_skips_serialization_for_foreign_owned_account() {
     }
 
     let bytes = read_data_bytes(&buf, 8, 8);
-    assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 42);
+    assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 999);
 }
 
 // -- 2. Stale detection: content-only change is NOT detected ---------

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -145,11 +145,10 @@ fn read_data_bytes(buf: &AccountBuffer<256>, offset: usize, len: usize) -> Vec<u
 fn exit_writes_modified_in_memory_state_to_guard() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
-        let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
         assert_eq!(acct.value, 42);
         acct.value = 999;
         acct.exit().unwrap();
@@ -164,12 +163,11 @@ fn exit_writes_modified_in_memory_state_to_guard() {
 fn exit_skips_serialization_for_foreign_owned_account() {
     let mut buf = AccountBuffer::<256>::new();
     setup_foreign_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
         let mut acct =
-            unsafe { BorshAccount::<ForeignCounter>::load_mut(view, &program_id) }.unwrap();
+            unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
         assert_eq!(acct.value, 42);
         acct.value = 999;
         acct.exit().unwrap();
@@ -183,12 +181,11 @@ fn exit_skips_serialization_for_foreign_owned_account() {
 fn release_borrow_skips_serialization_for_foreign_owned_account() {
     let mut buf = AccountBuffer::<256>::new();
     setup_foreign_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
         let mut acct =
-            unsafe { BorshAccount::<ForeignCounter>::load_mut(view, &program_id) }.unwrap();
+            unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
         assert_eq!(acct.value, 42);
         acct.value = 999;
         acct.release_borrow().unwrap();
@@ -220,10 +217,9 @@ fn release_borrow_skips_serialization_for_foreign_owned_account() {
 fn stale_detection_misses_content_only_out_of_band_mutation() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
     assert_eq!(acct.value, 42);
 
     // Out-of-band: somehow the bytes at data[8..16] get mutated while
@@ -259,10 +255,9 @@ fn stale_detection_misses_content_only_out_of_band_mutation() {
 fn reacquire_refreshes_self_data_from_cpi_changes() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     // Step 1: user modifies self.data.
     acct.value = 100;
@@ -275,7 +270,7 @@ fn reacquire_refreshes_self_data_from_cpi_changes() {
     set_data_bytes(&mut buf, 8, &777u64.to_le_bytes());
 
     // Step 4: user reacquires the borrow.
-    acct.reacquire_borrow_mut(&program_id).unwrap();
+    acct.reacquire_borrow_mut().unwrap();
 
     // Step 5: reacquire re-deserialized from buffer, so self.data
     // now reflects the CPI's write of 777, not the user's pre-release
@@ -310,10 +305,9 @@ fn reacquire_refreshes_self_data_from_cpi_changes() {
 fn reacquire_rejects_when_discriminator_changes_during_release() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     acct.release_borrow().unwrap();
 
@@ -323,7 +317,7 @@ fn reacquire_rejects_when_discriminator_changes_during_release() {
     let foreign_disc = [0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF];
     set_data_bytes(&mut buf, 0, &foreign_disc);
 
-    let result = acct.reacquire_borrow_mut(&program_id);
+    let result = acct.reacquire_borrow_mut();
     assert_eq!(
         result.err(),
         Some(ProgramError::InvalidAccountData),
@@ -337,18 +331,16 @@ fn reacquire_rejects_when_discriminator_changes_during_release() {
 // Even with disc + payload still valid, a released-window CPI could
 // transfer the account to a different owner. Without an owner check,
 // `reacquire_borrow_mut` would silently accept the now-foreign-owned
-// account as `BorshAccount<T>`. Post-fix: the caller passes `program_id`
-// into `reacquire_borrow_mut`, which re-runs `view.owned_by(&T::OWNER)`
-// against the live header.
+// account as `BorshAccount<T>`. Post-fix: `reacquire_borrow_mut` re-runs
+// `view.owned_by(&T::OWNER)` against the live header.
 
 #[test]
 fn reacquire_rejects_when_owner_changes_during_release() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     acct.release_borrow().unwrap();
 
@@ -357,7 +349,7 @@ fn reacquire_rejects_when_owner_changes_during_release() {
     // changes.
     buf.set_owner([0xFE; 32]);
 
-    let result = acct.reacquire_borrow_mut(&program_id);
+    let result = acct.reacquire_borrow_mut();
     assert_eq!(
         result.err(),
         Some(ProgramError::IllegalOwner),
@@ -376,10 +368,9 @@ fn reacquire_rejects_when_owner_changes_during_release() {
 fn exit_on_zero_lamport_account_is_noop() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     // Modify self.data.
     acct.value = 999;
@@ -410,10 +401,9 @@ fn exit_on_zero_lamport_account_is_noop() {
 fn release_borrow_commits_in_memory_changes_to_buffer() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     acct.value = 100;
     acct.release_borrow().unwrap();
@@ -478,10 +468,9 @@ fn release_borrow_zeroes_bytes_between_new_and_old_serialized_lengths() {
 fn deref_mut_panics_after_release_borrow() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     acct.release_borrow().unwrap();
     acct.value = 100;
@@ -497,10 +486,9 @@ fn deref_mut_panics_after_release_borrow() {
 fn stale_detection_fires_on_data_len_change() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     acct.value = 100;
 
@@ -569,10 +557,9 @@ fn codec_round_trip_advances_cursor() {
 fn reacquire_guard_only_rejects_buffer_shorter_than_discriminator() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
     // Simulate `realloc_account(new_space = 4)`: shrink below DISC_LEN.
     acct.release_borrow().unwrap();
@@ -594,10 +581,9 @@ fn reacquire_guard_only_rejects_buffer_shorter_than_discriminator() {
 fn exit_rejects_external_shrink_below_discriminator() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
     acct.value = 100;
 
     // Simulate an external resize to 4 bytes (below DISC_LEN = 8).

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -62,9 +62,7 @@ struct ShrinkableBytes {
 }
 
 impl Owner for ShrinkableBytes {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for ShrinkableBytes {
@@ -166,8 +164,7 @@ fn exit_serializes_mutably_loaded_foreign_owned_account() {
 
     {
         let view = unsafe { buf.view() };
-        let mut acct =
-            unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
+        let mut acct = unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
         assert_eq!(acct.value, 42);
         acct.value = 999;
         acct.exit().unwrap();
@@ -184,8 +181,7 @@ fn release_borrow_serializes_mutably_loaded_foreign_owned_account() {
 
     {
         let view = unsafe { buf.view() };
-        let mut acct =
-            unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
+        let mut acct = unsafe { BorshAccount::<ForeignCounter>::load_mut(view) }.unwrap();
         assert_eq!(acct.value, 42);
         acct.value = 999;
         acct.release_borrow().unwrap();
@@ -210,9 +206,8 @@ fn release_borrow_serializes_mutably_loaded_foreign_owned_account() {
 // correctly rejects it. Covered under regular `cargo test`.
 #[cfg_attr(
     miri,
-    ignore = "simulates external mutation by violating Rust's \
-    exclusive-borrow invariant — inexpressible under Tree Borrows; covered \
-    under cargo test"
+    ignore = "simulates external mutation by violating Rust's exclusive-borrow invariant — \
+              inexpressible under Tree Borrows; covered under cargo test"
 )]
 fn stale_detection_misses_content_only_out_of_band_mutation() {
     let mut buf = AccountBuffer::<256>::new();
@@ -353,9 +348,8 @@ fn reacquire_rejects_when_owner_changes_during_release() {
     assert_eq!(
         result.err(),
         Some(ProgramError::IllegalOwner),
-        "reacquire_borrow_mut must reject when the on-chain owner no longer matches \
-         `T::OWNER` — otherwise the program continues holding BorshAccount<T> over a \
-         foreign-owned account."
+        "reacquire_borrow_mut must reject when the on-chain owner no longer matches `T::OWNER` — \
+         otherwise the program continues holding BorshAccount<T> over a foreign-owned account."
     );
 }
 
@@ -420,12 +414,10 @@ fn release_borrow_commits_in_memory_changes_to_buffer() {
 fn exit_zeroes_bytes_between_new_and_old_serialized_lengths() {
     let mut buf = AccountBuffer::<256>::new();
     setup_shrinkable_bytes_buf(&mut buf, &[1, 2, 3], &[0xAA, 0xBB]);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
-        let mut acct =
-            unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view) }.unwrap();
         acct.items = vec![1, 2];
         acct.exit().unwrap();
     }
@@ -445,10 +437,9 @@ fn exit_zeroes_bytes_between_new_and_old_serialized_lengths() {
 fn release_borrow_zeroes_bytes_between_new_and_old_serialized_lengths() {
     let mut buf = AccountBuffer::<256>::new();
     setup_shrinkable_bytes_buf(&mut buf, &[1, 2, 3], &[0xAA, 0xBB]);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view) }.unwrap();
     acct.items.clear();
     acct.release_borrow().unwrap();
 

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -35,9 +35,7 @@ struct Counter {
 }
 
 impl Owner for Counter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Counter {
@@ -51,9 +49,7 @@ struct ForeignCounter {
 }
 
 impl Owner for ForeignCounter {
-    fn owner(_program_id: &Address) -> Address {
-        Address::new_from_array(FOREIGN_PROGRAM_ID)
-    }
+    const OWNER: Address = Address::new_from_array(FOREIGN_PROGRAM_ID);
 }
 
 impl Discriminator for ForeignCounter {
@@ -342,7 +338,7 @@ fn reacquire_rejects_when_discriminator_changes_during_release() {
 // transfer the account to a different owner. Without an owner check,
 // `reacquire_borrow_mut` would silently accept the now-foreign-owned
 // account as `BorshAccount<T>`. Post-fix: the caller passes `program_id`
-// into `reacquire_borrow_mut`, which re-runs `view.owned_by(&T::owner(program_id))`
+// into `reacquire_borrow_mut`, which re-runs `view.owned_by(&T::OWNER)`
 // against the live header.
 
 #[test]
@@ -366,7 +362,7 @@ fn reacquire_rejects_when_owner_changes_during_release() {
         result.err(),
         Some(ProgramError::IllegalOwner),
         "reacquire_borrow_mut must reject when the on-chain owner no longer matches \
-         `T::owner(program_id)` — otherwise the program continues holding BorshAccount<T> over a \
+         `T::OWNER` — otherwise the program continues holding BorshAccount<T> over a \
          foreign-owned account."
     );
 }

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -50,6 +50,7 @@ struct ForeignCounter {
 
 impl Owner for ForeignCounter {
     const OWNER: Address = Address::new_from_array(FOREIGN_PROGRAM_ID);
+    const SERIALIZE_ON_EXIT: bool = false;
 }
 
 impl Discriminator for ForeignCounter {

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -66,9 +66,7 @@ struct Vault {
 }
 
 impl Owner for Vault {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Vault {
@@ -359,9 +357,7 @@ struct CounterHeader {
 }
 
 impl Owner for CounterHeader {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for CounterHeader {

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -118,12 +118,10 @@ fn close_zeros_the_48_byte_header() {
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
     dest_buf.set_lamports(100);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view, &program_id) }.unwrap();
+        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
         vault.close(dest_view).unwrap();
     }
 
@@ -156,12 +154,10 @@ fn close_scrubs_discriminator_to_closed_sentinel() {
     let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view, &program_id) }.unwrap();
+        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
         vault.close(dest_view).unwrap();
     }
 
@@ -198,12 +194,10 @@ fn close_scrubs_discriminator_even_after_release_borrow() {
     let mut dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view, &program_id) }.unwrap();
+        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
 
         // Simulate the handler committing state and dropping the guard
         // (e.g. pre-CPI) before close runs in exit_accounts.
@@ -230,19 +224,17 @@ fn load_after_close_rejects_with_data_too_small() {
     let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view, &program_id) }.unwrap();
+        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
         vault.close(dest_view).unwrap();
     }
 
     // Even though data bytes retain the disc, the framework rejects
     // because `data_len = 0` (< DISC_LEN=8 → AccountDataTooSmall).
     let view = unsafe { buf.view() };
-    let result = BorshAccount::<Vault>::load(view, &program_id);
+    let result = BorshAccount::<Vault>::load(view);
     assert!(
         result.is_err(),
         "BorshAccount::load must reject a closed account (owner is [0;32] != program_id, AND \
@@ -265,12 +257,10 @@ fn resurrected_account_reload_rejects_after_disc_scrub() {
     let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view, &program_id) }.unwrap();
+        let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
         vault.close(dest_view).unwrap();
     }
 
@@ -285,7 +275,7 @@ fn resurrected_account_reload_rejects_after_disc_scrub() {
     // Post-fix: disc bytes are [u8::MAX; 8], which doesn't match
     // Vault::DISCRIMINATOR. Load must reject with InvalidAccountData.
     let view = unsafe { buf.view() };
-    let result = BorshAccount::<Vault>::load(view, &program_id);
+    let result = BorshAccount::<Vault>::load(view);
     assert!(
         result.is_err(),
         "Post-fix: reload must reject because scrubbed disc != Vault::DISCRIMINATOR"
@@ -329,9 +319,8 @@ fn create_account_zeroes_data_on_allocation() {
 
     // After this correct SVM behavior, the first 8 data bytes are
     // zero — no valid discriminator. Load rejects.
-    let program_id = Address::new_from_array(PROGRAM_ID);
     let view = unsafe { buf.view() };
-    let result = BorshAccount::<Vault>::load(view, &program_id);
+    let result = BorshAccount::<Vault>::load(view);
     assert!(
         result.is_err(),
         "after create_account's SVM-mandated zero-on-allocate, load must reject (data[..8] = [0; \
@@ -389,12 +378,10 @@ fn slab_close_scrubs_discriminator_to_closed_sentinel() {
     let mut dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view, &program_id) }.unwrap();
+        let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
         counter.close(dest_view).unwrap();
     }
 
@@ -417,11 +404,9 @@ fn slab_close_flips_is_mutable_so_deref_mut_panics() {
 
     let mut dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
-
-    let program_id = Address::new_from_array(PROGRAM_ID);
     let view = unsafe { buf.view() };
     let dest_view = unsafe { dest_buf.view() };
-    let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view, &program_id) }.unwrap();
+    let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
     counter.close(dest_view).unwrap();
 
     // Post-close: is_mutable should be flipped to false. DerefMut must
@@ -438,12 +423,10 @@ fn slab_resurrected_account_reload_rejects_after_disc_scrub() {
     let mut dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
-    let program_id = Address::new_from_array(PROGRAM_ID);
-
     {
         let view = unsafe { buf.view() };
         let dest_view = unsafe { dest_buf.view() };
-        let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view, &program_id) }.unwrap();
+        let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
         counter.close(dest_view).unwrap();
     }
 
@@ -457,7 +440,7 @@ fn slab_resurrected_account_reload_rejects_after_disc_scrub() {
     }
 
     let view = unsafe { buf.view() };
-    let result = Slab::<CounterHeader>::load(view, &program_id);
+    let result = Slab::<CounterHeader>::load(view);
     assert!(
         result.is_err(),
         "Post-fix: reload must reject because scrubbed disc != CounterHeader::DISCRIMINATOR"

--- a/lang-v2/tests/lamports.rs
+++ b/lang-v2/tests/lamports.rs
@@ -25,9 +25,7 @@ struct Counter {
 }
 
 impl Owner for Counter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Counter {

--- a/lang-v2/tests/lamports.rs
+++ b/lang-v2/tests/lamports.rs
@@ -15,10 +15,6 @@ use {
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
-fn program_id() -> Address {
-    Address::new_from_array(PROGRAM_ID)
-}
-
 #[derive(SchemaRead, SchemaWrite, Default, Clone)]
 struct Counter {
     value: u64,
@@ -62,7 +58,7 @@ fn borsh_account_get_add_and_sub_lamports() {
     setup_counter_buf(&mut buf);
 
     let view = unsafe { buf.view() };
-    let account = BorshAccount::<Counter>::load(view, &program_id()).unwrap();
+    let account = BorshAccount::<Counter>::load(view).unwrap();
     assert_eq!(account.get_lamports(), 100);
 
     account.add_lamports(900).unwrap();

--- a/lang-v2/tests/miri_slab_alignment.rs
+++ b/lang-v2/tests/miri_slab_alignment.rs
@@ -83,11 +83,9 @@ fn slab_align1_push_pop_roundtrip() {
     data[..8].copy_from_slice(&HEADER_DISC);
     buf.write_data(&data);
     buf.set_lamports(1_000_000_000);
-
-    let program_id = Address::new_from_array(PROGRAM_ID);
     let view = unsafe { buf.view() };
     let mut slab =
-        unsafe { Slab::<HeaderAlign1, ItemAlign1>::load_mut(view, &program_id) }.unwrap();
+        unsafe { Slab::<HeaderAlign1, ItemAlign1>::load_mut(view) }.unwrap();
 
     // Push 3 items.
     let items = [
@@ -119,11 +117,9 @@ fn slab_align1_swap_remove_preserves_correctness() {
     data[..8].copy_from_slice(&HEADER_DISC);
     buf.write_data(&data);
     buf.set_lamports(1_000_000_000);
-
-    let program_id = Address::new_from_array(PROGRAM_ID);
     let view = unsafe { buf.view() };
     let mut slab =
-        unsafe { Slab::<HeaderAlign1, ItemAlign1>::load_mut(view, &program_id) }.unwrap();
+        unsafe { Slab::<HeaderAlign1, ItemAlign1>::load_mut(view) }.unwrap();
 
     let a = ItemAlign1([0xAA; 16]);
     let b = ItemAlign1([0xBB; 16]);

--- a/lang-v2/tests/miri_slab_alignment.rs
+++ b/lang-v2/tests/miri_slab_alignment.rs
@@ -31,9 +31,7 @@ struct HeaderAlign1 {
 }
 
 impl Owner for HeaderAlign1 {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for HeaderAlign1 {

--- a/lang-v2/tests/miri_slab_construction.rs
+++ b/lang-v2/tests/miri_slab_construction.rs
@@ -57,7 +57,7 @@ fn setup_counter_buffer() -> AccountBuffer<128> {
     let data_len = 8 + core::mem::size_of::<Counter>();
     buf.init(
         [0xAA; 32], // address
-        PROGRAM_ID, // owner = Counter::owner(program_id) = program_id
+        PROGRAM_ID, // owner = Counter::OWNER
         data_len, /*is_signer*/ false, /*is_writable*/ true, /*executable*/ false,
     );
     // Write the discriminator into the first 8 bytes of data.
@@ -74,8 +74,7 @@ fn setup_counter_buffer() -> AccountBuffer<128> {
 fn load_succeeds_with_correct_disc_and_owner() {
     let buf = setup_counter_buffer();
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    let acct = CounterAccount::load(view, &program_id).unwrap();
+    let acct = CounterAccount::load(view).unwrap();
     assert_eq!(acct.value, 0);
     assert_eq!(acct.bump, 0);
 }
@@ -94,8 +93,7 @@ fn load_rejects_wrong_owner() {
     buf.write_data(&data);
 
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(CounterAccount::load(view, &program_id).is_err());
+    assert!(CounterAccount::load(view).is_err());
 }
 
 #[test]
@@ -109,8 +107,7 @@ fn load_rejects_wrong_disc() {
     buf.write_data(&data);
 
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(CounterAccount::load(view, &program_id).is_err());
+    assert!(CounterAccount::load(view).is_err());
 }
 
 // -- The header_ptr provenance witness --------------------------------
@@ -125,17 +122,16 @@ fn load_rejects_wrong_disc() {
 fn load_mut_deref_mut_writes_propagate_to_bytes() {
     let buf = setup_counter_buffer();
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
-        let mut acct = unsafe { CounterAccount::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { CounterAccount::load_mut(view) }.unwrap();
         acct.value = 0xDEADBEEF;
         acct.bump = 0xAB;
     } // acct drops here
 
     // Re-read through a fresh load to verify the writes hit the buffer.
     let view2 = unsafe { buf.view() };
-    let acct2 = CounterAccount::load(view2, &program_id).unwrap();
+    let acct2 = CounterAccount::load(view2).unwrap();
     assert_eq!(acct2.value, 0xDEADBEEF);
     assert_eq!(acct2.bump, 0xAB);
 }
@@ -148,16 +144,15 @@ fn load_mut_deref_mut_writes_propagate_to_bytes() {
 #[test]
 fn drop_mut_then_load_immutable_sees_writes() {
     let buf = setup_counter_buffer();
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
-        let mut acct = unsafe { CounterAccount::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { CounterAccount::load_mut(view) }.unwrap();
         acct.value = 99;
     }
 
     let view = unsafe { buf.view() };
-    let acct = CounterAccount::load(view, &program_id).unwrap();
+    let acct = CounterAccount::load(view).unwrap();
     assert_eq!(acct.value, 99);
 }
 
@@ -166,16 +161,15 @@ fn drop_mut_then_load_immutable_sees_writes() {
 #[test]
 fn multiple_mut_load_cycles_preserve_state() {
     let buf = setup_counter_buffer();
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     for i in 0u64..20 {
         let view = unsafe { buf.view() };
-        let mut acct = unsafe { CounterAccount::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { CounterAccount::load_mut(view) }.unwrap();
         acct.value = i * 10;
         drop(acct);
 
         let view_r = unsafe { buf.view() };
-        let acct_r = CounterAccount::load(view_r, &program_id).unwrap();
+        let acct_r = CounterAccount::load(view_r).unwrap();
         assert_eq!(acct_r.value, i * 10);
     }
 }

--- a/lang-v2/tests/miri_slab_construction.rs
+++ b/lang-v2/tests/miri_slab_construction.rs
@@ -36,9 +36,7 @@ struct Counter {
 }
 
 impl Owner for Counter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Counter {

--- a/lang-v2/tests/miri_wrapper_accounts.rs
+++ b/lang-v2/tests/miri_wrapper_accounts.rs
@@ -15,7 +15,6 @@ use anchor_lang_v2::{
     programs::{System, Token},
     AnchorAccount,
 };
-use pinocchio::address::Address;
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
@@ -29,8 +28,7 @@ fn system_account_loads_for_system_owned() {
         0, false, true, false,
     );
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    let acct = SystemAccount::load(view, &program_id).unwrap();
+    let acct = SystemAccount::load(view).unwrap();
     assert_eq!(acct.address().to_bytes(), [0x11; 32]);
 }
 
@@ -39,8 +37,7 @@ fn system_account_rejects_non_system_owner() {
     let buf = AccountBuffer::<256>::new();
     buf.init([0x11; 32], PROGRAM_ID, 0, false, true, false);
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(SystemAccount::load(view, &program_id).is_err());
+    assert!(SystemAccount::load(view).is_err());
 }
 
 // -- UncheckedAccount (always loads regardless of owner) -------------
@@ -51,9 +48,8 @@ fn unchecked_account_loads_for_any_owner() {
         let buf = AccountBuffer::<256>::new();
         buf.init([0x22; 32], owner, 0, false, true, false);
         let view = unsafe { buf.view() };
-        let program_id = Address::new_from_array(PROGRAM_ID);
         assert!(
-            UncheckedAccount::load(view, &program_id).is_ok(),
+            UncheckedAccount::load(view).is_ok(),
             "UncheckedAccount must accept any owner: {:?}",
             owner
         );
@@ -69,8 +65,7 @@ fn program_of_system_loads_when_address_matches_and_executable() {
         /*address = System::id()*/ [0; 32], [0; 32], 0, false, false, /*executable*/ true,
     );
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(Program::<System>::load(view, &program_id).is_ok());
+    assert!(Program::<System>::load(view).is_ok());
 }
 
 #[test]
@@ -82,8 +77,7 @@ fn program_of_token_rejects_wrong_address() {
         [0; 32], 0, false, false, true,
     );
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(Program::<Token>::load(view, &program_id).is_err());
+    assert!(Program::<Token>::load(view).is_err());
 }
 
 #[test]
@@ -93,9 +87,8 @@ fn program_rejects_non_executable_account() {
     let buf = AccountBuffer::<256>::new();
     buf.init([0; 32], [0; 32], 0, false, false, /*executable*/ false);
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
     // Under guardrails, Program<T> rejects non-executable.
-    assert!(Program::<System>::load(view, &program_id).is_err());
+    assert!(Program::<System>::load(view).is_err());
 }
 
 // -- Signer ----------------------------------------------------------
@@ -105,8 +98,7 @@ fn signer_loads_when_is_signer_set() {
     let buf = AccountBuffer::<256>::new();
     buf.init([0x33; 32], [0; 32], 0, /*signer*/ true, true, false);
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    let signer = Signer::load(view, &program_id).unwrap();
+    let signer = Signer::load(view).unwrap();
     assert_eq!(signer.address().to_bytes(), [0x33; 32]);
 }
 
@@ -115,8 +107,7 @@ fn signer_rejects_non_signer() {
     let buf = AccountBuffer::<256>::new();
     buf.init([0x33; 32], [0; 32], 0, /*signer*/ false, true, false);
     let view = unsafe { buf.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
-    assert!(Signer::load(view, &program_id).is_err());
+    assert!(Signer::load(view).is_err());
 }
 
 // -- Aliasing witnesses: multiple wrappers can co-exist if non-conflicting --
@@ -136,10 +127,9 @@ fn distinct_wrapper_types_on_distinct_buffers() {
 
     let view1 = unsafe { buf1.view() };
     let view2 = unsafe { buf2.view() };
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
-    let sys = SystemAccount::load(view1, &program_id).unwrap();
-    let unchecked = UncheckedAccount::load(view2, &program_id).unwrap();
+    let sys = SystemAccount::load(view1).unwrap();
+    let unchecked = UncheckedAccount::load(view2).unwrap();
 
     assert_ne!(sys.address().to_bytes(), unchecked.address().to_bytes());
 }

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -62,9 +62,7 @@ struct Stats {
 const STATS_DISC: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 
 impl Owner for Stats {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Stats {
@@ -316,9 +314,7 @@ struct Ledger {
 const LEDGER_DISC: [u8; 8] = [0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80];
 
 impl Owner for Ledger {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Ledger {

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -117,10 +117,9 @@ fn setup_stats_buf(buf: &mut AccountBuffer<256>, count: u32, flags: u32) {
 fn le_codec_immutable_load_deserializes() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 7, 0xABCD_1234);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let acct = StatsAccount::load(view, &program_id).unwrap();
+    let acct = StatsAccount::load(view).unwrap();
     assert_eq!(acct.count, 7);
     assert_eq!(acct.flags, 0xABCD_1234);
 }
@@ -131,11 +130,10 @@ fn le_codec_immutable_load_deserializes() {
 fn le_codec_load_mut_exit_writes_back() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
-        let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
         acct.count = 42;
         acct.flags = 0xDEAD_BEEF;
         acct.exit().unwrap();
@@ -155,10 +153,9 @@ fn le_codec_load_mut_exit_writes_back() {
 fn le_codec_release_borrow_commits() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
     acct.count = 999;
     acct.release_borrow().unwrap();
 
@@ -176,10 +173,9 @@ fn le_codec_release_borrow_commits() {
 fn le_codec_reacquire_refreshes_from_buffer() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
 
     acct.count = 100;
     acct.release_borrow().unwrap();
@@ -190,7 +186,7 @@ fn le_codec_reacquire_refreshes_from_buffer() {
     new_payload[4..8].copy_from_slice(&0x1111_2222u32.to_le_bytes());
     set_data_bytes(&mut buf, 8, &new_payload);
 
-    acct.reacquire_borrow_mut(&program_id).unwrap();
+    acct.reacquire_borrow_mut().unwrap();
     assert_eq!(acct.count, 777);
     assert_eq!(acct.flags, 0x1111_2222);
 }
@@ -203,10 +199,9 @@ fn le_codec_load_rejects_wrong_discriminator() {
     setup_stats_buf(&mut buf, 1, 0);
     // Corrupt the disc.
     set_data_bytes(&mut buf, 0, &[0u8; 8]);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let err = StatsAccount::load(view, &program_id).err();
+    let err = StatsAccount::load(view).err();
     assert_eq!(err, Some(ProgramError::InvalidAccountData));
 }
 
@@ -217,10 +212,9 @@ fn le_codec_load_rejects_wrong_owner() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
     buf.set_owner([0xFE; 32]);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let err = StatsAccount::load(view, &program_id).err();
+    let err = StatsAccount::load(view).err();
     assert_eq!(err, Some(ProgramError::IllegalOwner));
 }
 
@@ -233,13 +227,12 @@ fn le_codec_load_rejects_short_data() {
     buf.init([0xAA; 32], PROGRAM_ID, 8, false, true, false);
     buf.write_data(&STATS_DISC);
     buf.set_lamports(1_000_000_000);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
     // The codec returns InvalidAccountData when the payload is too short
     // (8 - 8 = 0 bytes available, codec needs 8).
     assert_eq!(
-        StatsAccount::load(view, &program_id).err(),
+        StatsAccount::load(view).err(),
         Some(ProgramError::InvalidAccountData)
     );
 }
@@ -250,14 +243,13 @@ fn le_codec_load_rejects_short_data() {
 fn le_codec_reacquire_rejects_disc_swap() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
     acct.release_borrow().unwrap();
 
     set_data_bytes(&mut buf, 0, &[0xFF; 8]);
-    let err = acct.reacquire_borrow_mut(&program_id).unwrap_err();
+    let err = acct.reacquire_borrow_mut().unwrap_err();
     assert_eq!(err, ProgramError::InvalidAccountData);
 }
 
@@ -267,14 +259,13 @@ fn le_codec_reacquire_rejects_disc_swap() {
 fn le_codec_reacquire_rejects_owner_change() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
     acct.release_borrow().unwrap();
 
     buf.set_owner([0xFE; 32]);
-    let err = acct.reacquire_borrow_mut(&program_id).unwrap_err();
+    let err = acct.reacquire_borrow_mut().unwrap_err();
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
@@ -284,10 +275,9 @@ fn le_codec_reacquire_rejects_owner_change() {
 fn le_codec_exit_on_closed_account_is_noop() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0xAABB_CCDD);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { StatsAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { StatsAccount::load_mut(view) }.unwrap();
     acct.count = 555;
     buf.set_lamports(0);
     acct.exit().unwrap();
@@ -370,10 +360,9 @@ fn setup_ledger_buf(buf: &mut AccountBuffer<256>, balance: u64, nonce: u32) {
 fn wincode_codec_load_deserializes() {
     let mut buf = AccountBuffer::<256>::new();
     setup_ledger_buf(&mut buf, 1_000_000, 42);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let acct = LedgerAccount::load(view, &program_id).unwrap();
+    let acct = LedgerAccount::load(view).unwrap();
     assert_eq!(acct.balance, 1_000_000);
     assert_eq!(acct.nonce, 42);
 }
@@ -382,11 +371,10 @@ fn wincode_codec_load_deserializes() {
 fn wincode_codec_load_mut_exit_round_trip() {
     let mut buf = AccountBuffer::<256>::new();
     setup_ledger_buf(&mut buf, 0, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     {
         let view = unsafe { buf.view() };
-        let mut acct = unsafe { LedgerAccount::load_mut(view, &program_id) }.unwrap();
+        let mut acct = unsafe { LedgerAccount::load_mut(view) }.unwrap();
         acct.balance = 9_999;
         acct.nonce = 7;
         acct.exit().unwrap();
@@ -394,7 +382,7 @@ fn wincode_codec_load_mut_exit_round_trip() {
 
     // Re-load and verify the wire bytes deserialize back to the new values.
     let view = unsafe { buf.view() };
-    let acct = LedgerAccount::load(view, &program_id).unwrap();
+    let acct = LedgerAccount::load(view).unwrap();
     assert_eq!(acct.balance, 9_999);
     assert_eq!(acct.nonce, 7);
 }
@@ -404,11 +392,10 @@ fn wincode_codec_rejects_wrong_disc() {
     let mut buf = AccountBuffer::<256>::new();
     setup_ledger_buf(&mut buf, 0, 0);
     set_data_bytes(&mut buf, 0, &[0u8; 8]);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
     assert_eq!(
-        LedgerAccount::load(view, &program_id).err(),
+        LedgerAccount::load(view).err(),
         Some(ProgramError::InvalidAccountData)
     );
 }
@@ -417,10 +404,9 @@ fn wincode_codec_rejects_wrong_disc() {
 fn wincode_codec_release_reacquire_picks_up_cpi_write() {
     let mut buf = AccountBuffer::<256>::new();
     setup_ledger_buf(&mut buf, 0, 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut acct = unsafe { LedgerAccount::load_mut(view, &program_id) }.unwrap();
+    let mut acct = unsafe { LedgerAccount::load_mut(view) }.unwrap();
     acct.release_borrow().unwrap();
 
     // Simulated CPI writes a new ledger payload using the same codec.
@@ -431,7 +417,7 @@ fn wincode_codec_release_reacquire_picks_up_cpi_write() {
     .unwrap();
     set_data_bytes(&mut buf, 8, &cpi_payload);
 
-    acct.reacquire_borrow_mut(&program_id).unwrap();
+    acct.reacquire_borrow_mut().unwrap();
     assert_eq!(acct.balance, 12_345);
     assert_eq!(acct.nonce, 99);
 }

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -33,9 +33,7 @@ struct Counter {
 }
 
 impl Owner for Counter {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
 }
 
 impl Discriminator for Counter {

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -111,10 +111,9 @@ fn slab_realloc_rejects_shrink_below_typed_header_layout() {
     let buf = setup_counter_account();
     let payer = AccountBuffer::<128>::new();
     payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut account = unsafe { CounterAccount::load_mut(view, &program_id) }.unwrap();
+    let mut account = unsafe { CounterAccount::load_mut(view) }.unwrap();
     let payer_view = unsafe { payer.view() };
 
     let err = account
@@ -133,10 +132,9 @@ fn slab_realloc_clamps_tail_len_to_resized_capacity() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
     let payer = AccountBuffer::<128>::new();
     payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     let payer_view = unsafe { payer.view() };
 
     slab.realloc_account(ITEMS_OFFSET + ITEM_SIZE, payer_view, false)
@@ -144,7 +142,7 @@ fn slab_realloc_clamps_tail_len_to_resized_capacity() {
 
     assert_eq!(slab.capacity(), 1);
     assert_eq!(slab.len(), 1);
-    assert_eq!(CounterLedger::load(view, &program_id).unwrap().len(), 1);
+    assert_eq!(CounterLedger::load(view).unwrap().len(), 1);
 }
 
 // -- `load_mut` rejects a buffer shrunk below ITEMS_OFFSET -----------
@@ -152,11 +150,10 @@ fn slab_realloc_clamps_tail_len_to_resized_capacity() {
 #[test]
 fn load_mut_rejects_data_len_below_items_offset() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     // Load succeeds — data_len (60) > ITEMS_OFFSET (28).
     let view = unsafe { buf.view() };
-    let slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     assert_eq!(slab.capacity(), 4);
     assert_eq!(slab.len(), 0);
     drop(slab);
@@ -170,7 +167,7 @@ fn load_mut_rejects_data_len_below_items_offset() {
     // this? `slab.rs:596` checks `data.len() < Self::ITEMS_OFFSET` —
     // returns AccountDataTooSmall. Good — `load_mut` catches it.
     let view2 = unsafe { buf.view() };
-    let reload = unsafe { CounterLedger::load_mut(view2, &program_id) };
+    let reload = unsafe { CounterLedger::load_mut(view2) };
     assert!(
         reload.is_err(),
         "load_mut should reject data_len < ITEMS_OFFSET — if it doesn't, the subsequent \
@@ -182,20 +179,18 @@ fn load_mut_rejects_data_len_below_items_offset() {
 fn load_rejects_len_greater_than_capacity_via_from_ref_validate_tail() {
     let buf = setup_ledger(/*capacity*/ 1, /*len*/ 2);
     let mut buf = buf;
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let result = CounterLedger::load(view, &program_id);
+    let result = CounterLedger::load(view);
     assert_eq!(result.err(), Some(ProgramError::InvalidAccountData));
 }
 
 #[test]
 fn load_mut_rejects_len_greater_than_capacity_via_validate_tail() {
     let mut buf = setup_ledger(/*capacity*/ 1, /*len*/ 2);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let result = unsafe { CounterLedger::load_mut(view, &program_id) };
+    let result = unsafe { CounterLedger::load_mut(view) };
     assert_eq!(result.err(), Some(ProgramError::InvalidAccountData));
 }
 
@@ -205,10 +200,9 @@ fn load_mut_rejects_len_greater_than_capacity_via_validate_tail() {
 #[test]
 fn capacity_returns_zero_when_data_len_below_items_offset() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 0);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     assert_eq!(slab.capacity(), 4);
 
     // External resize shrinks buffer while we still hold `slab`.
@@ -225,10 +219,9 @@ fn capacity_returns_zero_when_data_len_below_items_offset() {
 fn as_slice_clamps_len_to_capacity_after_external_shrink() {
     // Buffer with capacity 4, populated with 3 items (len=3).
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     assert_eq!(slab.len(), 3);
     assert_eq!(slab.capacity(), 4);
 
@@ -253,10 +246,9 @@ fn as_slice_clamps_len_to_capacity_after_external_shrink() {
 #[test]
 fn pop_after_external_shrink_uses_effective_len() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     assert_eq!(slab.len(), 3);
     assert_eq!(slab.capacity(), 4);
 
@@ -277,10 +269,9 @@ fn pop_after_external_shrink_uses_effective_len() {
 #[test]
 fn swap_remove_after_external_shrink_uses_effective_len() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
 
     // Shrink: capacity drops to 2 with the slab still in scope.
     buf.set_data_len((ITEMS_OFFSET + 2 * ITEM_SIZE) as u64);
@@ -296,10 +287,9 @@ fn swap_remove_after_external_shrink_uses_effective_len() {
 #[should_panic(expected = "swap_remove index out of bounds")]
 fn swap_remove_panics_when_index_geq_effective_len() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
 
     // Shrink: capacity drops to 1 with the slab still in scope.
     buf.set_data_len((ITEMS_OFFSET + ITEM_SIZE) as u64);
@@ -314,10 +304,9 @@ fn swap_remove_panics_when_index_geq_effective_len() {
 )]
 fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
     let mut buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = CounterLedger::load(view, &program_id).unwrap();
+    let mut slab = CounterLedger::load(view).unwrap();
     slab.clear();
 }
 
@@ -326,10 +315,9 @@ fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
 #[test]
 fn truncate_clamps_to_effective_len_after_shrink() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
 
     // Shrink while slab is in scope.
     buf.set_data_len((ITEMS_OFFSET + ITEM_SIZE) as u64);
@@ -352,10 +340,9 @@ fn truncate_clamps_to_effective_len_after_shrink() {
 #[test]
 fn slab_resize_to_capacity_clamps_len() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     assert_eq!(slab.len(), 3);
 
     // This is a smoke test for the defensive pattern. It also documents
@@ -375,10 +362,9 @@ fn slab_resize_to_capacity_clamps_len() {
 #[test]
 fn min_lamports_matches_rent_helper_for_current_space() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let view = unsafe { buf.view() };
-    let slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
 
     assert_eq!(slab.current_space(), ITEMS_OFFSET + 4 * ITEM_SIZE);
     assert_eq!(
@@ -390,7 +376,6 @@ fn min_lamports_matches_rent_helper_for_current_space() {
 #[test]
 fn refund_moves_excess_lamports_to_recipient() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required + 500);
@@ -400,7 +385,7 @@ fn refund_moves_excess_lamports_to_recipient() {
     recipient.set_lamports(25);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     let mut recipient_view = unsafe { recipient.view() };
 
     slab.refund(&mut recipient_view).unwrap();
@@ -412,7 +397,6 @@ fn refund_moves_excess_lamports_to_recipient() {
 #[test]
 fn refund_is_noop_when_account_is_at_rent_floor() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required);
@@ -422,7 +406,7 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
     recipient.set_lamports(25);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     let mut recipient_view = unsafe { recipient.view() };
 
     slab.refund(&mut recipient_view).unwrap();
@@ -434,7 +418,6 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 #[test]
 fn top_up_is_noop_when_account_already_has_enough_lamports() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
-    let program_id = Address::new_from_array(PROGRAM_ID);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required + 123);
@@ -444,7 +427,7 @@ fn top_up_is_noop_when_account_already_has_enough_lamports() {
     payer.set_lamports(999);
 
     let view = unsafe { buf.view() };
-    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
     let payer_view = unsafe { payer.view() };
 
     slab.top_up(&payer_view).unwrap();

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -735,7 +735,7 @@ impl AccountDeserialize for MetadataAccount {
 impl AnchorAccount for MetadataAccount {
     type Data = mpl_token_metadata::accounts::Metadata;
 
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self> {
+    fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
         let data = Self::parse(&data_ref)?;
@@ -791,7 +791,7 @@ impl AccountDeserialize for MasterEditionAccount {
 impl AnchorAccount for MasterEditionAccount {
     type Data = mpl_token_metadata::accounts::MasterEdition;
 
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self> {
+    fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
         let data = Self::parse(&data_ref)?;
@@ -849,7 +849,7 @@ impl AccountDeserialize for TokenRecordAccount {
 impl AnchorAccount for TokenRecordAccount {
     type Data = mpl_token_metadata::accounts::TokenRecord;
 
-    fn load(view: AccountView, _program_id: &Address) -> Result<Self> {
+    fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
         let data = Self::parse(&data_ref)?;

--- a/spl-v2/src/mint.rs
+++ b/spl-v2/src/mint.rs
@@ -73,11 +73,7 @@ impl SlabSchema for Mint {
     const MIN_DATA_LEN: usize = core::mem::size_of::<Self>();
 
     #[inline(always)]
-    fn validate(
-        view: &AccountView,
-        data: &[u8],
-        _program_id: &Address,
-    ) -> Result<(), ProgramError> {
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
         require!(view.owned_by(&Token::id()), ProgramError::IllegalOwner);
         require_eq!(
             data.len(),
@@ -105,7 +101,6 @@ impl SlabInit for Mint {
         payer: &AccountView,
         account: &AccountView,
         _space: usize,
-        _program_id: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError> {

--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -118,11 +118,7 @@ impl SlabSchema for TokenAccount {
     const MIN_DATA_LEN: usize = core::mem::size_of::<Self>();
 
     #[inline(always)]
-    fn validate(
-        view: &AccountView,
-        data: &[u8],
-        _program_id: &Address,
-    ) -> Result<(), ProgramError> {
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
         require!(view.owned_by(&Token::id()), ProgramError::IllegalOwner);
         // Exact size distinguishes TokenAccount (165) from Mint (82).
         require_eq!(
@@ -150,7 +146,6 @@ impl SlabInit for TokenAccount {
         payer: &AccountView,
         account: &AccountView,
         _space: usize,
-        _program_id: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError> {

--- a/spl-v2/src/token_interface.rs
+++ b/spl-v2/src/token_interface.rs
@@ -148,11 +148,7 @@ impl SlabSchema for Interface<crate::TokenAccount> {
     const MIN_DATA_LEN: usize = core::mem::size_of::<Self>();
 
     #[inline(always)]
-    fn validate(
-        view: &AccountView,
-        data: &[u8],
-        _program_id: &Address,
-    ) -> Result<(), ProgramError> {
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
         require!(
             view.owned_by(&Token::id()) || view.owned_by(&Token2022Program::id()),
             ProgramError::IllegalOwner
@@ -172,11 +168,7 @@ impl SlabSchema for Interface<crate::Mint> {
     const MIN_DATA_LEN: usize = core::mem::size_of::<Self>();
 
     #[inline(always)]
-    fn validate(
-        view: &AccountView,
-        data: &[u8],
-        _program_id: &Address,
-    ) -> Result<(), ProgramError> {
+    fn validate(view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
         require!(
             view.owned_by(&Token::id()) || view.owned_by(&Token2022Program::id()),
             ProgramError::IllegalOwner
@@ -230,7 +222,6 @@ impl SlabInit for Interface<crate::TokenAccount> {
         payer: &AccountView,
         account: &AccountView,
         _space: usize,
-        _program_id: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError> {
@@ -279,7 +270,6 @@ impl SlabInit for Interface<crate::Mint> {
         payer: &AccountView,
         account: &AccountView,
         _space: usize,
-        _program_id: &Address,
         params: &Self::Params<'a>,
         signer_seeds: Option<&[&[u8]]>,
     ) -> Result<(), ProgramError> {

--- a/tests-v2/Cargo.toml
+++ b/tests-v2/Cargo.toml
@@ -41,6 +41,7 @@ declare-program-types = { path = "programs/declare-program/types" }
 dispatch-remaining = { path = "programs/dispatch-remaining" }
 dup-mut = { path = "programs/dup-mut" }
 event-cpi-test = { path = "programs/event-cpi" }
+foreign-borsh-account = { path = "programs/foreign-borsh-account" }
 init-space-usability = { path = "programs/init-space-usability" }
 ix-macro = { path = "programs/ix-macro" }
 optional-accounts = { path = "programs/optional-accounts" }

--- a/tests-v2/programs/accounts/Cargo.toml
+++ b/tests-v2/programs/accounts/Cargo.toml
@@ -14,11 +14,12 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 no-idl = []
 no-log-ix-name = []
-idl-build = []
+idl-build = ["foreign-borsh-account/idl-build"]
 
 [dependencies]
 anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
 bytemuck = { version = "1", features = ["derive"] }
+foreign-borsh-account = { path = "../foreign-borsh-account" }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -11,6 +11,7 @@ use {
         prelude::*,
         programs::{AssociatedToken, Memo},
     },
+    foreign_borsh_account::ForeignBorshCounter,
     pinocchio::sysvars::{clock::Clock, rent::Rent},
     solana_program_error::ProgramError,
 };
@@ -19,8 +20,6 @@ declare_id!("Acc1111111111111111111111111111111111111111");
 
 const PROGRAM_OWNER: Address =
     anchor_lang_v2::address!("Acc1111111111111111111111111111111111111111");
-const FOREIGN_BORSH_OWNER: Address =
-    anchor_lang_v2::address!("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
 const SYSTEM_SEED: &str = "anchor-v2-seed";
 const SYSTEM_TRANSFER_SEED: &str = "anchor-v2-transfer";
 
@@ -47,25 +46,6 @@ pub struct LedgerEntry {
 }
 
 type LedgerAccount = Slab<Ledger, LedgerEntry>;
-
-#[derive(Clone, Default, SchemaRead, SchemaWrite)]
-pub struct ForeignBorshCounter {
-    pub value: u64,
-}
-
-impl Owner for ForeignBorshCounter {
-    const OWNER: Address = FOREIGN_BORSH_OWNER;
-    const SERIALIZE_ON_EXIT: bool = false;
-}
-
-impl Discriminator for ForeignBorshCounter {
-    const DISCRIMINATOR: &'static [u8] = &[0x0f, 0xb0, 0x52, 0x48, 0x0a, 0xcc, 0x7d, 0x01];
-}
-
-// TODO: Support foreign-program owners directly in `#[account(borsh)]` so
-// tests and users do not need to hand-roll `Owner`, `Discriminator`, and IDL
-// metadata for foreign-owned Borsh accounts.
-impl anchor_lang_v2::IdlAccountType for ForeignBorshCounter {}
 
 #[program]
 pub mod accounts_test {
@@ -600,8 +580,8 @@ pub mod accounts_test {
     }
 
     /// Mutates a foreign-owned `BorshAccount<T>` in memory. The generated exit
-    /// path must not serialize the mutation back to the account data because
-    /// the runtime owner is not this program.
+    /// path serializes mutable borrows; the runtime rejects the resulting
+    /// foreign account data write.
     #[discrim = 32]
     pub fn mutate_foreign_borsh_counter(
         ctx: &mut Context<MutateForeignBorshCounter>,

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -55,6 +55,7 @@ pub struct ForeignBorshCounter {
 
 impl Owner for ForeignBorshCounter {
     const OWNER: Address = FOREIGN_BORSH_OWNER;
+    const SERIALIZE_ON_EXIT: bool = false;
 }
 
 impl Discriminator for ForeignBorshCounter {

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -54,9 +54,7 @@ pub struct ForeignBorshCounter {
 }
 
 impl Owner for ForeignBorshCounter {
-    fn owner(_program_id: &Address) -> Address {
-        FOREIGN_BORSH_OWNER
-    }
+    const OWNER: Address = FOREIGN_BORSH_OWNER;
 }
 
 impl Discriminator for ForeignBorshCounter {

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -15,9 +15,7 @@ pub struct CalleeData {
 }
 
 impl Owner for CalleeData {
-    fn owner(_program_id: &Address) -> Address {
-        callee::id()
-    }
+    const OWNER: Address = callee::ID;
 }
 
 impl Discriminator for CalleeData {

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -16,6 +16,7 @@ pub struct CalleeData {
 
 impl Owner for CalleeData {
     const OWNER: Address = callee::ID;
+    const SERIALIZE_ON_EXIT: bool = false;
 }
 
 impl Discriminator for CalleeData {

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -16,7 +16,6 @@ pub struct CalleeData {
 
 impl Owner for CalleeData {
     const OWNER: Address = callee::ID;
-    const SERIALIZE_ON_EXIT: bool = false;
 }
 
 impl Discriminator for CalleeData {

--- a/tests-v2/programs/foreign-borsh-account/Cargo.toml
+++ b/tests-v2/programs/foreign-borsh-account/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "foreign-borsh-account"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+default = []
+idl-build = []
+
+[dependencies]
+anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
+wincode = { version = "0.5", features = ["derive"] }
+
+[lints.rust.unexpected_cfgs]
+level = "allow"

--- a/tests-v2/programs/foreign-borsh-account/src/lib.rs
+++ b/tests-v2/programs/foreign-borsh-account/src/lib.rs
@@ -1,0 +1,11 @@
+use anchor_lang_v2::prelude::*;
+
+pub const FOREIGN_BORSH_OWNER: &str = "Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u";
+
+declare_id!("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[derive(Clone, Default)]
+#[account(borsh)]
+pub struct ForeignBorshCounter {
+    pub value: u64,
+}

--- a/tests-v2/src/declare-program/serialization.rs
+++ b/tests-v2/src/declare-program/serialization.rs
@@ -87,7 +87,7 @@ fn declared_program_type_serialization_controls_account_traits() {
     );
 
     assert_eq!(
-        <serialization::ImplicitBorshAccount as anchor_lang_v2::Owner>::owner(&serialization::ID),
+        <serialization::ImplicitBorshAccount as anchor_lang_v2::Owner>::OWNER,
         serialization::ID
     );
 

--- a/tests-v2/tests/accounts.rs
+++ b/tests-v2/tests/accounts.rs
@@ -7,6 +7,7 @@ use {
         solana_program::instruction::{AccountMeta, Instruction},
         Id,
     },
+    foreign_borsh_account::{ForeignBorshCounter, FOREIGN_BORSH_OWNER},
     litesvm::{types::TransactionResult, LiteSVM},
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
@@ -61,13 +62,11 @@ fn ledger_pda() -> Pubkey {
 }
 
 fn foreign_borsh_owner() -> Pubkey {
-    "Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u"
-        .parse()
-        .unwrap()
+    FOREIGN_BORSH_OWNER.parse().unwrap()
 }
 
-fn foreign_borsh_counter_disc() -> [u8; 8] {
-    [0x0f, 0xb0, 0x52, 0x48, 0x0a, 0xcc, 0x7d, 0x01]
+fn foreign_borsh_counter_disc() -> &'static [u8] {
+    <ForeignBorshCounter as anchor_lang_v2::Discriminator>::DISCRIMINATOR
 }
 
 const SYSTEM_SEED: &str = "anchor-v2-seed";
@@ -452,14 +451,17 @@ fn lamports_helpers_reject_underflow_and_preserve_balances() {
 }
 
 #[test]
-fn foreign_borsh_account_mutation_is_not_written_on_exit() {
+fn foreign_borsh_account_mutation_is_rejected_on_exit() {
     let (mut svm, payer) = setup();
     let foreign_counter = Pubkey::new_unique();
     set_foreign_borsh_counter(&mut svm, foreign_counter, 42);
 
     let metas = vec![AccountMeta::new(foreign_counter, false)];
-    send_instruction(&mut svm, program_id(), vec![32], metas, &payer, &[])
-        .expect("foreign-owned BorshAccount<T> should load and handler should succeed");
+    let result = send_instruction(&mut svm, program_id(), vec![32], metas, &payer, &[]);
+    assert!(
+        result.is_err(),
+        "serializing a mutable foreign-owned BorshAccount<T> should be rejected by the runtime"
+    );
 
     let account = svm
         .get_account(&foreign_counter)
@@ -467,13 +469,13 @@ fn foreign_borsh_account_mutation_is_not_written_on_exit() {
     assert_eq!(account.owner, foreign_borsh_owner());
     assert_eq!(
         &account.data[..8],
-        &foreign_borsh_counter_disc(),
+        foreign_borsh_counter_disc(),
         "discriminator should be unchanged"
     );
     let value = u64::from_le_bytes(account.data[8..16].try_into().unwrap());
     assert_eq!(
         value, 42,
-        "generated exit must not serialize in-memory mutations into foreign-owned account data"
+        "failed transaction must leave foreign-owned account data unchanged"
     );
 }
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1128,14 +1128,13 @@ impl SlabSchema for BadHeader {
     fn validate(
         _view: &AccountView,
         _data: &[u8],
-        _program_id: &Address,
     ) -> core::result::Result<(), ProgramError> {
         Ok(())
     }
 }
 
-pub unsafe fn load_bad(view: AccountView, program_id: &Address) {
-    let _ = <Slab<BadHeader> as AnchorAccount>::load_mut(view, program_id);
+pub unsafe fn load_bad(view: AccountView) {
+    let _ = <Slab<BadHeader> as AnchorAccount>::load_mut(view);
 }
 "#,
     )
@@ -1170,14 +1169,13 @@ impl SlabSchema for BadHeader {
     fn validate(
         _view: &AccountView,
         _data: &[u8],
-        _program_id: &Address,
     ) -> core::result::Result<(), ProgramError> {
         Ok(())
     }
 }
 
-pub unsafe fn load_bad(view: AccountView, program_id: &Address) {
-    let _ = <Slab<BadHeader> as AnchorAccount>::load_mut(view, program_id);
+pub unsafe fn load_bad(view: AccountView) {
+    let _ = <Slab<BadHeader> as AnchorAccount>::load_mut(view);
 }
 "#,
     )
@@ -1356,9 +1354,7 @@ pub struct Data {
 }
 
 impl Owner for Data {
-    fn owner(program_id: &Address) -> Address {
-        *program_id
-    }
+    const OWNER: Address = Address::from_str_const("11111111111111111111111111111111");
 }
 
 impl Discriminator for Data {


### PR DESCRIPTION
## Summary

- Make `Owner` expose `OWNER` as an associated constant.
- Remove the account wrapper/init `program_id` plumbing that was only needed for dynamic owner lookup.
- Remove `BorshAccount`'s cached owner-derived serialization state while preserving foreign-owned account writeback behavior.

## Validation

- `cargo check -p anchor-lang-v2 -p anchor-derive-accounts-v2 -p anchor-spl-v2`
- `cargo test -p anchor-lang-v2 --features testing --test borsh_exit_semantics --test serialized_account_custom_codec`
- `cargo test -p tests-v2 foreign_borsh_account_mutation_is_not_written_on_exit`
