### PR TITLE
tests: Remove redundant config fields

### DIFF
--- a/tests/anchor-cli-account/Anchor.toml
+++ b/tests/anchor-cli-account/Anchor.toml
@@ -7,5 +7,3 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-
-[features]

--- a/tests/anchor-cli-idl/Anchor.toml
+++ b/tests/anchor-cli-idl/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = false
-
 [programs.localnet]
 idl_commands_one = "2uA3amp95zsEHUpo8qnLMhcFAUsiKVEcKHXS1JetFjU5"
 idl_commands_two = "DE4UbHnAcT6Kfh1fVTPRPwpiA3vipmQ4xR3gcLwX3wwS"

--- a/tests/anchor-cli-legacy-idl/Anchor.toml
+++ b/tests/anchor-cli-legacy-idl/Anchor.toml
@@ -14,5 +14,3 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 \"tests/**/*.ts\""
-
-[hooks]

--- a/tests/anchor-cli-legacy-idl/package.json
+++ b/tests/anchor-cli-legacy-idl/package.json
@@ -1,20 +1,16 @@
 {
-  "license": "ISC",
-  "scripts": {
-    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
-    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+  "name": "anchor-cli-legacy-idl",
+  "version": "0.1.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/otter-sec/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/otter-sec/anchor/issues"
   },
-  "dependencies": {
-    "@anchor-lang/core": "^1.0.2"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/otter-sec/anchor.git"
   },
-  "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "^9.0.3",
-    "ts-mocha": "^10.0.0",
-    "@types/bn.js": "^5.1.0",
-    "@types/chai": "^4.3.0",
-    "@types/mocha": "^9.0.0",
-    "typescript": "^5.7.3",
-    "prettier": "^2.6.2"
+  "engines": {
+    "node": ">=17"
   }
 }

--- a/tests/anchor-cli-legacy-idl/programs/anchor-cli-legacy-idl/Cargo.toml
+++ b/tests/anchor-cli-legacy-idl/programs/anchor-cli-legacy-idl/Cargo.toml
@@ -19,10 +19,8 @@ anchor-debug = []
 custom-heap = []
 custom-panic = []
 
-
 [dependencies]
 anchor-lang = { path = "../../../../lang" }
-
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/tests/anchor-cli-legacy-idl/rust-toolchain.toml
+++ b/tests/anchor-cli-legacy-idl/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.89.0"
-components = ["rustfmt","clippy"]
-profile = "minimal"

--- a/tests/anchor-cli-legacy-idl/tsconfig.json
+++ b/tests/anchor-cli-legacy-idl/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "types": ["mocha", "chai"],
-    "typeRoots": ["./node_modules/@types"],
     "lib": ["es2015"],
     "module": "commonjs",
     "target": "es6",

--- a/tests/auction-house/Anchor.toml
+++ b/tests/auction-house/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = true
-
 [programs.localnet]
 auction_house = "hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk"
 

--- a/tests/cashiers-check/Anchor.toml
+++ b/tests/cashiers-check/Anchor.toml
@@ -7,5 +7,3 @@ cashiers_check = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]

--- a/tests/cfo/Anchor.toml
+++ b/tests/cfo/Anchor.toml
@@ -41,5 +41,3 @@ program = "./deps/stake/target/deploy/registry.so"
 [[test.genesis]]
 address = "6ebQNeTPZ1j7k3TtkCCtEPRvG7GQsucQrZ7sSEDQi9Ks"
 program = "./deps/stake/target/deploy/lockup.so"
-
-[features]

--- a/tests/chat/Anchor.toml
+++ b/tests/chat/Anchor.toml
@@ -7,5 +7,3 @@ chat = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]

--- a/tests/cpi-returns/Anchor.toml
+++ b/tests/cpi-returns/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = false
-
 [programs.localnet]
 callee = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 caller = "HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L"

--- a/tests/declare-program/programs/declare-program/Cargo.toml
+++ b/tests/declare-program/programs/declare-program/Cargo.toml
@@ -10,7 +10,6 @@ name = "declare_program"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/declare-program/programs/external/Cargo.toml
+++ b/tests/declare-program/programs/external/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/errors/Anchor.toml
+++ b/tests/errors/Anchor.toml
@@ -9,8 +9,5 @@ multiple-errors = "Mu1tip1eErrors11111111111111111111111111111"
 [scripts]
 test = "yarn run ts-mocha -t 1000000 tests/*.ts"
 
