### PR TITLE
docs: document #[instruction(..)] compile-time validation

### DIFF
--- a/docs-v2/src/content/docs/updates/release-notes/1-0-0.mdx
+++ b/docs-v2/src/content/docs/updates/release-notes/1-0-0.mdx
@@ -303,7 +303,7 @@ Both the Rust and TypeScript Borsh implementations have been updated to `1.5.7`.
 
 ### `#[instruction(..)]{:rs}` argument validation
 
-The compiler now enforces that the types and count of arguments declared in `#[instruction(..)]{:rs}` match the corresponding instruction handler's signature, catching mismatches that were previously silent.
+The compiler now enforces that the types and count of arguments declared in `#[instruction(..)]{:rs}` match the corresponding instruction handler's signature, catching mismatches that were previously silent. See the [account constraints reference](/docs/v1/reference/account-constraints/#compile-time-validation) for examples and error messages.
 
 ---
 

--- a/docs-v2/src/content/docs/v1/reference/account-constraints.mdx
+++ b/docs-v2/src/content/docs/v1/reference/account-constraints.mdx
@@ -417,3 +417,53 @@ pub struct Initialize<'info> {
     // --snip--
 }
 ```
+
+### Compile-time validation
+
+Since Anchor 1.0, the compiler validates that the argument **count** and **types** declared in `#[instruction(..)]{:rs}` match the corresponding instruction handler signature ([#4000](https://github.com/otter-sec/anchor/pull/4000)). Mismatches that previously caused silent runtime deserialization failures now fail at compile time.
+
+Each entry in `#[instruction(..)]{:rs}` must include an explicit type (for example, `index: u64`). The attribute types are checked against the handler parameter types; they are not inferred from the handler alone.
+
+A **type mismatch** between the attribute and the handler produces a compile error:
+
+```rust showLineNumbers=false
+pub fn handler(ctx: Context<MyIx>, index: u64) -> Result<()> {
+    // --snip--
+}
+
+#[derive(Accounts)]
+#[instruction(index: u32)] // u32 here, u64 in the handler
+pub struct MyIx<'info> {
+    #[account(
+        seeds = [index.to_le_bytes().as_ref()],
+        bump,
+    )]
+    pub my_pda: Account<'info, MyPda>,
+}
+```
+
+```text
+error[E0277]: instruction handler argument type `u64` does not match
+              `#[instruction(...)]` attribute type `u32`
+```
+
+A **count mismatch** — when `#[instruction(..)]{:rs}` declares more arguments than the handler accepts — also fails at compile time:
+
+```rust showLineNumbers=false
+pub fn handler(ctx: Context<MyIx>, data: u64) -> Result<()> {
+    // --snip--
+}
+
+#[derive(Accounts)]
+#[instruction(data: u64, extra: u64)] // two args declared, handler has one
+pub struct MyIx<'info> {
+    // --snip--
+}
+```
+
+```text
+error: #[instruction(...)] on Account `MyIx<'_>` expects MORE args,
+       the ix `handler(...)` has only 1 args.
+```
+
+See the [1.0.0 release notes](/docs/updates/release-notes/1-0-0/#instruction-argument-validation) for the original announcement.

--- a/docs-v2/src/content/docs/v2/reference/account-constraints.mdx
+++ b/docs-v2/src/content/docs/v2/reference/account-constraints.mdx
@@ -82,3 +82,56 @@ pub admin: UncheckedAccount,
 ```
 
 Use this when an account address comes from a sibling account's field, a constant, or a domain-specific newtype that implements `Into<Address>{:rs}`.
+
+## Instruction attribute
+
+### `#[instruction(...)]{:rs}`
+
+Exposes instruction arguments to the `Accounts{:rs}` struct so constraints can reference them — for example, in `seeds{:rs}` or `space{:rs}` calculations:
+
+```rust showLineNumbers=false
+#[program]
+pub mod example {
+    use super::*;
+
+    pub fn initialize(ctx: &mut Context<Initialize>, input: String) -> Result<()> {
+        // --snip--
+    }
+}
+
+#[account(borsh)]
+pub struct DataAccount {
+    pub input: String,
+}
+
+#[derive(Accounts)]
+#[instruction(input: String)]
+pub struct Initialize {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + 4 + input.len(),
+    )]
+    pub new_account: BorshAccount<DataAccount>,
+    pub system_program: Program<System>,
+}
+```
+
+The `8` is the Anchor discriminator. The `4` is the borsh length prefix for `String{:rs}`.
+
+Arguments must appear in the same order as the handler signature. Listing every argument is valid. Omitting **trailing** arguments is valid when constraints only need the leading ones. Skipping a **leading** argument is invalid.
+
+### Compile-time validation
+
+Since Anchor 1.0, the compiler validates that the argument **count** and **types** in `#[instruction(..)]{:rs}` match the instruction handler ([#4000](https://github.com/otter-sec/anchor/pull/4000)). Each entry must include an explicit type (for example, `index: u64`); types are not inferred from the handler.
+
+A type mismatch fails at compile time:
+
+```text
+error[E0277]: instruction handler argument type `u64` does not match
+              `#[instruction(...)]` attribute type `u32`
+```
+
+Declaring more arguments in `#[instruction(..)]{:rs}` than the handler accepts also fails at compile time. See the [v1 account constraints reference](/docs/v1/reference/account-constraints/#compile-time-validation) for full examples and ordering rules.


### PR DESCRIPTION
## Summary

Documents compile-time validation for `#[instruction(..)]` argument count and types, merged in #4000. Closes #3737.

- Adds a **Compile-time validation** subsection to the v1 account-constraints reference with type/count mismatch examples and error messages
- Adds a matching **Instruction attribute** section to the v2 account-constraints reference
- Cross-links from the 1.0.0 release notes

**Out of scope:** name-only `#[instruction(arg)]` syntax (no manual type annotations) — left for a separate issue/PR if the team wants it.

## Test plan

- [ ] Preview docs site locally (if applicable)
- [ ] Verify internal links resolve:
  - `/docs/v1/reference/account-constraints/#compile-time-validation`
  - `/docs/v2/reference/account-constraints/#instruction-attribute`
  - `/docs/updates/release-notes/1-0-0/#instruction-argument-validation`