### PR TITLE
ci: Add retry logic to cargo build-sbf platform-tools install

### DIFF
--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -85,7 +85,23 @@ jobs:
 
       # Pre-install so concurrent `cargo build-sbf` invocations don't race on
       # the platform-tools extract-then-rename.
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      - name: Install platform-tools (with retry)
+        run: |
+          for attempt in {1..5}; do
+            if cargo build-sbf --tools-version v1.52 --install-only; then
+              echo "Platform-tools installed on attempt $attempt"
+              break
+            fi
+            if [ $attempt -lt 5 ]; then
+              echo "Attempt $attempt failed, retrying in 15 seconds..."
+              sleep 15
+            else
+              echo "Failed to install platform-tools after 5 attempts"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache the generated project's `target/` so subsequent runs reuse
       # compiled deps. Restored before `anchor init` (which is invoked with
@@ -174,7 +190,23 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      - name: Install platform-tools (with retry)
+        run: |
+          for attempt in {1..5}; do
+            if cargo build-sbf --tools-version v1.52 --install-only; then
+              echo "Platform-tools installed on attempt $attempt"
+              break
+            fi
+            if [ $attempt -lt 5 ]; then
+              echo "Attempt $attempt failed, retrying in 15 seconds..."
+              sleep 15
+            else
+              echo "Failed to install platform-tools after 5 attempts"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache cargo `target/` and `node_modules/` for the generated project.
       # `anchor init --force` leaves both alone, so the dirs survive a fresh


### PR DESCRIPTION
## Summary

The `template-tests` CI workflow intermittently fails during the following step:

```text
cargo build-sbf --tools-version v1.52 --install-only
```

with the error:

```text
[ERROR cargo_build_sbf::toolchain] Failed to install platform-tools: Failed to parse Github response: error decoding response body
```

This is caused by transient GitHub API failures or anonymous rate limits when `cargo-build-sbf` fetches `platform-tools` release metadata. The issue is nondeterministic—re-running the workflow typically succeeds—making this a CI reliability issue rather than a code bug.

This PR addresses both underlying causes.

## Changes

### Retry Logic

* Wrapped both `install-only` steps in retry loops:

  * `template-rust-tests`
  * `template-js-tests`
* Added up to **5 attempts** with a **15-second backoff**
* Prevents a single transient API failure from failing the entire workflow

### Authenticated GitHub Requests

* Passes `GITHUB_TOKEN` to `cargo-build-sbf`
* Enables authenticated GitHub API requests, increasing rate limits from:

  * Anonymous: **60 requests/hour**
  * Authenticated: **5,000 requests/hour**
* Provides a more permanent mitigation for API rate limiting

## Branch Target

* Targets `master`
* No breaking changes
* CI-only modification
