### PR TITLE
Fix v2 CPI optional sentinel handles

### DIFF
--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -41,9 +41,9 @@ pub fn invoke_signed<'a, 'seeds>(
     validate_handles(instruction, account_handles)?;
     validate_handle_borrows(instruction, account_handles)?;
 
-    // SAFETY: Validation above proves every instruction account has a matching
-    // handle, writable metas use writable handles, and AccountView borrow state
-    // permits the CPI.
+    // SAFETY: Validation above proves every non-sentinel instruction account
+    // has a matching handle, writable metas use writable handles, and
+    // AccountView borrow state permits the CPI.
     unsafe { invoke_signed_unchecked(instruction, account_handles, signer_seeds) }
 }
 
@@ -75,10 +75,7 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
-    require!(
-        account_handles.len() >= instruction.accounts.len(),
-        ProgramError::NotEnoughAccountKeys
-    );
+    let cpi_account_count = required_cpi_account_count(instruction, account_handles.len())?;
 
     let instruction_accounts = instruction_accounts(instruction);
     let instruction_view = InstructionView {
@@ -97,7 +94,7 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
             &instruction_view,
             from_raw_parts(
                 cpi_accounts.as_ptr() as *const CpiAccount,
-                instruction.accounts.len(),
+                cpi_account_count,
             ),
             &signers,
         );
