### PR TITLE
Reduce v2 CI disk pressure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,6 +81,8 @@ jobs:
       # boundary visible in the Actions UI.
       - name: v2 SBF runtime coverage
         run: make coverage-v2-sbf
+      - name: Prune v2 SBF coverage scratch
+        run: make coverage-v2-sbf-prune
       - name: v2 host coverage setup
         run: make coverage-v2-host-clean
       - name: v2 host coverage for anchor-lang-v2
@@ -88,6 +90,8 @@ jobs:
       - name: v2 host coverage for anchor-spl-v2
         run: make coverage-v2-host-spl
       - name: v2 host coverage for tests-v2
+        env:
+          CARGO_BUILD_JOBS: "1"
         run: make coverage-v2-host-tests
       - name: v2 host coverage for idl-build fixtures
         run: make coverage-v2-host-idl-build

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ coverage-v2-sbf: build-anchor-debug
 		--output $(PWD)/$(COVERAGE_DIR)/sbf.lcov \
 		-- $(TESTS_V2_COVERAGE_ARGS)
 
+.PHONY: coverage-v2-sbf-prune
+coverage-v2-sbf-prune:
+	@echo "==> Pruning SBF coverage scratch artifacts"
+	rm -rf $(COVERAGE_DIR)/traces target/deploy target/sbpf-solana-solana
+	find tests-v2/programs -type d -name target -prune -print0 | xargs -0 rm -rf
+
 # Always invoke cargo (it handles incremental) so the anchor binary picks up
 # any changes to coverage.rs / source_resolver / etc.
 .PHONY: build-anchor-debug


### PR DESCRIPTION
## Summary

- prune SBF coverage traces and SBF build scratch after `sbf.lcov` is generated
- serialize the `tests-v2` host coverage build/link step with `CARGO_BUILD_JOBS=1`

## Why

The `anchor-next` push for #4618 still exhausted runner disk in `v2 Tests`, but after `CARGO_INCREMENTAL=0` had already taken effect. The failure moved to the `tests-v2` host coverage phase while linking instrumented test binaries, with `No space left on device` followed by linker bus errors.

This reduces peak disk usage before that phase and avoids linking several large coverage test binaries concurrently.

## Operational Cleanup

- purged GitHub Actions caches for `refs/heads/anchor-next`
- reduced repository artifact/log retention from 90 days to 7 days

## Validation

- `git diff --check -- .github/workflows/tests.yaml Makefile`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/tests.yaml"); puts "yaml ok"'`
- `make -n coverage-v2-sbf-prune`
- `make -n coverage-v2-host-tests`
