### PR TITLE
Fix anchor-next CPI and PDA footguns

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1109,6 +1109,33 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 }
             })
             .collect();
+        let cpi_validate_steps: Vec<_> = fields
+            .iter()
+            .map(|f| {
+                let n = &f.name;
+                if parse::is_nested_type(&f.ty) {
+                    return quote! {
+                        anchor_lang_v2::ToCpiAccounts::validate_cpi_accounts(&self.#n)?;
+                    };
+                }
+                let writable = f.idl_writable;
+                if f.is_optional {
+                    quote! {
+                        if let ::core::option::Option::Some(__account) = &self.#n {
+                            if #writable && !__account.is_writable() {
+                                return Err(anchor_lang_v2::Error::InvalidArgument);
+                            }
+                        }
+                    }
+                } else {
+                    quote! {
+                        if #writable && !self.#n.is_writable() {
+                            return Err(anchor_lang_v2::Error::InvalidArgument);
+                        }
+                    }
+                }
+            })
+            .collect();
         // An empty Accounts struct would otherwise emit `pub struct Foo<'a> {}`,
         // which fails E0392 because nothing on `Self` references `'a`. Anchor
         // the lifetime via a `PhantomData<&'a ()>` field — kept hidden — and
@@ -1162,6 +1189,10 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                         let mut __handles = alloc::vec::Vec::new();
                         #(#cpi_handle_steps)*
                         __handles
+                    }
+                    fn validate_cpi_accounts(&self) -> anchor_lang_v2::Result<()> {
+                        #(#cpi_validate_steps)*
+                        Ok(())
                     }
                 }
             }
@@ -3657,7 +3688,7 @@ fn process_handler(
                 },
             )
         } else {
-            (quote! {}, quote! {})
+            (quote! { -> anchor_lang_v2::Result<()> }, quote! { Ok(()) })
         };
         quote! {
             pub fn #fn_name #lt_decl(
@@ -3671,7 +3702,7 @@ fn process_handler(
                     super::instruction::#ix_struct_name #ix_lt_use_local
                     as anchor_lang_v2::InstructionData
                 >::data(&__ix);
-                __ctx.invoke(&__data);
+                __ctx.invoke(&__data)?;
                 #ret_value
             }
         }
@@ -4877,7 +4908,7 @@ pub fn emit_cpi(input: TokenStream) -> TokenStream {
                 ctx.program_id,
                 __AnchorEventCpiAccounts { event_authority: __event_authority },
                 __event_authority_signers,
-            ).invoke(&__ix_data);
+            ).invoke(&__ix_data)?;
         }
     })
 }