@@ -110,12 +107,16 @@ pub(crate) fn validate_handles(
     instruction: &Instruction,
     account_handles: &[CpiHandle<'_>],
 ) -> ProgramResult {
-    require!(
-        account_handles.len() >= instruction.accounts.len(),
-        ProgramError::NotEnoughAccountKeys
-    );
+    let mut handle_index = 0;
 
-    for (meta, handle) in instruction.accounts.iter().zip(account_handles) {
+    for meta in &instruction.accounts {
+        if is_optional_account_sentinel(instruction, meta) {
+            continue;
+        }
+
+        let Some(handle) = account_handles.get(handle_index) else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
         require!(
             address_eq(&meta.pubkey, handle.address()),
             ProgramError::InvalidArgument
@@ -124,6 +125,8 @@ pub(crate) fn validate_handles(
         if meta.is_writable {
             require!(handle.is_writable(), ProgramError::InvalidArgument);
         }
+
+        handle_index += 1;
     }
 
     Ok(())
@@ -133,15 +136,49 @@ fn validate_handle_borrows(
     instruction: &Instruction,
     account_handles: &[CpiHandle<'_>],
 ) -> ProgramResult {
-    for (meta, handle) in instruction.accounts.iter().zip(account_handles) {
+    let mut handle_index = 0;
+
+    for meta in &instruction.accounts {
+        if is_optional_account_sentinel(instruction, meta) {
+            continue;
+        }
+
+        let Some(handle) = account_handles.get(handle_index) else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
         if meta.is_writable {
             handle.account_view().check_borrow_mut()?;
         } else {
             handle.account_view().check_borrow()?;
         }
+
+        handle_index += 1;
     }
 
     Ok(())
+}
+
+fn required_cpi_account_count(
+    instruction: &Instruction,
+    handle_count: usize,
+) -> Result<usize, ProgramError> {
+    let count = instruction
+        .accounts
+        .iter()
+        .filter(|meta| !is_optional_account_sentinel(instruction, meta))
+        .count();
+
+    require!(handle_count >= count, ProgramError::NotEnoughAccountKeys);
+
+    Ok(count)
+}
+
+fn is_optional_account_sentinel(
+    instruction: &Instruction,
+    meta: &solana_instruction::AccountMeta,
+) -> bool {
+    !meta.is_writable && !meta.is_signer && address_eq(&meta.pubkey, &instruction.program_id)
 }
 
 fn instruction_accounts(instruction: &Instruction) -> Vec<InstructionAccount<'_>> {

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -12,9 +12,17 @@ use {
     solana_program_error::ProgramError,
 };
 
+const ID: Address = Address::new_from_array([7; 32]);
+
 #[derive(ToCpiAccounts)]
 struct ReadonlyCpi<'a> {
     account: CpiHandle<'a>,
+}
+
+#[derive(ToCpiAccounts)]
+struct OptionalCpi<'a> {
+    account: CpiHandle<'a>,
+    optional: Option<CpiHandle<'a>>,
 }
 
 fn account_view(address: [u8; 32], writable: bool) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
@@ -31,7 +39,7 @@ fn instruction(account: Address, writable: bool) -> Instruction {
     };
 
     Instruction {
-        program_id: Address::new_from_array([7; 32]),
+        program_id: ID,
         accounts: vec![meta],
         data: vec![1, 2, 3],
     }
@@ -72,6 +80,23 @@ fn checked_invoke_rejects_missing_handle() {
 }
 
 #[test]
+fn checked_invoke_accepts_optional_none_program_id_sentinel() {
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let ix = Instruction {
+        program_id: ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*view.address(), false),
+            AccountMeta::new_readonly(ID, false),
+        ],
+        data: vec![],
+    };
+    let handles = [view.to_cpi_handle()];
+
+    program::invoke(&ix, &handles).unwrap();
+}
+
+#[test]
 fn checked_invoke_rejects_address_mismatch() {
     let buffer = account_view([1; 32], false);
     let view = unsafe { buffer.view() };
@@ -97,7 +122,7 @@ fn checked_invoke_rejects_readonly_handle_for_writable_meta() {
 
 #[test]
 fn invoke_ix_rejects_readonly_handle_for_writable_meta() {
-    let program = Address::new_from_array([7; 32]);
+    let program = ID;
     let buffer = account_view([1; 32], true);
     let view = unsafe { buffer.view() };
     let accounts = ReadonlyCpi {
@@ -114,6 +139,52 @@ fn invoke_ix_rejects_readonly_handle_for_writable_meta() {
         .unwrap_err();
 
     assert_eq!(err, ProgramError::InvalidArgument);
+}
+
+#[test]
+fn invoke_ix_accepts_optional_none_program_id_sentinel() {
+    let program = ID;
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let accounts = OptionalCpi {
+        account: view.to_cpi_handle(),
+        optional: None,
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new_readonly(*view.address(), false),
+            AccountMeta::new_readonly(program, false),
+        ],
+        data: vec![],
+    };
+
+    CpiContext::new(&program, accounts).invoke_ix(ix).unwrap();
+}
+
+#[test]
+fn invoke_ix_rejects_writable_program_id_meta_without_handle() {
+    let program = ID;
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let accounts = OptionalCpi {
+        account: view.to_cpi_handle(),
+        optional: None,
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new_readonly(*view.address(), false),
+            AccountMeta::new(program, false),
+        ],
+        data: vec![],
+    };
+
+    let err = CpiContext::new(&program, accounts)
+        .invoke_ix(ix)
+        .unwrap_err();
+
+    assert_eq!(err, ProgramError::NotEnoughAccountKeys);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes v2 CPI invocations that include optional-account `None` slots encoded as the invoked program id.

The root cause was that generated optional CPI accounts emit a readonly program-id sentinel meta but intentionally omit a `CpiHandle` for `None`. `CpiContext::invoke_ix()` validates a fully built `Instruction` through the lower-level program invoke path, which previously required one handle per instruction meta and then passed the full meta count as the CPI account count.

This change treats only readonly, non-signer metas whose pubkey equals the invoked program id as handleless optional sentinels. All other metas still require matching handles in order, and writable program-id metas are not skipped.

## Testing

- `CARGO_TARGET_DIR=/tmp/anchor-cpi-pr-target cargo test -p anchor-lang-v2 --features testing --test program_invoke`
- `CARGO_TARGET_DIR=/tmp/anchor-cpi-pr-target cargo test -p tests-v2 --test declare_program optional::declared_optional_cpi_none_executes_with_program_id_sentinel -- --exact`
