### PR TITLE
ci: Reduce CI flakiness in tests/misc, setup-solana, and template-tests

### DIFF
--- a/.cspell-anchor-dictionary.txt
+++ b/.cspell-anchor-dictionary.txt
@@ -55,6 +55,7 @@ namespacing
 nonblocking
 openbook
 orderbooks
+osec
 pathlib
 pdas
 pdksh

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -19,8 +19,14 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_VERSION }}/install)"
+        # Pipe (not `$(...)`) so curl failures propagate to the retry action.
+        command: |
+          set -euo pipefail
+          curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_VERSION }}/install | sh
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Verify Solana install
+      run: command -v solana-keygen || { echo "Solana install failed - solana-keygen not on PATH"; exit 1; }
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase
       shell: bash

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -84,8 +84,16 @@ jobs:
       - run: chmod +x ~/.cargo/bin/anchor
 
       # Pre-install so concurrent `cargo build-sbf` invocations don't race on
-      # the platform-tools extract-then-rename.
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      # the platform-tools extract-then-rename. Retry on transient
+      # `Failed to parse Github response` from the platform-tools release API.
+      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
+        with:
+          retry_wait_seconds: 30
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          shell: bash
+          command: cargo build-sbf --tools-version v1.52 --install-only
 
       # Cache the generated project's `target/` so subsequent runs reuse
       # compiled deps. Restored before `anchor init` (which is invoked with
@@ -174,7 +182,16 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      # Retry on transient `Failed to parse Github response` from the
+      # platform-tools release API (same flake as the matching step above).
+      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
+        with:
+          retry_wait_seconds: 30
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          shell: bash
+          command: cargo build-sbf --tools-version v1.52 --install-only
 
       # Cache cargo `target/` and `node_modules/` for the generated project.
       # `anchor init --force` leaves both alone, so the dirs survive a fresh

--- a/tests/misc/Anchor.toml
+++ b/tests/misc/Anchor.toml
@@ -13,5 +13,8 @@ remaining_accounts = "RemainingAccounts11111111111111111111111111"
 [workspace]
 exclude = ["programs/shared"]
 
+# `transaction` mode produces one block per transaction, giving deterministic
+# confirmation and avoiding the intermittent `TransactionExpiredTimeoutError`
+# seen with `clock` mode under CI load.
 [surfpool]
-block_production_mode = "clock"
+block_production_mode = "transaction"

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -1006,14 +1006,18 @@ const miscTest = (
           })
           .rpc({ commitment: "confirmed" });
 
-        let otherMint = await Token.createMint(
-          program.provider.connection,
-          wallet.payer,
-          provider.wallet.publicKey,
-          provider.wallet.publicKey,
-          9,
-          TOKEN_PROGRAM_ID
-        );
+        // Create the second mint through the Anchor provider (program instruction)
+        // rather than the legacy `Token.createMint` helper.
+        const otherMint = anchor.web3.Keypair.generate();
+        await program.rpc.testInitMint({
+          accounts: {
+            mint: otherMint.publicKey,
+            payer: provider.wallet.publicKey,
+            systemProgram: anchor.web3.SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          },
+          signers: [otherMint],
+        });
 
         await nativeAssert.rejects(
           async () => {
@@ -1044,12 +1048,19 @@ const miscTest = (
           })
           .rpc({ commitment: "confirmed" });
 
-        await localClient.setAuthority(
-          associatedToken,
-          anchor.web3.Keypair.generate().publicKey,
-          "AccountOwner",
-          wallet.payer,
-          []
+        // Change the token account's owner via a SetAuthority instruction sent
+        // through the Anchor provider instead of the legacy `setAuthority` helper
+        await program.provider.sendAndConfirm(
+          new anchor.web3.Transaction().add(
+            Token.createSetAuthorityInstruction(
+              TOKEN_PROGRAM_ID,
+              associatedToken,
+              anchor.web3.Keypair.generate().publicKey,
+              "AccountOwner",
+              provider.wallet.publicKey,
+              []
+            )
+          )
         );
 
         await nativeAssert.rejects(


### PR DESCRIPTION
## Summary

- `tests/misc`: switch surfpool `block_production_mode` from `clock` to `transaction` and replace legacy `@solana/spl-token` `Token.createMint` / `setAuthority` calls with Anchor-provider equivalents.
- `.github/actions/setup-solana/action.yaml`: replace `sh -c "$(curl ...)"` with a `curl ... | sh` pipeline under `set -euo pipefail` and add a `command -v solana-keygen` verify step so installer failures stop being silent.
- `.github/workflows/template-tests.yaml`: wrap both `cargo build-sbf --install-only` calls in `nick-fields/retry` (3 attempts / 30s wait / 5 min timeout) to absorb transient `Failed to parse Github response` errors from the platform-tools release API.
- `.cspell-anchor-dictionary.txt`: add `osec`.