### PR TITLE
fix(lang): reject invalid migration exits and tighten max_len parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - idl: Bump version to 0.1.3 ([#4453](https://github.com/solana-foundation/anchor/pull/4453)).
 - lang: Migrate `anchor-syn` from syn 1.x to syn 2.0, allowing use of modern Rust syntax ([#4523](https://github.com/solana-foundation/anchor/issues/4523)).
 - lang: Avoid fatal errors in IDL building when modern Rust syntax is in use ([#4520](https://github.com/solana-foundation/anchor/pull/4520)).
+- lang: Return `InvalidProgramId` when `Migration::exit` cannot persist migrated state because `To::owner()` does not match `program_id` ([#4622](https://github.com/otter-sec/anchor/pull/4622)).
 - client: Avoid panic in `parse_logs_response` when a program-emitted log line ends with `invoke [1]` ([#4461](https://github.com/solana-foundation/anchor/issues/4461)).
 - cli: Correctly honor `--skip-seed-phrase-validation` in `keygen recover` ([#4417](https://github.com/solana-foundation/anchor/pull/4417)).
 - spl: Fix wrong owner pubkey in CPI Guard enable/disable ([#4322](https://github.com/solana-foundation/anchor/pull/4322)).

--- a/lang/derive/space/src/lib.rs
+++ b/lang/derive/space/src/lib.rs
@@ -49,63 +49,76 @@ pub fn derive_init_space(item: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let name = input.ident.clone();
 
-    let process_struct_fields = |fields: Punctuated<Field, Comma>| {
-        let recurse = fields.into_iter().map(|f| {
-            let mut max_len_args = get_max_len_args(&f.attrs);
-            len_from_type(f.ty, &mut max_len_args)
-        });
+    let process_struct_fields =
+        |fields: Punctuated<Field, Comma>| -> Result<TokenStream2, syn::Error> {
+            let recurse = fields
+                .into_iter()
+                .map(|f| {
+                    let mut max_len_args = get_max_len_args(&f.attrs)?;
+                    Ok(len_from_type(f.ty, &mut max_len_args))
+                })
+                .collect::<Result<Vec<_>, syn::Error>>()?;
 
-        quote! {
-            #[automatically_derived]
-            impl #impl_generics anchor_lang::Space for #name #ty_generics #where_clause {
-                const INIT_SPACE: usize = 0 #(+ #recurse)*;
-            }
-        }
-    };
-
-    let expanded: TokenStream2 = match input.data {
-        syn::Data::Struct(strct) => match strct.fields {
-            Fields::Named(named) => process_struct_fields(named.named),
-            Fields::Unnamed(unnamed) => process_struct_fields(unnamed.unnamed),
-            Fields::Unit => quote! {
+            Ok(quote! {
                 #[automatically_derived]
                 impl #impl_generics anchor_lang::Space for #name #ty_generics #where_clause {
-                    const INIT_SPACE: usize = 0;
+                    const INIT_SPACE: usize = 0 #(+ #recurse)*;
                 }
+            })
+        };
+
+    let expanded = (|| -> Result<TokenStream2, syn::Error> {
+        match input.data {
+            syn::Data::Struct(strct) => match strct.fields {
+                Fields::Named(named) => process_struct_fields(named.named),
+                Fields::Unnamed(unnamed) => process_struct_fields(unnamed.unnamed),
+                Fields::Unit => Ok(quote! {
+                    #[automatically_derived]
+                    impl #impl_generics anchor_lang::Space for #name #ty_generics #where_clause {
+                        const INIT_SPACE: usize = 0;
+                    }
+                }),
             },
-        },
-        syn::Data::Enum(enm) => {
-            let variants = enm.variants.into_iter().map(|v| {
-                let len = v.fields.into_iter().map(|f| {
-                    let mut max_len_args = get_max_len_args(&f.attrs);
-                    len_from_type(f.ty, &mut max_len_args)
-                });
+            syn::Data::Enum(enm) => {
+                let variants = enm
+                    .variants
+                    .into_iter()
+                    .map(|v| {
+                        let len = v
+                            .fields
+                            .into_iter()
+                            .map(|f| {
+                                let mut max_len_args = get_max_len_args(&f.attrs)?;
+                                Ok(len_from_type(f.ty, &mut max_len_args))
+                            })
+                            .collect::<Result<Vec<_>, syn::Error>>()?;
 
-                quote! {
-                    0 #(+ #len)*
-                }
-            });
+                        Ok(quote! {
+                            0 #(+ #len)*
+                        })
+                    })
+                    .collect::<Result<Vec<_>, syn::Error>>()?;
 
-            let max = gen_max(variants);
+                let max = gen_max(variants.into_iter());
 
-            quote! {
-                #[automatically_derived]
-                impl anchor_lang::Space for #name {
-                    const INIT_SPACE: usize = 1 + #max;
-                }
+                Ok(quote! {
+                    #[automatically_derived]
+                    impl anchor_lang::Space for #name {
+                        const INIT_SPACE: usize = 1 + #max;
+                    }
+                })
             }
-        }
-        _ => {
-            return syn::Error::new(
+            _ => Err(syn::Error::new(
                 input.ident.span(),
                 "#[derive(InitSpace)] is only supported on structs and enums",
-            )
-            .into_compile_error()
-            .into()
+            )),
         }
-    };
+    })();
 
-    TokenStream::from(expanded)
+    TokenStream::from(match expanded {
+        Ok(expanded) => expanded,
+        Err(err) => err.into_compile_error(),
+    })
 }
 
 fn gen_max<T: Iterator<Item = TokenStream2>>(mut iter: T) -> TokenStream2 {
@@ -211,7 +224,7 @@ fn parse_len_arg(item: ParseStream) -> Result<VecDeque<TokenStream2>, syn::Error
             Expr::Lit(ExprLit {
                 lit: Lit::Int(lit_int),
                 ..
-            }) => result.push_back(quote!(#lit_int)),
+            }) => result.push_back(quote!(#lit_int as usize)),
             other => {
                 return Err(syn::Error::new(
                     other.span(),
@@ -224,11 +237,14 @@ fn parse_len_arg(item: ParseStream) -> Result<VecDeque<TokenStream2>, syn::Error
     Ok(result)
 }
 
-fn get_max_len_args(attributes: &[Attribute]) -> Option<VecDeque<TokenStream2>> {
+fn get_max_len_args(
+    attributes: &[Attribute],
+) -> Result<Option<VecDeque<TokenStream2>>, syn::Error> {
     attributes
         .iter()
         .find(|a| a.path().is_ident("max_len"))
-        .and_then(|a| a.parse_args_with(parse_len_arg).ok())
+        .map(|a| a.parse_args_with(parse_len_arg))
+        .transpose()
 }
 
 fn get_next_arg(ident: &Ident, args: &mut Option<VecDeque<TokenStream2>>) -> TokenStream2 {
@@ -251,7 +267,7 @@ mod tests {
     fn parse_len_arg_accepts_int_literals_and_paths() {
         let mut args = parse_len_arg.parse_str("10, module::MAX_LEN").unwrap();
 
-        assert_eq!(args.pop_back().unwrap().to_string(), "10");
+        assert_eq!(args.pop_back().unwrap().to_string(), "10 as usize");
         assert_eq!(
             args.pop_back().unwrap().to_string(),
             "(module :: MAX_LEN as usize)"
@@ -261,6 +277,18 @@ mod tests {
     #[test]
     fn parse_len_arg_rejects_non_integer_literals() {
         let err = parse_len_arg.parse_str("1.5").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "max_len only accepts integer literals, identifiers, or paths"
+        );
+    }
+
+    #[test]
+    fn get_max_len_args_propagates_parse_errors() {
+        let attr = syn::parse_quote!(#[max_len(1.5)]);
+
+        let err = get_max_len_args(&[attr]).unwrap_err();
 
         assert_eq!(
             err.to_string(),

--- a/lang/derive/space/src/lib.rs
+++ b/lang/derive/space/src/lib.rs
@@ -9,8 +9,8 @@ use {
         punctuated::Punctuated,
         spanned::Spanned,
         token::Comma,
-        Attribute, DeriveInput, Expr, Field, Fields, GenericArgument, PathArguments, Token, Type,
-        TypeArray,
+        Attribute, DeriveInput, Expr, ExprLit, Field, Fields, GenericArgument, Lit, PathArguments,
+        Token, Type, TypeArray,
     },
 };
 
@@ -206,13 +206,19 @@ fn parse_len_arg(item: ParseStream) -> Result<VecDeque<TokenStream2>, syn::Error
 
     // Push them in reverse because get_next_arg() pops from the back
     for expr in exprs.into_iter().rev() {
-        if !matches!(expr, Expr::Path(_) | Expr::Lit(_)) {
-            return Err(syn::Error::new(
-                expr.span(),
-                "max_len only accepts identifiers, literals, or paths",
-            ));
+        match expr {
+            Expr::Path(path) => result.push_back(quote!((#path as usize))),
+            Expr::Lit(ExprLit {
+                lit: Lit::Int(lit_int),
+                ..
+            }) => result.push_back(quote!(#lit_int)),
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "max_len only accepts integer literals, identifiers, or paths",
+                ))
+            }
         }
-        result.push_back(quote!((#expr as usize)));
     }
 
     Ok(result)
@@ -234,5 +240,31 @@ fn get_next_arg(ident: &Ident, args: &mut Option<VecDeque<TokenStream2>>) -> Tok
         }
     } else {
         quote_spanned!(ident.span() => compile_error!("Expected max_len attribute."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, syn::parse::Parser};
+
+    #[test]
+    fn parse_len_arg_accepts_int_literals_and_paths() {
+        let mut args = parse_len_arg.parse_str("10, module::MAX_LEN").unwrap();
+
+        assert_eq!(args.pop_back().unwrap().to_string(), "10");
+        assert_eq!(
+            args.pop_back().unwrap().to_string(),
+            "(module :: MAX_LEN as usize)"
+        );
+    }
+
+    #[test]
+    fn parse_len_arg_rejects_non_integer_literals() {
+        let err = parse_len_arg.parse_str("1.5").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "max_len only accepts integer literals, identifiers, or paths"
+        );
     }
 }

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -373,7 +373,8 @@ where
                 // Only persist if the owner is the current program
                 let expected_owner = To::owner();
                 if &expected_owner != program_id {
-                    return Ok(());
+                    return Err(Error::from(ErrorCode::InvalidProgramId)
+                        .with_pubkeys((*program_id, expected_owner)));
                 }
 
                 // Serialize the migrated data
@@ -481,6 +482,7 @@ mod tests {
     const TEST_DISCRIMINATOR_V1: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     const TEST_DISCRIMINATOR_V2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
     const TEST_OWNER: Pubkey = Pubkey::new_from_array([1u8; 32]);
+    const TEST_OTHER_OWNER: Pubkey = Pubkey::new_from_array([2u8; 32]);
 
     #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, PartialEq)]
     struct AccountV1 {
@@ -541,6 +543,26 @@ mod tests {
     }
 
     impl AccountSerialize for AccountV2 {
+        fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
+            writer.write_all(&TEST_DISCRIMINATOR_V2)?;
+            AnchorSerialize::serialize(self, writer)?;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, PartialEq)]
+    struct AccountV2OtherOwner {
+        pub data: u64,
+        pub new_field: u64,
+    }
+
+    impl Owner for AccountV2OtherOwner {
+        fn owner() -> Pubkey {
+            TEST_OTHER_OWNER
+        }
+    }
+
+    impl AccountSerialize for AccountV2OtherOwner {
         fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
             writer.write_all(&TEST_DISCRIMINATOR_V2)?;
             AnchorSerialize::serialize(self, writer)?;
@@ -858,5 +880,40 @@ mod tests {
         let result: Result<Migration<AccountV1, AccountV2>> = Migration::try_from(&info);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_exit_fails_when_migrated_owner_does_not_match_program_id() {
+        let key = Pubkey::default();
+        let mut lamports = 100;
+        let v1 = AccountV1 { data: 42 };
+        let mut data = vec![0u8; 100];
+        data[..8].copy_from_slice(&TEST_DISCRIMINATOR_V1);
+        v1.serialize(&mut &mut data[8..]).unwrap();
+
+        let info = create_account_info(&key, &TEST_OWNER, &mut lamports, &mut data);
+        let mut migration: Migration<AccountV1, AccountV2OtherOwner> =
+            Migration::try_from(&info).unwrap();
+
+        migration
+            .migrate(AccountV2OtherOwner {
+                data: 42,
+                new_field: 100,
+            })
+            .unwrap();
+
+        let err = migration
+            .exit(&TEST_OWNER)
+            .expect_err("exit must fail when migrated data cannot be persisted");
+        match err {
+            Error::AnchorError(e) => {
+                assert_eq!(e.error_code_number, ErrorCode::InvalidProgramId as u32);
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+
+        let mut persisted_data: &[u8] = &info.try_borrow_data().unwrap();
+        let persisted = AccountV1::try_deserialize(&mut persisted_data).unwrap();
+        assert_eq!(persisted.data, 42);
     }
 }


### PR DESCRIPTION
Audit V1.1 Suggestions: 

- `Migration::exit()` now errors with `InvalidProgramId` instead of returning `Ok(())` when `To::owner()` doesn’t match `program_id`, and 
- `parse_len_arg()` now only accepts integer literals plus identifiers/paths, so floats no longer slip through.