### PR TITLE
Add AVM download progress indicators and verify download hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "clap 4.6.1",
  "clap_complete",
  "dirs",
+ "indicatif",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ solana-transaction = "3.0.1"
 
 # Non solana crates
 cargo_toml = "0.22.3"
+indicatif = "0.18.2"
 # Solana crates currently use 0.12, make sure to bump this to 0.13
 # when they do to avoid duplicate deps
 reqwest = { version = "0.12.28", default-features = false }

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
+indicatif.workspace = true
 reqwest = { workspace = true, default-features = false, features = [
   "blocking",
   "json",

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -6,6 +6,7 @@ use {
     anyhow::{anyhow, bail, Context, Error, Result},
     cargo_toml::Manifest,
     chrono::{TimeZone, Utc},
+    indicatif::{ProgressBar, ProgressStyle},
     reqwest::{header::USER_AGENT, StatusCode},
     semver::{Prerelease, Version},
     serde::{de, Deserialize},
@@ -13,10 +14,11 @@ use {
     std::{
         fmt::Write as FmtWrite,
         fs,
-        io::{BufRead, Write},
+        io::{self, BufRead, Write},
         path::{Path, PathBuf},
         process::{Command, Stdio},
         sync::LazyLock,
+        time::Duration,
     },
 };
 pub use {
@@ -40,6 +42,7 @@ const NIGHTLY_S3_BASE_URL: &str = "https://anchor-releases.s3-eu-west-1.amazonaw
 const HTTP_CLIENT_TIMEOUT_SECS: u64 = 5;
 /// Longer timeout for release asset downloads, which can take longer than metadata requests.
 const DOWNLOAD_CLIENT_TIMEOUT_SECS: u64 = 60;
+const DOWNLOAD_PROGRESS_TICK_MS: u64 = 100;
 
 /// Shared HTTP client with a short timeout, used for metadata/API requests.
 static HTTP_CLIENT: LazyLock<reqwest::blocking::Client> = LazyLock::new(|| {
@@ -56,6 +59,59 @@ pub(crate) static DOWNLOAD_CLIENT: LazyLock<reqwest::blocking::Client> = LazyLoc
         .build()
         .expect("Failed to build download HTTP client")
 });
+
+fn download_progress_bar(content_length: Option<u64>) -> ProgressBar {
+    let progress = match content_length {
+        Some(total) if total > 0 => {
+            let progress = ProgressBar::new(total);
+            progress.set_style(
+                ProgressStyle::default_bar()
+                    .template(
+                        "{spinner:.green} {msg} [{elapsed_precise}] [{bar:40.cyan/blue}] \
+                         {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+                    )
+                    .expect("download progress template must be valid")
+                    .progress_chars("#>-"),
+            );
+            progress
+        }
+        _ => {
+            let progress = ProgressBar::new_spinner();
+            progress.set_style(
+                ProgressStyle::default_spinner()
+                    .template(
+                        "{spinner:.green} {msg} [{elapsed_precise}] {bytes} ({bytes_per_sec})",
+                    )
+                    .expect("download spinner template must be valid"),
+            );
+            progress
+        }
+    };
+    progress.enable_steady_tick(Duration::from_millis(DOWNLOAD_PROGRESS_TICK_MS));
+    progress
+}
+
+pub(crate) fn download_response_to_writer(
+    response: reqwest::blocking::Response,
+    message: impl Into<String>,
+    writer: &mut impl Write,
+) -> Result<u64> {
+    let progress = download_progress_bar(response.content_length());
+    progress.set_message(message.into());
+    let mut reader = progress.wrap_read(response);
+    let result = io::copy(&mut reader, writer);
+    progress.finish_and_clear();
+    result.context("reading download response")
+}
+
+fn download_response_to_vec(
+    response: reqwest::blocking::Response,
+    message: impl Into<String>,
+) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    download_response_to_writer(response, message, &mut bytes)?;
+    Ok(bytes)
+}
 
 /// Storage directory for AVM, customizable by setting the $AVM_HOME, defaults to ~/.avm
 pub static AVM_HOME: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -502,11 +558,11 @@ pub fn install_version(
         } else {
             ""
         };
-        let res = DOWNLOAD_CLIENT
-            .get(format!(
-                "https://github.com/otter-sec/anchor/releases/download/v{version}/anchor-{version}-{target}{ext}"
-            ))
-            .send()?;
+        let url = format!(
+            "https://github.com/otter-sec/anchor/releases/download/v{version}/\
+             anchor-{version}-{target}{ext}"
+        );
+        let res = DOWNLOAD_CLIENT.get(&url).send()?;
         match res.status() {
             StatusCode::NOT_FOUND => bail!(
                 "No prebuilt binary found for version `{version}` (HTTP 404). Try `avm install \
@@ -520,7 +576,8 @@ pub fn install_version(
         }
 
         let bin_path = version_binary_path(&version);
-        fs::write(&bin_path, res.bytes()?)?;
+        let bytes = download_response_to_vec(res, format!("Downloading anchor {version}"))?;
+        fs::write(&bin_path, bytes)?;
 
         // Set file to executable on UNIX
         #[cfg(unix)]
@@ -590,7 +647,7 @@ fn install_solana_verify() -> Result<()> {
     let url = format!(
         "https://github.com/Ellipsis-Labs/solana-verifiable-build/releases/download/v{SOLANA_VERIFY_VERSION}/solana-verify-{os}"
     );
-    let res = DOWNLOAD_CLIENT.get(url).send()?;
+    let res = DOWNLOAD_CLIENT.get(&url).send()?;
     if !res.status().is_success() {
         bail!(
             "Failed to download `solana-verify-{os} v{SOLANA_VERIFY_VERSION} (status code: {})",
@@ -598,7 +655,11 @@ fn install_solana_verify() -> Result<()> {
         );
     } else {
         let bin_path = get_bin_dir_path().join("solana-verify");
-        fs::write(&bin_path, res.bytes()?)?;
+        let bytes = download_response_to_vec(
+            res,
+            format!("Downloading solana-verify {SOLANA_VERIFY_VERSION}"),
+        )?;
+        fs::write(&bin_path, bytes)?;
         #[cfg(unix)]
         fs::set_permissions(
             bin_path,
@@ -1076,9 +1137,9 @@ fn download_nightly_artifact(artifact: &NightlyArtifact, dest: &Path) -> Result<
     if !response.status().is_success() {
         bail!("Failed to download `{url}` (status {})", response.status());
     }
-    let bytes = response
-        .bytes()
-        .with_context(|| format!("Reading response body from {url}"))?;
+    let bytes =
+        download_response_to_vec(response, format!("Downloading nightly {}", artifact.tool))
+            .with_context(|| format!("Reading response body from {url}"))?;
     let actual = sha256_hex(bytes.as_ref());
     if !actual.eq_ignore_ascii_case(&artifact.sha256) {
         bail!(
@@ -1086,7 +1147,7 @@ fn download_nightly_artifact(artifact: &NightlyArtifact, dest: &Path) -> Result<
             artifact.sha256
         );
     }
-    fs::write(dest, bytes.as_ref()).with_context(|| format!("Writing {}", dest.display()))?;
+    fs::write(dest, &bytes).with_context(|| format!("Writing {}", dest.display()))?;
     Ok(())
 }
 

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -38,6 +38,8 @@ const UPDATE_CHECK_INTERVAL_SECS: i64 = 60 * 60;
 const NIGHTLY_MANIFEST_URL: &str =
     "https://anchor-releases.s3-eu-west-1.amazonaws.com/nightly/latest/manifest.json";
 const NIGHTLY_S3_BASE_URL: &str = "https://anchor-releases.s3-eu-west-1.amazonaws.com/";
+const ANCHOR_GITHUB_REPO: &str = "otter-sec/anchor";
+const SOLANA_VERIFY_GITHUB_REPO: &str = "Ellipsis-Labs/solana-verifiable-build";
 /// Shorter HTTP timeout so a slow or unreachable GitHub does not stall the CLI for long.
 const HTTP_CLIENT_TIMEOUT_SECS: u64 = 5;
 /// Longer timeout for release asset downloads, which can take longer than metadata requests.
@@ -111,6 +113,62 @@ fn download_response_to_vec(
     let mut bytes = Vec::new();
     download_response_to_writer(response, message, &mut bytes)?;
     Ok(bytes)
+}
+
+#[derive(Deserialize)]
+struct GithubRelease {
+    assets: Vec<GithubReleaseAsset>,
+}
+
+#[derive(Deserialize)]
+struct GithubReleaseAsset {
+    name: String,
+    digest: Option<String>,
+}
+
+fn github_release_asset_sha256(repo: &str, tag: &str, asset_name: &str) -> Result<String> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/tags/{tag}");
+    let response = HTTP_CLIENT
+        .get(&url)
+        .header(USER_AGENT, "avm https://github.com/otter-sec/anchor")
+        .send()
+        .with_context(|| format!("Fetching release metadata from {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("Failed to fetch release metadata for `{repo}` tag `{tag}` (status {status})");
+    }
+
+    let release: GithubRelease = response
+        .json()
+        .with_context(|| format!("Parsing release metadata from {url}"))?;
+    let asset = release
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| anyhow!("Release `{repo}` tag `{tag}` does not include `{asset_name}`"))?;
+    let digest = asset.digest.ok_or_else(|| {
+        anyhow!("Release asset `{asset_name}` in `{repo}` tag `{tag}` does not include a digest")
+    })?;
+    parse_github_sha256_digest(&digest)
+        .with_context(|| format!("Parsing digest for release asset `{asset_name}`"))
+}
+
+fn parse_github_sha256_digest(digest: &str) -> Result<String> {
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        bail!("Unsupported release asset digest `{digest}`");
+    };
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("Invalid SHA-256 release asset digest `{digest}`");
+    }
+    Ok(hex.to_ascii_lowercase())
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str, artifact: &str) -> Result<()> {
+    let actual = sha256_hex(bytes);
+    if !actual.eq_ignore_ascii_case(expected) {
+        bail!("Checksum mismatch for `{artifact}`: expected {expected}, got {actual}");
+    }
+    Ok(())
 }
 
 /// Storage directory for AVM, customizable by setting the $AVM_HOME, defaults to ~/.avm
@@ -558,10 +616,11 @@ pub fn install_version(
         } else {
             ""
         };
-        let url = format!(
-            "https://github.com/otter-sec/anchor/releases/download/v{version}/\
-             anchor-{version}-{target}{ext}"
-        );
+        let asset_name = format!("anchor-{version}-{target}{ext}");
+        let tag = format!("v{version}");
+        let expected_sha256 = github_release_asset_sha256(ANCHOR_GITHUB_REPO, &tag, &asset_name)?;
+        let url =
+            format!("https://github.com/{ANCHOR_GITHUB_REPO}/releases/download/{tag}/{asset_name}");
         let res = DOWNLOAD_CLIENT.get(&url).send()?;
         match res.status() {
             StatusCode::NOT_FOUND => bail!(
@@ -577,6 +636,7 @@ pub fn install_version(
 
         let bin_path = version_binary_path(&version);
         let bytes = download_response_to_vec(res, format!("Downloading anchor {version}"))?;
+        verify_sha256(&bytes, &expected_sha256, &url)?;
         fs::write(&bin_path, bytes)?;
 
         // Set file to executable on UNIX
@@ -644,8 +704,12 @@ fn solana_verify_installed() -> Result<bool> {
 fn install_solana_verify() -> Result<()> {
     println!("Installing solana-verify...");
     let os = std::env::consts::OS;
+    let asset_name = format!("solana-verify-{os}");
+    let tag = format!("v{SOLANA_VERIFY_VERSION}");
+    let expected_sha256 =
+        github_release_asset_sha256(SOLANA_VERIFY_GITHUB_REPO, &tag, &asset_name)?;
     let url = format!(
-        "https://github.com/Ellipsis-Labs/solana-verifiable-build/releases/download/v{SOLANA_VERIFY_VERSION}/solana-verify-{os}"
+        "https://github.com/{SOLANA_VERIFY_GITHUB_REPO}/releases/download/{tag}/{asset_name}"
     );
     let res = DOWNLOAD_CLIENT.get(&url).send()?;
     if !res.status().is_success() {
@@ -659,6 +723,7 @@ fn install_solana_verify() -> Result<()> {
             res,
             format!("Downloading solana-verify {SOLANA_VERIFY_VERSION}"),
         )?;
+        verify_sha256(&bytes, &expected_sha256, &url)?;
         fs::write(&bin_path, bytes)?;
         #[cfg(unix)]
         fs::set_permissions(
@@ -1578,6 +1643,41 @@ mod tests {
             sha256_hex(b"anchor"),
             "79bfb0e2ba76b9d447606ddbcc494834f05a4c11deb052e74b49ea307a3c5bcd"
         );
+    }
+
+    #[test]
+    fn test_parse_github_sha256_digest() {
+        assert_eq!(
+            parse_github_sha256_digest(
+                "sha256:79BFB0E2BA76B9D447606DDBCC494834F05A4C11DEB052E74B49EA307A3C5BCD"
+            )
+            .unwrap(),
+            "79bfb0e2ba76b9d447606ddbcc494834f05a4c11deb052e74b49ea307a3c5bcd"
+        );
+
+        let err = parse_github_sha256_digest(
+            "sha512:79bfb0e2ba76b9d447606ddbcc494834f05a4c11deb052e74b49ea307a3c5bcd",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("Unsupported release asset digest"));
+
+        let err = parse_github_sha256_digest("sha256:not-a-valid-digest")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Invalid SHA-256 release asset digest"));
+    }
+
+    #[test]
+    fn test_verify_sha256_rejects_mismatch() {
+        let expected = sha256_hex(b"expected binary");
+        verify_sha256(b"expected binary", &expected, "anchor-test-binary").unwrap();
+
+        let err = verify_sha256(b"tampered binary", &expected, "anchor-test-binary")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Checksum mismatch for `anchor-test-binary`"));
+        assert!(err.contains(&expected));
     }
 
     #[test]

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -17,6 +17,7 @@
 //! `platform-tools-{linux|osx|windows}-{x86_64|aarch64}.tar.bz2`.
 use {
     crate::{
+        download_response_to_writer,
         resolve::{resolve_solana_version, SolanaResolution, SolanaResolutionSource},
         solana::installable_solana_cli_versions_for_req,
         AVM_HOME, DOWNLOAD_CLIENT,
@@ -676,7 +677,7 @@ fn looks_installed(dir: &Path) -> bool {
 }
 
 fn download_to(url: &str, dest: &Path) -> Result<()> {
-    let mut response = DOWNLOAD_CLIENT
+    let response = DOWNLOAD_CLIENT
         .get(url)
         .send()
         .with_context(|| format!("Sending GET {url}"))?;
@@ -685,8 +686,7 @@ fn download_to(url: &str, dest: &Path) -> Result<()> {
     }
     let mut file =
         fs::File::create(dest).with_context(|| format!("Creating {}", dest.display()))?;
-    response
-        .copy_to(&mut file)
+    download_response_to_writer(response, "Downloading platform-tools", &mut file)
         .with_context(|| format!("Writing {}", dest.display()))?;
     Ok(())
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,7 +79,7 @@ sha2 = "0.10"
 toml = "0.7.6"
 walkdir = "2.3.2"
 bs58 = "0.5.1"
-indicatif = "0.18.2"
+indicatif.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 # `anchor test --profile` — flamegraph rendering from LiteSVM register traces.


### PR DESCRIPTION
- add an AVM download progress helper that shows a byte progress bar when content length is available and a spinner fallback otherwise
- use the progress helper for prebuilt Anchor binaries, solana-verify, nightly artifacts, and platform-tools downloads
- verify stable Anchor and solana-verify release downloads against the GitHub release asset SHA-256 digest before writing executable files
- move indicatif into workspace dependencies and consume it from both CLI and AVM
