### PR TITLE
fix(lang): qualify bare error! calls in require macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Fixes
 
 - lang: Shorten invariant lifetimes during `Context` creation ([#4363](https://github.com/solana-foundation/anchor/pull/4363)).
+- lang: Qualify bare `error!` calls in require macros so they don't depend on global prelude imports ([#4639](https://github.com/otter-sec/anchor/pull/4639)).
 - ts: Guard recursive IDL layouts against stack overflows while preserving supported recursive types ([#4604](https://github.com/solana-foundation/anchor/pull/4604)).
 - idl: Bump version to 0.1.3 ([#4453](https://github.com/solana-foundation/anchor/pull/4453)).
 - lang: Migrate `anchor-syn` from syn 1.x to syn 2.0, allowing use of modern Rust syntax ([#4523](https://github.com/solana-foundation/anchor/issues/4523)).

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -771,7 +771,7 @@ macro_rules! require {
 macro_rules! require_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(error!($error_code).with_values(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
@@ -801,7 +801,7 @@ macro_rules! require_eq {
 macro_rules! require_neq {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(error!($error_code).with_values(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
@@ -831,7 +831,7 @@ macro_rules! require_neq {
 macro_rules! require_keys_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(error!($error_code).with_pubkeys(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_pubkeys(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
@@ -861,7 +861,7 @@ macro_rules! require_keys_eq {
 macro_rules! require_keys_neq {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(error!($error_code).with_pubkeys(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_pubkeys(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
@@ -893,7 +893,7 @@ macro_rules! require_keys_neq {
 macro_rules! require_gt {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 <= $value2 {
-            return Err(error!($error_code).with_values(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
@@ -921,7 +921,7 @@ macro_rules! require_gt {
 macro_rules! require_gte {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 < $value2 {
-            return Err(error!($error_code).with_values(($value1, $value2)));
+            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {


### PR DESCRIPTION
### Problem
Some declarative macros in `anchor-lang` (like `require_eq!`, `require_gt!`, etc.) relied on the `error!` macro being available in the caller's scope via the prelude glob import. This caused issues when the prelude wasn't imported.

### Fix
Qualified all bare `error!` calls inside `macro_rules!` in [lang/src/lib.rs](cci:7://file:///home/ibrahim/Desktop/anchor/lang/src/lib.rs:0:0-0:0) with `anchor_lang::error!`. This ensures the macros are self-contained and resolve correctly regardless of the caller's imports.
