### PR TITLE
fix(lang): snapshot CPI return data for Return::get()

### DIFF
--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -55,7 +55,13 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
                 let ty = convert_idl_type_to_syn_type(ty);
                 (
                     quote! { anchor_lang::Result<Return::<#ty>> },
-                    quote! { Ok(Return::<#ty> { phantom: std::marker::PhantomData, program_id: ctx.program_id }) },
+                    quote! {
+                        Ok(Return::<#ty> {
+                            phantom: std::marker::PhantomData,
+                            program_id: ctx.program_id,
+                            return_data: anchor_lang::__private::CpiReturnData::snapshot(),
+                        })
+                    },
                 )
             },
             None => (
@@ -108,16 +114,12 @@ fn gen_cpi_return_type() -> proc_macro2::TokenStream {
         pub struct Return<T> {
             phantom: std::marker::PhantomData<T>,
             program_id: anchor_lang::solana_program::pubkey::Pubkey,
+            return_data: anchor_lang::__private::CpiReturnData,
         }
 
         impl<T: AnchorDeserialize> Return<T> {
             pub fn get(&self) -> T {
-                let (key, data) = anchor_lang::solana_program::program::get_return_data().unwrap();
-                if key != self.program_id {
-                    anchor_lang::solana_program::log::sol_log("CPI return data program_id mismatch");
-                    panic!();
-                }
-                T::try_from_slice(&data).unwrap()
+                self.return_data.get(self.program_id)
             }
 
             /// Read return data without validating the program_id.

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -653,6 +653,56 @@ pub mod __private {
     pub trait IsSameType<T> {}
 
     impl<T> IsSameType<T> for T {}
+
+    #[doc(hidden)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct CpiReturnData {
+        program_id: Option<Pubkey>,
+        data_len: usize,
+        data: [u8; crate::solana_program::program::MAX_RETURN_DATA],
+    }
+
+    impl CpiReturnData {
+        #[doc(hidden)]
+        pub fn new(return_data: Option<(Pubkey, Vec<u8>)>) -> Self {
+            let mut snapshot = Self {
+                program_id: None,
+                data_len: 0,
+                data: [0u8; crate::solana_program::program::MAX_RETURN_DATA],
+            };
+
+            if let Some((program_id, data)) = return_data {
+                let data_len = data.len();
+                snapshot.data[..data_len].copy_from_slice(&data);
+                snapshot.program_id = Some(program_id);
+                snapshot.data_len = data_len;
+            }
+
+            snapshot
+        }
+
+        #[doc(hidden)]
+        pub fn snapshot() -> Self {
+            Self::new(crate::solana_program::program::get_return_data())
+        }
+
+        #[doc(hidden)]
+        pub fn get<T: crate::AnchorDeserialize>(&self, expected_program_id: Pubkey) -> T {
+            let program_id = self.program_id.unwrap();
+            if program_id != expected_program_id {
+                crate::solana_program::log::sol_log("CPI return data program_id mismatch");
+                panic!();
+            }
+
+            T::try_from_slice(&self.data[..self.data_len]).unwrap()
+        }
+
+        #[doc(hidden)]
+        pub fn return_data(&self) -> Option<(Pubkey, &[u8])> {
+            self.program_id
+                .map(|program_id| (program_id, &self.data[..self.data_len]))
+        }
+    }
 }
 
 /// Ensures a condition is true, otherwise returns with the given error.

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -40,7 +40,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     "()" => (quote! {anchor_lang::Result<()> }, quote! { Ok(()) }),
                     _ => (
                         quote! { anchor_lang::Result<crate::cpi::Return::<#ret_type>> },
-                        quote! { Ok(crate::cpi::Return::<#ret_type> { phantom: crate::cpi::PhantomData, program_id: ctx.program_id }) }
+                        quote! {
+                            Ok(crate::cpi::Return::<#ret_type> {
+                                phantom: crate::cpi::PhantomData,
+                                program_id: ctx.program_id,
+                                return_data: anchor_lang::__private::CpiReturnData::snapshot(),
+                            })
+                        }
                     )
                 };
 
@@ -94,16 +100,12 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             pub struct Return<T> {
                 phantom: std::marker::PhantomData<T>,
                 program_id: anchor_lang::solana_program::pubkey::Pubkey,
+                return_data: anchor_lang::__private::CpiReturnData,
             }
 
             impl<T: AnchorDeserialize> Return<T> {
                 pub fn get(&self) -> T {
-                    let (key, data) = anchor_lang::solana_program::program::get_return_data().unwrap();
-                    if key != self.program_id {
-                        anchor_lang::solana_program::log::sol_log("CPI return data program_id mismatch");
-                        panic!();
-                    }
-                    T::try_from_slice(&data).unwrap()
+                    self.return_data.get(self.program_id)
                 }
 
                 /// Read return data without validating the program_id.

--- a/lang/tests/cpi_return_data.rs
+++ b/lang/tests/cpi_return_data.rs
@@ -1,0 +1,35 @@
+use anchor_lang::{__private::CpiReturnData, solana_program::pubkey::Pubkey};
+
+#[test]
+fn test_cpi_return_data_snapshot_keeps_original_bytes() {
+    let program_id = Pubkey::new_unique();
+    let original = 10u64;
+    let original_bytes = borsh::to_vec(&original).unwrap();
+    let snapshot = CpiReturnData::new(Some((program_id, original_bytes.clone())));
+
+    let spoofed = 999u64;
+    let spoofed_bytes = borsh::to_vec(&spoofed).unwrap();
+    let later = CpiReturnData::new(Some((program_id, spoofed_bytes.clone())));
+
+    let (snapshot_program_id, snapshot_bytes) = snapshot.return_data().unwrap();
+    assert_eq!(snapshot_program_id, program_id);
+    assert_eq!(snapshot_bytes, original_bytes.as_slice());
+
+    let (later_program_id, later_bytes) = later.return_data().unwrap();
+    assert_eq!(later_program_id, program_id);
+    assert_eq!(later_bytes, spoofed_bytes.as_slice());
+
+    assert_eq!(snapshot.get::<u64>(program_id), original);
+    assert_eq!(later.get::<u64>(program_id), spoofed);
+}
+
+#[test]
+#[should_panic]
+fn test_cpi_return_data_snapshot_rejects_program_id_mismatch() {
+    let program_id = Pubkey::new_unique();
+    let other_program_id = Pubkey::new_unique();
+    let value = 10u64;
+    let snapshot = CpiReturnData::new(Some((other_program_id, borsh::to_vec(&value).unwrap())));
+
+    let _ = snapshot.get::<u64>(program_id);
+}

--- a/tests/cpi-returns/programs/callee/src/lib.rs
+++ b/tests/cpi-returns/programs/callee/src/lib.rs
@@ -21,6 +21,10 @@ pub mod callee {
         Ok(10)
     }
 
+    pub fn return_u64_spoofed(_ctx: Context<CpiReturn>) -> Result<u64> {
+        Ok(999)
+    }
+
     pub fn return_struct(_ctx: Context<CpiReturn>) -> Result<StructReturn> {
         let s = StructReturn { value: 11 };
         Ok(s)

--- a/tests/cpi-returns/programs/caller/src/lib.rs
+++ b/tests/cpi-returns/programs/caller/src/lib.rs
@@ -29,9 +29,7 @@ pub mod caller {
         Ok(())
     }
 
-    pub fn cpi_call_return_u64_same_program_spoofed(
-        ctx: Context<CpiReturnContext>,
-    ) -> Result<()> {
+    pub fn cpi_call_return_u64_same_program_spoofed(ctx: Context<CpiReturnContext>) -> Result<()> {
         let cpi_program_id = ctx.accounts.cpi_return_program.key();
         let cpi_accounts = CpiReturn {
             account: ctx.accounts.cpi_return.to_account_info(),
@@ -119,12 +117,14 @@ pub mod caller {
         Ok(())
     }
 
-    /// PoC: Demonstrates that get() (with fix) REJECTS spoofed return data.
+    /// Demonstrates that get() (with fix) preserves the original return data
+    /// even if a later CPI from a different program overwrites the global
+    /// return-data slot.
     ///
     /// Same flow as above, but uses get() instead of get_unchecked().
-    /// This will panic because the program_id from get_return_data() doesn't
-    /// match the expected callee program_id.
-    pub fn cpi_call_return_u64_spoofed_rejected(ctx: Context<SpoofedReturnContext>) -> Result<()> {
+    /// Because get() now reads the snapshot captured immediately after the
+    /// callee CPI returns, the later malicious overwrite is ignored.
+    pub fn cpi_call_return_u64_spoofed_preserved(ctx: Context<SpoofedReturnContext>) -> Result<()> {
         // Step 1: CPI to callee, which returns u64 = 10
         let cpi_program_id = ctx.accounts.cpi_return_program.key();
         let cpi_accounts = CpiReturn {
@@ -141,9 +141,10 @@ pub mod caller {
         let spoof_ctx = CpiContext::new(malicious_program_id, spoof_accounts);
         malicious::cpi::spoof_return_data(spoof_ctx)?;
 
-        // Step 3: Use get() (FIXED) — this validates program_id and will PANIC
-        // because return data was set by malicious, not callee.
-        let _value = result.get();
+        // Step 3: Use get() (FIXED) — this reads the invoke-time snapshot, not
+        // the current global return-data slot.
+        let value = result.get();
+        anchor_lang::solana_program::log::sol_log_data(&[&borsh::to_vec(&value).unwrap()]);
 
         Ok(())
     }

--- a/tests/cpi-returns/programs/caller/src/lib.rs
+++ b/tests/cpi-returns/programs/caller/src/lib.rs
@@ -29,6 +29,27 @@ pub mod caller {
         Ok(())
     }
 
+    pub fn cpi_call_return_u64_same_program_spoofed(
+        ctx: Context<CpiReturnContext>,
+    ) -> Result<()> {
+        let cpi_program_id = ctx.accounts.cpi_return_program.key();
+        let cpi_accounts = CpiReturn {
+            account: ctx.accounts.cpi_return.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(cpi_program_id, cpi_accounts);
+        let result = callee::cpi::return_u64(cpi_ctx)?;
+
+        let spoof_accounts = CpiReturn {
+            account: ctx.accounts.cpi_return.to_account_info(),
+        };
+        let spoof_ctx = CpiContext::new(cpi_program_id, spoof_accounts);
+        callee::cpi::return_u64_spoofed(spoof_ctx)?;
+
+        let solana_return = result.get();
+        anchor_lang::solana_program::log::sol_log_data(&[&borsh::to_vec(&solana_return).unwrap()]);
+        Ok(())
+    }
+
     pub fn cpi_call_return_struct(ctx: Context<CpiReturnContext>) -> Result<()> {
         let cpi_program_id = ctx.accounts.cpi_return_program.key();
         let cpi_accounts = CpiReturn {

--- a/tests/cpi-returns/tests/cpi-return.ts
+++ b/tests/cpi-returns/tests/cpi-return.ts
@@ -321,4 +321,36 @@ describe("CPI return", () => {
       console.log(`    Error: ${e.message?.substring(0, 100)}...\n`);
     }
   });
+
+  it("FIX: get() keeps the original return data after a later CPI to the same program", async () => {
+    const tx = await callerProgram.methods
+      .cpiCallReturnU64SameProgramSpoofed()
+      .accounts({
+        cpiReturn: cpiReturn.publicKey,
+        cpiReturnProgram: calleeProgram.programId,
+      })
+      .rpc(confirmOptions);
+
+    const t = await provider.connection.getTransaction(tx, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+
+    const dataPrefix = "Program data: ";
+    const dataLogs = t.meta.logMessages.filter((log) =>
+      log.startsWith(dataPrefix)
+    );
+    const lastDataLog = dataLogs[dataLogs.length - 1];
+    const b64Data = lastDataLog.slice(dataPrefix.length);
+    const buffer = Buffer.from(b64Data, "base64");
+
+    const reader = new borsh.BinaryReader(buffer);
+    const value = reader.readU64().toNumber();
+
+    assert.equal(
+      value,
+      10,
+      "Expected get() to return the original callee value, not the later spoofed one"
+    );
+  });
 });

--- a/tests/cpi-returns/tests/cpi-return.ts
+++ b/tests/cpi-returns/tests/cpi-return.ts
@@ -288,38 +288,38 @@ describe("CPI return", () => {
     console.log(`    Caller received: ${spoofedValue} (SPOOFED!)\n`);
   });
 
-  it("FIX: get() rejects spoofed return data with program_id validation", async () => {
-    // After the fix, get() validates the program_id from get_return_data()
-    // against the expected program. This should FAIL because the return data
-    // was set by the malicious program, not the callee.
-    try {
-      await callerProgram.methods
-        .cpiCallReturnU64SpoofedRejected()
-        .accounts({
-          authority: provider.wallet.publicKey,
-          cpiReturn: cpiReturn.publicKey,
-          cpiReturnProgram: calleeProgram.programId,
-          maliciousProgram: maliciousProgram.programId,
-        })
-        .rpc(confirmOptions);
+  it("FIX: get() keeps the original return data after a later CPI from a different program", async () => {
+    const tx = await callerProgram.methods
+      .cpiCallReturnU64SpoofedPreserved()
+      .accounts({
+        authority: provider.wallet.publicKey,
+        cpiReturn: cpiReturn.publicKey,
+        cpiReturnProgram: calleeProgram.programId,
+        maliciousProgram: maliciousProgram.programId,
+      })
+      .rpc(confirmOptions);
 
-      // If we get here, the fix didn't work
-      assert.fail("Expected transaction to fail due to program_id mismatch");
-    } catch (e) {
-      // Verify the error is specifically from the program_id validation,
-      // not some unrelated failure.
-      const errStr = JSON.stringify(e);
-      assert(
-        errStr.includes("program_id mismatch") ||
-          errStr.includes("ProgramFailedToComplete"),
-        `Expected program_id mismatch error, got: ${e.message?.substring(
-          0,
-          200
-        )}`
-      );
-      console.log(`\n  FIX CONFIRMED: get() rejected spoofed return data`);
-      console.log(`    Error: ${e.message?.substring(0, 100)}...\n`);
-    }
+    const t = await provider.connection.getTransaction(tx, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+
+    const dataPrefix = "Program data: ";
+    const dataLogs = t.meta.logMessages.filter((log) =>
+      log.startsWith(dataPrefix)
+    );
+    const lastDataLog = dataLogs[dataLogs.length - 1];
+    const b64Data = lastDataLog.slice(dataPrefix.length);
+    const buffer = Buffer.from(b64Data, "base64");
+
+    const reader = new borsh.BinaryReader(buffer);
+    const value = reader.readU64().toNumber();
+
+    assert.equal(
+      value,
+      10,
+      "Expected get() to return the original callee value, not the later spoofed one"
+    );
   });
 
   it("FIX: get() keeps the original return data after a later CPI to the same program", async () => {


### PR DESCRIPTION
CPI `Return::get()` now reads an invoke-time snapshot instead of live global return data, so a later CPI to the same program can’t overwrite the original value.

