### PR TITLE
fix(lang-v2): refund only rent savings when shrinking accounts

### DIFF
--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -570,19 +570,24 @@ pub fn realloc_account(
     use pinocchio::Resize;
 
     let old_space = account.data_len();
-    let required = rent_exempt_lamports(new_space)?;
+    let new_rent_minimum = rent_exempt_lamports(new_space)?;
     let current_lamports = account.lamports();
 
     if new_space > old_space {
-        let deficit = required.saturating_sub(current_lamports);
+        let deficit = new_rent_minimum.saturating_sub(current_lamports);
         if deficit > 0 {
             transfer_lamports_unchecked(payer, &*account as &AccountView, deficit)?;
         }
     } else if new_space < old_space {
-        let old_required = rent_exempt_lamports(old_space)?;
-        let rent_savings = old_required.saturating_sub(required);
-        let available_above_new_floor = current_lamports.saturating_sub(required);
-        let refund = rent_savings.min(available_above_new_floor);
+        let old_rent_minimum = rent_exempt_lamports(old_space)?;
+        // Shrinking should only reclaim rent that was reserved for bytes we are
+        // removing, not unrelated lamports the account might be holding.
+        let reclaimable_rent = old_rent_minimum.saturating_sub(new_rent_minimum);
+        // Cap the refund by the lamports actually available above the new rent
+        // floor so underfunded oversized accounts cannot underflow here.
+        let lamports_above_new_minimum =
+            current_lamports.saturating_sub(new_rent_minimum);
+        let refund = reclaimable_rent.min(lamports_above_new_minimum);
         if refund > 0 {
             let mut payer_mut = *payer;
             // `checked_add` rather than `+`: overflow-checks is disabled in

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -579,8 +579,11 @@ pub fn realloc_account(
             transfer_lamports_unchecked(payer, &*account as &AccountView, deficit)?;
         }
     } else if new_space < old_space {
-        let excess = current_lamports.saturating_sub(required);
-        if excess > 0 {
+        let old_required = rent_exempt_lamports(old_space)?;
+        let rent_savings = old_required.saturating_sub(required);
+        let available_above_new_floor = current_lamports.saturating_sub(required);
+        let refund = rent_savings.min(available_above_new_floor);
+        if refund > 0 {
             let mut payer_mut = *payer;
             // `checked_add` rather than `+`: overflow-checks is disabled in
             // release builds, and this arithmetic is on user-supplied account
@@ -588,10 +591,14 @@ pub fn realloc_account(
             // unreachable in practice, but silent wrap would be a downgrade.
             let new_payer_lamports = payer_mut
                 .lamports()
-                .checked_add(excess)
+                .checked_add(refund)
                 .ok_or(ProgramError::ArithmeticOverflow)?;
             payer_mut.set_lamports(new_payer_lamports);
-            account.set_lamports(required);
+            account.set_lamports(
+                current_lamports
+                    .checked_sub(refund)
+                    .ok_or(ProgramError::ArithmeticOverflow)?,
+            );
         }
     }
 

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -4,7 +4,7 @@ pub use pinocchio::instruction::{InstructionAccount, InstructionView};
 #[cfg(feature = "const-rent")]
 use pinocchio::sysvars::rent::{ACCOUNT_STORAGE_OVERHEAD, DEFAULT_LAMPORTS_PER_BYTE};
 use {
-    crate::require,
+    crate::{require, traits::AccountViewCompat},
     pinocchio::{account::AccountView, address::Address},
     solana_program_error::ProgramError,
 };
@@ -589,21 +589,26 @@ pub fn realloc_account(
             current_lamports.saturating_sub(new_rent_minimum);
         let refund = reclaimable_rent.min(lamports_above_new_minimum);
         if refund > 0 {
-            let mut payer_mut = *payer;
-            // `checked_add` rather than `+`: overflow-checks is disabled in
-            // release builds, and this arithmetic is on user-supplied account
-            // lamports. The total SOL supply is bounded so overflow is
-            // unreachable in practice, but silent wrap would be a downgrade.
-            let new_payer_lamports = payer_mut
-                .lamports()
-                .checked_add(refund)
-                .ok_or(ProgramError::ArithmeticOverflow)?;
-            payer_mut.set_lamports(new_payer_lamports);
-            account.set_lamports(
-                current_lamports
-                    .checked_sub(refund)
-                    .ok_or(ProgramError::ArithmeticOverflow)?,
-            );
+            // When the payer aliases the resized account, the refund is a
+            // no-op transfer. Skip the lamport writes so we do not overwrite
+            // the first write with the second and accidentally burn lamports.
+            if payer.key() != account.key() {
+                let mut payer_mut = *payer;
+                // `checked_add` rather than `+`: overflow-checks is disabled in
+                // release builds, and this arithmetic is on user-supplied account
+                // lamports. The total SOL supply is bounded so overflow is
+                // unreachable in practice, but silent wrap would be a downgrade.
+                let new_payer_lamports = payer_mut
+                    .lamports()
+                    .checked_add(refund)
+                    .ok_or(ProgramError::ArithmeticOverflow)?;
+                payer_mut.set_lamports(new_payer_lamports);
+                account.set_lamports(
+                    current_lamports
+                        .checked_sub(refund)
+                        .ok_or(ProgramError::ArithmeticOverflow)?,
+                );
+            }
         }
     }
 

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -4,7 +4,7 @@ pub use pinocchio::instruction::{InstructionAccount, InstructionView};
 #[cfg(feature = "const-rent")]
 use pinocchio::sysvars::rent::{ACCOUNT_STORAGE_OVERHEAD, DEFAULT_LAMPORTS_PER_BYTE};
 use {
-    crate::{require, traits::AccountViewCompat},
+    crate::require,
     pinocchio::{account::AccountView, address::Address},
     solana_program_error::ProgramError,
 };
@@ -592,7 +592,7 @@ pub fn realloc_account(
             // When the payer aliases the resized account, the refund is a
             // no-op transfer. Skip the lamport writes so we do not overwrite
             // the first write with the second and accidentally burn lamports.
-            if payer.key() != account.key() {
+            if payer.address() != account.address() {
                 let mut payer_mut = *payer;
                 // `checked_add` rather than `+`: overflow-checks is disabled in
                 // release builds, and this arithmetic is on user-supplied account

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -148,6 +148,73 @@ fn slab_realloc_clamps_tail_len_to_resized_capacity() {
     assert_eq!(CounterLedger::load(view).unwrap().len(), 1);
 }
 
+#[test]
+fn slab_realloc_shrink_refunds_only_rent_delta_not_vault_balance() {
+    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(25);
+
+    let old_space = ITEMS_OFFSET + 4 * ITEM_SIZE;
+    let new_space = ITEMS_OFFSET + ITEM_SIZE;
+    let old_required = expected_min_lamports(old_space).unwrap();
+    let new_required = expected_min_lamports(new_space).unwrap();
+    let rent_delta = old_required - new_required;
+    let vault_balance = 1_000_000;
+
+    buf.set_lamports(old_required + vault_balance);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    slab.realloc_account(new_space, payer_view, false).unwrap();
+
+    assert_eq!(
+        payer_view.lamports(),
+        25 + rent_delta,
+        "shrinking should only refund the rent savings for the removed bytes",
+    );
+    assert_eq!(
+        slab.view().lamports(),
+        new_required + vault_balance,
+        "vault lamports unrelated to rent must remain on the account after shrink",
+    );
+}
+
+#[test]
+fn slab_realloc_shrink_refund_is_capped_by_available_lamports_above_new_floor() {
+    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(25);
+
+    let new_space = ITEMS_OFFSET + ITEM_SIZE;
+    let new_required = expected_min_lamports(new_space).unwrap();
+
+    // Simulate an underfunded oversized account: only 7 lamports are
+    // available above the new rent floor, even though shrinking would save
+    // more than that in ideal rent terms.
+    buf.set_lamports(new_required + 7);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    slab.realloc_account(new_space, payer_view, false).unwrap();
+
+    assert_eq!(
+        payer_view.lamports(),
+        25 + 7,
+        "refund must be capped by the lamports actually available above the new rent floor",
+    );
+    assert_eq!(
+        slab.view().lamports(),
+        new_required,
+        "the shrunken account must retain at least the new rent-exempt minimum",
+    );
+}
+
 // -- `load_mut` rejects a buffer shrunk below ITEMS_OFFSET -----------
 
 #[test]

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -215,6 +215,35 @@ fn slab_realloc_shrink_refund_is_capped_by_available_lamports_above_new_floor() 
     );
 }
 
+#[test]
+fn slab_realloc_shrink_with_self_payer_preserves_lamports_and_still_resizes() {
+    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+
+    let old_space = ITEMS_OFFSET + 4 * ITEM_SIZE;
+    let new_space = ITEMS_OFFSET + ITEM_SIZE;
+    let old_required = expected_min_lamports(old_space).unwrap();
+    let vault_balance = 1_000_000;
+
+    buf.set_lamports(old_required + vault_balance);
+
+    let payer_view = unsafe { buf.view() };
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+
+    slab.realloc_account(new_space, payer_view, false).unwrap();
+
+    assert_eq!(
+        slab.view().lamports(),
+        old_required + vault_balance,
+        "when payer == account, shrinking should not burn lamports while refunding to self",
+    );
+    assert_eq!(
+        slab.current_space(),
+        new_space,
+        "self-payer shrink should still resize the account",
+    );
+}
+
 // -- `load_mut` rejects a buffer shrunk below ITEMS_OFFSET -----------
 
 #[test]


### PR DESCRIPTION
Fixes shrink refunds draining vault balances. Realloc now refunds only rent savings from removed bytes, capped by lamports above the new rent floor, with regressions confirming correct behavior.