### PR TITLE
Pad shrunken serialized account tails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "solana-msg 3.1.0",
  "solana-program-error 3.0.0",
  "solana-program-log",
+ "solana-program-memory 3.1.0",
  "solana-sha256-hasher 3.1.0",
  "solana-system-interface 2.0.0",
  "solana-sysvar 3.1.1",

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -57,6 +57,7 @@ solana-address = { version = "2.0", features = ["bytemuck", "syscalls", "curve25
 solana-instruction = { version = "3", default-features = false }
 solana-program-error = "3.0"
 solana-msg = { version = "3.1", default-features = false, features = ["alloc"] }
+solana-program-memory.workspace = true
 solana-program-log = { version = "1.1", features = ["macro"], optional = true }
 solana-sha256-hasher = { version = "3.1", features = ["sha2"] }
 solana-system-interface = { version = "2.0", features = ["bincode"] }

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -9,6 +9,7 @@ use {
         address::Address,
     },
     solana_program_error::ProgramError,
+    solana_program_memory::sol_memset,
 };
 
 /// Discriminator length in bytes. All `#[account]` types use an 8-byte
@@ -23,7 +24,9 @@ pub(crate) const DISC_LEN: usize = 8;
 /// bounds the impl satisfies.
 ///
 /// Both methods operate on a slice cursor (`&mut &[u8]` / `&mut &mut [u8]`)
-/// so length-prefixed encodings can advance the cursor as they consume bytes.
+/// and must advance it by the bytes they consume. `SerializedAccount` uses
+/// that cursor position to scrub stale bytes when a value serializes shorter
+/// than it did at load time.
 pub trait AnchorAccountSerialize<T> {
     /// Serialize `value` into the buffer past the discriminator.
     fn serialize(value: &T, buf: &mut &mut [u8]) -> Result<(), ProgramError>;
@@ -55,6 +58,7 @@ where
     view: AccountView,
     data: T,
     borrow: SerializedAccountBorrow,
+    serialized_len: usize,
     serialize_on_exit: bool,
     _serializer: PhantomData<S>,
 }
@@ -98,7 +102,12 @@ where
     /// this, `exit()` becomes a no-op until `reacquire_borrow_mut()` is
     /// called. Immutable / already-released borrows skip the commit.
     pub fn release_borrow(&mut self) -> Result<(), ProgramError> {
-        Self::serialize_current_owner(&self.data, &mut self.borrow, self.serialize_on_exit)?;
+        Self::serialize_current_owner(
+            &self.data,
+            &mut self.borrow,
+            &mut self.serialized_len,
+            self.serialize_on_exit,
+        )?;
         self.borrow = SerializedAccountBorrow::Released;
         Ok(())
     }
@@ -110,13 +119,23 @@ where
     fn serialize_current_owner(
         data: &T,
         borrow: &mut SerializedAccountBorrow,
+        serialized_len: &mut usize,
         serialize_on_exit: bool,
     ) -> Result<(), ProgramError> {
         if !serialize_on_exit {
             return Ok(());
         }
         if let SerializedAccountBorrow::Mutable { ref mut guard } = borrow {
-            S::serialize(data, &mut &mut guard[DISC_LEN..])?;
+            let payload_len = guard.len() - DISC_LEN;
+            let mut payload = &mut guard[DISC_LEN..];
+            S::serialize(data, &mut payload)?;
+
+            let new_serialized_len = payload_len - payload.len();
+            let zero_len = serialized_len
+                .saturating_sub(new_serialized_len)
+                .min(payload.len());
+            unsafe { sol_memset(&mut payload[..zero_len], 0, zero_len) };
+            *serialized_len = new_serialized_len;
         }
         Ok(())
     }
@@ -152,7 +171,9 @@ where
             T::DISCRIMINATOR,
             ProgramError::InvalidAccountData
         );
-        self.data = S::deserialize(&mut &data_ref[DISC_LEN..])?;
+        let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[DISC_LEN..])?;
+        self.data = data;
+        self.serialized_len = serialized_len;
         self.serialize_on_exit = Self::should_serialize_for_program(&self.view, program_id);
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
         self.borrow = SerializedAccountBorrow::Mutable { guard };
