### PR TITLE
Document nightly CLI install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ For a quickstart guide and in depth tutorials, see the [Anchor book](https://boo
 
 To jump straight to examples, go [here](https://github.com/otter-sec/anchor/tree/master/examples). For the latest Rust and TypeScript API documentation, see [docs.rs](https://docs.rs/anchor-lang) and the [typedoc](https://www.anchor-lang.com/docs/clients/typescript).
 
+## Installation
+
+The recommended way to install the Anchor CLI is with the Anchor Version Manager (AVM).
+
+```sh
+curl -sSfL https://raw.githubusercontent.com/solana-foundation/anchor/master/avm/install | sh
+```
+
+The installer downloads the latest nightly AVM and Anchor CLI binaries, enables
+the nightly channel, and links the `avm` and `anchor` commands into
+`~/.cargo/bin` when possible. After that, `anchor` will use the latest cached
+nightly build and periodically check for updates.
+
+If you already have AVM installed, you can enable the nightly channel directly:
+
+```sh
+avm nightly
+```
+
+To leave nightly mode and return to normal AVM version resolution, run:
+
+```sh
+avm nightly --disable
+```
+
 ## Packages
 
 | Package                 | Description                                              | Version                                                                                                                          | Docs                                                                                                            |


### PR DESCRIPTION
## Summary
- add README installation guidance for AVM
- document installing nightly AVM via curl | sh
- document enabling and disabling nightly mode with avm nightly

## Testing
- git diff --check HEAD~1..HEAD