### PR TITLE
fix(lang-v2): enforce Slab mutability for direct account mutations

### DIFF
--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -253,6 +253,18 @@ where
         &self.view
     }
 
+    /// Enforce that this slab came from `load_mut` before any method mutates
+    /// account bytes, lamports, or data length.
+    #[inline(always)]
+    fn assert_mutable(&self) {
+        if !self.is_mutable {
+            panic!(
+                "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your \
+                 accounts struct."
+            );
+        }
+    }
+
     /// Re-run the slab's load-time schema checks after a CPI that may have
     /// changed owner, discriminator, data length, or tail metadata.
     ///
@@ -385,6 +397,7 @@ where
     /// Uses a `system::Transfer` CPI; `payer` must be a signer on the outer
     /// transaction (pinocchio enforces signerness at CPI time).
     pub fn top_up(&mut self, payer: &AccountView) -> Result<(), ProgramError> {
+        self.assert_mutable();
         let required = self.min_lamports()?;
         let current = self.view.lamports();
         if current >= required {
@@ -400,6 +413,7 @@ where
     /// Direct lamport arithmetic, no CPI — callers must only use this for
     /// accounts whose owner permits in-program lamport mutation.
     pub fn refund(&mut self, recipient: &mut AccountView) -> Result<(), ProgramError> {
+        self.assert_mutable();
         let required = self.min_lamports()?;
         let current = self.view.lamports();
         if current <= required {
@@ -447,12 +461,7 @@ where
     /// Mutable account data bytes. Panics if the slab was loaded read-only.
     #[inline(always)]
     fn guard_bytes_mut(&mut self) -> &mut [u8] {
-        if !self.is_mutable {
-            panic!(
-                "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your \
-                 accounts struct."
-            );
-        }
+        self.assert_mutable();
         // SAFETY: is_mutable guarantees this was loaded via load_mut.
         // AccountView data is valid for the instruction lifetime.
         unsafe { self.view.borrow_unchecked_mut() }
@@ -711,6 +720,7 @@ where
     pub fn resize_to_capacity(&mut self, new_capacity: u32) -> Result<(), ProgramError> {
         use pinocchio::Resize;
 
+        self.assert_mutable();
         let new_space = Self::try_space_for(new_capacity)?;
         let mut view_mut = self.view;
         // SAFETY: Slab owns exclusive access to the data (enforced by the
@@ -790,6 +800,7 @@ where
     }
 
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
+        self.assert_mutable();
         let mut self_view = self.view;
         let dest_lamports = destination
             .lamports()
@@ -841,6 +852,7 @@ where
         payer: AccountView,
         zero: bool,
     ) -> pinocchio::ProgramResult {
+        self.assert_mutable();
         let mut view = *self.account();
         if new_space != view.data_len() {
             if new_space < Self::ITEMS_OFFSET {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -259,8 +259,8 @@ where
     fn assert_mutable(&self) {
         if !self.is_mutable {
             panic!(
-                "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your \
-                 accounts struct."
+                "Tried to mutate `Slab<H, T>` through a read-only load. Add `#[account(mut)]` \
+                 to your accounts struct."
             );
         }
     }
@@ -903,12 +903,7 @@ where
     fn deref_mut(&mut self) -> &mut H {
         // Always checked (not guardrails-gated): creating `&mut H` from a
         // const-provenance pointer is UB, so this must run even in release.
-        if !self.is_mutable {
-            panic!(
-                "Slab<H, T> mutably dereferenced but loaded read-only. Add #[account(mut)] to \
-                 your accounts struct."
-            );
-        }
+        self.assert_mutable();
         // SAFETY: is_mutable guarantees header_ptr was derived via data_mut_ptr
         // (write provenance). No other live mutable borrow exists; we hold &mut self.
         unsafe { &mut *self.header_ptr }

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -498,8 +498,7 @@ fn account_load_mut_rejects_non_writable() {
 
 #[test]
 #[should_panic(
-    expected = "Slab<H, T> mutably dereferenced but loaded read-only. Add #[account(mut)] to your \
-                accounts struct."
+    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
 )]
 fn account_deref_mut_panics_when_loaded_read_only() {
     let mut buf = AccountBuffer::<128>::new();

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -397,7 +397,7 @@ fn slab_close_scrubs_discriminator_to_closed_sentinel() {
 }
 
 #[test]
-#[should_panic(expected = "Slab<H, T> mutably dereferenced but loaded read-only")]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn slab_close_flips_is_mutable_so_deref_mut_panics() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);
@@ -448,7 +448,7 @@ fn slab_resurrected_account_reload_rejects_after_disc_scrub() {
 }
 
 #[test]
-#[should_panic(expected = "Slab<H, T> mutated through a read-only load")]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn slab_close_panics_after_read_only_load_even_if_account_is_writable() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);
@@ -464,7 +464,7 @@ fn slab_close_panics_after_read_only_load_even_if_account_is_writable() {
 }
 
 #[test]
-#[should_panic(expected = "Slab<H, T> mutated through a read-only load")]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn slab_realloc_panics_after_read_only_load_even_if_account_is_writable() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -51,7 +51,7 @@ use {
         prelude::BorshAccount,
         testing::AccountBuffer,
         wincode::{SchemaRead, SchemaWrite},
-        AnchorAccount, Discriminator, Owner,
+        AccountRealloc, AnchorAccount, Discriminator, Owner,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::{account::RuntimeAccount, address::Address},
@@ -445,4 +445,39 @@ fn slab_resurrected_account_reload_rejects_after_disc_scrub() {
         result.is_err(),
         "Post-fix: reload must reject because scrubbed disc != CounterHeader::DISCRIMINATOR"
     );
+}
+
+#[test]
+#[should_panic(expected = "Slab<H, T> mutated through a read-only load")]
+fn slab_close_panics_after_read_only_load_even_if_account_is_writable() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf);
+
+    let dest_buf = AccountBuffer::<256>::new();
+    dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
+
+    let view = unsafe { buf.view() };
+    let dest_view = unsafe { dest_buf.view() };
+
+    let mut counter = Slab::<CounterHeader>::load(view).unwrap();
+    counter.close(dest_view).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Slab<H, T> mutated through a read-only load")]
+fn slab_realloc_panics_after_read_only_load_even_if_account_is_writable() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf);
+
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(10_000_000_000);
+
+    let view = unsafe { buf.view() };
+    let payer_view = unsafe { payer.view() };
+
+    let mut counter = Slab::<CounterHeader>::load(view).unwrap();
+    counter
+        .realloc_account(counter.current_space() + 16, payer_view, true)
+        .unwrap();
 }

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -191,7 +191,7 @@ fn close_scrubs_discriminator_even_after_release_borrow() {
     let mut buf = AccountBuffer::<256>::new();
     setup_vault_buf(&mut buf);
 
-    let mut dest_buf = AccountBuffer::<256>::new();
+    let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
     {
@@ -211,6 +211,30 @@ fn close_scrubs_discriminator_even_after_release_borrow() {
         &[u8::MAX; 8][..],
         "scrub must run regardless of borrow state — release_borrow + close is legal and must not \
          leave the discriminator intact",
+    );
+}
+
+#[test]
+fn second_borsh_close_after_manual_close_is_noop() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_vault_buf(&mut buf);
+
+    let dest_buf = AccountBuffer::<256>::new();
+    dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
+    dest_buf.set_lamports(100);
+
+    let view = unsafe { buf.view() };
+    let dest_view = unsafe { dest_buf.view() };
+    let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
+
+    vault.close(dest_view).unwrap();
+    vault.close(dest_view).unwrap();
+
+    let dest_raw = unsafe { &*(dest_buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        dest_raw.lamports,
+        100 + 1_000_000_000,
+        "second close should be a no-op once the lamports were already drained"
     );
 }
 
@@ -375,7 +399,7 @@ fn slab_close_scrubs_discriminator_to_closed_sentinel() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);
 
-    let mut dest_buf = AccountBuffer::<256>::new();
+    let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
     {
@@ -402,7 +426,7 @@ fn slab_close_flips_is_mutable_so_deref_mut_panics() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);
 
-    let mut dest_buf = AccountBuffer::<256>::new();
+    let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
     let view = unsafe { buf.view() };
     let dest_view = unsafe { dest_buf.view() };
@@ -416,11 +440,28 @@ fn slab_close_flips_is_mutable_so_deref_mut_panics() {
 }
 
 #[test]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
+fn second_slab_close_after_manual_close_panics() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf);
+
+    let dest_buf = AccountBuffer::<256>::new();
+    dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
+
+    let view = unsafe { buf.view() };
+    let dest_view = unsafe { dest_buf.view() };
+    let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
+
+    counter.close(dest_view).unwrap();
+    counter.close(dest_view).unwrap();
+}
+
+#[test]
 fn slab_resurrected_account_reload_rejects_after_disc_scrub() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf);
 
-    let mut dest_buf = AccountBuffer::<256>::new();
+    let dest_buf = AccountBuffer::<256>::new();
     dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, true, false);
 
     {

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -352,6 +352,19 @@ fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
     slab.clear();
 }
 