--- a/lang-v2/derive/src/pda.rs
+++ b/lang-v2/derive/src/pda.rs
@@ -17,6 +17,8 @@ use {
 };
 
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
+const MAX_PDA_SEEDS: usize = 16;
+const MAX_PDA_SEED_LEN: usize = 32;
 
 thread_local! {
     /// `None`   = not yet attempted.
@@ -145,6 +147,10 @@ pub(crate) fn seeds_as_byte_literals(seeds: &[&syn::Expr]) -> Option<Vec<Vec<u8>
 pub(crate) fn precompute_pda(seeds: &[&[u8]], program_id: &[u8; 32]) -> Option<(u8, [u8; 32])> {
     use curve25519_dalek::edwards::CompressedEdwardsY;
 
+    if seeds.len() >= MAX_PDA_SEEDS || seeds.iter().any(|seed| seed.len() > MAX_PDA_SEED_LEN) {
+        return None;
+    }
+
     let mut bump: i32 = u8::MAX as i32;
     while bump >= 0 {
         let mut hasher = Sha256::new();
@@ -190,6 +196,23 @@ mod tests {
         assert_eq!(bump, 253);
         // PDA must be a non-zero 32-byte hash.
         assert!(pda.iter().any(|b| *b != 0));
+    }
+
+    #[test]
+    fn precompute_pda_rejects_seed_count_that_leaves_no_bump_slot() {
+        let program_id = [7u8; 32];
+        let seeds = [&[][..]; MAX_PDA_SEEDS];
+
+        assert!(precompute_pda(&seeds, &program_id).is_none());
+    }
+
+    #[test]
+    fn precompute_pda_rejects_oversized_seed() {
+        let program_id = [7u8; 32];
+        let long = [0u8; MAX_PDA_SEED_LEN + 1];
+        let seeds = [long.as_slice()];
+
+        assert!(precompute_pda(&seeds, &program_id).is_none());
     }
 
     #[test]

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -319,12 +319,7 @@ where
             return Ok(());
         }
         let deficit = required - current;
-        pinocchio_system::instructions::Transfer {
-            from: payer,
-            to: &self.view,
-            lamports: deficit,
-        }
-        .invoke()
+        crate::cpi::transfer_lamports_unchecked(payer, &self.view, deficit)
     }
 
     /// Move excess lamports (current - min_lamports) from the account to

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -74,7 +74,9 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     /// Invoke the CPI with the given instruction data. Collects accounts
     /// from [`ToCpiAccounts`], appends remaining accounts, and calls
     /// `invoke_signed_unchecked`.
-    pub fn invoke(&self, data: &[u8]) {
+    pub fn invoke(&self, data: &[u8]) -> ProgramResult {
+        self.accounts.validate_cpi_accounts()?;
+
         let mut instruction_accounts = self.accounts.to_instruction_accounts();
         let mut handles = self.accounts.to_cpi_handles();
 
@@ -93,6 +95,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
             data,
             accounts: &instruction_accounts,
         };
+        validate_instruction_handles(&instruction_accounts, &handles)?;
 
         // Convert signer seeds to pinocchio Signers.
         // SAFETY: pinocchio::cpi::Seed is repr(C) { *const u8, u64, PhantomData }
@@ -138,6 +141,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
                 &signers,
             );
         }
+        Ok(())
     }
 
     /// Invoke a fully built instruction using this context's CPI handles.
@@ -159,6 +163,28 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
         // remains set while the wrapper is alive.
         unsafe { crate::program::invoke_signed_unchecked(&ix, &handles, self.signer_seeds) }
     }
