### PR TITLE
cli: Warn if `event-cpi` instruction is unreachable with custom discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli: Bump `cargo_toml` to allow parsing `resolver = "3"` ([#4515](https://github.com/solana-foundation/anchor/pull/4515)).
 - ts: Validate instruction args in `BorshInstructionCoder.encode` to reject typo'd or missing fields instead of silently ignoring them ([#4560](https://github.com/solana-foundation/anchor/pull/4560)).
 - ts: Align TS `camelCase` conversion with Rust `heck` for digit-letter identifiers so generated client names match Rust identifiers ([#4571](https://github.com/solana-foundation/anchor/pull/4571)).
+- cli: Warn if `event-cpi` instruction is unreachable with custom discriminators ([#4614](https://github.com/solana-foundation/anchor/pull/4614)).
 
 ### Breaking
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3324,12 +3324,29 @@ fn generate_idl(
 ) -> Result<Idl> {
     check_idl_build_feature()?;
 
-    anchor_lang_idl::build::IdlBuilder::new()
+    let idl = anchor_lang_idl::build::IdlBuilder::new()
         .resolution(cfg.features.resolution)
         .skip_lint(cfg.features.skip_lint || skip_lint)
         .no_docs(no_docs)
         .cargo_args(cargo_args.into())
-        .build()
+        .build()?;
+
+    // Warn users if there is a potential for a conflict between user-defined discriminators and
+    // hardcoded `event-cpi` discriminator.
+    //
+    // Note: Warn independent of whether the user has the `event-cpi` feature enabled to make sure
+    // there are no potential conflicts in the future if/when the user decides to enable it.
+    idl.instructions
+        .iter()
+        .filter(|ix| anchor_lang::event::EVENT_IX_TAG_LE.starts_with(&ix.discriminator))
+        .for_each(|ix| {
+            eprintln!(
+                "Warning: Instruction conflicts with `event-cpi` instruction discriminator: `{}`",
+                ix.name
+            );
+        });
+
+    Ok(idl)
 }
 
 fn idl_fetch(


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/otter-sec/anchor/issues/4272, user-defined discriminators can make the auto-generated `event-cpi` instruction unreachable.

This is mostly a theoretical issue because the `event-cpi` instruction discriminator starts with `228`, meaning a program would need to have ~228 instructions for this to become an issue in the real world.

IIRC, the reason why I haven't made this a hard error while adding the custom discriminator support was because:

- not a security issue (footgun)
- very unlikely to manifest in the real world
- no simple way to check it directly in `lang`
- didn't want to blindly block using certain discriminators (IDL ixs also had the same problem) if the user didn't have those features enabled (would likely complicate the IDL crate with additional features).

### Summary of changes

Warn during CLI IDL generation when the `event-cpi` instruction is unreachable due to conflicts with the user-defined discriminators.

```
Warning: Instruction conflicts with `event-cpi` instruction discriminator: `<name>`
```

Resolves https://github.com/otter-sec/anchor/issues/4272