### PR TITLE
Fix diagnostic ambiguity and preserve macro span fidelity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -86,6 +86,8 @@ jobs:
       # Pre-install so concurrent `cargo build-sbf` invocations don't race on
       # the platform-tools extract-then-rename.
       - run: cargo build-sbf --tools-version v1.52 --install-only
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache the generated project's `target/` so subsequent runs reuse
       # compiled deps. Restored before `anchor init` (which is invoked with
@@ -175,6 +177,8 @@ jobs:
       - run: chmod +x ~/.cargo/bin/anchor
 
       - run: cargo build-sbf --tools-version v1.52 --install-only
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache cargo `target/` and `node_modules/` for the generated project.
       # `anchor init --force` leaves both alone, so the dirs survive a fresh

--- a/lang/syn/src/codegen/program/accounts.rs
+++ b/lang/syn/src/codegen/program/accounts.rs
@@ -1,7 +1,13 @@
-use {crate::Program, heck::SnakeCase, quote::quote};
+use {
+    crate::Program,
+    heck::SnakeCase,
+    quote::{quote, quote_spanned},
+    syn::spanned::Spanned,
+};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let mut accounts = std::collections::HashMap::new();
+    let mut ix_spans = std::collections::HashMap::new();
 
     // Go through instruction accounts.
     for ix in &program.ixs {
@@ -11,19 +17,24 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             "__client_accounts_{}",
             anchor_ident.to_string().to_snake_case()
         );
+        ix_spans.insert(macro_name.clone(), ix.raw_method.span());
         accounts.insert(macro_name, ix.cfgs.as_slice());
     }
 
     // Build the tokens from all accounts
     let account_structs: Vec<proc_macro2::TokenStream> = accounts
         .iter()