+#[test]
+#[should_panic(
+    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
+                struct."
+)]
+fn resize_to_capacity_panics_when_loaded_read_only() {
+    let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
+
+    let view = unsafe { buf.view() };
+    let mut slab = CounterLedger::load(view).unwrap();
+    slab.resize_to_capacity(4).unwrap();
+}
+
 // -- Regression: truncate clamps to effective_len ---------------------
 
 #[test]
@@ -437,6 +450,28 @@ fn refund_moves_excess_lamports_to_recipient() {
 }
 
 #[test]
+#[should_panic(
+    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
+                struct."
+)]
+fn refund_panics_when_loaded_read_only() {
+    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+
+    let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
+    buf.set_lamports(required + 500);
+
+    let mut recipient = AccountBuffer::<128>::new();
+    recipient.init([0xBB; 32], PROGRAM_ID, 0, false, true, false);
+    recipient.set_lamports(25);
+
+    let view = unsafe { buf.view() };
+    let mut slab = CounterLedger::load(view).unwrap();
+    let mut recipient_view = unsafe { recipient.view() };
+
+    slab.refund(&mut recipient_view).unwrap();
+}
+
+#[test]
 fn refund_is_noop_when_account_is_at_rent_floor() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
@@ -455,6 +490,28 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 
     assert_eq!(slab.view().lamports(), required);
     assert_eq!(recipient_view.lamports(), 25);