-[features]
-seeds = false
-
 [surfpool]
 block_production_mode = "clock"

--- a/tests/escrow/programs/escrow/Cargo.toml
+++ b/tests/escrow/programs/escrow/Cargo.toml
@@ -10,7 +10,6 @@ name = "escrow"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/events/programs/events/Cargo.toml
+++ b/tests/events/programs/events/Cargo.toml
@@ -10,7 +10,6 @@ name = "events"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/floats/programs/floats/Cargo.toml
+++ b/tests/floats/programs/floats/Cargo.toml
@@ -10,7 +10,6 @@ name = "floats"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/idl/programs/docs/Cargo.toml
+++ b/tests/idl/programs/docs/Cargo.toml
@@ -10,7 +10,6 @@ name = "docs"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/idl/programs/generics/Cargo.toml
+++ b/tests/idl/programs/generics/Cargo.toml
@@ -10,7 +10,6 @@ name = "generics"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 idl-build = ["anchor-lang/idl-build", "external/idl-build"]

--- a/tests/idl/programs/relations-derivation/Cargo.toml
+++ b/tests/idl/programs/relations-derivation/Cargo.toml
@@ -10,7 +10,6 @@ name = "relations_derivation"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 idl-build = ["anchor-lang/idl-build"]
 default = []

--- a/tests/ido-pool/programs/ido-pool/Cargo.toml
+++ b/tests/ido-pool/programs/ido-pool/Cargo.toml
@@ -10,7 +10,6 @@ name = "ido_pool"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/interface-account/programs/interface-account/Cargo.toml
+++ b/tests/interface-account/programs/interface-account/Cargo.toml
@@ -12,7 +12,6 @@ name = "interface_account"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]

--- a/tests/interface-account/programs/new/Cargo.toml
+++ b/tests/interface-account/programs/new/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "lib"]
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]

--- a/tests/interface-account/programs/old/Cargo.toml
+++ b/tests/interface-account/programs/old/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "lib"]
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]

--- a/tests/lazy-account/programs/lazy-account/Cargo.toml
+++ b/tests/lazy-account/programs/lazy-account/Cargo.toml
@@ -12,7 +12,6 @@ name = "lazy_account"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]

--- a/tests/lockup/Anchor.toml
+++ b/tests/lockup/Anchor.toml
@@ -8,5 +8,3 @@ registry = "HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]

--- a/tests/misc/programs/init-if-needed/Cargo.toml
+++ b/tests/misc/programs/init-if-needed/Cargo.toml
@@ -10,7 +10,6 @@ name = "init_if_needed"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/misc/programs/misc-optional/Cargo.toml
+++ b/tests/misc/programs/misc-optional/Cargo.toml
@@ -10,7 +10,6 @@ name = "misc_optional"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/misc/programs/misc/Cargo.toml
+++ b/tests/misc/programs/misc/Cargo.toml
@@ -10,7 +10,6 @@ name = "misc"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/misc/programs/overflow-checks/Cargo.toml
+++ b/tests/misc/programs/overflow-checks/Cargo.toml
@@ -10,7 +10,6 @@ name = "overflow_checks"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/misc/programs/remaining-accounts/Cargo.toml
+++ b/tests/misc/programs/remaining-accounts/Cargo.toml
@@ -10,7 +10,6 @@ name = "remaining_accounts"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/multiple-suites-run-single/Anchor.toml
+++ b/tests/multiple-suites-run-single/Anchor.toml
@@ -1,5 +1,3 @@
-[features]
-seeds = false
 [programs.localnet]
 multiple_suites_run_single = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 

--- a/tests/multiple-suites-run-single/programs/multiple-suites-run-single/Cargo.toml
+++ b/tests/multiple-suites-run-single/programs/multiple-suites-run-single/Cargo.toml
@@ -10,7 +10,6 @@ name = "multiple_suites_run_single"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/multiple-suites/Anchor.toml
+++ b/tests/multiple-suites/Anchor.toml
@@ -1,5 +1,3 @@
-[features]
-seeds = false
 [programs.localnet]
 multiple_suites = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 

--- a/tests/multisig/Anchor.toml
+++ b/tests/multisig/Anchor.toml
@@ -7,5 +7,3 @@ multisig = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]

