### PR TITLE
Replaced MAX_SIGN_ATTEMPTS const with an CLI arg

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -235,6 +235,9 @@ pub enum Command {
         /// Environment variables to pass into the docker container
         #[clap(short, long, required = false)]
         env: Vec<String>,
+        /// Max number of times to re-sign with a fresh blockhash when one expires during buffer writes
+        #[clap(long, default_value = "5")]
+        max_sign_attempts: usize,
         /// Arguments to pass to the underlying `cargo build-sbf` command.
         #[clap(required = false, last = true)]
         cargo_args: Vec<String>,
@@ -273,6 +276,9 @@ pub enum Command {
         /// Don't upload IDL during deployment (IDL is uploaded by default)
         #[clap(long)]
         no_idl: bool,
+        /// Max number of times to re-sign with a fresh blockhash when one expires during buffer writes
+        #[clap(long, default_value = "5")]
+        max_sign_attempts: usize,
         /// Arguments to pass to the underlying `solana program deploy` command.
         #[clap(required = false, last = true)]
         solana_args: Vec<String>,
@@ -505,6 +511,9 @@ pub enum ProgramCommand {
         /// Make the program immutable after deployment (cannot be upgraded)
         #[clap(long = "final")]
         make_final: bool,
+        /// Max number of times to re-sign with a fresh blockhash when one expires during buffer writes
+        #[clap(long, default_value = "5")]
+        max_sign_attempts: usize,
         /// Additional arguments to configure deployment (e.g., --with-compute-unit-price 1000)
         #[clap(required = false, last = true)]
         solana_args: Vec<String>,
@@ -526,6 +535,9 @@ pub enum ProgramCommand {
         /// Maximum transaction length
         #[clap(long)]
         max_len: Option<usize>,
+        /// Max number of times to re-sign with a fresh blockhash when one expires during buffer writes
+        #[clap(long, default_value = "5")]
+        max_sign_attempts: usize,
     },
     /// Set a new buffer authority
     SetBufferAuthority {
@@ -1216,6 +1228,7 @@ fn process_command(opts: Opts) -> Result<()> {
             program_keypair,
             verifiable,
             no_idl,
+            max_sign_attempts,
             solana_args,
         } => {
             eprintln!(
@@ -1227,6 +1240,7 @@ fn process_command(opts: Opts) -> Result<()> {
                 program_keypair,
                 verifiable,
                 no_idl,
+                max_sign_attempts,
                 solana_args,
             )
         }
@@ -1265,6 +1279,7 @@ fn process_command(opts: Opts) -> Result<()> {
             validator,
             args,
             env,
+            max_sign_attempts,
             cargo_args,
             skip_lint,
         } => test(
@@ -1280,6 +1295,7 @@ fn process_command(opts: Opts) -> Result<()> {
             validator,
             args,
             env,
+            max_sign_attempts,
             cargo_args,
         ),
         Command::Airdrop { amount, pubkey } => airdrop(&opts.cfg_override, amount, pubkey),
@@ -3169,6 +3185,7 @@ fn test(
     validator_type: ValidatorType,
     extra_args: Vec<String>,
     env_vars: Vec<String>,
+    max_sign_attempts: usize,
     cargo_args: Vec<String>,
 ) -> Result<()> {
     let test_paths = tests_to_run
@@ -3217,7 +3234,7 @@ fn test(
         // In either case, skip the deploy if the user specifies.
         let is_localnet = cfg.provider.cluster == Cluster::Localnet;
         if (!is_localnet || skip_local_validator) && !skip_deploy {
-            deploy(cfg_override, None, None, false, true, vec![])?;
+            deploy(cfg_override, None, None, false, true, max_sign_attempts, vec![])?;
         }
 
         cfg.run_hooks(HookType::PreTest)?;
@@ -4193,6 +4210,7 @@ fn deploy(
     program_keypair: Option<String>,
     verifiable: bool,
     no_idl: bool,
+    max_sign_attempts: usize,
     solana_args: Vec<String>,
 ) -> Result<()> {
     // Execute the code within the workspace
@@ -4232,6 +4250,7 @@ fn deploy(
                 None, // max_len
                 no_idl,
                 false, // make_final
+                max_sign_attempts,
                 solana_args.clone(),
             )?;
         }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3234,7 +3234,15 @@ fn test(
         // In either case, skip the deploy if the user specifies.
         let is_localnet = cfg.provider.cluster == Cluster::Localnet;
         if (!is_localnet || skip_local_validator) && !skip_deploy {
-            deploy(cfg_override, None, None, false, true, max_sign_attempts, vec![])?;
+            deploy(
+                cfg_override,
+                None,
+                None,
+                false,
+                true,
+                max_sign_attempts,
+                vec![],
+            )?;
         }
 
         cfg.run_hooks(HookType::PreTest)?;

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -192,6 +192,7 @@ pub fn process_deploy(
     verifiable: bool,
     no_idl: bool,
     make_final: bool,
+    max_sign_attempts: usize,
     solana_args: Vec<String>,
 ) -> Result<()> {
     // If explicit filepath provided, deploy single program
@@ -207,6 +208,7 @@ pub fn process_deploy(
             max_len,
             no_idl,
             make_final,
+            max_sign_attempts,
             solana_args,
         );
     }
@@ -250,6 +252,7 @@ pub fn process_deploy(
             verifiable,
             no_idl,
             make_final,
+            max_sign_attempts,
             solana_args,
         );
     }
@@ -266,6 +269,7 @@ pub fn process_deploy(
         max_len,
         no_idl,
         make_final,
+        max_sign_attempts,
         solana_args,
     )
 }
@@ -278,6 +282,7 @@ fn deploy_workspace(
     verifiable: bool,
     no_idl: bool,
     make_final: bool,
+    max_sign_attempts: usize,
     solana_args: Vec<String>,
 ) -> Result<()> {
     // Get programs from workspace (Anchor or non-Anchor)
@@ -324,6 +329,7 @@ fn deploy_workspace(
             None, // max_len
             no_idl,
             make_final,
+            max_sign_attempts,
             solana_args.clone(),
         )?;
     }
@@ -345,6 +351,7 @@ pub fn program(cfg_override: &ConfigOverride, cmd: ProgramCommand) -> Result<()>
             max_len,
             no_idl,
             make_final,
+            max_sign_attempts,
             solana_args,
         } => process_deploy(
             cfg_override,
@@ -358,6 +365,7 @@ pub fn program(cfg_override: &ConfigOverride, cmd: ProgramCommand) -> Result<()>
             false, // verifiable
             no_idl,
             make_final,
+            max_sign_attempts,
             solana_args,
         ),
         ProgramCommand::WriteBuffer {
@@ -366,6 +374,7 @@ pub fn program(cfg_override: &ConfigOverride, cmd: ProgramCommand) -> Result<()>
             buffer,
             buffer_authority,
             max_len,
+            max_sign_attempts,
         } => program_write_buffer(
             cfg_override,
             program_filepath,
@@ -373,6 +382,7 @@ pub fn program(cfg_override: &ConfigOverride, cmd: ProgramCommand) -> Result<()>
             buffer,
             buffer_authority,
             max_len,
+            max_sign_attempts,
         ),
         ProgramCommand::SetBufferAuthority {
             buffer,
@@ -484,6 +494,7 @@ pub fn program_deploy(
     max_len: Option<usize>,
     no_idl: bool,
     make_final: bool,
+    max_sign_attempts: usize,
     solana_args: Vec<String>,
 ) -> Result<()> {
     let (rpc_client, config) = get_rpc_client_and_config(cfg_override)?;
@@ -584,6 +595,7 @@ pub fn program_deploy(
                 &upgrade_authority.pubkey(),
                 &buffer_keypair,
                 max_len,
+                max_sign_attempts,
                 CommitmentConfig::confirmed(),
                 RpcSendTransactionConfig {
                     skip_preflight: false,
@@ -619,6 +631,7 @@ pub fn program_deploy(
                 &upgrade_authority.pubkey(),
                 &buffer_keypair,
                 max_len,
+                max_sign_attempts,
                 CommitmentConfig::confirmed(),
                 RpcSendTransactionConfig {
                     skip_preflight: false,
@@ -969,6 +982,7 @@ fn program_write_buffer(
     _buffer: Option<String>,
     buffer_authority: Option<String>,
     max_len: Option<usize>,
+    max_sign_attempts: usize,
 ) -> Result<()> {
     let (rpc_client, config) = get_rpc_client_and_config(cfg_override)?;
     let payer = get_payer_keypair(cfg_override, &config)?;
@@ -1016,6 +1030,7 @@ fn program_write_buffer(
         &buffer_authority_keypair.pubkey(),
         &buffer_keypair,
         max_len,
+        max_sign_attempts,
         CommitmentConfig::confirmed(),
         RpcSendTransactionConfig {
             skip_preflight: false,
@@ -1391,6 +1406,7 @@ pub fn program_upgrade(
             &upgrade_authority_keypair.pubkey(),
             &buffer_keypair,
             None, // max_len
+            5,    // max_sign_attempts
             CommitmentConfig::confirmed(),
             RpcSendTransactionConfig {
                 skip_preflight: false,
@@ -1860,6 +1876,7 @@ pub fn write_program_buffer(
     buffer_authority: &Pubkey,
     buffer_keypair: &dyn Signer,
     max_len: Option<usize>,
+    max_sign_attempts: usize,
     commitment: CommitmentConfig,
     send_transaction_config: RpcSendTransactionConfig,
 ) -> Result<Pubkey> {
@@ -1902,7 +1919,6 @@ pub fn write_program_buffer(
         &blockhash,
     );
 
-    const MAX_SIGN_ATTEMPTS: usize = 5;
     send_deploy_messages(
         rpc_client,
         initial_message,
@@ -1912,7 +1928,7 @@ pub fn write_program_buffer(
         Some(buffer_keypair),
         Some(payer),
         None,
-        MAX_SIGN_ATTEMPTS,
+        max_sign_attempts,
         commitment,
         send_transaction_config,
     )?;

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -250,8 +250,7 @@ impl<T: AccountDeserialize> Key for Program<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::system_program::System;
+    use {super::*, crate::system_program::System};
 
     fn account_info<'a>(
         key: &'a Pubkey,
@@ -275,10 +274,9 @@ mod tests {
             .err()
             .expect("non-system key must be rejected");
         match err {
-            Error::AnchorError(e) => assert_eq!(
-                e.error_code_number,
-                ErrorCode::InvalidProgramId as u32,
-            ),
+            Error::AnchorError(e) => {
+                assert_eq!(e.error_code_number, ErrorCode::InvalidProgramId as u32,)
+            }
             other => panic!("unexpected error variant: {other:?}"),
         }
     }


### PR DESCRIPTION
gm

When deploying programs to devnet, it often almost succeeds but fails due to the hard maximum of 5 retries. That wasted enough time for me to decide to change it.

I removed the `MAX_SIGN_ATTEMPTS` constant and replaced the places that used it with a `--max-sign-attempts` argument. Default behaviour remains the same.