+}
+
+fn validate_instruction_handles(
+    instruction_accounts: &[InstructionAccount<'_>],
+    handles: &[CpiHandle<'_>],
+) -> ProgramResult {
+    let mut account_index = 0;
+    for handle in handles {
+        while account_index < instruction_accounts.len()
+            && !address_eq(instruction_accounts[account_index].address, handle.address())
+        {
+            account_index += 1;
+        }
+        if account_index == instruction_accounts.len() {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        if instruction_accounts[account_index].is_writable && !handle.is_writable() {
+            return Err(ProgramError::InvalidArgument);
+        }
+        account_index += 1;
+    }
+    Ok(())
 }
 
 #[inline(always)]
@@ -184,7 +210,13 @@ pub fn invoke_signed_fixed<'a, const N: usize>(
     instruction_accounts: &[InstructionAccount<'a>; N],
     handles: &[CpiHandle<'a>; N],
     signer_seeds: &'a [&'a [&'a [u8]]],
-) {
+) -> ProgramResult {
+    for (account, handle) in instruction_accounts.iter().zip(handles.iter()) {
+        if account.is_writable && !handle.is_writable() {
+            return Err(ProgramError::InvalidArgument);
+        }
+    }
+
     let instruction = InstructionView {
         program_id: program,
         data,
@@ -222,4 +254,5 @@ pub fn invoke_signed_fixed<'a, const N: usize>(
             }
         }
     }
+    Ok(())
 }

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -5,7 +5,7 @@ pub use pinocchio::instruction::{InstructionAccount, InstructionView};
 use pinocchio::sysvars::rent::{ACCOUNT_STORAGE_OVERHEAD, DEFAULT_LAMPORTS_PER_BYTE};
 use {
     pinocchio::{account::AccountView, address::Address},
-    solana_program_error::ProgramError,
+    solana_program_error::{ProgramError, ProgramResult},
 };
 
 /// Largest `space` that won't overflow `u64` in the const rent formula.
@@ -15,14 +15,12 @@ const MAX_SAFE_SPACE: u64 = (u64::MAX / DEFAULT_LAMPORTS_PER_BYTE) - ACCOUNT_STO
 
 /// System program `Transfer` instruction discriminant (variant index).
 /// Encoded as `u32 LE` in the first 4 bytes of the instruction data.
-#[cfg(feature = "account-resize")]
 const SYSTEM_TRANSFER_VARIANT: u8 = 2;
 
 // Pin the protocol-mandated discriminant at compile time. Without this,
 // the wire-format Kani harness below would still pass if someone edited
 // `SYSTEM_TRANSFER_VARIANT` (both sides of its byte-equality reference
 // the same constant).
-#[cfg(feature = "account-resize")]
 const _: () = assert!(SYSTEM_TRANSFER_VARIANT == 2);
 
 /// Encode a System program `Transfer` instruction body.
@@ -31,13 +29,59 @@ const _: () = assert!(SYSTEM_TRANSFER_VARIANT == 2);
 /// the real encoder byte-for-byte against the documented wire format. The
 /// encoding is otherwise only reachable through `realloc_account`'s unsafe
 /// CPI path, which Kani cannot model (the CPI syscall is opaque to CBMC).
-#[cfg(feature = "account-resize")]
 #[inline]
+#[cfg_attr(not(target_os = "solana"), allow(dead_code))]
 fn encode_system_transfer(lamports: u64) -> [u8; 12] {
     let mut data = [0u8; 12];
     data[0] = SYSTEM_TRANSFER_VARIANT;
     data[4..12].copy_from_slice(&lamports.to_le_bytes());
     data
+}
+
+/// Transfer lamports through the System program without Pinocchio's borrow
+/// preflight. Used when the recipient's data borrow flag is intentionally held
+/// by a typed wrapper, but the CPI only touches lamports.
+#[inline]
+pub(crate) fn transfer_lamports_unchecked(
+    from: &AccountView,
+    to: &AccountView,
+    lamports: u64,
+) -> ProgramResult {
+    #[cfg(not(target_os = "solana"))]
+    {
+        let new_from = from
+            .lamports()
+            .checked_sub(lamports)
+            .ok_or(ProgramError::InsufficientFunds)?;
+        let new_to = to
+            .lamports()
+            .checked_add(lamports)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+        let mut from_mut = *from;
+        let mut to_mut = *to;
+        from_mut.set_lamports(new_from);
+        to_mut.set_lamports(new_to);
+        return Ok(());
+    }
+
+    #[cfg(target_os = "solana")]
+    unsafe {
+        let ix_data = encode_system_transfer(lamports);
+        let cpi_accounts: [pinocchio::cpi::CpiAccount; 2] = [
+            pinocchio::cpi::CpiAccount::from(from),
+            pinocchio::cpi::CpiAccount::from(to),
+        ];
+        let instruction = pinocchio::instruction::InstructionView {
+            program_id: &pinocchio_system::ID,
+            accounts: &[
+                pinocchio::instruction::InstructionAccount::writable_signer(from.address()),
+                pinocchio::instruction::InstructionAccount::writable(to.address()),
+            ],
+            data: &ix_data,
+        };
+        pinocchio::cpi::invoke_unchecked(&instruction, &cpi_accounts);
+        Ok(())
+    }
 }
 
 /// Compute the rent-exempt minimum balance for an account of `space` bytes.
@@ -507,29 +551,7 @@ pub fn realloc_account(
     if new_space > old_space {
         let deficit = required.saturating_sub(current_lamports);
         if deficit > 0 {
-            // SAFETY: Transfer writes lamports only (via raw pointer, not
-            // through the borrow system). BorshAccount's RefMut guards data
-            // bytes — disjoint region, no aliasing. The unchecked path
-            // bypasses pinocchio's borrow-flag check which would otherwise
-            // reject the CPI while the RefMut is held.
-            let ix_data = encode_system_transfer(deficit);
-            unsafe {
-                let cpi_accounts: [pinocchio::cpi::CpiAccount; 2] = [
-                    pinocchio::cpi::CpiAccount::from(payer),
-                    pinocchio::cpi::CpiAccount::from(&*account as &AccountView),
-                ];
-                let instruction = pinocchio::instruction::InstructionView {
-                    program_id: &pinocchio_system::ID,
-                    accounts: &[
-                        pinocchio::instruction::InstructionAccount::writable_signer(
-                            payer.address(),
-                        ),
-                        pinocchio::instruction::InstructionAccount::writable(account.address()),
-                    ],
-                    data: &ix_data,
-                };
-                pinocchio::cpi::invoke_unchecked(&instruction, &cpi_accounts);
-            }
+            transfer_lamports_unchecked(payer, &*account, deficit)?;
         }
     } else if new_space < old_space {
         let excess = current_lamports.saturating_sub(required);

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -8,6 +8,9 @@ use {
     solana_program_error::{ProgramError, ProgramResult},
 };
 
+const MAX_PDA_SEEDS: usize = solana_address::MAX_SEEDS;
+const MAX_PDA_SEED_LEN: usize = solana_address::MAX_SEED_LEN;
+
 /// Largest `space` that won't overflow `u64` in the const rent formula.
 /// In practice unreachable (Solana caps accounts at 10 MiB).
 #[cfg(feature = "const-rent")]
@@ -22,6 +25,25 @@ const SYSTEM_TRANSFER_VARIANT: u8 = 2;
 // `SYSTEM_TRANSFER_VARIANT` (both sides of its byte-equality reference
 // the same constant).
 const _: () = assert!(SYSTEM_TRANSFER_VARIANT == 2);
+
+#[inline(always)]
+fn validate_pda_create_seeds(seeds: &[&[u8]]) -> Result<(), ProgramError> {
+    if seeds.len() > MAX_PDA_SEEDS {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    if seeds.iter().any(|seed| seed.len() > MAX_PDA_SEED_LEN) {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    Ok(())
+}
+
+#[inline(always)]
+fn validate_pda_find_seeds(seeds: &[&[u8]]) -> Result<(), ProgramError> {
+    if seeds.len() >= MAX_PDA_SEEDS {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    validate_pda_create_seeds(seeds)
+}
 
 /// Encode a System program `Transfer` instruction body.
 ///
@@ -179,9 +201,7 @@ pub fn try_find_program_address(
     seeds: &[&[u8]],
     program_id: &Address,
 ) -> Result<(Address, u8), ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_find_seeds(seeds)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -204,9 +224,7 @@ pub fn find_and_verify_program_address(
     program_id: &Address,
     expected: &Address,
 ) -> Result<u8, ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_find_seeds(seeds)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -241,6 +259,8 @@ pub fn create_program_address(
     seeds: &[&[u8]],
     program_id: &Address,
 ) -> Result<Address, ProgramError> {
+    validate_pda_create_seeds(seeds)?;
+
     #[cfg(target_os = "solana")]
     {
         let computed = hash_pda_seeds(seeds, program_id)?;
@@ -265,6 +285,8 @@ pub fn verify_program_address(
     program_id: &Address,
     expected: &Address,
 ) -> Result<(), ProgramError> {
+    validate_pda_create_seeds(seeds)?;
+
     #[cfg(target_os = "solana")]
     {
         let computed = hash_pda_seeds(seeds, program_id)?;
@@ -300,9 +322,7 @@ pub fn find_and_verify_program_address_skip_curve(
     program_id: &Address,
     expected: &Address,
 ) -> Result<u8, ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_find_seeds(seeds)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -388,10 +408,6 @@ fn check_off_curve(addr: &Address) -> Result<(), ProgramError> {
 fn hash_pda_seeds(seeds: &[&[u8]], program_id: &Address) -> Result<Address, ProgramError> {
     use solana_define_syscall::definitions::sol_sha256;
     const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
-
-    if seeds.len() > 17 {
-        return Err(ProgramError::InvalidSeeds);
-    }
 
     let n = seeds.len();
     let mut slices = core::mem::MaybeUninit::<[&[u8]; 19]>::uninit();
@@ -610,6 +626,44 @@ mod const_rent_tests {
             rent_exempt_lamports(0).unwrap(),
             ACCOUNT_STORAGE_OVERHEAD * DEFAULT_LAMPORTS_PER_BYTE,
         );
+    }
+}
+
+#[cfg(test)]
+mod pda_seed_limit_tests {
+    use super::*;
+
+    const EMPTY: &[u8] = &[];
+
+    #[test]
+    fn find_rejects_seed_count_that_leaves_no_bump_slot() {
+        let program_id = Address::new_from_array([1; 32]);
+        let seeds = [EMPTY; MAX_PDA_SEEDS];
+
+        let err = try_find_program_address(&seeds, &program_id).unwrap_err();
+
+        assert_eq!(err, ProgramError::InvalidSeeds);
+    }
+
+    #[test]
+    fn find_rejects_oversized_seed() {
+        let program_id = Address::new_from_array([1; 32]);
+        let long = [0u8; MAX_PDA_SEED_LEN + 1];
+        let seeds = [long.as_slice()];
+
+        let err = try_find_program_address(&seeds, &program_id).unwrap_err();
+
+        assert_eq!(err, ProgramError::InvalidSeeds);
+    }
+
+    #[test]
+    fn create_rejects_too_many_full_seeds() {
+        let program_id = Address::new_from_array([1; 32]);
+        let seeds = [EMPTY; MAX_PDA_SEEDS + 1];
+
+        let err = create_program_address(&seeds, &program_id).unwrap_err();
+
+        assert_eq!(err, ProgramError::InvalidSeeds);
     }
 }
 

--- a/lang-v2/src/system_program.rs
+++ b/lang-v2/src/system_program.rs
@@ -54,8 +54,7 @@ fn checked_seed(seed: &str) -> Result<&[u8], ProgramError> {
 #[inline]
 fn invoke<'a, T: ToCpiAccounts<'a>>(ctx: &CpiContext<'a, T>, data: &[u8]) -> ProgramResult {
     check_system_program(ctx.program)?;
-    ctx.invoke(data);
-    Ok(())
+    ctx.invoke(data)
 }
 
 pub fn advance_nonce_account<'a>(ctx: CpiContext<'a, AdvanceNonceAccount<'a>>) -> ProgramResult {

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -82,6 +82,12 @@ pub trait ToCpiAccounts<'a> {
 
     /// Collect all CPI handles for the invocation.
     fn to_cpi_handles(&self) -> alloc::vec::Vec<CpiHandle<'a>>;
+
+    /// Validate that the provided CPI handles satisfy the generated account
+    /// metadata. Implemented by generated CPI account structs.
+    fn validate_cpi_accounts(&self) -> ProgramResult {
+        Ok(())
+    }
 }
 
 pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
@@ -277,13 +283,10 @@ impl ToCpiHandle for CpiHandle<'_> {
 impl ToCpiHandleMut for CpiHandle<'_> {
     #[inline(always)]
     fn try_to_cpi_handle_mut(&mut self) -> Result<CpiHandle<'_>, ProgramError> {
-        if !self.account_view().is_writable() {
+        if !self.is_writable() {
             return Err(ProgramError::InvalidArgument);
         }
-        Ok(CpiHandle {
-            view: self.account_view(),
-            writable: true,
-        })
+        Ok(*self)
     }
 }
 

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -58,6 +58,20 @@ fn account_view_converts_to_cpi_handles() {
 }
 
 #[test]
+fn readonly_cpi_handle_cannot_be_upgraded_to_writable() {
+    let buffer = account_view([1; 32], true);
+    let view = unsafe { buffer.view() };
+    let mut readonly = CpiHandle::readonly(&view);
+
+    let err = match readonly.try_to_cpi_handle_mut() {
+        Ok(_) => panic!("read-only CPI handle unexpectedly upgraded to writable"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err, ProgramError::InvalidArgument);
+}
+
+#[test]
 fn checked_invoke_rejects_missing_handle() {
     let ix = instruction(Address::new_from_array([1; 32]), false);
 

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -384,3 +384,25 @@ fn top_up_is_noop_when_account_already_has_enough_lamports() {
     assert_eq!(slab.view().lamports(), required + 123);
     assert_eq!(payer_view.lamports(), 999);
 }
+
+#[test]
+fn top_up_transfers_deficit_from_payer() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let program_id = Address::new_from_array(PROGRAM_ID);
+
+    let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
+    buf.set_lamports(required - 200);
+
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(999);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view, &program_id) }.unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    slab.top_up(&payer_view).unwrap();
+
+    assert_eq!(slab.view().lamports(), required);
+    assert_eq!(payer_view.lamports(), 799);
+}

--- a/spl-v2/src/associated_token.rs
+++ b/spl-v2/src/associated_token.rs
@@ -93,8 +93,7 @@ pub fn create<'a>(ctx: CpiContext<'a, Create<'a>>) -> Result<(), ProgramError> {
         }
     }
     crate::token_shared::validate_token_interface_program(ctx.accounts.token_program.address())?;
-    ctx.invoke(&[0]);
-    Ok(())
+    ctx.invoke(&[0])
 }
 
 pub fn create_idempotent<'a>(
@@ -113,6 +112,5 @@ pub fn create_idempotent<'a>(
         }
     }
     crate::token_shared::validate_token_interface_program(ctx.accounts.token_program.address())?;
-    ctx.invoke(&[1]);
-    Ok(())
+    ctx.invoke(&[1])
 }

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -34,7 +34,20 @@ pub mod caller {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::set_data(cpi_ctx, value);
+        callee::cpi::set_data(cpi_ctx, value)?;
+        Ok(())
+    }
+
+    pub fn proxy_set_data_readonly_handle(
+        ctx: &mut Context<ProxySetData>,
+        value: u64,
+    ) -> Result<()> {
+        let cpi_accounts = callee::cpi::accounts::SetData {
+            data: ctx.accounts.callee_data.cpi_handle(),
+            authority: ctx.accounts.authority.cpi_handle(),
+        };
+        let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
+        callee::cpi::set_data(cpi_ctx, value)?;
         Ok(())
     }
 
@@ -46,7 +59,7 @@ pub mod caller {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::noop(cpi_ctx);
+        callee::cpi::noop(cpi_ctx)?;
         Ok(())
     }
 
@@ -59,7 +72,7 @@ pub mod caller {
             ctx.accounts.callee_program.address(),
             callee::cpi::accounts::Empty::new(),
         );
-        callee::cpi::empty(cpi_ctx);
+        callee::cpi::empty(cpi_ctx)?;
         Ok(())
     }
 
@@ -74,7 +87,7 @@ pub mod caller {
             spectator: ctx.accounts.spectator.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::touch(cpi_ctx, delta);
+        callee::cpi::touch(cpi_ctx, delta)?;
         Ok(())
     }
 }

--- a/tests-v2/programs/declare-program/cpi/src/lib.rs
+++ b/tests-v2/programs/declare-program/cpi/src/lib.rs
@@ -18,8 +18,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.external_program.address(), cpi_accounts);
-        external_cpi::cpi::set_value(cpi_ctx, value);
-        Ok(())
+        external_cpi::cpi::set_value(cpi_ctx, value)
     }
 
     #[discrim = 1]
