### PR TITLE
Optimize v2 coverage CI steps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,12 +13,15 @@ on:
 
 env:
   SOLANA_VERSION: "3.1.10"
+  SBF_TOOLS_VERSION: "v1.52"
 
 jobs:
   test-v2:
     name: v2 Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/
@@ -27,17 +30,13 @@ jobs:
       # once for the whole job is cheaper than splitting the matrix.
       - uses: ./.github/actions/setup-solana/
 
-      # Split caches: the cargo home (registry/git/installed binaries)
-      # only churns on dep additions, whereas ./target/ churns on any
-      # source change. Keeping them separate means a pure-source PR still
-      # gets a clean registry restore, and restore-keys prefix fallbacks
-      # let Cargo.lock-changing PRs pick up a partial target/ from a
-      # prior run and only rebuild the diff instead of the world.
+      # Cache dependency downloads, but do not cache target directories here:
+      # coverage and debugger runs leave multi-GB artifacts behind, and saving
+      # or restoring those archives costs more than it buys in this job.
       - uses: actions/cache@v4
         name: Cache Cargo home
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -45,39 +44,22 @@ jobs:
           restore-keys: |
             cargo-home-${{ runner.os }}-v2-
 
-      - uses: actions/cache@v4
-        name: Cache cargo target
-        with:
-          path: ./target/
-          # Per-ref primary key so concurrent branches don't clobber each
-          # other's incremental state; restore chain falls back first to
-          # the lockfile-matched cache from any ref, then to any v2 cache.
-          key: cargo-target-${{ runner.os }}-v2-${{ hashFiles('**/Cargo.lock') }}-${{ github.ref_name }}
-          restore-keys: |
-            cargo-target-${{ runner.os }}-v2-${{ hashFiles('**/Cargo.lock') }}-
-            cargo-target-${{ runner.os }}-v2-
-
-      # `bench/` is its own cargo workspace, so its build artifacts live
-      # in `bench/target/` (separate tree from `./target/` above). The
-      # `anchor debugger` smoke step below triggers `cargo build-sbf` +
-      # `cargo test --features profile` for each anchor-v2 program —
-      # all of which write here. Keyed on `bench/Cargo.lock` since that
-      # is the lockfile that gates bench-workspace dep resolution.
-      - uses: actions/cache@v4
-        name: Cache bench cargo target
-        with:
-          path: ./bench/target/
-          key: cargo-target-bench-${{ runner.os }}-v2-${{ hashFiles('bench/Cargo.lock') }}-${{ github.ref_name }}
-          restore-keys: |
-            cargo-target-bench-${{ runner.os }}-v2-${{ hashFiles('bench/Cargo.lock') }}-
-            cargo-target-bench-${{ runner.os }}-v2-
-
       # Install platform-tools up front so the concurrent `cargo build-sbf`
       # invocations fired by parallel test threads don't race on the
-      # one-time extract-then-rename of `~/.cache/solana/v1.52/platform-tools`
-      # (surfaces in CI as `Unable to rename: No such file or directory`).
-      # Version must match `tests-v2/src/lib.rs::build_program`.
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      # one-time extract-then-rename of the platform-tools directory (surfaces
+      # in CI as `Unable to rename: No such file or directory`).
+      # SBF_TOOLS_VERSION must match `tests-v2/src/lib.rs::build_program`.
+      #
+      # Cache the platform-tools directory separately from the Solana tool
+      # suite cache. The Solana cache is keyed by CLI version and may already
+      # be a hit before this directory exists, so it will not save platform
+      # tools that `cargo build-sbf --install-only` downloads later in the job.
+      - uses: actions/cache@v4
+        name: Cache SBF platform tools
+        with:
+          path: ~/.cache/solana/${{ env.SBF_TOOLS_VERSION }}/platform-tools
+          key: solana-platform-tools-${{ runner.os }}-${{ env.SBF_TOOLS_VERSION }}
+      - run: cargo build-sbf --tools-version "$SBF_TOOLS_VERSION" --install-only
 
       # Tools for `make coverage-v2`:
       #   - lcov for merging sbf.lcov + host.lcov and generating the report.
@@ -86,22 +68,33 @@ jobs:
       # The three direct `cargo test -p anchor-{lang,spl}-v2` / `-p tests-v2`
       # invocations that used to live here (including `anchor-lang-v2`'s
       # `--features testing` flag for the Miri-witnesses scaffold) are
-      # subsumed by the `make coverage-v2` call below — the Makefile's
-      # host-coverage step runs the same packages under instrumentation.
-      - run: sudo apt-get install -y lcov
+      # subsumed by the coverage-v2 steps below — the Makefile's host
+      # coverage targets run the same packages under instrumentation.
+      - name: Install lcov
+        run: sudo apt-get install -y --no-install-recommends lcov
       - name: Install cargo-llvm-cov