--- a/tests/multisig/programs/multisig/Cargo.toml
+++ b/tests/multisig/programs/multisig/Cargo.toml
@@ -10,7 +10,6 @@ name = "multisig"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/pda-derivation/Anchor.toml
+++ b/tests/pda-derivation/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = true
-
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/pda-derivation/programs/pda-derivation/Cargo.toml
+++ b/tests/pda-derivation/programs/pda-derivation/Cargo.toml
@@ -10,7 +10,6 @@ name = "pda_derivation"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/pyth/Anchor.toml
+++ b/tests/pyth/Anchor.toml
@@ -7,5 +7,3 @@ pyth = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-
-[features]

--- a/tests/pyth/programs/pyth/Cargo.toml
+++ b/tests/pyth/programs/pyth/Cargo.toml
@@ -10,7 +10,6 @@ name = "pyth"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/realloc/Anchor.toml
+++ b/tests/realloc/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = false
-
 [programs.localnet]
 realloc = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 

--- a/tests/realloc/programs/realloc/Cargo.toml
+++ b/tests/realloc/programs/realloc/Cargo.toml
@@ -10,7 +10,6 @@ name = "realloc"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/relations-derivation/Anchor.toml
+++ b/tests/relations-derivation/Anchor.toml
@@ -1,6 +1,3 @@
-[features]
-seeds = true
-
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"

--- a/tests/relations-derivation/programs/relations-derivation/Cargo.toml
+++ b/tests/relations-derivation/programs/relations-derivation/Cargo.toml
@@ -10,7 +10,6 @@ name = "relations_derivation"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/safety-checks/Anchor.toml
+++ b/tests/safety-checks/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/safety-checks/programs/account-info/Cargo.toml
+++ b/tests/safety-checks/programs/account-info/Cargo.toml
@@ -10,7 +10,6 @@ name = "account_info"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/safety-checks/programs/ignore-non-accounts/Cargo.toml
+++ b/tests/safety-checks/programs/ignore-non-accounts/Cargo.toml
@@ -10,7 +10,6 @@ name = "ignore_non_accounts"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/safety-checks/programs/unchecked-account/Cargo.toml
+++ b/tests/safety-checks/programs/unchecked-account/Cargo.toml
@@ -10,7 +10,6 @@ name = "unchecked_account"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/solana-program-deps/matching/Anchor.toml
+++ b/tests/solana-program-deps/matching/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/solana-program-deps/matching/programs/matching-solana-program/Cargo.toml
+++ b/tests/solana-program-deps/matching/programs/matching-solana-program/Cargo.toml
@@ -10,7 +10,6 @@ name = "matching_solana_program"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/solana-program-deps/mismatched/Anchor.toml
+++ b/tests/solana-program-deps/mismatched/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/solana-program-deps/mismatched/programs/mismatched-solana-program/Cargo.toml
+++ b/tests/solana-program-deps/mismatched/programs/mismatched-solana-program/Cargo.toml
@@ -10,7 +10,6 @@ name = "mismatched_solana_program"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/spl/metadata/programs/metadata/Cargo.toml
+++ b/tests/spl/metadata/programs/metadata/Cargo.toml
@@ -10,7 +10,6 @@ name = "metadata"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/spl/token-extensions/Anchor.toml
+++ b/tests/spl/token-extensions/Anchor.toml
@@ -8,7 +8,5 @@ token_extensions = "tKEkkQtgMXhdaz5NMTR3XbdUu215sZyHSj6Menvous1"
 [scripts]
 test = "yarn run ts-mocha -t 1000000 tests/*.ts"
 
-[features]
-
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"

--- a/tests/spl/token-extensions/programs/token-extensions/Cargo.toml
+++ b/tests/spl/token-extensions/programs/token-extensions/Cargo.toml
@@ -10,7 +10,6 @@ name = "token_extensions"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
+++ b/tests/spl/token-wrapper/programs/token-wrapper/Cargo.toml
@@ -10,7 +10,6 @@ name = "token_wrapper"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
+++ b/tests/spl/transfer-hook/programs/transfer-hook/Cargo.toml
@@ -10,7 +10,6 @@ name = "transfer_hook"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/swap/Anchor.toml
+++ b/tests/swap/Anchor.toml
@@ -11,5 +11,3 @@ program = "prebuilt-programs/openbook_dex.so"
 
 [scripts]
 test = "yarn run mocha -t 1000000 tests/"
-
-[features]

