### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -3,7 +3,7 @@ description: "Setup Solana"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       name: Cache Solana Tool Suite
       id: cache-solana
       with:
@@ -11,7 +11,7 @@ runs:
           ~/.cache/solana/
           ~/.local/share/solana/
         key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_VERSION }}
-    - uses: nick-fields/retry@v2
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:
         retry_wait_seconds: 300

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -3,7 +3,7 @@ description: "Setup Solana"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       name: Cache Solana Tool Suite
       id: cache-solana
       with:

--- a/.github/actions/setup-surfpool/action.yaml
+++ b/.github/actions/setup-surfpool/action.yaml
@@ -3,7 +3,7 @@ description: "Installs and caches the Surfpool CLI"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       name: Cache Surfpool Binary
       id: cache-surfpool
       with:
@@ -13,7 +13,7 @@ runs:
         # Issue: https://github.com/solana-foundation/anchor/issues/4160
         key: surfpool-${{ runner.os }}-v${{ env.SURFPOOL_CLI_VERSION }}
 
-    - uses: nick-fields/retry@v2
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       if: steps.cache-surfpool.outputs.cache-hit != 'true'
       with:
         retry_wait_seconds: 300

--- a/.github/actions/setup-surfpool/action.yaml
+++ b/.github/actions/setup-surfpool/action.yaml
@@ -3,7 +3,7 @@ description: "Installs and caches the Surfpool CLI"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       name: Cache Surfpool Binary
       id: cache-surfpool
       with:

--- a/.github/actions/setup-ts/action.yaml
+++ b/.github/actions/setup-ts/action.yaml
@@ -3,17 +3,17 @@ description: "Setup ts"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       name: Cache Typescript node_modules
       id: cache-typescript-node-modules
       with:
         path: |
           ./ts/node_modules/
         key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/yarn.lock') }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       name: Cache Typescript Dist
       id: cache-typescript-dist
       with:

--- a/.github/actions/setup-ts/action.yaml
+++ b/.github/actions/setup-ts/action.yaml
@@ -3,17 +3,17 @@ description: "Setup ts"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       name: Cache Typescript node_modules
       id: cache-typescript-node-modules
       with:
         path: |
           ./ts/node_modules/
         key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/yarn.lock') }}
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       name: Cache Typescript Dist
       id: cache-typescript-dist
       with:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,7 +5,9 @@ runs:
   steps:
     - run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev
       shell: bash
-    - run: echo "ANCHOR_VERSION=$(cat ./VERSION)" >> $GITHUB_ENV
+    - run: |
+        version=$(cat ./VERSION | tr -cd '[:alnum:]._-')
+        echo "ANCHOR_VERSION=$version" >> $GITHUB_ENV
       shell: bash
     - run: git submodule update --init --recursive --depth 1
       shell: bash

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     name: Build and publish aarch64-unknown-linux-gnu binary
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout tag v${{ inputs.version }}
         uses: actions/checkout@v4

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -19,7 +19,6 @@ jobs:
   build:
     name: Build and publish aarch64-unknown-linux-gnu binary
     runs-on: ubuntu-24.04-arm
-    permissions: write-all
     steps:
       - name: Checkout tag v${{ inputs.version }}
         uses: actions/checkout@v4
@@ -47,7 +46,7 @@ jobs:
 
           # Create the release if it doesn't already exist
           if ! gh release view "$tag" > /dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --target "$(git rev-parse HEAD)" --notes "aarch64-unknown-linux-gnu binary for Anchor ${tag}"
