### PR TITLE
Fix recursive IDL type layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- ts: Guard recursive IDL layouts against stack overflows while preserving supported recursive types ([#4604](https://github.com/solana-foundation/anchor/pull/4604)).
 - idl: Bump version to 0.1.3 ([#4453](https://github.com/solana-foundation/anchor/pull/4453)).
 - lang: Migrate `anchor-syn` from syn 1.x to syn 2.0, allowing use of modern Rust syntax ([#4523](https://github.com/solana-foundation/anchor/issues/4523)).
 - lang: Avoid fatal errors in IDL building when modern Rust syntax is in use ([#4520](https://github.com/solana-foundation/anchor/pull/4520)).

--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -98,6 +98,15 @@ impl<T: Lazy> Lazy for Option<T> {
     }
 }
 
+impl<T: Lazy + Clone> Lazy for Box<T> {
+    const SIZED: bool = T::SIZED;
+
+    #[inline(always)]
+    fn size_of(buf: &[u8]) -> usize {
+        T::size_of(buf)
+    }
+}
+
 impl<T: Lazy> Lazy for Vec<T> {
     const SIZED: bool = false;
 

--- a/lang/tests/serialization.rs
+++ b/lang/tests/serialization.rs
@@ -35,6 +35,95 @@ fn test_instruction_data() {
     );
 }
 
+#[test]
+fn test_recursive_enum_serialization() {
+    #[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+    enum RecursiveNode {
+        Leaf,
+        Branch { children: Vec<RecursiveNode> },
+    }
+
+    let node = RecursiveNode::Branch {
+        children: vec![
+            RecursiveNode::Leaf,
+            RecursiveNode::Branch {
+                children: vec![RecursiveNode::Leaf],
+            },
+        ],
+    };
+    let data = borsh::to_vec(&node).unwrap();
+
+    assert_eq!(RecursiveNode::try_from_slice(&data).unwrap(), node);
+}
+
+#[test]
+fn test_mutually_recursive_enum_serialization() {
+    #[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+    enum A {
+        Leaf,
+        Branch { children: Vec<B> },
+    }
+
+    #[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+    enum B {
+        Leaf,
+        Branch { children: Vec<A> },
+    }
+
+    let a = A::Branch {
+        children: vec![
+            B::Leaf,
+            B::Branch {
+                children: vec![A::Leaf],
+            },
+        ],
+    };
+    let data = borsh::to_vec(&a).unwrap();
+
+    assert_eq!(A::try_from_slice(&data).unwrap(), a);
+}
+
+#[test]
+fn test_option_recursive_enum_serialization() {
+    #[derive(Clone, Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+    enum OptionalNode {
+        Leaf,
+        Branch { child: Option<Box<OptionalNode>> },
+    }
+
+    let node = OptionalNode::Branch {
+        child: Some(Box::new(OptionalNode::Branch {
+            child: Some(Box::new(OptionalNode::Leaf)),
+        })),
+    };
+    let data = borsh::to_vec(&node).unwrap();
+
+    assert_eq!(OptionalNode::try_from_slice(&data).unwrap(), node);
+}
+
+#[test]
+fn test_type_alias_recursive_edge_serialization() {
+    type AliasChildren = Vec<AliasNode>;
+
+    #[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+    enum AliasNode {
+        Leaf,
+        Branch { children: AliasChildren },
+    }
+
+    let node = AliasNode::Branch {
+        children: vec![
+            AliasNode::Leaf,
+            AliasNode::Branch {
+                children: vec![AliasNode::Leaf],
+            },
+        ],
+    };
+    let data = borsh::to_vec(&node).unwrap();
+
+    assert_eq!(AliasNode::try_from_slice(&data).unwrap(), node);
+}
+
 #[cfg(not(feature = "lazy-account"))]
 #[test]
 /// Test for <https://github.com/otter-sec/anchor/issues/4377>;

--- a/ts/packages/anchor/src/coder/borsh/idl.ts
+++ b/ts/packages/anchor/src/coder/borsh/idl.ts
@@ -13,11 +13,70 @@ import { IdlError } from "../../error.js";
 
 type PartialField = { name?: string } & Pick<IdlField, "type">;
 
+const MAX_LAZY_LAYOUT_RECURSION_DEPTH = 256;
+
+class LazyDefinedLayout extends Layout {
+  private static recursionDepth = 0;
+  private resolvedLayout?: Layout;
+
+  constructor(private readonly buildLayout: () => Layout, property?: string) {
+    super(-1, property);
+  }
+
+  private get layout(): Layout {
+    if (!this.resolvedLayout) {
+      this.resolvedLayout = this.buildLayout();
+    }
+    return this.resolvedLayout;
+  }
+
+  private withRecursionGuard<T>(cb: () => T): T {
+    if (LazyDefinedLayout.recursionDepth >= MAX_LAZY_LAYOUT_RECURSION_DEPTH) {
+      throw new IdlError(
+        `Recursive IDL layout exceeded maximum depth: ${this.property}`
+      );
+    }
+
+    LazyDefinedLayout.recursionDepth += 1;
+    try {
+      return cb();
+    } finally {
+      LazyDefinedLayout.recursionDepth -= 1;
+    }
+  }
+
+  decode(b: Buffer, offset?: number) {
+    return this.withRecursionGuard(() => this.layout.decode(b, offset));
+  }
+
+  encode(src: unknown, b: Buffer, offset?: number): number {
+    return this.withRecursionGuard(() => this.layout.encode(src, b, offset));
+  }
+
+  getSpan(b: Buffer, offset?: number): number {
+    return this.withRecursionGuard(() => this.layout.getSpan(b, offset));
+  }
+
+  replicate(name: string): this {
+    return new LazyDefinedLayout(this.buildLayout, name) as this;
+  }
+}
+
 export class IdlCoder {
   public static fieldLayout(
     field: PartialField,
     types: IdlTypeDef[] = [],
     genericArgs?: IdlGenericArg[] | null
+  ): Layout {
+    return IdlCoder.fieldLayoutWithContext(field, types, genericArgs);
+  }
+
+  private static fieldLayoutWithContext(
+    field: PartialField,
+    types: IdlTypeDef[] = [],
+    genericArgs?: IdlGenericArg[] | null,
+    definedTypeStack: string[] = [],
+    allowRecursive = false
   ): Layout {
     const fieldName = field.name;
     switch (field.type) {
@@ -78,17 +137,25 @@ export class IdlCoder {
       default: {
         if ("option" in field.type) {
           return borsh.option(
-            IdlCoder.fieldLayout(
+            IdlCoder.fieldLayoutWithContext(
               { type: field.type.option },
               types,
-              genericArgs
+              genericArgs,
+              definedTypeStack,
+              true
             ),
             fieldName
           );
         }
         if ("vec" in field.type) {
           return borsh.vec(
-            IdlCoder.fieldLayout({ type: field.type.vec }, types, genericArgs),
+            IdlCoder.fieldLayoutWithContext(
+              { type: field.type.vec },
+              types,
+              genericArgs,
+              definedTypeStack,
+              true
+            ),
             fieldName
           );
         }
@@ -97,7 +164,13 @@ export class IdlCoder {
           len = IdlCoder.resolveArrayLen(len, genericArgs);
 
           return borsh.array(
-            IdlCoder.fieldLayout({ type }, types, genericArgs),
+            IdlCoder.fieldLayoutWithContext(
+              { type },
+              types,
+              genericArgs,
+              definedTypeStack,
+              allowRecursive
+            ),
             len,
             fieldName
           );
@@ -113,11 +186,31 @@ export class IdlCoder {
             throw new IdlError(`Type not found: ${field.name}`);
           }
 
-          return IdlCoder.typeDefLayout({
+          const fieldGenericArgs = genericArgs ?? field.type.defined.generics;
+          const layout = () =>
+            IdlCoder.typeDefLayoutWithContext({
+              typeDef,
+              types,
+              genericArgs: fieldGenericArgs,
+              name: fieldName,
+            });
+
+          if (definedTypeStack.includes(definedName)) {
+            if (!allowRecursive) {
+              throw new IdlError(
+                `Recursive type must be wrapped in an option or vector: ${definedName}`
+              );
+            }
+
+            return new LazyDefinedLayout(layout, fieldName);
+          }
+
+          return IdlCoder.typeDefLayoutWithContext({
             typeDef,
             types,
-            genericArgs: genericArgs ?? field.type.defined.generics,
+            genericArgs: fieldGenericArgs,
             name: fieldName,
+            definedTypeStack: [...definedTypeStack, definedName],
           });
         }
         if ("generic" in field.type) {
@@ -126,9 +219,12 @@ export class IdlCoder {
             throw new IdlError(`Invalid generic field: ${field.name}`);
           }
 
-          return IdlCoder.fieldLayout(
+          return IdlCoder.fieldLayoutWithContext(
             { ...field, type: genericArg.type },
-            types
+            types,
+            undefined,
+            definedTypeStack,
+            allowRecursive
           );
         }
 
@@ -153,6 +249,29 @@ export class IdlCoder {
     genericArgs?: IdlGenericArg[] | null;
     name?: string;
   }): Layout {
+    return IdlCoder.typeDefLayoutWithContext({
+      typeDef,
+      types,
+      name,
+      genericArgs,
+    });
+  }
+
+  private static typeDefLayoutWithContext({
+    typeDef,
+    types,
+    name,
+    genericArgs,
+    definedTypeStack,
+  }: {
+    typeDef: IdlTypeDef;
+    types: IdlTypeDef[];
+    genericArgs?: IdlGenericArg[] | null;
+    name?: string;
+    definedTypeStack?: string[];
+  }): Layout {
+    const typeStack = definedTypeStack ?? [typeDef.name];
+
     switch (typeDef.type.kind) {
       case "struct": {
         const fieldLayouts = handleDefinedFields(
@@ -167,7 +286,12 @@ export class IdlCoder {
                     genericArgs,
                   })
                 : genericArgs;
-              return IdlCoder.fieldLayout(f, types, genArgs);
+              return IdlCoder.fieldLayoutWithContext(
+                f,
+                types,
+                genArgs,
+                typeStack
+              );
             }),
           (fields) =>
             fields.map((f, i) => {
@@ -178,10 +302,11 @@ export class IdlCoder {
                     genericArgs,
                   })
                 : genericArgs;
-              return IdlCoder.fieldLayout(
+              return IdlCoder.fieldLayoutWithContext(
                 { name: i.toString(), type: f },
                 types,
-                genArgs
+                genArgs,
+                typeStack
               );
             })
         );
@@ -203,7 +328,12 @@ export class IdlCoder {
                       genericArgs,
                     })
                   : genericArgs;
-                return IdlCoder.fieldLayout(f, types, genArgs);
+                return IdlCoder.fieldLayoutWithContext(
+                  f,
+                  types,
+                  genArgs,
+                  typeStack
+                );
               }),
             (fields) =>
               fields.map((f, i) => {
@@ -214,10 +344,11 @@ export class IdlCoder {
                       genericArgs,
                     })
                   : genericArgs;
-                return IdlCoder.fieldLayout(
+                return IdlCoder.fieldLayoutWithContext(
                   { name: i.toString(), type: f },
                   types,
-                  genArgs
+                  genArgs,
+                  typeStack
                 );
               })
           );
@@ -235,7 +366,12 @@ export class IdlCoder {
       }
 
       case "type": {
-        return IdlCoder.fieldLayout({ type: typeDef.type.alias, name }, types);
+        return IdlCoder.fieldLayoutWithContext(
+          { type: typeDef.type.alias, name },
+          types,
+          genericArgs,
+          typeStack
+        );
       }
     }
   }
@@ -247,6 +383,15 @@ export class IdlCoder {
     ty: IdlType,
     idl: Idl,
     genericArgs?: IdlGenericArg[] | null
+  ): number {
+    return IdlCoder.typeSizeWithContext(ty, idl, genericArgs);
+  }
+
+  private static typeSizeWithContext(
+    ty: IdlType,
+    idl: Idl,
+    genericArgs?: IdlGenericArg[] | null,
+    definedTypeStack: string[] = []
   ): number {
     switch (ty) {
       case "bool":
@@ -287,25 +432,62 @@ export class IdlCoder {
         return 32;
       default:
         if ("option" in ty) {
-          return 1 + IdlCoder.typeSize(ty.option, idl, genericArgs);
+          return (
+            1 +
+            IdlCoder.typeSizeWithContext(
+              ty.option,
+              idl,
+              genericArgs,
+              definedTypeStack
+            )
+          );
         }
         if ("coption" in ty) {
-          return 4 + IdlCoder.typeSize(ty.coption, idl, genericArgs);
+          return (
+            4 +
+            IdlCoder.typeSizeWithContext(
+              ty.coption,
+              idl,
+              genericArgs,
+              definedTypeStack
+            )
+          );
         }
         if ("vec" in ty) {
+          IdlCoder.assertNonRecursiveType(
+            ty.vec,
+            idl,
+            genericArgs,
+            definedTypeStack
+          );
           return 1;
         }
         if ("array" in ty) {
           let [type, len] = ty.array;
           len = IdlCoder.resolveArrayLen(len, genericArgs);
-          return IdlCoder.typeSize(type, idl, genericArgs) * len;
+          return (
+            IdlCoder.typeSizeWithContext(
+              type,
+              idl,
+              genericArgs,
+              definedTypeStack
+            ) * len
+          );
         }
         if ("defined" in ty) {
-          const typeDef = idl.types?.find((t) => t.name === ty.defined.name);
+          const typeName = ty.defined.name;
+          if (definedTypeStack.includes(typeName)) {
+            throw new IdlError(
+              `Recursive types do not have a static size: ${typeName}`
+            );
+          }
+
+          const typeDef = idl.types?.find((t) => t.name === typeName);
           if (!typeDef) {
             throw new IdlError(`Type not found: ${JSON.stringify(ty)}`);
           }
 
+          const typeStack = [...definedTypeStack, typeName];
           const typeSize = (type: IdlType) => {
             const genArgs = genericArgs ?? ty.defined.generics;
             const args = genArgs
@@ -316,7 +498,7 @@ export class IdlCoder {
                 })
               : genArgs;
 
-            return IdlCoder.typeSize(type, idl, args);
+            return IdlCoder.typeSizeWithContext(type, idl, args, typeStack);
           };
 
           switch (typeDef.type.kind) {
@@ -343,7 +525,12 @@ export class IdlCoder {
             }
 
             case "type": {
-              return IdlCoder.typeSize(typeDef.type.alias, idl, genericArgs);
+              return IdlCoder.typeSizeWithContext(
+                typeDef.type.alias,
+                idl,
+                genericArgs,
+                typeStack
+              );
             }
           }
         }
@@ -353,10 +540,122 @@ export class IdlCoder {
             throw new IdlError(`Invalid generic: ${ty.generic}`);
           }
 
-          return IdlCoder.typeSize(genericArg.type, idl, genericArgs);
+          return IdlCoder.typeSizeWithContext(
+            genericArg.type,
+            idl,
+            genericArgs,
+            definedTypeStack
+          );
         }
 
         throw new Error(`Invalid type ${JSON.stringify(ty)}`);
+    }
+  }
+
+  private static assertNonRecursiveType(
+    ty: IdlType,
+    idl: Idl,
+    genericArgs?: IdlGenericArg[] | null,
+    definedTypeStack: string[] = []
+  ): void {
+    if (typeof ty === "string") return;
+
+    if ("option" in ty) {
+      return IdlCoder.assertNonRecursiveType(
+        ty.option,
+        idl,
+        genericArgs,
+        definedTypeStack
+      );
+    }
+    if ("coption" in ty) {
+      return IdlCoder.assertNonRecursiveType(
+        ty.coption,
+        idl,
+        genericArgs,
+        definedTypeStack
+      );
+    }
+    if ("vec" in ty) {
+      return IdlCoder.assertNonRecursiveType(
+        ty.vec,
+        idl,
+        genericArgs,
+        definedTypeStack
+      );
+    }
+    if ("array" in ty) {
+      return IdlCoder.assertNonRecursiveType(
+        ty.array[0],
+        idl,
+        genericArgs,
+        definedTypeStack
+      );
+    }
+    if ("generic" in ty) {
+      const genericArg = genericArgs?.at(0);
+      if (genericArg?.kind !== "type") {
+        return;
+      }
+
+      return IdlCoder.assertNonRecursiveType(
+        genericArg.type,
+        idl,
+        genericArgs,
+        definedTypeStack
+      );
+    }
+    if ("defined" in ty) {
+      const typeName = ty.defined.name;
+      if (definedTypeStack.includes(typeName)) {
+        throw new IdlError(
+          `Recursive types do not have a static size: ${typeName}`
+        );
+      }
+
+      const typeDef = idl.types?.find((t) => t.name === typeName);
+      if (!typeDef) {
+        throw new IdlError(`Type not found: ${JSON.stringify(ty)}`);
+      }
+
+      const typeStack = [...definedTypeStack, typeName];
+      const checkType = (type: IdlType) => {
+        const genArgs = genericArgs ?? ty.defined.generics;
+        const args = genArgs
+          ? IdlCoder.resolveGenericArgs({
+              type,
+              typeDef,
+              genericArgs: genArgs,
+            })
+          : genArgs;
+
+        return IdlCoder.assertNonRecursiveType(type, idl, args, typeStack);
+      };
+
+      switch (typeDef.type.kind) {
+        case "struct": {
+          return handleDefinedFields(
+            typeDef.type.fields,
+            () => undefined,
+            (fields) => fields.forEach((f) => checkType(f.type)),
+            (fields) => fields.forEach((f) => checkType(f))
+          );
+        }
+        case "enum": {
+          typeDef.type.variants.forEach((variant) =>
+            handleDefinedFields(
+              variant.fields,
+              () => undefined,
+              (fields) => fields.forEach((f) => checkType(f.type)),
+              (fields) => fields.forEach((f) => checkType(f))
+            )
+          );
+          return;
+        }
+        case "type": {
+          return checkType(typeDef.type.alias);
+        }
+      }
     }
   }
 

--- a/ts/packages/anchor/tests/coder-types.spec.ts
+++ b/ts/packages/anchor/tests/coder-types.spec.ts
@@ -2,6 +2,68 @@ import * as assert from "assert";
 import { BorshCoder, Idl } from "../src";
 import BN from "bn.js";
 
+function recursiveCoderIdl(
+  typeName: string,
+  types: NonNullable<Idl["types"]>
+): Idl {
+  return {
+    address: "Test111111111111111111111111111111111111111",
+    metadata: {
+      name: "recursive",
+      version: "0.0.0",
+      spec: "0.1.0",
+    },
+    instructions: [
+      {
+        name: "visit",
+        accounts: [],
+        args: [
+          {
+            name: "value",
+            type: {
+              defined: {
+                name: typeName,
+              },
+            },
+          },
+        ],
+        discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+      },
+    ],
+    accounts: [
+      {
+        name: typeName,
+        discriminator: [8, 7, 6, 5, 4, 3, 2, 1],
+      },
+    ],
+    types,
+  };
+}
+
+async function assertRecursiveCoderRoundTrip(
+  idl: Idl,
+  typeName: string,
+  value: unknown,
+  recursiveName = typeName
+) {
+  const coder = new BorshCoder(idl);
+
+  const encodedType = coder.types.encode(typeName, value);
+  assert.deepEqual(coder.types.decode(typeName, encodedType), value);
+
+  const encodedIx = coder.instruction.encode("visit", { value });
+  assert.deepEqual(coder.instruction.decode(encodedIx)?.data, { value });
+
+  const encodedAccount = await coder.accounts.encode(typeName, value);
+  assert.deepEqual(coder.accounts.decode(typeName, encodedAccount), value);
+  assert.throws(
+    () => coder.accounts.size(typeName),
+    new RegExp(`Recursive types do not have a static size: ${recursiveName}`)
+  );
+
+  return coder;
+}
+
 describe("coder.types", () => {
   test("Can encode and decode user-defined types", () => {
     const idl: Idl = {
@@ -95,6 +157,248 @@ describe("coder.types", () => {
     assert.strictEqual(
       coder.types.decode("IntegerTest", encoded).toString(),
       testing.toString()
+    );
+  });
+
+  test("Can encode and decode self-recursive vec user-defined types", async () => {
+    const idl = recursiveCoderIdl("RecursiveNode", [
+      {
+        name: "RecursiveNode",
+        type: {
+          kind: "enum",
+          variants: [
+            {
+              name: "leaf",
+            },
+            {
+              name: "branch",
+              fields: [
+                {
+                  name: "children",
+                  type: {
+                    vec: {
+                      defined: {
+                        name: "RecursiveNode",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    const recursiveNode = {
+      branch: {
+        children: [
+          { leaf: {} },
+          {
+            branch: {
+              children: [{ leaf: {} }],
+            },
+          },
+        ],
+      },
+    };
+
+    await assertRecursiveCoderRoundTrip(idl, "RecursiveNode", recursiveNode);
+  });
+
+  test("Can encode and decode mutually recursive user-defined types", async () => {
+    const idl = recursiveCoderIdl("A", [
+      {
+        name: "A",
+        type: {
+          kind: "enum",
+          variants: [
+            {
+              name: "leaf",
+            },
+            {
+              name: "branch",
+              fields: [
+                {
+                  name: "children",
+                  type: {
+                    vec: {
+                      defined: {
+                        name: "B",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        name: "B",
+        type: {
+          kind: "enum",
+          variants: [
+            {
+              name: "leaf",
+            },
+            {
+              name: "branch",
+              fields: [
+                {
+                  name: "children",
+                  type: {
+                    vec: {
+                      defined: {
+                        name: "A",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    const a = {
+      branch: {
+        children: [
+          { leaf: {} },
+          {
+            branch: {
+              children: [{ leaf: {} }],
+            },
+          },
+        ],
+      },
+    };
+
+    const coder = await assertRecursiveCoderRoundTrip(idl, "A", a);
+    const b = {
+      branch: {
+        children: [{ leaf: {} }],
+      },
+    };
+    const encodedB = coder.types.encode("B", b);
+    assert.deepEqual(coder.types.decode("B", encodedB), b);
+  });
+
+  test("Can encode and decode option-recursive user-defined types", async () => {
+    const idl = recursiveCoderIdl("OptionalNode", [
+      {
+        name: "OptionalNode",
+        type: {
+          kind: "enum",
+          variants: [
+            {
+              name: "leaf",
+            },
+            {
+              name: "branch",
+              fields: [
+                {
+                  name: "child",
+                  type: {
+                    option: {
+                      defined: {
+                        name: "OptionalNode",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    const optionalNode = {
+      branch: {
+        child: {
+          branch: {
+            child: { leaf: {} },
+          },
+        },
+      },
+    };
+
+    await assertRecursiveCoderRoundTrip(idl, "OptionalNode", optionalNode);
+  });
+
+  test("Can encode and decode recursive type aliases", async () => {
+    const idl = recursiveCoderIdl("Tree", [
+      {
+        name: "Tree",
+        type: {
+          kind: "type",
+          alias: {
+            vec: {
+              defined: {
+                name: "Tree",
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const tree = [[], [[]]];
+
+    await assertRecursiveCoderRoundTrip(idl, "Tree", tree);
+  });
+
+  test("Rejects recursive decodes beyond maximum layout depth", () => {
+    const idl = recursiveCoderIdl("Tree", [
+      {
+        name: "Tree",
+        type: {
+          kind: "type",
+          alias: {
+            vec: {
+              defined: {
+                name: "Tree",
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const coder = new BorshCoder(idl);
+    const depth = 300;
+    const data = Buffer.alloc((depth + 1) * 4);
+    for (let i = 0; i < depth; i += 1) {
+      data.writeUInt32LE(1, i * 4);
+    }
+    data.writeUInt32LE(0, depth * 4);
+
+    assert.throws(
+      () => coder.types.decode("Tree", data),
+      /Recursive IDL layout exceeded maximum depth/
+    );
+  });
+
+  test("Rejects unguarded recursive user-defined types", () => {
+    const idl = recursiveCoderIdl("BadNode", [
+      {
+        name: "BadNode",
+        type: {
+          kind: "struct",
+          fields: [
+            {
+              name: "child",
+              type: {
+                defined: {
+                  name: "BadNode",
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    assert.throws(
+      () => new BorshCoder(idl),
+      /Recursive type must be wrapped in an option or vector: BadNode/
     );
   });
 });


### PR DESCRIPTION
## Summary

- Add deferred layout resolution for cyclic IDL `defined` references so recursive types can be encoded and decoded without overflowing layout construction.
- Reject unguarded recursive `defined` edges during layout construction so malicious direct-self IDLs fail fast instead of recursing at encode/decode time.
- Bound lazy recursive layout operations so malicious deeply nested recursive payloads fail with `IdlError` instead of overflowing the JS stack.
- Keep the public `IdlCoder` method signatures unchanged by keeping recursion-tracking state internal.
- Make static account sizing throw for recursive type graphs instead of returning a placeholder size that can under-allocate.
- Add TS regressions covering self-recursion through `Vec`, mutual recursion, recursion through `Option`, and recursive type aliases through the type, instruction, and account coders.
- Add Rust regressions covering the representable recursive serialization shapes: self-recursion through `Vec`, mutual recursion, recursion through `Option<Box<_>>`, and a recursive edge through a type alias.

## Root Cause

`IdlCoder.fieldLayout` eagerly expanded every `defined` type by calling back into `typeDefLayout`. For recursive IDLs such as `RecursiveNode -> Vec<RecursiveNode>`, layout construction re-entered the same type indefinitely before any encode/decode operation could run.

## Validation

- `cargo fmt --all --check`
- `cargo test -p anchor-lang --test serialization`
- `yarn --cwd ts/packages/anchor lint`
- `yarn --cwd ts/packages/anchor jest tests/coder-types.spec.ts --runInBand`
- `yarn --cwd ts/packages/anchor build:node`
- `git diff --check`

Fixes #2087.