@@ -32,8 +31,7 @@ pub mod declare_program {
             payer: ctx.accounts.payer.cpi_handle_mut(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.external_program.address(), cpi_accounts);
-        external_cpi::cpi::composite(cpi_ctx, count);
-        Ok(())
+        external_cpi::cpi::composite(cpi_ctx, count)
     }
 
     #[discrim = 2]
@@ -54,8 +52,7 @@ pub mod declare_program {
                 tag,
                 owner: *ctx.accounts.authority.address(),
             },
-        );
-        Ok(())
+        )
     }
 
     #[discrim = 3]
@@ -65,8 +62,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.alt_program.address(), cpi_accounts);
-        alt_cpi::cpi::bump(cpi_ctx, delta);
-        Ok(())
+        alt_cpi::cpi::bump(cpi_ctx, delta)
     }
 
     #[discrim = 4]
@@ -81,8 +77,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.hash_program.address(), cpi_accounts);
-        hash_cpi::cpi::apply(cpi_ctx, delta, flag, marker);
-        Ok(())
+        hash_cpi::cpi::apply(cpi_ctx, delta, flag, marker)
     }
 }
 

--- a/tests-v2/programs/declare-program/optional/src/lib.rs
+++ b/tests-v2/programs/declare-program/optional/src/lib.rs
@@ -20,8 +20,7 @@ pub mod declare_program_optional {
                 .map(|account| account.cpi_handle()),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.optional_program.address(), cpi_accounts);