-        .map(|(macro_name, cfgs)| {
+        .map(|(macro_name_str, cfgs)| {
             #[allow(
                 clippy::unwrap_used,
                 reason = "computed from valid Rust identifier via snake_case"
             )]
-            let macro_name: proc_macro2::TokenStream = macro_name.parse().unwrap();
-            quote! {
+            let macro_name: proc_macro2::TokenStream = macro_name_str.parse().unwrap();
+            let ix_span = ix_spans
+                .get(macro_name_str)
+                .copied()
+                .unwrap_or_else(proc_macro2::Span::call_site);
+            quote_spanned! { ix_span =>
                 #(#cfgs)*
                 pub use crate::#macro_name::*;
             }

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -1,4 +1,9 @@
-use {crate::IxArg, anyhow::Result, heck::CamelCase, quote::quote};
+use {
+    crate::IxArg,
+    anyhow::Result,
+    heck::CamelCase,
+    quote::{quote, quote_spanned},
+};
 
 // Namespace for calculating instruction sighash signatures for any instruction
 // not affecting program state.
@@ -28,7 +33,7 @@ pub fn gen_discriminator(namespace: &str, name: impl ToString) -> proc_macro2::T
 
 pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> Result<proc_macro2::TokenStream> {
     let ix_arg_names: Vec<&syn::Ident> = args.iter().map(|arg| &arg.name).collect();
-    let ix_name_camel = generate_ix_variant_name(name)?;
+    let ix_name_camel = generate_ix_variant_name(name);
 
     let variant = if args.is_empty() {
         quote! {
@@ -44,6 +49,32 @@ pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> Result<proc_macro2::To
     Ok(variant)
 }
 
-pub fn generate_ix_variant_name(name: &str) -> Result<syn::Ident> {
-    Ok(syn::parse_str(&name.to_camel_case())?)
+pub fn generate_ix_variant_spanned(
+    name: &str,
+    args: &[IxArg],
+    span: proc_macro2::Span,
+) -> proc_macro2::TokenStream {
+    let ix_arg_names: Vec<&syn::Ident> = args.iter().map(|arg| &arg.name).collect();
+    let ix_name_camel = generate_ix_variant_name_spanned(name, span);
+
+    if args.is_empty() {
+        quote_spanned! { span =>
+            #ix_name_camel
+        }
+    } else {
+        quote_spanned! { span =>
+            #ix_name_camel {
+                #(#ix_arg_names),*
+            }
+        }
+    }
+}
+
+pub fn generate_ix_variant_name(name: &str) -> syn::Ident {
+    generate_ix_variant_name_spanned(name, proc_macro2::Span::call_site())
+}
+
+pub fn generate_ix_variant_name_spanned(name: &str, span: proc_macro2::Span) -> syn::Ident {
+    let n = name.to_camel_case();
+    syn::Ident::new(&n, span)
 }

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -1,10 +1,11 @@
 use {
     crate::{
-        codegen::program::common::{generate_ix_variant, generate_ix_variant_name},
+        codegen::program::common::{generate_ix_variant_name_spanned, generate_ix_variant_spanned},
         Program,
     },
     heck::SnakeCase,
-    quote::{quote, ToTokens},
+    quote::{quote, quote_spanned, ToTokens},
+    syn::spanned::Spanned,
 };
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
@@ -14,25 +15,17 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .iter()
         .map(|ix| {
             #[allow(clippy::unwrap_used, reason = "computed from valid Rust identifier as module path")]
-            let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
+            let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", ix.anchor_ident).parse().unwrap();
             let cpi_method = {
                 let name = &ix.raw_method.sig.ident;
                 let name_str = name.to_string();
-                let ix_variant = match generate_ix_variant(&name_str, &ix.args) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        let err = e.to_string();
-                        return quote! { compile_error!(concat!("error generating ix variant: `", #err, "`")) };
-                    }
-                };
+                let ix_span = ix.raw_method.span();
+                let ix_variant = generate_ix_variant_spanned(&name_str, &ix.args, ix_span);
                 let method_name = &ix.ident;
                 let args: Vec<&syn::PatType> = ix.args.iter().map(|arg| &arg.raw_arg).collect();
-                let discriminator = match generate_ix_variant_name(&name_str) {
-                    Ok(name) => quote! { <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR },
-                    Err(e) => {
-                        let err = e.to_string();
-                        return quote! { compile_error!(concat!("error generating ix variant name: `", #err, "`")) };
-                    }
+                let discriminator = {
+                    let name = generate_ix_variant_name_spanned(&name_str, ix_span);
+                    quote_spanned! { ix_span => <instruction::#name as anchor_lang::Discriminator>::DISCRIMINATOR }
                 };
                 let ret_type = &ix.returns.ty.to_token_stream();
                 let ix_cfgs = &ix.cfgs;
@@ -43,10 +36,11 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         quote! { Ok(crate::cpi::Return::<#ret_type> { phantom: crate::cpi::PhantomData, program_id: ctx.program_id }) }
                     )
                 };
+                let spanned_method_name = quote_spanned! { ix_span => #method_name };
 
                 quote! {
                     #(#ix_cfgs)*
-                    pub fn #method_name<'a, 'b, 'c, 'info>(
+                    pub fn #spanned_method_name<'a, 'b, 'c, 'info>(
                         ctx: anchor_lang::context::CpiContext<'a, 'b, 'c, 'info, #accounts_ident<'info>>,
                         #(#args),*
                     ) -> #method_ret {

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -1,4 +1,9 @@
-use {crate::Program, heck::CamelCase, quote::quote};
+use {
+    crate::Program,
+    heck::CamelCase,
+    quote::{quote, quote_spanned},
+    syn::spanned::Spanned,
+};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     // Dispatch all global instructions.
@@ -13,13 +18,15 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             .to_camel_case()
             .parse()
             .expect("Failed to parse ix method name in camel as `TokenStream`");
+        let ix_span = ix.raw_method.span();
         let discriminator = quote! { instruction::#ix_name_camel::DISCRIMINATOR };
+        let spanned_method_name = quote_spanned! { ix_span => #ix_method_name };
         let ix_cfgs = &ix.cfgs;
 
         quote! {
             #(#ix_cfgs)*
             if data.starts_with(#discriminator) {
-                return __private::__global::#ix_method_name(
+                return __private::__global::#spanned_method_name(
                     program_id,
                     accounts,
                     &data[#discriminator.len()..],
@@ -52,8 +59,10 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .map(|fallback_fn| {
             let program_name = &program.name;
             let fn_name = &fallback_fn.raw_method.sig.ident;
+            let fallback_span = fallback_fn.raw_method.span();
+            let spanned_fn_name = quote_spanned! { fallback_span => #fn_name };
             quote! {
-                #program_name::#fn_name(program_id, accounts, data)
+                #program_name::#spanned_fn_name(program_id, accounts, data)
             }
         })
         .unwrap_or_else(|| {

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -1,6 +1,7 @@
 use {
     crate::{codegen::program::common::*, Program},
-    quote::{quote, ToTokens},
+    quote::{quote, quote_spanned, ToTokens},
+    syn::spanned::Spanned,
 };
 
 // Generate non-inlined wrappers for each instruction handler, since Solana's
@@ -26,20 +27,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let ix_arg_names: Vec<&syn::Ident> = ix.args.iter().map(|arg| &arg.name).collect();
             let ix_method_name = &ix.raw_method.sig.ident;
             let ix_method_name_str = ix_method_name.to_string();
-            let ix_name = match generate_ix_variant_name(&ix_method_name_str) {
-                Ok(name) => quote! { #name },
-                Err(e) => {
-                    let err = e.to_string();
-                    return quote! { compile_error!(concat!("error generating ix variant name: `", #err, "`")) };
-                }
-            };
-            let variant_arm = match generate_ix_variant(&ix_method_name_str, &ix.args) {
-                Ok(v) => v,
-                Err(e) => {
-                    let err = e.to_string();
-                    return quote! { compile_error!(concat!("error generating ix variant arm: `", #err, "`")) };
-                }
-            };
+            let ix_span = ix.raw_method.span();
+            let ix_name = generate_ix_variant_name(&ix_method_name_str);
+            let variant_arm = generate_ix_variant_spanned(&ix_method_name_str, &ix.args, ix_span);
 
             let ix_name_log = format!("Instruction: {ix_name}");
             let accounts_struct_name = &ix.anchor_ident;
@@ -78,7 +68,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         &format!("__anchor_validate_ix_arg_type_{}", idx),
                         proc_macro2::Span::call_site(),
                     );
-                    quote! {
+                    let arg_ty_span = arg_ty.span();
+                    quote_spanned! { arg_ty_span =>
                         const _: fn() = || {
                             let _: fn(&#arg_ty) = #accounts_struct_name::#method_name;
                         };

--- a/lang/syn/src/codegen/program/instruction.rs
+++ b/lang/syn/src/codegen/program/instruction.rs
@@ -1,8 +1,7 @@
 use {
-    crate::{codegen::program::common::*, parser, Program},
-    heck::CamelCase,
-    quote::{quote, quote_spanned, ToTokens},
-    syn::Type,
+    crate::{codegen::program::common::*, Program},
+    quote::{quote, ToTokens},
+    syn::{spanned::Spanned, Type},
 };
 
 /// Returns true for primitives, common std types, and types wrapped in Option/Vec.
@@ -73,24 +72,16 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .map(|ix| {
             let name = &ix.raw_method.sig.ident.to_string();
             let ix_cfgs = &ix.cfgs;
-            let Ok(ix_name_camel) = syn::parse_str::<syn::Ident>(&name.to_camel_case()) else {
-                return quote_spanned! { ix.raw_method.sig.ident.span()=>
-                    compile_error!("failed to parse ix method name after conversion to camelCase");
-                };
-            };
+            let ix_span = ix.raw_method.span();
+            let ix_name_camel = generate_ix_variant_name_spanned(name, ix_span);
             let raw_args: Vec<proc_macro2::TokenStream> = ix
                 .args
                 .iter()
                 .map(|arg| {
-                    #[allow(
-                        clippy::unwrap_used,
-                        reason = "\"pub \" prepended to a valid field token string is always \
-                                  valid Rust"
-                    )]
-                    let ts = format!("pub {}", parser::tts_to_string(&arg.raw_arg))
-                        .parse()
-                        .unwrap();
-                    ts
+                    let raw_arg = &arg.raw_arg;
+                    quote! {
+                        pub #raw_arg
+                    }
                 })
                 .collect();
 

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -16,7 +16,22 @@ use {
 
 /// Generate the IDL build print function for the program module.
 pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
-    check_safety_comments().unwrap_or_else(|e| panic!("Safety checks failed: {e}"));
+    // Check safety comments and emit compile errors spanned at the offending field if needed.
+    let safety_check_tokens = match check_safety_comments() {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            // Use the span of the first instruction if available, otherwise use the program module span
+            let error_span = program
+                .ixs
+                .first()
+                .map(|ix| ix.raw_method.span())
+                .unwrap_or_else(|| program.program_mod.span());
+            return syn::Error::new(error_span, e.to_string()).to_compile_error();
+        }
+    };
+    if !safety_check_tokens.is_empty() {
+        return safety_check_tokens;
+    }
 
     let idl = get_idl_module_path();
     let no_docs = get_no_docs();
@@ -152,12 +167,13 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
 }
 
 /// Check safety comments.
-fn check_safety_comments() -> Result<()> {
+/// Returns an empty TokenStream if OK, or a TokenStream with compile_error! if there are violations.
+fn check_safety_comments() -> Result<TokenStream> {
     let skip_lint = option_env!("ANCHOR_IDL_BUILD_SKIP_LINT")
         .map(|val| val == "TRUE")
         .unwrap_or_default();
     if skip_lint {
-        return Ok(());
+        return Ok(TokenStream::new());
     }
 
     let program_path = get_program_path();
@@ -175,7 +191,7 @@ fn check_safety_comments() -> Result<()> {
         //
         // Given this feature is not a critical one, and it works by default with `anchor build`,
         // we can fail silently in the case of an error rather than panicking.
-        return Ok(());
+        return Ok(TokenStream::new());
     }
 
     program_path

--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -1,11 +1,14 @@
 use {
-    anyhow::{anyhow, Result},
+    anyhow::Result,
+    proc_macro2::TokenStream,
+    quote::quote_spanned,
     std::{
         collections::BTreeMap,
         path::{Path, PathBuf},
     },
     syn::{
         parse::{Error as ParseError, Result as ParseResult},
+        spanned::Spanned,
         Ident, ImplItem, ImplItemConst, Type, TypePath,
     },
 };
@@ -57,12 +60,13 @@ impl CrateContext {
         ModuleContext { detail }
     }
 
-    // Perform Anchor safety checks on the parsed create
-    pub fn safety_checks(&self) -> Result<()> {
+    // Perform Anchor safety checks on the parsed crate
+    // Returns a TokenStream with compile_error! if there are issues, or empty TokenStream if OK.
+    pub fn safety_checks(&self) -> Result<TokenStream> {
         // Check all structs for unsafe field types, i.e. AccountInfo and UncheckedAccount.
         for ctx in self.modules.values() {
-            for unsafe_field in ctx.unsafe_struct_fields() {
-                // Check if unsafe field type has been documented with a /// SAFETY: doc string.
+            for (struct_name, unsafe_field) in ctx.unsafe_struct_fields_with_struct_name() {
+                // Check if unsafe field type has been documented with a /// CHECK: doc string.
                 let is_documented = unsafe_field.attrs.iter().any(|attr| {
                     if let syn::Meta::NameValue(syn::MetaNameValue {
                         value:
@@ -84,31 +88,28 @@ impl CrateContext {
                         reason = "unsafe fields always have idents (named fields only)"
                     )]
                     let ident = unsafe_field.ident.as_ref().unwrap();
-                    let span = ident.span();
-                    // Error if undocumented.
-                    #[allow(
-                        clippy::unwrap_used,
-                        reason = "file paths are always valid during compilation"
-                    )]
-                    let canonical = ctx.file.canonicalize().unwrap();
-                    return Err(anyhow!(
-                        r#"
-        {}:{}:{}
-        Struct field "{}" is unsafe, but is not documented.
-        Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
-        Alternatively, for reasons like quick prototyping, you may disable the safety checks
-        by using the `skip-lint` option.
-        See https://www.anchor-lang.com/docs/references/account-types#uncheckedaccountinfo for more information.
-                    "#,
-                        canonical.display(),
-                        span.start().line,
-                        span.start().column,
-                        ident
-                    ));
+                    let field_name = ident.to_string();
+                    let field_span = unsafe_field.span();
+
+                    let error_msg = format!(
+                        "Struct \"{}\" field \"{}\" is unsafe, but is not documented. \
+                         Please add a `/// CHECK:` doc comment explaining why no checks \
+                         through types are necessary. \
+                         Alternatively, for reasons like quick prototyping, you may disable \
+                         the safety checks by using the `skip-lint` option. \
+                         See https://www.anchor-lang.com/docs/the-accounts-struct#safety-checks \
+                         for more information.",
+                        struct_name,
+                        field_name
+                    );
+
+                    return Ok(quote_spanned! { field_span =>
+                        compile_error!(#error_msg);
+                    });
                 };
             }
         }
-        Ok(())
+        Ok(TokenStream::new())
     }
 }
 
@@ -255,7 +256,7 @@ impl ParsedModule {
         })
     }
 
-    fn unsafe_struct_fields(&self) -> impl Iterator<Item = &syn::Field> {
+    fn unsafe_struct_fields_with_struct_name(&self) -> impl Iterator<Item = (String, &syn::Field)> {
         let accounts_filter = |item_struct: &&syn::ItemStruct| {
             item_struct.attrs.iter().any(|attr| {
                 attr.path().is_ident("derive")
@@ -273,14 +274,18 @@ impl ParsedModule {
 
         self.structs()
             .filter(accounts_filter)
-            .flat_map(|s| &s.fields)
-            .filter(|f| match &f.ty {
+            .flat_map(|s| {
+                let struct_name = s.ident.to_string();
+                s.fields.iter().map(move |f| (struct_name.clone(), f))
+            })
+            .filter(|(_, f)| match &f.ty {
                 syn::Type::Path(syn::TypePath {
                     path: syn::Path { segments, .. },
                     ..
                 }) => {
-                    segments.len() == 1 && segments[0].ident == "UncheckedAccount"
-                        || segments[0].ident == "AccountInfo"
+                    segments.len() == 1
+                        && (segments[0].ident == "UncheckedAccount"
+                            || segments[0].ident == "AccountInfo")
                 }
                 _ => false,
             })

--- a/tests/safety-checks/programs/unchecked-account/src/lib.rs
+++ b/tests/safety-checks/programs/unchecked-account/src/lib.rs
@@ -5,12 +5,22 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 pub mod unchecked_account {
     use super::*;
-    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+    pub fn initialize_func_one(_ctx: Context<FuncOne>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn initialize_func_two(_ctx: Context<FuncTwo>) -> Result<()> {
         Ok(())
     }
 }
 
 #[derive(Accounts)]
-pub struct Initialize<'info> {
+pub struct FuncOne<'info> {
+    /// CHECK: This account is checked in FuncOne
+    unchecked: UncheckedAccount<'info>,
+}
+
+#[derive(Accounts)]
+pub struct FuncTwo<'info> {
     unchecked: UncheckedAccount<'info>,
 }

--- a/tests/safety-checks/test.sh
+++ b/tests/safety-checks/test.sh
@@ -1,37 +1,60 @@
 #!/bin/bash
+set -e
 
-echo "Building programs"
+echo "Safety Checks Test Suite"
 
 #
-# Build the UncheckedAccount variant.
+# UncheckedAccount with duplicate field names
 #
-pushd programs/unchecked-account/
-output=$(anchor build --ignore-keys 2>&1 > /dev/null)
-if ! [[ $output =~ "Struct field \"unchecked\" is unsafe" ]]; then
-   echo "Error: expected /// CHECK error"
+
+echo "[TEST 1] UncheckedAccount - Duplicate field names with struct context tracking"
+pushd programs/unchecked-account/ > /dev/null
+output=$(anchor build --ignore-keys 2>&1 || true)
+if [[ $output =~ "Struct \"FuncTwo\" field \"unchecked\" is unsafe" ]]; then
+   echo "✓ PASS: Error message includes struct name (FuncTwo)"
+else
+   echo "✗ FAIL: Error message should include 'Struct \"FuncTwo\" field \"unchecked\" is unsafe'"
+   echo "Actual output:"
+   echo "$output"
    exit 1
 fi
-popd
+popd > /dev/null
+echo ""
 
 #
-# Build the AccountInfo variant.
+# AccountInfo field safety check
 #
-pushd programs/account-info/
-output=$(anchor build --ignore-keys 2>&1 > /dev/null)
-if ! [[ $output =~ "Struct field \"unchecked\" is unsafe" ]]; then
-   echo "Error: expected /// CHECK error"
+
+echo "[TEST 2] AccountInfo - Struct name validation"
+pushd programs/account-info/ > /dev/null
+output=$(anchor build --ignore-keys 2>&1 || true)
+if [[ $output =~ "Struct \"Initialize\" field \"unchecked\" is unsafe" ]]; then
+   echo "✓ PASS: Error message includes struct name (Initialize)"
+else
+   echo "✗ FAIL: Error message should include 'Struct \"Initialize\" field \"unchecked\" is unsafe'"
+   echo "Actual output:"
+   echo "$output"
    exit 1
 fi
-popd
+popd > /dev/null
+echo ""
 
 #
-# Build the control variant.
+# Non-Account structs should be ignored
 #
-pushd programs/ignore-non-accounts/
-if ! anchor build --ignore-keys ; then
-   echo "Error: anchor build failed when it shouldn't have"
+
+echo "[TEST 3] Non-Account structs - Safety checks should be ignored"
+pushd programs/ignore-non-accounts/ > /dev/null
+if anchor build --ignore-keys > /dev/null 2>&1 ; then
+   echo "✓ PASS: Build succeeded (non-account structs properly ignored)"
+else
+   echo "✗ FAIL: Build should succeed for non-account structs"
    exit 1
 fi
-popd
+popd > /dev/null
+echo ""
 
-echo "Success. As expected, all builds failed that were supposed to fail."
+echo "All Tests Passed"
+echo "✓ Struct names correctly included in error messages"
+echo "✓ Duplicate field names are properly distinguished"
+echo "✓ Non-account structs do not trigger false positives"


### PR DESCRIPTION
Resolves #4015 
## Summary

This PR improves developer UX by preserving macro span fidelity across generated instruction variants and improving diagnostic clarity in safety checks involving duplicate account names.

## Changes

### Precise Safety Diagnostics

- Refactored `safety_checks` to iterate through structs individually, mapping unsafe fields back to their parent struct.
- Safety diagnostics now include the specific struct name and exact source location when a required `/// CHECK` comment is missing.
- Replaced `anyhow` panics with `compile_error!` using `quote_spanned!` for more actionable compiler diagnostics.

Example diagnostic:

```text
Struct "FuncTwo" field "unchecked" is unsafe