+            gh release create "$tag" --title "$tag" --notes "aarch64-unknown-linux-gnu binary for Anchor ${tag}"
           fi
 
           # Upload the binary (--clobber replaces an existing asset with the same name)

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -1,0 +1,53 @@
+name: Build aarch64-unknown-linux-gnu
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.31.1 — no 'v' prefix)"
+        required: true
+        type: string
+
+env:
+  TARGET: aarch64-unknown-linux-gnu
+  VERSION: ${{ inputs.version }}
+
+jobs:
+  build:
+    name: Build and publish aarch64-unknown-linux-gnu binary
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout tag v${{ inputs.version }}
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
+      - name: Build release binary
+        run: cargo build --release --locked --package anchor-cli
+
+      - name: Rename binary
+        run: mv target/release/anchor "anchor-${VERSION}-${TARGET}"
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${VERSION}"
+          asset="anchor-${VERSION}-${TARGET}"
+
+          # Create the release if it doesn't already exist
+          if ! gh release view "$tag" > /dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --target "$(git rev-parse HEAD)" --notes "aarch64-unknown-linux-gnu binary for Anchor ${tag}"
+          fi
+
+          # Upload the binary (--clobber replaces an existing asset with the same name)
+          gh release upload "$tag" "$asset" --clobber

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build and publish aarch64-unknown-linux-gnu binary
     runs-on: ubuntu-24.04-arm
-
+    permissions: write-all
     steps:
       - name: Checkout tag v${{ inputs.version }}
         uses: actions/checkout@v4

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 env:
   TARGET: aarch64-unknown-linux-gnu
   VERSION: ${{ inputs.version }}