--- a/tests/swap/programs/swap/Cargo.toml
+++ b/tests/swap/programs/swap/Cargo.toml
@@ -10,7 +10,6 @@ name = "swap"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/test-instruction-validation/fail-args-count/Anchor.toml
+++ b/tests/test-instruction-validation/fail-args-count/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/test-instruction-validation/fail-args-count/programs/test-instruction-validation/Cargo.toml
+++ b/tests/test-instruction-validation/fail-args-count/programs/test-instruction-validation/Cargo.toml
@@ -12,7 +12,6 @@ name = "test_instruction_validation"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = ["anchor-lang/anchor-debug"]

--- a/tests/test-instruction-validation/fail-type/Anchor.toml
+++ b/tests/test-instruction-validation/fail-type/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/test-instruction-validation/fail-type/programs/test-instruction-validation/Cargo.toml
+++ b/tests/test-instruction-validation/fail-type/programs/test-instruction-validation/Cargo.toml
@@ -12,7 +12,6 @@ name = "test_instruction_validation"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = ["anchor-lang/anchor-debug"]

--- a/tests/test-instruction-validation/pass-args-count/Anchor.toml
+++ b/tests/test-instruction-validation/pass-args-count/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/test-instruction-validation/pass-args-count/programs/test-instruction-validation/Cargo.toml
+++ b/tests/test-instruction-validation/pass-args-count/programs/test-instruction-validation/Cargo.toml
@@ -12,7 +12,6 @@ name = "test_instruction_validation"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = ["anchor-lang/anchor-debug"]

--- a/tests/test-instruction-validation/pass-type/Anchor.toml
+++ b/tests/test-instruction-validation/pass-type/Anchor.toml
@@ -1,5 +1,3 @@
-[toolchain]
-
 [features]
 resolution = true
 skip-lint = false

--- a/tests/test-instruction-validation/pass-type/programs/test-instruction-validation/Cargo.toml
+++ b/tests/test-instruction-validation/pass-type/programs/test-instruction-validation/Cargo.toml
@@ -12,7 +12,6 @@ name = "test_instruction_validation"
 default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
-
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = ["anchor-lang/anchor-debug"]

--- a/tests/tictactoe/programs/tictactoe/Cargo.toml
+++ b/tests/tictactoe/programs/tictactoe/Cargo.toml
@@ -10,7 +10,6 @@ name = "tictactoe"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]

--- a/tests/typescript/programs/typescript/Cargo.toml
+++ b/tests/typescript/programs/typescript/Cargo.toml
@@ -10,7 +10,6 @@ name = "typescript"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]

--- a/tests/validator-clone/Anchor.toml
+++ b/tests/validator-clone/Anchor.toml
@@ -1,5 +1,3 @@
-[features]
-seeds = false
 [programs.localnet]
 validator_clone = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 

--- a/tests/validator-clone/programs/validator-clone/Cargo.toml
+++ b/tests/validator-clone/programs/validator-clone/Cargo.toml
@@ -10,7 +10,6 @@ name = "validator_clone"
 
 [features]
 no-entrypoint = []
-
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []

--- a/tests/zero-copy/Anchor.toml
+++ b/tests/zero-copy/Anchor.toml
@@ -11,6 +11,3 @@ test = "yarn run mocha -t 1000000 tests/"
 [programs.localnet]
 zero_cpi = "ErjUjtqKE5AGWUsjseSJCVLtddM6rhaMbDqmhzraF9h6"
 zero_copy = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
-
-[features]
-

--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -10,7 +10,6 @@ name = "zero_copy"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 test-sbf = []

--- a/tests/zero-copy/programs/zero-cpi/Cargo.toml
+++ b/tests/zero-copy/programs/zero-cpi/Cargo.toml
@@ -10,7 +10,6 @@ name = "zero_cpi"
 
 [features]
 no-entrypoint = []
-
 cpi = ["no-entrypoint"]
 default = []
 idl-build = ["anchor-lang/idl-build"]


### PR DESCRIPTION
### Problem

Tests configurations include redundant fields, such as `features.seeds`.

### Summary of changes

- Remove the redundant `Anchor.toml` fields
- Remove the extra newlines in `Cargo.toml`s
- In [`anchor-cli-legacy-idl` tests](https://github.com/otter-sec/anchor/tree/31967ec8fe08bcd0e1efd96a7aabfd21404fc7e0/tests/anchor-cli-legacy-idl):
    - Fix redundantly depending on non-workspace dependencies (TS)
    - Remove `rust-toolchain.toml` (as it will require unnecessary syncing in the future)