@@ -186,11 +207,18 @@ where
         Ok(())
     }
 
+    fn deserialize_payload_with_len(payload: &[u8]) -> Result<(T, usize), ProgramError> {
+        let payload_len = payload.len();
+        let mut cursor = payload;
+        let data = S::deserialize(&mut cursor)?;
+        Ok((data, payload_len - cursor.len()))
+    }
+
     fn validate_and_load(
         view: AccountView,
         data: &[u8],
         program_id: &Address,
-    ) -> Result<T, ProgramError> {
+    ) -> Result<(T, usize), ProgramError> {
         // Hot path: a single owner check. The "uninitialized placeholder"
         // disambiguation lives in `cold_owner_error` (slab.rs) — see
         // the comment there for why this is safe.
@@ -206,7 +234,7 @@ where
             T::DISCRIMINATOR,
             ProgramError::InvalidAccountData
         );
-        S::deserialize(&mut &data[DISC_LEN..])
+        Self::deserialize_payload_with_len(&data[DISC_LEN..])
     }
 }
 
@@ -220,7 +248,7 @@ where
 
     fn load(view: AccountView, program_id: &Address) -> Result<Self, ProgramError> {
         let data_ref = view.try_borrow()?;
-        let data = Self::validate_and_load(view, &data_ref, program_id)?;
+        let (data, serialized_len) = Self::validate_and_load(view, &data_ref, program_id)?;
         // SAFETY: AccountView's raw pointer is valid for the entire instruction
         // lifetime (Solana runtime guarantee). We hold the Ref to prevent
         // subsequent mutable borrows on the same account (duplicate detection).
@@ -229,6 +257,7 @@ where
             view,
             data,
             borrow: SerializedAccountBorrow::Immutable { _guard: guard },
+            serialized_len,
             serialize_on_exit: Self::should_serialize_for_program(&view, program_id),
             _serializer: PhantomData,
         })
@@ -249,7 +278,7 @@ where
         }
         let mut view_mut = view;
         let data_ref = view_mut.try_borrow_mut()?;
-        let data = Self::validate_and_load(view, &data_ref, program_id)?;
+        let (data, serialized_len) = Self::validate_and_load(view, &data_ref, program_id)?;
         // SAFETY: Same as load(). RefMut provides exclusive access and prevents
         // any other borrow on the same account.
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
@@ -257,6 +286,7 @@ where
             view,
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
+            serialized_len,
             serialize_on_exit: Self::should_serialize_for_program(&view, program_id),
             _serializer: PhantomData,
         })
@@ -323,7 +353,12 @@ where
             self.borrow = SerializedAccountBorrow::Released;
             self.reacquire_guard_only()?;
         }
-        Self::serialize_current_owner(&self.data, &mut self.borrow, self.serialize_on_exit)?;
+        Self::serialize_current_owner(
+            &self.data,
+            &mut self.borrow,
+            &mut self.serialized_len,
+            self.serialize_on_exit,
+        )?;
         Ok(())
     }
 }
@@ -482,11 +517,12 @@ where
             Some(dst) => *dst = *disc,
             None => return Err(ProgramError::AccountDataTooSmall),
         }
-        let data = S::deserialize(&mut &guard[DISC_LEN..])?;
+        let (data, serialized_len) = Self::deserialize_payload_with_len(&guard[DISC_LEN..])?;
         Ok(Self {
             view: *account,
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
+            serialized_len,
             serialize_on_exit: true,
             _serializer: PhantomData,
         })

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -60,12 +60,31 @@ impl Discriminator for ForeignCounter {
     const DISCRIMINATOR: &'static [u8] = &[0x23, 0xaa, 0x41, 0x17, 0x83, 0x62, 0xdd, 0x09];
 }
 
