### PR TITLE
syn: Remove `anyhow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Validate instruction args in `BorshInstructionCoder.encode` to reject typo'd or missing fields instead of silently ignoring them ([#4560](https://github.com/solana-foundation/anchor/pull/4560)).
 - ts: Align TS `camelCase` conversion with Rust `heck` for digit-letter identifiers so generated client names match Rust identifiers ([#4571](https://github.com/solana-foundation/anchor/pull/4571)).
 - cli: Warn if `event-cpi` instruction is unreachable with custom discriminators ([#4614](https://github.com/solana-foundation/anchor/pull/4614)).
+- syn: Remove `anyhow` ([#4640](https://github.com/solana-foundation/anchor/pull/4640)).
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ dependencies = [
 name = "anchor-syn"
 version = "1.0.2"
 dependencies = [
- "anyhow",
  "bs58",
  "cargo_toml",
  "heck 0.3.3",

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -28,7 +28,6 @@ idl-build = ["cargo_toml"]
 init-if-needed = []
 
 [dependencies]
-anyhow = "1"
 bs58 = "0.5"
 
 # `idl-build` feature only

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -1,4 +1,4 @@
-use {crate::IxArg, anyhow::Result, heck::CamelCase, quote::quote};
+use {crate::IxArg, heck::CamelCase, quote::quote, syn::Result};
 
 // Namespace for calculating instruction sighash signatures for any instruction
 // not affecting program state.
@@ -45,5 +45,5 @@ pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> Result<proc_macro2::To
 }
 
 pub fn generate_ix_variant_name(name: &str) -> Result<syn::Ident> {
-    Ok(syn::parse_str(&name.to_camel_case())?)
+    syn::parse_str(&name.to_camel_case())
 }

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -1,9 +1,9 @@
 use {
     super::common::{get_idl_module_path, get_no_docs},
     crate::{AccountField, AccountsStruct, ConstraintSeedsGroup, Field, InitKind, Ty},
-    anyhow::{anyhow, Result},
     proc_macro2::TokenStream,
     quote::{quote, ToTokens},
+    syn::Result,
 };
 
 /// Generate the IDL build impl for the Accounts struct.
@@ -21,7 +21,7 @@ pub fn gen_idl_build_impl_accounts_struct(accounts: &AccountsStruct) -> TokenStr
         .fields
         .iter()
         .map(
-            |acc| -> syn::Result<(TokenStream, Option<(&syn::TypePath, TokenStream)>)> {
+            |acc| -> Result<(TokenStream, Option<(&syn::TypePath, TokenStream)>)> {
                 match acc {
                     AccountField::Field(acc) => {
                         let name = acc.ident.to_string();
@@ -131,7 +131,7 @@ pub fn gen_idl_build_impl_accounts_struct(accounts: &AccountsStruct) -> TokenStr
                 }
             },
         )
-        .collect::<syn::Result<Vec<_>>>();
+        .collect::<Result<Vec<_>>>();
     let (accounts, defined) = match result {
         Ok(result) => result.into_iter().unzip::<_, _, Vec<_>, Vec<_>>(),
         Err(error) => return error.into_compile_error(),
@@ -427,7 +427,10 @@ fn parse_seed(seed: &syn::Expr, accounts: &AccountsStruct) -> Result<TokenStream
             )
         }),
         syn::Expr::Reference(rf) => parse_seed(&rf.expr, accounts),
-        _ => Err(anyhow!("Unexpected seed: {seed:?}")),
+        expr => Err(syn::Error::new_spanned(
+            expr,
+            format!("Unexpected seed: {seed:?}"),
+        )),
     }
 }
 
@@ -450,13 +453,19 @@ impl SeedPath {
 
         // Check unsupported cases e.g. `&(account.field + 1).to_le_bytes()`
         if !seed_str.contains('"') && seed_str.contains(['+', '-', '*', '/', '%', '^']) {
-            return Err(anyhow!("Seed expression not supported: {seed:#?}"));
+            return Err(syn::Error::new_spanned(
+                seed,
+                format!("Seed expression not supported: {seed:#?}"),
+            ));
         }
 
         // Break up the seed into each subfield component.
         let mut components = seed_str.split('.').collect::<Vec<_>>();
         if components.len() <= 1 {
-            return Err(anyhow!("Seed is in unexpected format: {seed:#?}"));
+            return Err(syn::Error::new_spanned(
+                seed,
+                format!("Seed is in unexpected format: {seed:#?}"),
+            ));
         }
 
         // The name of the variable (or field).

--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -1,5 +1,5 @@
 use {
-    anyhow::{anyhow, Result},
+    crate::AnyResult as Result,
     proc_macro2::TokenStream,
     quote::{quote, ToTokens},
     std::path::{Path, PathBuf},
@@ -14,7 +14,7 @@ pub fn find_path(name: &str, path: impl AsRef<Path>) -> Result<PathBuf> {
         }
     }
 
-    Err(anyhow!("Path ({path:?}) not found"))
+    Err(format!("Path ({path:?}) not found").into())
 }
 
 pub fn get_no_docs() -> bool {
@@ -26,7 +26,7 @@ pub fn get_no_docs() -> bool {
 pub fn get_program_path() -> Result<PathBuf> {
     std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH")
         .map(PathBuf::from)
-        .map_err(|_| anyhow!("Failed to get program path"))
+        .map_err(|_| format!("Failed to get program path").into())
 }
 
 pub fn get_idl_module_path() -> TokenStream {

--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -26,7 +26,7 @@ pub fn get_no_docs() -> bool {
 pub fn get_program_path() -> Result<PathBuf> {
     std::env::var("ANCHOR_IDL_BUILD_PROGRAM_PATH")
         .map(PathBuf::from)
-        .map_err(|_| format!("Failed to get program path").into())
+        .map_err(|e| format!("Failed to get program path: {e}").into())
 }
 
 pub fn get_idl_module_path() -> TokenStream {

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -33,11 +33,11 @@ fn recursively_find_type(
     let crate_name = use_path
         .split("::")
         .next()
-        .ok_or_else(|| format!("Use path should include a crate name"))?;
+        .ok_or("Use path should include a crate name")?;
     let (crate_name, version) = lock_file
         .iter()
         .find(|(name, _)| name == crate_name || name == &crate_name.replace('_', "-"))
-        .ok_or_else(|| format!("Crate should exist in the lock file"))?;
+        .ok_or("Crate should exist in the lock file")?;
 
     let crate_path = registry_path.join(format!("{crate_name}-{version}"));
     let lib_path = crate_path.join("src").join("lib.rs");
@@ -76,7 +76,7 @@ fn get_registry_path() -> Result<PathBuf> {
     let cargo_home = env::var_os("CARGO_HOME")
         .map(PathBuf::from)
         .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cargo")))
-        .ok_or_else(|| format!("Cargo home not found"))?;
+        .ok_or("Cargo home not found")?;
     let path = cargo_home.join("registry").join("src");
     fs::read_dir(&path)?
         .filter_map(|entry| entry.ok())
@@ -89,7 +89,7 @@ fn get_registry_path() -> Result<PathBuf> {
             }
         })
         .map(|name| path.join(name))
-        .ok_or_else(|| format!("crates.io registry not found"))
+        .ok_or("crates.io registry not found")
         .map_err(Into::into)
 }
 

--- a/lang/syn/src/idl/external.rs
+++ b/lang/syn/src/idl/external.rs
@@ -1,7 +1,6 @@
 use {
     super::common::{find_path, get_program_path},
-    crate::parser::context::CrateContext,
-    anyhow::{anyhow, Result},
+    crate::{parser::context::CrateContext, AnyResult as Result},
     cargo_toml::Manifest,
     quote::ToTokens,
     std::{
@@ -14,7 +13,7 @@ pub fn get_external_type(name: &str, path: impl AsRef<Path>) -> Result<Option<sy
     let use_path = get_uses(path.as_ref())?
         .into_iter()
         .find(|u| u.rsplit("::").next() == Some(name))
-        .ok_or_else(|| anyhow!("`{name}` not found in use statements"))?;
+        .ok_or_else(|| format!("`{name}` not found in use statements"))?;
 
     // Get crate name and version from lock file
     let program_path = get_program_path()?;
@@ -34,11 +33,11 @@ fn recursively_find_type(
     let crate_name = use_path
         .split("::")
         .next()
-        .ok_or_else(|| anyhow!("Use path should include a crate name"))?;
+        .ok_or_else(|| format!("Use path should include a crate name"))?;
     let (crate_name, version) = lock_file
         .iter()
         .find(|(name, _)| name == crate_name || name == &crate_name.replace('_', "-"))
-        .ok_or_else(|| anyhow!("Crate should exist in the lock file"))?;
+        .ok_or_else(|| format!("Crate should exist in the lock file"))?;
 
     let crate_path = registry_path.join(format!("{crate_name}-{version}"));
     let lib_path = crate_path.join("src").join("lib.rs");
@@ -77,7 +76,7 @@ fn get_registry_path() -> Result<PathBuf> {
     let cargo_home = env::var_os("CARGO_HOME")
         .map(PathBuf::from)
         .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cargo")))
-        .ok_or_else(|| anyhow!("Cargo home not found"))?;
+        .ok_or_else(|| format!("Cargo home not found"))?;
     let path = cargo_home.join("registry").join("src");
     fs::read_dir(&path)?
         .filter_map(|entry| entry.ok())
@@ -90,7 +89,8 @@ fn get_registry_path() -> Result<PathBuf> {
             }
         })
         .map(|name| path.join(name))
-        .ok_or_else(|| anyhow!("crates.io registry not found"))
+        .ok_or_else(|| format!("crates.io registry not found"))
+        .map_err(Into::into)
 }
 
 fn parse_lock_file(path: impl AsRef<Path>) -> Result<Vec<(String, String)>> {
@@ -102,12 +102,13 @@ fn parse_lock_file(path: impl AsRef<Path>) -> Result<Vec<(String, String)>> {
                 let line = pkg
                     .lines()
                     .find(|line| line.starts_with(key))
-                    .ok_or_else(|| anyhow!("`{key}` line not found"))?;
+                    .ok_or_else(|| format!("`{key}` line not found"))?;
 
                 line.split('"')
                     .nth(1)
                     .map(ToOwned::to_owned)
-                    .ok_or_else(|| anyhow!("`{key}` value not found"))
+                    .ok_or_else(|| format!("`{key}` value not found"))
+                    .map_err(Into::into)
             };
             Ok((get_value("name")?, get_value("version")?))
         })

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -7,21 +7,18 @@ use {
         parser::{context::CrateContext, docs},
         Program,
     },
-    anyhow::{anyhow, Result},
     heck::CamelCase,
     proc_macro2::TokenStream,
     quote::{format_ident, quote},
     syn::spanned::Spanned,
+    syn::Result,
 };
 
 /// Generate the IDL build print function for the program module.
 pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
-    if let Err(error) = check_safety_comments() {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            format!("Safety checks failed: {error}"),
-        )
-        .into_compile_error();
+    if let Err(e) = check_safety_comments() {
+        return syn::Error::new(e.span(), format!("Safety checks failed: {e}"))
+            .into_compile_error();
     }
 
     let idl = get_idl_module_path();
@@ -70,7 +67,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                         defined,
                     ))
                 })
-                .collect::<syn::Result<Vec<_>>>()?
+                .collect::<Result<Vec<_>>>()?
                 .into_iter()
                 .unzip::<_, Vec<_>, Vec<_>, Vec<_>>();
 
@@ -100,7 +97,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                 defined,
             ))
         })
-        .collect::<syn::Result<Vec<_>>>();
+        .collect::<Result<Vec<_>>>();
     let (instructions, defined) = match result {
         Err(e) => return e.into_compile_error(),
         Ok(v) => v.into_iter().unzip::<_, Vec<_>, Vec<_>, Vec<_>>(),
@@ -166,8 +163,7 @@ fn check_safety_comments() -> Result<()> {
         return Ok(());
     }
 
-    let program_path = get_program_path();
-    if program_path.is_err() {
+    let Ok(program_path) = get_program_path() else {
         // Getting the program path can fail in the following scenarios:
         //
         // - Anchor CLI version is incompatible with the current version
@@ -182,11 +178,9 @@ fn check_safety_comments() -> Result<()> {
         // Given this feature is not a critical one, and it works by default with `anchor build`,
         // we can fail silently in the case of an error rather than panicking.
         return Ok(());
-    }
+    };
 
-    program_path
-        .map(|path| path.join("src").join("lib.rs"))
-        .map(CrateContext::parse)?
-        .map_err(|e| anyhow!("Failed to parse crate: {e}"))?
+    CrateContext::parse(program_path.join("src").join("lib.rs"))
+        .map_err(|e| syn::Error::new(e.span(), format!("Failed to parse crate: {e}")))?
         .safety_checks()
 }

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -10,8 +10,7 @@ use {
     heck::CamelCase,
     proc_macro2::TokenStream,
     quote::{format_ident, quote},
-    syn::spanned::Spanned,
-    syn::Result,
+    syn::{spanned::Spanned, Result},
 };
 
 /// Generate the IDL build print function for the program module.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -29,6 +29,10 @@ use {
     },
 };
 
+/// Generic result type, only used when [`syn::Error`] doesn't make sense.
+#[cfg(feature = "idl-build")]
+pub(crate) type AnyResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
 #[derive(Debug)]
 pub struct Program {
     pub ixs: Vec<Ix>,
@@ -64,7 +68,7 @@ pub struct ProgramArgs {
 }
 
 impl Parse for ProgramArgs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
         let mut parsed = Self::default();
         let args = input.parse_terminated(Ident::parse, Token![,])?;
 

--- a/lang/syn/src/parser/accounts/event_cpi.rs
+++ b/lang/syn/src/parser/accounts/event_cpi.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, ToTokens};
 
 /// This struct is used to keep the authority account information in sync.
 pub struct EventAuthority {
@@ -19,8 +19,7 @@ impl EventAuthority {
 
     /// Returns the name without surrounding quotes.
     pub fn name_token_stream(&self) -> proc_macro2::TokenStream {
-        let name_ident = syn::Ident::new(self.name, proc_macro2::Span::call_site());
-        quote! {#name_ident}
+        syn::Ident::new(self.name, proc_macro2::Span::call_site()).to_token_stream()
     }
 }
 

--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -1,11 +1,11 @@
 use {
-    anyhow::{anyhow, Result},
+    proc_macro2::Span,
     std::{
         collections::BTreeMap,
         path::{Path, PathBuf},
     },
     syn::{
-        parse::{Error as ParseError, Result as ParseResult},
+        parse::{Error as ParseError, Result},
         Ident, ImplItem, ImplItemConst, Type, TypePath,
     },
 };
@@ -91,8 +91,10 @@ impl CrateContext {
                         reason = "file paths are always valid during compilation"
                     )]
                     let canonical = ctx.file.canonicalize().unwrap();
-                    return Err(anyhow!(
-                        r#"
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            r#"
         {}:{}:{}
         Struct field "{}" is unsafe, but is not documented.
         Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
@@ -100,10 +102,11 @@ impl CrateContext {
         by using the `skip-lint` option.
         See https://www.anchor-lang.com/docs/references/account-types#uncheckedaccountinfo for more information.
                     "#,
-                        canonical.display(),
-                        span.start().line,
-                        span.start().column,
-                        ident
+                            canonical.display(),
+                            span.start().line,
+                            span.start().column,
+                            ident,
+                        ),
                     ));
                 };
             }
@@ -143,7 +146,8 @@ impl ParsedModule {
     fn parse_recursive(root: &Path) -> Result<BTreeMap<String, ParsedModule>> {
         let mut modules = BTreeMap::new();
 
-        let root_content = std::fs::read_to_string(root)?;
+        let root_content =
+            std::fs::read_to_string(root).map_err(|e| syn::Error::new(Span::call_site(), e))?;
         let root_file = syn::parse_file(&root_content)?;
         let root_mod = Self::new(
             String::new(),
@@ -166,11 +170,7 @@ impl ParsedModule {
         Ok(modules)
     }
 
-    fn from_item_mod(
-        parent_file: &Path,
-        parent_path: &str,
-        item: syn::ItemMod,
-    ) -> ParseResult<Self> {
+    fn from_item_mod(parent_file: &Path, parent_path: &str, item: syn::ItemMod) -> Result<Self> {
         Ok(match item.content {
             Some((_, items)) => {
                 // The module content is within the parent file being parsed


### PR DESCRIPTION
### Problem

`anyhow` doesn't fit well in a parsing crate like `anchor-syn`.

### Summary of changes

- Replace `anyhow` usage with `syn` and a simple `AnyResult` type
- Remove the `anyhow` dependency
- Update `Cargo.lock`