+}
+
+#[test]
+#[should_panic(
+    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
+                struct."
+)]
+fn top_up_panics_when_loaded_read_only() {
+    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+
+    let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
+    buf.set_lamports(required - 1);
+
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(999);
+
+    let view = unsafe { buf.view() };
+    let mut slab = CounterLedger::load(view).unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    slab.top_up(&payer_view).unwrap();
 }
 
 #[test]

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -341,8 +341,7 @@ fn swap_remove_panics_when_index_geq_effective_len() {
 
 #[test]
 #[should_panic(
-    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
-                struct."
+    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
 )]
 fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
     let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
@@ -354,8 +353,7 @@ fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
 
 #[test]
 #[should_panic(
-    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
-                struct."
+    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
 )]
 fn resize_to_capacity_panics_when_loaded_read_only() {
     let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
@@ -451,8 +449,7 @@ fn refund_moves_excess_lamports_to_recipient() {
 
 #[test]
 #[should_panic(
-    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
-                struct."
+    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
 )]
 fn refund_panics_when_loaded_read_only() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
@@ -494,8 +491,7 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 
 #[test]
 #[should_panic(
-    expected = "Slab<H, T> mutated through a read-only load. Add #[account(mut)] to your accounts \
-                struct."
+    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
 )]
 fn top_up_panics_when_loaded_read_only() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -98,6 +98,16 @@ pub mod accounts_test {
         Ok(())
     }
 