+#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+struct ShrinkableBytes {
+    items: Vec<u8>,
+}
+
+impl Owner for ShrinkableBytes {
+    fn owner(program_id: &Address) -> Address {
+        *program_id
+    }
+}
+
+impl Discriminator for ShrinkableBytes {
+    const DISCRIMINATOR: &'static [u8] = &[0x5f, 0x81, 0x5c, 0x91, 0xb1, 0x7a, 0x4d, 0xa0];
+}
+
 fn counter_disc() -> [u8; 8] {
     [0xff, 0xb0, 0x04, 0xf5, 0xbc, 0xfd, 0x7c, 0x19]
 }
 
 fn foreign_counter_disc() -> [u8; 8] {
     [0x23, 0xaa, 0x41, 0x17, 0x83, 0x62, 0xdd, 0x09]
+}
+
+fn shrinkable_bytes_disc() -> [u8; 8] {
+    [0x5f, 0x81, 0x5c, 0x91, 0xb1, 0x7a, 0x4d, 0xa0]
 }
 
 fn setup_counter_buf(buf: &mut AccountBuffer<256>, initial_value: u64) {
@@ -86,6 +105,20 @@ fn setup_foreign_counter_buf(buf: &mut AccountBuffer<256>, initial_value: u64) {
     let mut data = [0u8; 16];
     data[..8].copy_from_slice(&foreign_counter_disc());
     data[8..16].copy_from_slice(&initial_value.to_le_bytes());
+    buf.write_data(&data);
+    buf.set_lamports(1_000_000_000);
+}
+
+fn setup_shrinkable_bytes_buf(buf: &mut AccountBuffer<256>, items: &[u8], reserved_tail: &[u8]) {
+    let serialized_len = 4 + items.len();
+    let data_len = 8 + serialized_len + reserved_tail.len();
+    buf.init([0xAA; 32], PROGRAM_ID, data_len, false, true, false);
+
+    let mut data = Vec::with_capacity(data_len);
+    data.extend_from_slice(&shrinkable_bytes_disc());
+    data.extend_from_slice(&(items.len() as u32).to_le_bytes());
+    data.extend_from_slice(items);
+    data.extend_from_slice(reserved_tail);
     buf.write_data(&data);
     buf.set_lamports(1_000_000_000);
 }
@@ -394,6 +427,53 @@ fn release_borrow_commits_in_memory_changes_to_buffer() {
         u64::from_le_bytes(bytes.try_into().unwrap()),
         100,
         "release_borrow must serialize self.data so a subsequent CPI sees the in-memory mutations"
+    );
+}
+
+#[test]
+fn exit_zeroes_bytes_between_new_and_old_serialized_lengths() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_shrinkable_bytes_buf(&mut buf, &[1, 2, 3], &[0xAA, 0xBB]);
+    let program_id = Address::new_from_array(PROGRAM_ID);
+
+    {
+        let view = unsafe { buf.view() };
+        let mut acct =
+            unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view, &program_id) }.unwrap();
+        acct.items = vec![1, 2];
+        acct.exit().unwrap();
+    }
+
+    let data = read_data_bytes(&buf, 0, 17);
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&shrinkable_bytes_disc());
+    expected.extend_from_slice(&2u32.to_le_bytes());
+    expected.extend_from_slice(&[1, 2, 0, 0xAA, 0xBB]);
+    assert_eq!(
+        data, expected,
+        "exit must zero the old serialized tail without clearing reserved account capacity"
+    );
+}
+
+#[test]
+fn release_borrow_zeroes_bytes_between_new_and_old_serialized_lengths() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_shrinkable_bytes_buf(&mut buf, &[1, 2, 3], &[0xAA, 0xBB]);
+    let program_id = Address::new_from_array(PROGRAM_ID);
+
+    let view = unsafe { buf.view() };
+    let mut acct = unsafe { BorshAccount::<ShrinkableBytes>::load_mut(view, &program_id) }.unwrap();
+    acct.items.clear();
+    acct.release_borrow().unwrap();
+
+    let data = read_data_bytes(&buf, 0, 17);
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&shrinkable_bytes_disc());
+    expected.extend_from_slice(&0u32.to_le_bytes());
+    expected.extend_from_slice(&[0, 0, 0, 0xAA, 0xBB]);
+    assert_eq!(
+        data, expected,
+        "release_borrow must commit a shrink with zero padding before any CPI observes the bytes"
     );
 }
 

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -71,11 +71,7 @@ impl Discriminator for Stats {
     const DISCRIMINATOR: &'static [u8] = &STATS_DISC;
 }
 
