### PR TITLE
Fix v2 seeds::program client PDA derivation

### DIFF
--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -591,12 +591,16 @@ fn docs_value(docs: &[String]) -> Value {
 // ---------------------------------------------------------------------------
 
 /// Classified seed expression. Only explicitly recognized shapes carry
-/// structured IDL metadata; unsupported expressions are emitted as opaque
-/// `{"kind":"expr"}` placeholders.
+/// structured IDL metadata; unsupported regular seed expressions are emitted
+/// as opaque `{"kind":"expr"}` placeholders. Program seed expressions can use
+/// the runtime variant because `seeds::program` must evaluate to address bytes.
 #[derive(Clone)]
 pub enum SeedJson {
     /// Pre-serialized JSON object — known at macro time.
     Static(String),
+    /// Token expression evaluating to `alloc::string::String` at IDL-build
+    /// time.
+    Runtime(TokenStream2),
 }
 
 impl SeedJson {
@@ -606,6 +610,7 @@ impl SeedJson {
             SeedJson::Static(s) => quote! {
                 anchor_lang_v2::__alloc::string::String::from(#s)
             },
+            SeedJson::Runtime(ts) => ts,
         }
     }
 }
@@ -633,6 +638,23 @@ impl SeedJson {
 /// expression; this only avoids over-promising IDL/client metadata.
 pub fn classify_seed(expr: &Expr, field_names: &[String], ix_arg_names: &[String]) -> SeedJson {
     classify_seed_inner(expr, field_names, ix_arg_names)
+}
+
+/// Classify `seeds::program = <expr>` into an IDL seed. Unlike arbitrary PDA
+/// seed expressions, this expression is semantically a program id, so opaque
+/// expressions are evaluated during IDL build and emitted as const bytes.
+pub fn classify_program_seed(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> SeedJson {
+    let seed = classify_seed_inner(expr, field_names, ix_arg_names);
+    match seed {
+        SeedJson::Static(ref s) if s == r#"{"kind":"expr"}"# => SeedJson::Runtime(quote! {
+            anchor_lang_v2::idl_build::__idl_const_seed_json(#expr)
+        }),
+        _ => seed,
+    }
 }
 
 fn static_seed(value: Value) -> SeedJson {
@@ -838,6 +860,16 @@ mod tests {
     fn expect_static(seed: SeedJson) -> String {
         match seed {
             SeedJson::Static(s) => s,
+            SeedJson::Runtime(ts) => {
+                panic!("expected Static seed, got Runtime: {}", ts);
+            }
+        }
+    }
+
+    fn expect_runtime(seed: SeedJson) -> String {
+        match seed {
+            SeedJson::Static(s) => panic!("expected Runtime seed, got Static: {s}"),
+            SeedJson::Runtime(ts) => ts.to_string(),
         }
     }
 
@@ -989,6 +1021,19 @@ mod tests {
     fn marker_id_call_is_opaque_expr() {
         let s = expect_static(classify(syn::parse_quote!(System::id()), &[], &[]));
         assert_eq!(s, r#"{"kind":"expr"}"#);
+    }
+
+    #[test]
+    fn program_marker_id_call_flows_through_runtime_const_seed() {
+        let fields = Vec::new();
+        let args = Vec::new();
+        let ts = expect_runtime(classify_program_seed(
+            &syn::parse_quote!(System::id()),
+            &fields,
+            &args,
+        ));
+        assert!(ts.contains("__idl_const_seed_json"), "got: {ts}");
+        assert!(ts.contains("System :: id"), "got: {ts}");
     }
 
     #[test]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1163,6 +1163,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         Program(proc_macro2::TokenStream),
         Pda {
             seed_exprs: Vec<proc_macro2::TokenStream>,
+            program_ref: proc_macro2::TokenStream,
             deps: Vec<String>,
         },
     }
@@ -1203,34 +1204,61 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 // seeds (e.g. `seeds = my_fn()`) are opaque to the
                 // macro and fall through to FieldKind::Required.
                 if let syn::Expr::Array(arr) = seeds_expr {
-                    if attrs.seeds_program.is_none() {
-                        let mut seed_exprs = Vec::new();
-                        let mut deps = Vec::new();
-                        let mut all_derivable = true;
+                    let mut seed_exprs = Vec::new();
+                    let mut deps = Vec::new();
+                    let mut all_derivable = true;
 
-                        for seed in &arr.elems {
-                            if let Some(bytes) = pda::seed_as_const_bytes(seed) {
-                                let lits: Vec<_> = bytes.iter().map(|b| quote! { #b }).collect();
-                                seed_exprs.push(quote! { &[#(#lits),*] as &[u8] });
-                            } else if let Some(ref root) = idl::receiver_root_ident_str(seed) {
-                                if raw_field_names.contains(root) {
-                                    let ident =
-                                        syn::Ident::new(root, proc_macro2::Span::call_site());
-                                    seed_exprs.push(quote! { #ident.as_ref() });
-                                    deps.push(root.clone());
-                                } else {
-                                    all_derivable = false;
-                                    break;
-                                }
+                    for seed in &arr.elems {
+                        if let Some(bytes) = pda::seed_as_const_bytes(seed) {
+                            let lits: Vec<_> = bytes.iter().map(|b| quote! { #b }).collect();
+                            seed_exprs.push(quote! { &[#(#lits),*] as &[u8] });
+                        } else if let Some(ref root) = idl::receiver_root_ident_str(seed) {
+                            if raw_field_names.contains(root) {
+                                let ident = syn::Ident::new(root, proc_macro2::Span::call_site());
+                                seed_exprs.push(quote! { #ident.as_ref() });
+                                deps.push(root.clone());
                             } else {
                                 all_derivable = false;
                                 break;
                             }
+                        } else {
+                            all_derivable = false;
+                            break;
                         }
+                    }
 
-                        if all_derivable {
-                            return (f, FieldKind::Pda { seed_exprs, deps });
+                    let program_ref = match &attrs.seeds_program {
+                        Some(program) => {
+                            if let Some(ref root) = idl::receiver_root_ident_str(program) {
+                                if raw_field_names.contains(root) {
+                                    let ident =
+                                        syn::Ident::new(root, proc_macro2::Span::call_site());
+                                    if !deps.contains(root) {
+                                        deps.push(root.clone());
+                                    }
+                                    quote! { &#ident }
+                                } else if ix_arg_names.contains(root) {
+                                    all_derivable = false;
+                                    quote! {}
+                                } else {
+                                    quote! { &#program }
+                                }
+                            } else {
+                                quote! { &#program }
+                            }
                         }
+                        None => quote! { &#accounts_program_id },
+                    };
+
+                    if all_derivable {
+                        return (
+                            f,
+                            FieldKind::Pda {
+                                seed_exprs,
+                                program_ref,
+                                deps,
+                            },
+                        );
                     }
                 }
             }
@@ -1321,12 +1349,16 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                     };
                     Some(quote! { let #ident = #init; })
                 }
-                FieldKind::Pda { seed_exprs, .. } => {
+                FieldKind::Pda {
+                    seed_exprs,
+                    program_ref,
+                    ..
+                } => {
                     if f.is_optional {
                         Some(quote! {
                             let #ident = {
                                 let (__addr, _) = anchor_lang_v2::find_program_address(
-                                    &[#(#seed_exprs),*], &#accounts_program_id,
+                                    &[#(#seed_exprs),*], #program_ref,
                                 );
                                 Some(__addr)
                             };
@@ -1334,7 +1366,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                     } else {
                         Some(quote! {
                             let (#ident, _) = anchor_lang_v2::find_program_address(
-                                &[#(#seed_exprs),*], &#accounts_program_id,
+                                &[#(#seed_exprs),*], #program_ref,
                             );
                         })
                     }
@@ -1443,11 +1475,31 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 }
             }
 
+            let program_ref = match &attrs.seeds_program {
+                Some(program) => {
+                    if let Some(ref root_name) = idl::receiver_root_ident_str(program) {
+                        if raw_field_names.contains(root_name) || ix_arg_names.contains(root_name) {
+                            let param_ident =
+                                syn::Ident::new(root_name, proc_macro2::Span::call_site());
+                            if seen_params.insert(root_name.clone()) {
+                                params.push(quote! { #param_ident: &anchor_lang_v2::Address });
+                            }
+                            quote! { #param_ident }
+                        } else {
+                            quote! { &#program }
+                        }
+                    } else {
+                        quote! { &#program }
+                    }
+                }
+                None => quote! { &#accounts_program_id },
+            };
+
             Some(quote! {
                 pub fn #fn_name(#(#params),*) -> (anchor_lang_v2::Address, u8) {
                     anchor_lang_v2::find_program_address(
                         &[#(#seed_exprs),*],
-                        &#accounts_program_id,
+                        #program_ref,
                     )
                 }
             })

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1222,7 +1222,7 @@ pub fn parse_field(
             program: attrs
                 .seeds_program
                 .as_ref()
-                .map(|p| crate::idl::classify_seed(p, field_names, ix_arg_names)),
+                .map(|p| crate::idl::classify_program_seed(p, field_names, ix_arg_names)),
         }
     });
     let idl_field_ty: Option<syn::Type> = {

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -184,3 +184,25 @@ where
         T::__register_idl_deps(accounts, types);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Runtime seed-const JSON emission
+// ---------------------------------------------------------------------------
+//
+// Used by the `Accounts` derive for opaque `seeds::program = ...`
+// expressions. The expression is evaluated inside `__idl_accounts()` and
+// emitted as the IDL's `{"kind":"const","value":[...]}` shape.
+pub fn __idl_const_seed_json(value: impl AsRef<[u8]>) -> alloc::string::String {
+    let bytes = value.as_ref();
+    let mut s = alloc::string::String::from(r#"{"kind":"const","value":["#);
+    let mut first = true;
+    for b in bytes {
+        if !first {
+            s.push(',');
+        }
+        first = false;
+        s.push_str(&alloc::format!("{b}"));
+    }
+    s.push_str("]}");
+    s
+}

--- a/tests-v2/programs/client-builders/src/lib.rs
+++ b/tests-v2/programs/client-builders/src/lib.rs
@@ -2,6 +2,9 @@ use anchor_lang_v2::prelude::*;
 
 declare_id!("BF748KR4UhPq7xbhFQYd7yFKmh5UYdqed9GbD6oZvEyu");
 
+pub const OTHER_PROGRAM: Address =
+    anchor_lang_v2::address!("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
 #[account]
 pub struct Vault {
     pub value: u64,
@@ -55,6 +58,11 @@ pub mod client_builders {
         }
         Ok(())
     }
+
+    #[discrim = 5]
+    pub fn check_external_pda(_ctx: &mut Context<CheckExternalPda>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -90,4 +98,10 @@ pub struct OptionalBuilderCase {
     #[account(mut)]
     pub user_state: Option<Account<UserState>>,
     pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct CheckExternalPda {
+    #[account(seeds = [b"external"], bump, seeds::program = OTHER_PROGRAM)]
+    pub external_pda: UncheckedAccount,
 }

--- a/tests-v2/tests/client_builders.rs
+++ b/tests-v2/tests/client_builders.rs
@@ -16,6 +16,12 @@ fn program_id() -> Pubkey {
         .unwrap()
 }
 
+fn other_program() -> Pubkey {
+    "Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u"
+        .parse()
+        .unwrap()
+}
+
 fn setup() -> (LiteSVM, Keypair, Keypair) {
     let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let deploy_dir = test_dir.join("target/deploy");
@@ -55,6 +61,10 @@ fn vault_value(svm: &LiteSVM, vault: Pubkey) -> u64 {
     u64::from_le_bytes(account.data[8..16].try_into().unwrap())
 }
 
+fn external_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"external"], &other_program()).0
+}
+
 #[test]
 fn resolved_builder_derives_pda_program_id_and_sends_instruction() {
     let (mut svm, payer, authority) = setup();
@@ -84,6 +94,21 @@ fn resolved_builder_derives_pda_program_id_and_sends_instruction() {
     let account = svm.get_account(&vault).expect("vault created");
     assert_eq!(account.owner, program_id());
     assert_eq!(account.data[48], bump);
+}
+
+#[test]
+fn seeds_program_override_drives_client_pda_derivation() {
+    let (mut svm, payer, _) = setup();
+    let (external_pda, _) = accounts::CheckExternalPda::find_external_pda_address();
+    let local_pda = Pubkey::find_program_address(&[b"external"], &program_id()).0;
+
+    assert_eq!(external_pda, self::external_pda());
+    assert_ne!(external_pda, local_pda);
+
+    let ix = instruction::CheckExternalPda {}.to_instruction(accounts::CheckExternalPdaResolved {});
+    assert_eq!(ix.accounts[0].pubkey, external_pda);
+
+    send_ix(&mut svm, ix, &payer, &[]).expect("external PDA derived with seeds::program");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- thread `seeds::program` through v2 generated client PDA derivation
- use the override program id in generated `find_<account>_address()` helpers
- add client-builder coverage for both the helper and resolved account metas deriving the external-program PDA
- keep marker `seeds::program = AssociatedToken::id()` IDL output deserializable by emitting the program seed as const address bytes

## Tests

- `cargo test -p tests-v2 --test idl_metadata -- --nocapture`
- `cargo test -p anchor-derive-accounts-v2`
- `cargo test -p tests-v2 --test client_builders -- --nocapture`
- `cargo test -p tests-v2 --test constraints seeds_program_override -- --nocapture`