+    /// Manually closes a boxed counter even though the account also carries
+    /// `close = receiver`; the derive exit path will call close a second time.
+    #[discrim = 40]
+    pub fn manual_close_boxed(ctx: &mut Context<CloseBoxed>) -> Result<()> {
+        ctx.accounts
+            .counter
+            .close(*ctx.accounts.receiver.account())?;
+        Ok(())
+    }
+
     /// Reads the Clock sysvar through `Deref` forwarding to the inner type.
     #[discrim = 5]
     pub fn read_clock(ctx: &mut Context<ReadClock>) -> Result<()> {
@@ -588,6 +598,17 @@ pub mod accounts_test {
         Ok(())
     }
 
+    /// Manually closes a borsh-backed account even though the account also
+    /// carries `close = receiver`; the derive exit path will call close a
+    /// second time, which is a no-op for `BorshAccount`.
+    #[discrim = 39]
+    pub fn manual_close_borsh_counter(ctx: &mut Context<CloseBorshCounter>) -> Result<()> {
+        ctx.accounts
+            .counter
+            .close(*ctx.accounts.receiver.account())?;
+        Ok(())
+    }
+
     /// Mutates a foreign-owned `BorshAccount<T>` in memory. The generated exit
     /// path serializes mutable borrows; the runtime rejects the resulting
     /// foreign account data write.
@@ -754,6 +775,17 @@ pub mod accounts_test {
         ctx.accounts.counter.value = ctx.accounts.counter.value.wrapping_add(args.amount);
         Ok(())
     }
+
+    /// Manually closes a slab-backed account even though the account also
+    /// carries `close = receiver`; the derive exit path will try to close it
+    /// again after `is_mutable` was flipped by the first close.
+    #[discrim = 38]
+    pub fn manual_close_ledger(ctx: &mut Context<CloseLedger>) -> Result<()> {
+        ctx.accounts
+            .ledger
+            .close(*ctx.accounts.receiver.account())?;
+        Ok(())
+    }
 }
 
 // -- Accounts structs --------------------------------------------------------
@@ -838,6 +870,14 @@ pub struct TransferFromBorshCounterWithLamportsHelpers {
 }
 
 #[derive(Accounts)]
