### PR TITLE
ts: Update `engines.node` to `>= 20.18`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - ts: Validate instruction args in `BorshInstructionCoder.encode` to reject typo'd or missing fields instead of silently ignoring them ([#4560](https://github.com/solana-foundation/anchor/pull/4560)).
 - ts: Align TS `camelCase` conversion with Rust `heck` for digit-letter identifiers so generated client names match Rust identifiers ([#4571](https://github.com/solana-foundation/anchor/pull/4571)).
 - cli: Warn if `event-cpi` instruction is unreachable with custom discriminators ([#4614](https://github.com/solana-foundation/anchor/pull/4614)).
+- ts: Update `engines.node` to `>= 20.18` ([#4647](https://github.com/solana-foundation/anchor/pull/4647)).
 
 ### Breaking
 

--- a/tests/account-generation-test/package.json
+++ b/tests/account-generation-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "account-generation-test",
-  "version": "0.32.1",
+  "version": "0.1.0",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/coral-xyz/anchor#readme",
   "bugs": {
@@ -11,7 +11,7 @@
     "url": "https://github.com/coral-xyz/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/anchor-cli-account/package.json
+++ b/tests/anchor-cli-account/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/anchor-cli-idl/package.json
+++ b/tests/anchor-cli-idl/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "./test.sh"

--- a/tests/anchor-cli-legacy-idl/package.json
+++ b/tests/anchor-cli-legacy-idl/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/auction-house/package.json
+++ b/tests/auction-house/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test --skip-lint"

--- a/tests/bench/package.json
+++ b/tests/bench/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test --skip-lint"

--- a/tests/bpf-upgradeable-state/package.json
+++ b/tests/bpf-upgradeable-state/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/cashiers-check/package.json
+++ b/tests/cashiers-check/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/cfo/package.json
+++ b/tests/cfo/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor run test-with-build"

--- a/tests/chat/package.json
+++ b/tests/chat/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/composite/package.json
+++ b/tests/composite/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/cpi-returns/package.json
+++ b/tests/cpi-returns/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor run test-with-build"

--- a/tests/custom-coder/package.json
+++ b/tests/custom-coder/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test --skip-lint"

--- a/tests/custom-discriminator/package.json
+++ b/tests/custom-discriminator/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/custom-program/package.json
+++ b/tests/custom-program/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/declare-id/package.json
+++ b/tests/declare-id/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/declare-program/package.json
+++ b/tests/declare-program/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/duplicate-mutable-accounts/package.json
+++ b/tests/duplicate-mutable-accounts/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/errors/package.json
+++ b/tests/errors/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/escrow/package.json
+++ b/tests/escrow/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/events/package.json
+++ b/tests/events/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/floats/package.json
+++ b/tests/floats/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/idl/package.json
+++ b/tests/idl/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/ido-pool/package.json
+++ b/tests/ido-pool/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/interface-account/package.json
+++ b/tests/interface-account/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/lazy-account/package.json
+++ b/tests/lazy-account/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/lockup/package.json
+++ b/tests/lockup/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/misc/package.json
+++ b/tests/misc/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/multiple-suites-run-single/package.json
+++ b/tests/multiple-suites-run-single/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/multiple-suites/package.json
+++ b/tests/multiple-suites/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/multisig/package.json
+++ b/tests/multisig/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/optional/package.json
+++ b/tests/optional/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/pda-derivation/package.json
+++ b/tests/pda-derivation/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/pyth/package.json
+++ b/tests/pyth/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/realloc/package.json
+++ b/tests/realloc/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/relations-derivation/package.json
+++ b/tests/relations-derivation/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/metadata/package.json
+++ b/tests/spl/metadata/package.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   }
 }

--- a/tests/spl/token-extensions/package.json
+++ b/tests/spl/token-extensions/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/token-proxy/package.json
+++ b/tests/spl/token-proxy/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/token-wrapper/package.json
+++ b/tests/spl/token-wrapper/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/spl/transfer-hook/package.json
+++ b/tests/spl/transfer-hook/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/swap/package.json
+++ b/tests/swap/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/system-accounts/package.json
+++ b/tests/system-accounts/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/sysvars/package.json
+++ b/tests/sysvars/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/tictactoe/package.json
+++ b/tests/tictactoe/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/typescript/package.json
+++ b/tests/typescript/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/validator-clone/package.json
+++ b/tests/validator-clone/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/tests/zero-copy/package.json
+++ b/tests/zero-copy/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/otter-sec/anchor.git"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "test": "anchor test"

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18"
   },
   "scripts": {
     "build": "rimraf dist/ && yarn build:node && yarn build:browser",


### PR DESCRIPTION
### Problem

`node` v17 is not enough to make the default TS package installation work:

```
error rpc-websockets@9.3.10: The engine "node" is incompatible with this module. Expected version ">=18". Got "17.9.1"
```

Similar issue with `node` v18 (https://github.com/otter-sec/anchor/pull/3687):

```
error @solana/codecs-numbers@2.3.0: The engine "node" is incompatible with this module. Expected version ">=20.18.0". Got "18.20.8"
```

### Summary of changes

Require `engines.node >= 20.18`.

**Note:** This is technically a breaking change, but even `node` v20 is already EOL and is more than 3 years behind the latest version. Requiring v20 will allow us to support all the neat browser-`node` compat features that were implemented in v18-20.