### PR TITLE
lang: Fix missing error messages of the generated errors in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - lang: Shorten invariant lifetimes during `Context` creation ([#4363](https://github.com/solana-foundation/anchor/pull/4363)).
 - ts: Guard recursive IDL layouts against stack overflows while preserving supported recursive types ([#4604](https://github.com/solana-foundation/anchor/pull/4604)).
+- lang: Fix missing error messages of the generated errors in `declare_program!` ([#4652](https://github.com/solana-foundation/anchor/pull/4652)).
 - idl: Bump version to 0.1.3 ([#4453](https://github.com/solana-foundation/anchor/pull/4453)).
 - lang: Migrate `anchor-syn` from syn 1.x to syn 2.0, allowing use of modern Rust syntax ([#4523](https://github.com/solana-foundation/anchor/issues/4523)).
 - lang: Avoid fatal errors in IDL building when modern Rust syntax is in use ([#4520](https://github.com/solana-foundation/anchor/pull/4520)).

--- a/lang/attribute/program/src/declare_program/mods/error.rs
+++ b/lang/attribute/program/src/declare_program/mods/error.rs
@@ -8,7 +8,13 @@ pub fn gen_error_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let errors = idl.errors.iter().map(|e| {
         let name = format_ident!("{}", e.name);
         let code = e.code;
+        let msg = e
+            .msg
+            .as_ref()
+            .map(|msg| quote! { #[msg(#msg)] })
+            .unwrap_or_default();
         quote! {
+            #msg
             #name = #code,
         }
     });

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -442,11 +442,16 @@
   "errors": [
     {
       "code": 6000,
-      "name": "MyNormalError"
+      "name": "Default"
     },
     {
       "code": 6500,
-      "name": "MyErrorWithSpecialOffset"
+      "name": "WithOffset"
+    },
+    {
+      "code": 6501,
+      "name": "WithMsg",
+      "msg": "Custom msg"
     }
   ],
   "types": [

--- a/tests/declare-program/programs/declare-program/tests/error.rs
+++ b/tests/declare-program/programs/declare-program/tests/error.rs
@@ -1,0 +1,20 @@
+#![cfg(not(feature = "idl-build"))]
+
+use anchor_lang::prelude::*;
+
+declare_program!(external);
+use external::error::ExternalError;
+
+#[test]
+pub fn test_error_code() {
+    assert_eq!(ExternalError::Default as u32, 6000);
+    assert_eq!(ExternalError::WithOffset as u32, 6500);
+    assert_eq!(ExternalError::WithMsg as u32, 6501);
+}
+
+#[test]
+pub fn test_error_msg() {
+    assert_eq!(ExternalError::Default.to_string().as_str(), "Default");
+    assert_eq!(ExternalError::WithOffset.to_string().as_str(), "WithOffset");
+    assert_eq!(ExternalError::WithMsg.to_string().as_str(), "Custom msg");
+}

--- a/tests/declare-program/programs/declare-program/tests/parsers.rs
+++ b/tests/declare-program/programs/declare-program/tests/parsers.rs
@@ -303,12 +303,3 @@ pub fn test_instruction_parser() {
         Err(e) => panic!("Expected Ok result, got error: {:?}", e),
     };
 }
-
-#[test]
-#[cfg(not(feature = "idl-build"))]
-pub fn test_errors() {
-    use external::error::ExternalError;
-
-    assert_eq!(ExternalError::MyNormalError as u32, 6000);
-    assert_eq!(ExternalError::MyErrorWithSpecialOffset as u32, 6500);
-}

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -135,11 +135,11 @@ pub mod external {
 }
 
 #[error_code]
-pub enum ExternalProgramError {
-    // Should have offset 6000
-    MyNormalError,
-    // Should have offset 6500
-    MyErrorWithSpecialOffset = 500,
+pub enum ExternalError {
+    Default,
+    WithOffset = 500,
+    #[msg("Custom msg")]
+    WithMsg,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
### Problem

`declare_program!` doesn't account for custom error messages during error generation. For example, with the following error definition:

```rs
#[error_code]
pub enum ExternalError {
    Default,
    #[msg("Custom msg")]
    WithMsg,
}
```

and the following assertions:

```rs
assert_eq!(ExternalError::Default.to_string().as_str(), "Default");
assert_eq!(ExternalError::WithMsg.to_string().as_str(), "Custom msg");
```

the last assertion fails:

```
thread 'test_error_msg' (406948) panicked at programs/declare-program/tests/error.rs:19:5:
assertion `left == right` failed
  left: "WithMsg"
 right: "Custom msg"
```

### Summary of changes

- Add the missing error messages to the generated errors in `declare_program!`
- Add error message generation tests and move all error tests to a dedicated file