@@ -16,8 +19,6 @@ jobs:
   build:
     name: Build and publish aarch64-unknown-linux-gnu binary
     runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout tag v${{ inputs.version }}

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "stable"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout tag v${{ inputs.version }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: v${{ inputs.version }}
 
       - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: v${{ inputs.version }}
+          persist-credentials: false
 
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -85,7 +85,7 @@ jobs:
       - name: Attest build provenance
         # `id-token: write` is not granted for PRs from forks
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: ${{ inputs.dist }}/anchor-${{ steps.prepare.outputs.version }}-${{ matrix.target }}*
 

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -68,17 +70,22 @@ jobs:
       - name: Prepare
         id: prepare
         shell: bash
+        env:
+          DIST: ${{ inputs.dist }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$DRY_RUN" == "true" ]]; then
             version="dry-run"
           else
             version=$(echo $GITHUB_REF_NAME | cut -dv -f2)
           fi
           ext=""
-          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
+          [[ "$MATRIX_OS" == windows-latest ]] && ext=".exe"
 
-          mkdir ${{ inputs.dist }}
-          mv "target/${{ matrix.target }}/release/anchor$ext" ${{ inputs.dist }}/anchor-$version-${{ matrix.target }}$ext
+          mkdir "$DIST"
+          mv "target/$MATRIX_TARGET/release/anchor$ext" "$DIST/anchor-$version-$MATRIX_TARGET$ext"
 
           echo "version=$version" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/check-actions.yml
+++ b/.github/workflows/check-actions.yml
@@ -1,0 +1,31 @@
+name: Check Allowed Actions
+on:
+  pull_request:
+    paths: [".github/workflows/**"]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2
+        with:
+          version: "1.3.1"
+          url: "https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_amd64.tar.gz"
+          checksum: "d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
+      - name: Pull check-actions from GHCR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ACTOR: ${{ github.actor }}
+        run: |
+          echo "${GH_TOKEN}" | oras login ghcr.io -u "${GH_ACTOR}" --password-stdin
+          mkdir -p .check-actions
+          cd .check-actions
+          oras pull ghcr.io/wormholelabs-xyz/action-audit/check-actions:sha-214d369@sha256:7a18183c22b6e79ba21453b041925b728d4d9c47201fc522a17086dbd5779178
+      - uses: ./.check-actions

--- a/.github/workflows/check-actions.yml
+++ b/.github/workflows/check-actions.yml
@@ -13,7 +13,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2
         with:
           version: "1.3.1"

--- a/.github/workflows/global-lint.yaml
+++ b/.github/workflows/global-lint.yaml
@@ -10,9 +10,9 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       # Pinned version of the v7.2.0 tag, which is a lightweight and hence mutable tag
-      - uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d
+      - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 #v8
         with:
           # For now, only lint markdown files
           files: |

--- a/.github/workflows/global-lint.yaml
+++ b/.github/workflows/global-lint.yaml
@@ -9,10 +9,14 @@ on:
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       # Pinned version of the v7.2.0 tag, which is a lightweight and hence mutable tag
-      - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 #v8
+      - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 # v8.3.0
         with:
           # For now, only lint markdown files
           files: |

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   no-caching-tests:
     name: Reusable
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: false

--- a/.github/workflows/no-unpinned-docker.yaml
+++ b/.github/workflows/no-unpinned-docker.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: chmod 755 ./docker/check-docker-pin.sh
       - run: ./docker/check-docker-pin.sh

--- a/.github/workflows/no-unpinned-docker.yaml
+++ b/.github/workflows/no-unpinned-docker.yaml
@@ -8,8 +8,12 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - run: chmod 755 ./docker/check-docker-pin.sh
       - run: ./docker/check-docker-pin.sh

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,12 +17,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -66,6 +68,8 @@ jobs:
       - name: Create release branch
         env:
           VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -xeou pipefail
 
@@ -77,4 +81,4 @@ jobs:
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "v$VERSION"
-          git push --set-upstream origin "$BRANCH"
+          git push --set-upstream "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
 
       - name: Publish crates
         env:
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Attest crate checksum manifest
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         if: ${{ !inputs.dry_run && steps.crate-artifacts.outputs.found == 'true' }}
         with:
           subject-path: target/package/SHA256SUMS

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -45,6 +47,8 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -55,7 +59,7 @@ jobs:
 
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish crates
         env:

--- a/.github/workflows/publish-npmjs.yaml
+++ b/.github/workflows/publish-npmjs.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-npmjs.yaml
+++ b/.github/workflows/publish-npmjs.yaml
@@ -17,8 +17,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -43,8 +45,10 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -14,18 +14,25 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DIST: dist-dry-run
 
 jobs:
   publish-crates-dryrun:
     name: Publish crates (dry-run)
+    permissions:
+      contents: read
     uses: ./.github/workflows/publish-crates.yaml
     with:
       dry_run: true
 
   publish-npmjs-dryrun:
     name: Publish npmjs packages (dry-run)
+    permissions:
+      contents: read
     uses: ./.github/workflows/publish-npmjs.yaml
     with:
       dry_run: true
@@ -36,6 +43,10 @@ jobs:
 
   build-cli-dryrun:
     name: Build binaries (dry-run)
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-cli.yaml
     with:
       dry_run: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,17 +137,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -156,7 +156,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: docker/build
           push: true
@@ -169,7 +169,7 @@ jobs:
           sbom: true
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         id: attest
         with:
           subject-name: ${{ env.IMAGE_NAME }}
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Force fetch upstream tags
         run: git fetch --tags --force
@@ -45,6 +46,7 @@ jobs:
         id: verify
         env:
           RELEASE_MANAGERS: ${{ vars.RELEASE_MANAGERS }}
+          VERSION_TAG: ${{ steps.info.outputs.version_tag }}
         run: |
           if [ -z "${RELEASE_MANAGERS}" ]; then
             echo "RELEASE_MANAGERS variable is not set"
@@ -57,14 +59,14 @@ jobs:
             curl -fsSL "https://github.com/${u}.gpg" | gpg --batch --import >/dev/null
           done
 
-          echo "Verifying the tag: ${{ steps.info.outputs.version_tag }}"
-          if ! git verify-tag -v "${{ steps.info.outputs.version_tag }}" 2>&1; then
+          echo "Verifying the tag: ${VERSION_TAG}"
+          if ! git verify-tag -v "${VERSION_TAG}" 2>&1; then
             echo "❌ Tag verification failed!"
             echo "passed=false" >> $GITHUB_OUTPUT
             exit 1
           fi
           # Run it again to capture the output
-          git verify-tag -v "${{ steps.info.outputs.version_tag }}" 2>&1 | tee /tmp/verify-output.txt;
+          git verify-tag -v "${VERSION_TAG}" 2>&1 | tee /tmp/verify-output.txt;
 
           # SSH verification output typically includes the key fingerprint
           # Use GNU grep with Perl regex for cleaner extraction (Linux environment)
@@ -91,13 +93,17 @@ jobs:
           echo "key_id=$KEY_SHA256" >> $GITHUB_OUTPUT
 
       - name: Summary
+        env:
+          VERSION: ${{ steps.info.outputs.version }}
+          SHA: ${{ steps.info.outputs.sha }}
+          KEY_ID: ${{ steps.verify.outputs.key_id }}
         run: |
           echo "## Tag Verification Summary 🔐" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag:** ${{ steps.info.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** ${{ steps.info.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${SHA}" >> $GITHUB_STEP_SUMMARY
           echo "- **Signature:** ✅ Verified" >> $GITHUB_STEP_SUMMARY
-          echo "- **Signed by:** ${{ steps.verify.outputs.key_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Signed by:** ${KEY_ID}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Proceeding with release build..." >> $GITHUB_STEP_SUMMARY
 
@@ -105,6 +111,11 @@ jobs:
     name: Publish crates
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/publish-crates.yaml
     with:
       dry_run: false
@@ -114,6 +125,9 @@ jobs:
     name: Publish npmjs packages
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-npmjs.yaml
     with:
       dry_run: false
@@ -135,9 +149,11 @@ jobs:
       IMAGE_NAME: solanafoundation/anchor
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -156,7 +172,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: docker/build
           push: true
@@ -180,6 +196,10 @@ jobs:
     name: Build binaries
     needs: verify-tag
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-cli.yaml
     with:
       dry_run: false
@@ -190,8 +210,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify-tag, build-cli]
     if: ${{ needs.verify-tag.outputs.verification_passed == 'true' }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -229,8 +253,10 @@ jobs:
       name: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-cargo-build
@@ -77,9 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -93,7 +93,7 @@ jobs:
         if: env.CARGO_PROFILE != 'debug'
 
       - run: chmod +x ~/.cargo/bin/anchor
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/anchor
@@ -106,8 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -118,7 +118,7 @@ jobs:
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: basic-0 cache
         id: cache-basic-0
@@ -126,7 +126,7 @@ jobs:
           path: ./examples/tutorial/basic-0/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: basic-1 cache
         id: cache-basic-1
@@ -134,7 +134,7 @@ jobs:
           path: ./examples/tutorial/basic-1/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: basic-2 cache
         id: cache-basic-2
@@ -142,7 +142,7 @@ jobs:
           path: ./examples/tutorial/basic-2/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: basic-3 cache
         id: cache-basic-3
@@ -150,7 +150,7 @@ jobs:
           path: ./examples/tutorial/basic-3/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: basic-4 cache
         id: cache-basic-4
@@ -181,18 +181,18 @@ jobs:
           - path: tests/composite/
             name: composite.so
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +rwx ~/.cargo/bin/anchor
 
       - run: cd ${{ matrix.node.path }} && anchor build --skip-lint --ignore-keys
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ matrix.node.name }}
           path: ${{ matrix.node.path }}target/deploy/${{ matrix.node.name }}
@@ -204,37 +204,37 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: optional.so
           path: tests/optional/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: events.so
           path: tests/events/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: basic_4.so
           path: examples/tutorial/basic-4/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: basic_2.so
           path: examples/tutorial/basic-2/target/deploy/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: composite.so
           path: tests/composite/target/deploy/
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache client/example target
         id: cache-test-target
@@ -252,13 +252,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -266,13 +266,13 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache tests/bpf-upgradeable-state target
         id: cache-test-target
@@ -350,13 +350,13 @@ jobs:
       matrix:
         template: [mocha, jest, rust, mollusk, litesvm]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -364,7 +364,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -500,13 +500,13 @@ jobs:
             path: tests/test-instruction-validation
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -514,13 +514,13 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         if: ${{ env.CACHE != 'false' }}
         name: Cache ${{ matrix.node.path }} target
         id: cache-test-target

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -42,11 +42,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-cargo-build
@@ -78,8 +80,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -107,6 +111,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
@@ -118,7 +124,7 @@ jobs:
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: basic-0 cache
         id: cache-basic-0
@@ -126,7 +132,7 @@ jobs:
           path: ./examples/tutorial/basic-0/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: basic-1 cache
         id: cache-basic-1
@@ -134,7 +140,7 @@ jobs:
           path: ./examples/tutorial/basic-1/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: basic-2 cache
         id: cache-basic-2
@@ -142,7 +148,7 @@ jobs:
           path: ./examples/tutorial/basic-2/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: basic-3 cache
         id: cache-basic-3
@@ -150,7 +156,7 @@ jobs:
           path: ./examples/tutorial/basic-3/target
           key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: basic-4 cache
         id: cache-basic-4
@@ -182,6 +188,8 @@ jobs:
             name: composite.so
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
 
@@ -205,6 +213,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
 
@@ -234,7 +244,7 @@ jobs:
         with:
           name: composite.so
           path: tests/composite/target/deploy/
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache client/example target
         id: cache-test-target
@@ -253,12 +263,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -272,7 +284,7 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache tests/bpf-upgradeable-state target
         id: cache-test-target
@@ -351,12 +363,14 @@ jobs:
         template: [mocha, jest, rust, mollusk, litesvm]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -501,12 +515,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -520,7 +536,7 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: ${{ env.CACHE != 'false' }}
         name: Cache ${{ matrix.node.path }} target
         id: cache-test-target

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,8 @@ on:
 jobs:
   tests:
     name: Reusable
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: true


### PR DESCRIPTION
## Summary

This PR addresses zizmor security findings in the GitHub Actions workflow files.

## Findings Fixed

- **`github-env`** (`.github/actions/setup/action.yaml`): Sanitize VERSION file content with `tr -cd '[:alnum:]._-'` before writing to `$GITHUB_ENV` to prevent potential code execution via environment file injection.

- **`template-injection`** (`.github/workflows/build-cli.yaml`): Move `${{ inputs.dist }}` and `${{ matrix.os }}`, `${{ matrix.target }}` into `env:` block instead of using them directly in `run:` script to prevent template expansion attacks.

- **`template-injection`** (`.github/workflows/release.yaml`): Move `${{ steps.info.outputs.version_tag }}`, `${{ steps.info.outputs.version }}`, `${{ steps.info.outputs.sha }}`, and `${{ steps.verify.outputs.key_id }}` into `env:` blocks in the `verify` and `summary` steps.

- **`artipacked`** (multiple files): Added `persist-credentials: false` to all `actions/checkout` steps across `build-aarch64-linux.yml`, `build-cli.yaml`, `check-actions.yml`, `global-lint.yaml`, `no-unpinned-docker.yaml`, `prepare-release.yaml`, `publish-crates.yaml`, `publish-npmjs.yaml`, `release.yaml`, and `reusable-tests.yaml`. Updated `prepare-release.yaml` to use explicit token auth for `git push` since credentials are no longer persisted.

- **`ref-version-mismatch`** (multiple files): Updated version comments to match actual tags pointed to by pinned SHAs:
  - `actions/cache # v5` → `# v5.0.4`
  - `actions/setup-node # v6` → `# v6.3.0`
  - `streetsidesoftware/cspell-action #v8` → `# v8.3.0`
  - `rust-lang/crates-io-auth-action # v1` → `# v1.0.4`
  - `docker/login-action # v4` → `# v4.0.0`
  - `docker/build-push-action # v7` → `# v7.0.0`

- **`excessive-permissions`** (multiple files): Added explicit `permissions:` blocks to jobs missing them in `global-lint.yaml`, `no-caching-tests.yaml`, `no-unpinned-docker.yaml`, `release-pr.yaml`, `release.yaml`, and `tests.yaml`. Added workflow-level `permissions: contents: read` to `release-pr.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)