-        optional_callee::cpi::record(cpi_ctx, value);
-        Ok(())
+        optional_callee::cpi::record(cpi_ctx, value)
     }
 }
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -219,10 +219,10 @@ pub fn build_cpi<'a>(
     program: &'a Address,
     authority: CpiHandle<'a>,
     data: CpiHandle<'a>,
-) {
+) -> anchor_lang_v2::Result<()> {
     let accounts = declared::cpi::accounts::Invoke { authority, data };
     let ctx = CpiContext::new(program, accounts);
-    declared::cpi::invoke(ctx, 5);
+    declared::cpi::invoke(ctx, 5)
 }
 "#,
         &["cpi"],

--- a/tests-v2/tests/cpi.rs
+++ b/tests-v2/tests/cpi.rs
@@ -218,6 +218,37 @@ fn test_cpi_set_data_rejects_wrong_authority() {
     assert_eq!(stored, 77, "value should be unchanged after failed CPI");
 }
 
+#[test]
+fn test_cpi_rejects_readonly_handle_for_writable_account() {
+    let (mut svm, payer) = setup();
+    let authority = keypair_for("authority");
+    svm.airdrop(&authority.pubkey(), 1_000_000_000).unwrap();
+    let data_pda = init_data_account(&mut svm, &payer, &authority);
+
+    let proxy_data = caller::instruction::ProxySetDataReadonlyHandle { value: 999 }.data();
+    let proxy_metas = vec![
+        AccountMeta::new(data_pda, false),
+        AccountMeta::new_readonly(authority.pubkey(), true),
+        AccountMeta::new_readonly(callee_id(), false),
+    ];
+    let result = call_raw(
+        &mut svm,
+        caller_id(),
+        proxy_data,
+        proxy_metas,
+        &payer,
+        &[&authority],
+    );
+    assert!(
+        result.is_err(),
+        "writable CPI account built from cpi_handle() should fail validation"
+    );
+
+    let account = svm.get_account(&data_pda).unwrap();
+    let stored = u64::from_le_bytes(account.data[8..16].try_into().unwrap());
+    assert_eq!(stored, 0, "value should be unchanged after rejected CPI");
+}
+
 /// Drives the no-extra-args branch of the cpi-wrapper codegen
 /// (`callee::cpi::noop`). Also confirms that the `cpi::accounts::SetData`
 /// re-export is reachable through more than one wrapper — i.e. the


### PR DESCRIPTION
## Summary
- reject generated CPI writable account slots backed by read-only CpiHandles
- route Slab::top_up through the unchecked lamport transfer path used by realloc
- validate PDA seed counts and per-seed lengths before create/find paths, and avoid derive-time precompute for invalid literals

## Tests
- cargo test -p anchor-lang-v2 --features testing --test program_invoke readonly_cpi_handle_cannot_be_upgraded_to_writable
- cargo test -p tests-v2 --test cpi test_cpi_rejects_readonly_handle_for_writable_account
- cargo test -p anchor-lang-v2 --features testing --test slab_resize_reproducers top_up_transfers_deficit_from_payer
- cargo test -p anchor-lang-v2 --features testing pda_seed_limit_tests
- cargo test -p anchor-derive-accounts-v2 pda::tests
- cargo test -p tests-v2 --test compile_fail program_interface

Note: left the SerializedAccount deref borrow-lifetime issue out, since it is handled in a separate PR.