+pub struct CloseBorshCounter {
+    #[account(mut, close = receiver, seeds = [b"borsh-counter"], bump)]
+    pub counter: BorshAccount<BorshCounter>,
+    #[account(mut)]
+    pub receiver: SystemAccount,
+}
+
+#[derive(Accounts)]
 pub struct MutateForeignBorshCounter {
     #[account(mut)]
     pub counter: BorshAccount<ForeignBorshCounter>,
@@ -868,6 +908,14 @@ pub struct InitializeBoxed {
 pub struct CloseBoxed {
     #[account(mut, close = receiver, seeds = [b"boxed-counter"], bump)]
     pub counter: Box<Account<Counter>>,
+    #[account(mut)]
+    pub receiver: SystemAccount,
+}
+
+#[derive(Accounts)]
+pub struct CloseLedger {
+    #[account(mut, close = receiver, seeds = [b"ledger"], bump)]
+    pub ledger: LedgerAccount,
     #[account(mut)]
     pub receiver: SystemAccount,
 }

--- a/tests-v2/tests/accounts.rs
+++ b/tests-v2/tests/accounts.rs
@@ -344,6 +344,60 @@ fn dynamic_slab_methods_work_in_program_execution() {
 }
 
 #[test]
+fn manual_close_ledger_then_derive_close_fails_and_rolls_back() {
+    let (mut svm, payer) = setup();
+    let ledger = ledger_pda();
+    let init_metas = vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(ledger, false),
+        AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
+    ];
+    call_raw(&mut svm, &payer, 35, init_metas).expect("initialize_ledger should succeed");
+
+    let receiver = keypair_for("ledger-manual-close-receiver");
+    svm.airdrop(&receiver.pubkey(), 10_000_000).unwrap();
+
+    let ledger_before = svm.get_account(&ledger).expect("ledger exists");
+    let receiver_before = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+
+    let metas = vec![
+        AccountMeta::new(ledger, false),
+        AccountMeta::new(receiver.pubkey(), false),
+    ];
+    let result = send_instruction(&mut svm, program_id(), vec![38], metas, &payer, &[]);
+    let err = format!(
+        "{:?}",
+        result
+            .as_ref()
+            .err()
+            .expect("manual_close_ledger should fail")
+    );
+    assert!(
+        err.contains("Program failed to complete")
+            || err.contains("panic")
+            || err.contains("Tried to mutate `Slab<H, T>` through a read-only load"),
+        "expected the second derive close to trip the Slab mutability guard, got: {err}"
+    );
+
+    let ledger_after = svm
+        .get_account(&ledger)
+        .expect("failed transaction should roll back");
+    let receiver_after = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+    assert_eq!(
+        ledger_after.lamports, ledger_before.lamports,
+        "the failed transaction should roll back the first manual close",
+    );
+    assert_eq!(
+        ledger_after.data, ledger_before.data,
+        "the failed transaction should preserve the slab contents",
+    );
+    assert_eq!(
+        receiver_after, receiver_before,
+        "the receiver must not keep lamports from a failed double-close transaction",
+    );
+}
+
+#[test]
 fn explicit_space_annotation_allocates_requested_bytes() {
     let (mut svm, payer) = setup();
     let counter = do_initialize_borsh_counter(&mut svm, &payer);
@@ -907,6 +961,85 @@ fn close_boxed_transfers_lamports_and_clears_account() {
     match svm.get_account(&counter) {
         None => {}
         Some(account) => assert_eq!(account.lamports, 0, "closed boxed account should be empty"),
+    }
+}
+
+#[test]
+fn manual_close_boxed_then_derive_close_fails_and_rolls_back() {
+    let (mut svm, payer) = setup();
+    let counter = do_initialize_boxed(&mut svm, &payer);
+    let receiver = keypair_for("boxed-manual-close-receiver");
+    svm.airdrop(&receiver.pubkey(), 10_000_000).unwrap();
+
+    let receiver_before = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+    let counter_before = svm.get_account(&counter).unwrap().lamports;
+    let counter_data_before = svm.get_account(&counter).unwrap().data;
+
+    let metas = vec![
+        AccountMeta::new(counter, false),
+        AccountMeta::new(receiver.pubkey(), false),
+    ];
+    let result = send_instruction(&mut svm, program_id(), vec![40], metas, &payer, &[]);
+    let err = format!(
+        "{:?}",
+        result
+            .as_ref()
+            .err()
+            .expect("manual_close_boxed should fail")
+    );
+    assert!(
+        err.contains("Program failed to complete")
+            || err.contains("panic")
+            || err.contains("Tried to mutate `Slab<H, T>` through a read-only load"),
+        "expected the second derive close to trip the Slab mutability guard, got: {err}"
+    );
+
+    let receiver_after = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+    let counter_after = svm
+        .get_account(&counter)
+        .expect("failed transaction should roll back");
+    assert_eq!(
+        receiver_after, receiver_before,
+        "the failed transaction should not leave lamports with the receiver",
+    );
+    assert_eq!(
+        counter_after.lamports, counter_before,
+        "the failed transaction should roll back the first manual close",
+    );
+    assert_eq!(
+        counter_after.data, counter_data_before,
+        "the failed transaction should preserve the boxed account contents",
+    );
+}
+
+#[test]
+fn manual_close_borsh_counter_then_derive_close_still_succeeds() {
+    let (mut svm, payer) = setup();
+    let counter = do_initialize_borsh_counter(&mut svm, &payer);
+    let receiver = keypair_for("borsh-manual-close-receiver");
+    svm.airdrop(&receiver.pubkey(), 10_000_000).unwrap();
+
+    let receiver_before = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+    let counter_before = svm.get_account(&counter).unwrap().lamports;
+
+    let metas = vec![
+        AccountMeta::new(counter, false),
+        AccountMeta::new(receiver.pubkey(), false),
+    ];
+    send_instruction(&mut svm, program_id(), vec![39], metas, &payer, &[]).expect(
+        "manual_close_borsh_counter should still succeed after the derive issues a second close",
+    );
+
+    let receiver_after = svm.get_account(&receiver.pubkey()).unwrap().lamports;
+    assert_eq!(
+        receiver_after,
+        receiver_before + counter_before,
+        "the borsh manual close should transfer the lamports exactly once",
+    );
+
+    match svm.get_account(&counter) {
+        None => {}
+        Some(account) => assert_eq!(account.lamports, 0, "closed borsh account should be empty"),
     }
 }
 


### PR DESCRIPTION
Prevents read-only `Slab::loads` from mutating accounts. Added shared mutability checks before `close`, `realloc_account`, `resize_to_capacity`, `refund`, and `top_up`, plus regression tests proving read-only misuse now panics.