-        run: |
-          if ! command -v cargo-llvm-cov >/dev/null; then
-            cargo install cargo-llvm-cov --locked
-          fi
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      # `make coverage-v2` runs the same v2 test suites we used to invoke
-      # directly (`cargo test -p anchor-lang-v2 -p anchor-spl-v2 -p tests-v2`)
-      # but under llvm-cov instrumentation, and additionally runs SBF
-      # trace-based coverage via `anchor coverage`. Test pass/fail signal
-      # is preserved — a failing test exits the make invocation non-zero.
-      # The combined LCOV is shipped to Codecov in the step below.
-      - run: make coverage-v2
+      # Run the v2 test suite with coverage enabled, split across the same SBF
+      # and host-side coverage boundaries used by `make coverage-v2`. Each
+      # step still fails on test failure while keeping the slowest package
+      # boundary visible in the Actions UI.
+      - name: v2 SBF runtime coverage
+        run: make coverage-v2-sbf
+      - name: v2 host coverage setup
+        run: make coverage-v2-host-clean
+      - name: v2 host coverage for anchor-lang-v2
+        run: make coverage-v2-host-lang
+      - name: v2 host coverage for anchor-spl-v2
+        run: make coverage-v2-host-spl
+      - name: v2 host coverage for tests-v2
+        run: make coverage-v2-host-tests
+      - name: v2 host coverage for idl-build fixtures
+        run: make coverage-v2-host-idl-build
+      - name: Generate v2 coverage report
+        run: |
+          make coverage-v2-host-report
+          make coverage-v2-report
 
       # Upload to Codecov. The action handles comment posting on PRs via
       # the Codecov GitHub App — including fork PRs, where the token

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ TESTS_V2_COVERAGE_TESTS := \
 TESTS_V2_COVERAGE_ARGS := $(foreach test,$(TESTS_V2_COVERAGE_TESTS),--test $(test))
 
 .PHONY: coverage-v2
-coverage-v2: coverage-v2-sbf coverage-v2-host coverage-v2-merge coverage-v2-html
+coverage-v2:
+	$(MAKE) coverage-v2-sbf
+	$(MAKE) coverage-v2-host
+	$(MAKE) coverage-v2-report
 	@echo ""
 	@echo "Coverage report: $(COVERAGE_HTML)/index.html"
 
@@ -86,12 +89,24 @@ build-anchor-debug:
 # profile flag diff would force a full SBF rebuild).
 .PHONY: coverage-v2-host
 coverage-v2-host:
+	$(MAKE) coverage-v2-host-clean
+	$(MAKE) coverage-v2-host-lang
+	$(MAKE) coverage-v2-host-spl
+	$(MAKE) coverage-v2-host-tests
+	$(MAKE) coverage-v2-host-idl-build
+	$(MAKE) coverage-v2-host-report
+
+.PHONY: coverage-v2-host-clean
+coverage-v2-host-clean:
 	@echo "==> Host-side coverage (derive macros + test harness)"
 	@command -v cargo-llvm-cov >/dev/null || { \
 		echo "cargo-llvm-cov not installed. Run: cargo install cargo-llvm-cov"; \
 		exit 1; \
 	}
 	cargo llvm-cov clean --workspace
+
+.PHONY: coverage-v2-host-lang
+coverage-v2-host-lang:
 	# First pass: `anchor-lang-v2` with its `testing` feature enabled — the
 	# Miri-witnesses integration tests need the `anchor_lang_v2::testing`
 	# scaffold. Split into its own invocation because `testing` is a
@@ -99,15 +114,24 @@ coverage-v2-host:
 	# fail when `anchor-spl-v2` / `tests-v2` don't define it.
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report -p anchor-lang-v2 --features testing
+
+.PHONY: coverage-v2-host-spl
+coverage-v2-host-spl:
 	# Second pass: `anchor-spl-v2` under default features.
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report -p anchor-spl-v2
+
+.PHONY: coverage-v2-host-tests
+coverage-v2-host-tests:
 	# Third pass: the tests-v2 runtime/e2e suite under default features.
 	# Keep compile_fail.rs out of the coverage path: it exercises diagnostics
 	# by repeatedly compiling throwaway fixtures, which is slow and does not
 	# execute framework runtime paths for source coverage.
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report -p tests-v2 $(TESTS_V2_COVERAGE_ARGS)
+
+.PHONY: coverage-v2-host-idl-build
+coverage-v2-host-idl-build:
 	# Fourth pass: the test programs that declare a local `idl-build` feature,
 	# run with `--features idl-build` so the IDL-emission code paths fire —
 	# derive-emitted `IdlAccountType` impls, `__idl_accounts()` /
