### PR TITLE
ts: Fix `Buffer` is not assignable to `Uint8Array` in `NodeWallet.local`

### DIFF
--- a/ts/packages/anchor/src/nodewallet.ts
+++ b/ts/packages/anchor/src/nodewallet.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "buffer";
 import {
   Keypair,
   PublicKey,
@@ -24,7 +23,7 @@ export default class NodeWallet implements Wallet {
     }
 
     const payer = Keypair.fromSecretKey(
-      Buffer.from(
+      Uint8Array.from(
         JSON.parse(
           require("fs").readFileSync(process.env.ANCHOR_WALLET, {
             encoding: "utf-8",

--- a/ts/packages/anchor/src/nodewallet.ts
+++ b/ts/packages/anchor/src/nodewallet.ts
@@ -13,7 +13,7 @@ import { isVersionedTransaction } from "./utils/common.js";
 export default class NodeWallet implements Wallet {
   constructor(readonly payer: Keypair) {}
 
-  static local(): NodeWallet | never {
+  static local(): NodeWallet {
     const process = require("process");
 
     if (!process.env.ANCHOR_WALLET) {

--- a/ts/packages/anchor/src/nodewallet.ts
+++ b/ts/packages/anchor/src/nodewallet.ts
@@ -16,7 +16,7 @@ export default class NodeWallet implements Wallet {
   static local(): NodeWallet | never {
     const process = require("process");
 
-    if (!process.env.ANCHOR_WALLET || process.env.ANCHOR_WALLET === "") {
+    if (!process.env.ANCHOR_WALLET) {
       throw new Error(
         "expected environment variable `ANCHOR_WALLET` is not set."
       );

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "buffer";
 import { Commitment, PublicKey } from "@solana/web3.js";
 import { BorshCoder, Coder } from "../coder/index.js";
 import {


### PR DESCRIPTION
### Problem

In newer TS versions (>=v5.7) passing a `Buffer` to a function that expects `Uint8Array` gives this error:

```
Argument of type 'Buffer' is not assignable to parameter of type 'Uint8Array<ArrayBufferLike>'.
  The types of 'slice(...).buffer' are incompatible between these types.
    Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
      Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
        Types of property '[Symbol.toStringTag]' are incompatible.
          Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
```

For example, in `NodeWallet.local` impl:

https://github.com/otter-sec/anchor/blob/fc3308ad1d1473803ade70b6921ce766dfb5d37b/ts/packages/anchor/src/nodewallet.ts#L26-L34

The main reason why we use `Buffer` in the library in the first place is because `@solana/web3.js` expected it, but in this instance, [`Keypair.fromSecretKey` actually expects `Uint8Array`](https://github.com/solana-foundation/solana-web3.js/blob/5b4e63daed1561ce58585a639041732c04aa354a/src/keypair.ts#L52); therefore, there is no reason to use `Buffer` here.

I think it's probably worth reducing `Buffer` usage, especially internal usage, but I don't think we can eliminate it fully in v1, since that would break things.

### Summary of changes

- Fix `Buffer` is not assignable to type `Uint8Array` in `NodeWallet.local`
- Remove redundant empty string check for `ANCHOR_WALLET` environment variable (previous `!` accounts for empty string)
- Remove redundant `| never` return type (`ty | never` is always `ty`)
- Remove unused `Buffer` import in `program/index.ts`