-/// User-defined codec. Fixed 8-byte LE layout, no length prefix. Does not
-/// advance the cursor — `SerializedAccount` only ever calls these methods
-/// once per load/exit over the full post-discriminator region, so the
-/// cursor-advance contract of the trait is not exercised here. A composing
-/// codec would advance `*buf = &buf[consumed..]`.
+/// User-defined codec. Fixed 8-byte LE layout, no length prefix.
 struct LeCodec;
 
 impl AnchorAccountSerialize<Stats> for LeCodec {
@@ -83,8 +79,11 @@ impl AnchorAccountSerialize<Stats> for LeCodec {
         if buf.len() < 8 {
             return Err(ProgramError::InvalidAccountData);
         }
-        buf[..4].copy_from_slice(&value.count.to_le_bytes());
-        buf[4..8].copy_from_slice(&value.flags.to_le_bytes());
+        let tmp = core::mem::take(buf);
+        let (payload, rest) = tmp.split_at_mut(8);
+        payload[..4].copy_from_slice(&value.count.to_le_bytes());
+        payload[4..8].copy_from_slice(&value.flags.to_le_bytes());
+        *buf = rest;
         Ok(())
     }
 
@@ -92,9 +91,11 @@ impl AnchorAccountSerialize<Stats> for LeCodec {
         if buf.len() < 8 {
             return Err(ProgramError::InvalidAccountData);
         }
+        let (payload, rest) = buf.split_at(8);
+        *buf = rest;
         Ok(Stats {
-            count: u32::from_le_bytes(buf[..4].try_into().unwrap()),
-            flags: u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+            count: u32::from_le_bytes(payload[..4].try_into().unwrap()),
+            flags: u32::from_le_bytes(payload[4..8].try_into().unwrap()),
         })
     }
 }
@@ -229,7 +230,7 @@ fn le_codec_load_rejects_wrong_owner() {
 
 #[test]
 fn le_codec_load_rejects_short_data() {
-    let mut buf = AccountBuffer::<256>::new();
+    let buf = AccountBuffer::<256>::new();
     // Disc-length only, no payload.
     buf.init([0xAA; 32], PROGRAM_ID, 8, false, true, false);
     buf.write_data(&STATS_DISC);
@@ -338,12 +339,21 @@ where
         if buf.len() < bytes.len() {
             return Err(ProgramError::AccountDataTooSmall);
         }
-        buf[..bytes.len()].copy_from_slice(&bytes);
+        let tmp = core::mem::take(buf);
+        let (payload, rest) = tmp.split_at_mut(bytes.len());
+        payload.copy_from_slice(&bytes);
+        *buf = rest;
         Ok(())
     }
 
     fn deserialize(buf: &mut &[u8]) -> Result<T, ProgramError> {
-        wincode::deserialize(*buf).map_err(|_| ProgramError::InvalidAccountData)
+        let value: T = wincode::deserialize(*buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let bytes = wincode::serialize(&value).map_err(|_| ProgramError::InvalidAccountData)?;
+        if buf.len() < bytes.len() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        *buf = &buf[bytes.len()..];
+        Ok(value)
     }
 }
 


### PR DESCRIPTION
## Summary
- track the serialized payload length consumed when SerializedAccount loads or reacquires account data
- zero bytes in the new_len..old_len range after shorter writeback on exit or release_borrow
- update custom codec tests to honor the cursor-advance contract used for shrink-tail scrubbing

## Validation
- cargo test -p anchor-lang-v2 --features testing --test borsh_exit_semantics -- --nocapture
- cargo test -p anchor-lang-v2 --features testing --test serialized_account_custom_codec -- --nocapture
- git diff --check