@@ -121,6 +145,13 @@ coverage-v2-host:
 	CARGO_PROFILE_RELEASE_DEBUG=2 \
 	cargo llvm-cov --no-report --features idl-build \
 		-p constraints -p derives-test -p accounts-test -p spl-test
+
+.PHONY: coverage-v2-host-report
+coverage-v2-host-report:
+	@command -v cargo-llvm-cov >/dev/null || { \
+		echo "cargo-llvm-cov not installed. Run: cargo install cargo-llvm-cov"; \
+		exit 1; \
+	}
 	cargo llvm-cov report \
 		--lcov \
 		--output-path $(COVERAGE_DIR)/host.lcov \
@@ -149,9 +180,21 @@ coverage-v2-host:
 # over-reaching.
 .PHONY: coverage-v2-merge
 coverage-v2-merge: build-anchor-debug $(COVERAGE_DIR)/sbf.lcov $(COVERAGE_DIR)/host.lcov
+	$(MAKE) coverage-v2-merge-existing
+
+.PHONY: coverage-v2-merge-existing
+coverage-v2-merge-existing: build-anchor-debug
 	@echo "==> Merging coverage"
 	@command -v lcov >/dev/null || { \
 		echo "lcov not installed. Run: brew install lcov  (or apt install lcov)"; \
+		exit 1; \
+	}
+	@test -s $(COVERAGE_DIR)/sbf.lcov || { \
+		echo "Missing $(COVERAGE_DIR)/sbf.lcov. Run: make coverage-v2-sbf"; \
+		exit 1; \
+	}
+	@test -s $(COVERAGE_DIR)/host.lcov || { \
+		echo "Missing $(COVERAGE_DIR)/host.lcov. Run: make coverage-v2-host"; \
 		exit 1; \
 	}
 	$(PWD)/target/debug/anchor coverage-filter-host \
@@ -204,9 +247,17 @@ $(COVERAGE_DIR)/host.lcov: coverage-v2-host
 # run don't leak into the tree.
 .PHONY: coverage-v2-html
 coverage-v2-html: $(COVERAGE_DIR)/combined.lcov
+	$(MAKE) coverage-v2-html-existing
+
+.PHONY: coverage-v2-html-existing
+coverage-v2-html-existing:
 	@echo "==> Generating HTML report"
 	@command -v genhtml >/dev/null || { \
 		echo "genhtml not installed (ships with lcov)."; \
+		exit 1; \
+	}
+	@test -s $(COVERAGE_DIR)/combined.lcov || { \
+		echo "Missing $(COVERAGE_DIR)/combined.lcov. Run: make coverage-v2-merge"; \
 		exit 1; \
 	}
 	rm -rf $(COVERAGE_HTML)
@@ -228,6 +279,11 @@ coverage-v2-html: $(COVERAGE_DIR)/combined.lcov
 		--quiet
 
 $(COVERAGE_DIR)/combined.lcov: coverage-v2-merge
+
+.PHONY: coverage-v2-report
+coverage-v2-report:
+	$(MAKE) coverage-v2-merge-existing
+	$(MAKE) coverage-v2-html-existing
 
 .PHONY: coverage-v2-clean
 coverage-v2-clean:


### PR DESCRIPTION
## Summary

- split the v2 coverage CI run into named SBF and host coverage steps
- expose Makefile targets for each host coverage phase while preserving `make coverage-v2`
- install `cargo-llvm-cov` from prebuilt releases via `taiki-e/install-action`
- cache SBF platform-tools independently from the Solana CLI cache
- keep dependency caching, but stop caching the root and bench `target/` trees for this coverage job
- disable Cargo incremental compilation in the v2 CI job to reduce `target/llvm-cov-target` disk pressure
- keep coverage report generation in one workflow step

## Why

Recent successful Tests runs spend roughly a minute installing `cargo-llvm-cov` and another minute in `cargo build-sbf --install-only`. The former was compiling a CI tool from source; the latter can miss caching because the broader Solana cache is keyed by CLI version and may already be a hit before platform-tools are downloaded.

The first optimized revision exposed another issue: restoring the old full `./target/` cache filled the hosted runner disk during `Cache cargo target`. The latest successful run also showed the fresh root target archive was 4.59 GB and the bench target archive was 553 MB, adding about 1m39s of post-job cache upload while preserving the same disk-pressure risk. This revision avoids those target caches entirely for the v2 coverage job.

The follow-up run then reached the `tests-v2` host coverage phase but exhausted disk while writing incremental query-cache files under `target/llvm-cov-target`, so the v2 job now sets `CARGO_INCREMENTAL=0`.

## Validation

- `git diff --check -- .github/workflows/tests.yaml Makefile`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/tests.yaml"); puts "yaml ok"'`
- `make -n coverage-v2`
- `make -n coverage-v2-host`
- `make -n coverage-v2-report`
