### PR TITLE
lang: Sync type derives and simplify internal args creation in `declare_program!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Reduce cloning in `realloc` constraint when shrinking ([#4642](https://github.com/solana-foundation/anchor/pull/4642)).
 - syn: Remove `anyhow` ([#4640](https://github.com/solana-foundation/anchor/pull/4640)).
 - ts: Update `engines.node` to `>= 20.18` ([#4647](https://github.com/solana-foundation/anchor/pull/4647)).
+- lang: Sync type derives and simplify internal args creation in `declare_program!` ([#4667](https://github.com/solana-foundation/anchor/pull/4667)).
 
 ### Breaking
 

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -156,8 +156,7 @@ pub fn convert_idl_type_def_to_ts(
     };
 
     let attrs = {
-        let debug_attr = quote!(#[derive(Debug)]);
-
+        let debug_attr = can_derive_debug(ty_def, ty_defs).then_some(quote!(#[derive(Debug)]));
         let default_attr =
             can_derive_default(ty_def, ty_defs).then_some(quote!(#[derive(Default)]));
 
@@ -176,7 +175,8 @@ pub fn convert_idl_type_def_to_ts(
         };
 
         let clone_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)
-            .then(|| quote!(#[derive(Clone)]))
+            .then(|| can_derive_clone(ty_def, ty_defs).then_some(quote!(#[derive(Clone)])))
+            .flatten()
             .unwrap_or_default();
 
         let copy_attr = matches!(ty_def.serialization, IdlSerialization::Borsh)

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -362,7 +362,7 @@ fn can_derive_default(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-pub fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_copy_ty(inner, ty_defs),
         IdlType::Array(inner, len) => {
@@ -389,7 +389,7 @@ pub fn can_derive_copy_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-pub fn can_derive_clone_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+fn can_derive_clone_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_clone_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_clone_ty(inner, ty_defs),
@@ -408,7 +408,7 @@ pub fn can_derive_clone_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-pub fn can_derive_debug_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+fn can_derive_debug_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_debug_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_debug_ty(inner, ty_defs),
@@ -427,7 +427,7 @@ pub fn can_derive_debug_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     }
 }
 
-pub fn can_derive_default_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
+fn can_derive_default_ty(ty: &IdlType, ty_defs: &[IdlTypeDef]) -> bool {
     match ty {
         IdlType::Option(inner) => can_derive_default_ty(inner, ty_defs),
         IdlType::Vec(inner) => can_derive_default_ty(inner, ty_defs),

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -1,10 +1,11 @@
 use {
     super::common::{
-        can_derive_clone_ty, can_derive_copy_ty, can_derive_debug_ty, can_derive_default_ty,
-        convert_idl_type_to_syn_type, gen_discriminator, get_all_instruction_accounts,
+        convert_idl_type_def_to_ts, gen_discriminator, get_all_instruction_accounts,
         get_canonical_program_id,
     },
-    anchor_lang_idl::types::{Idl, IdlInstructionAccountItem},
+    anchor_lang_idl::types::{
+        Idl, IdlDefinedFields, IdlInstructionAccountItem, IdlTypeDef, IdlTypeDefTy,
+    },
     anchor_syn::{
         codegen::accounts::{__client_accounts, __cpi_client_accounts},
         parser::accounts,
@@ -32,24 +33,23 @@ pub fn gen_internal_mod(idl: &Idl) -> proc_macro2::TokenStream {
 fn gen_internal_args_mod(idl: &Idl) -> proc_macro2::TokenStream {
     let ixs = idl.instructions.iter().map(|ix| {
         let ix_struct_name = format_ident!("{}", ix.name.to_camel_case());
-
-        let fields = ix.args.iter().map(|arg| {
-            let name = format_ident!("{}", arg.name);
-            let ty = convert_idl_type_to_syn_type(&arg.ty);
-            quote! { pub #name: #ty }
-        });
-
-        let ix_struct = if ix.args.is_empty() {
-            quote! {
-                pub struct #ix_struct_name;
-            }
-        } else {
-            quote! {
-                pub struct #ix_struct_name {
-                    #(#fields),*
-                }
-            }
-        };
+        let ty_def = convert_idl_type_def_to_ts(
+            &IdlTypeDef {
+                name: ix_struct_name.to_string(),
+                docs: vec![String::from("Instruction arguments")],
+                ty: IdlTypeDefTy::Struct {
+                    fields: if ix.args.is_empty() {
+                        None
+                    } else {
+                        Some(IdlDefinedFields::Named(ix.args.to_owned()))
+                    },
+                },
+                generics: Default::default(),
+                repr: Default::default(),
+                serialization: Default::default(),
+            },
+            &idl.types,
+        );
 
         let discriminator = gen_discriminator(&ix.discriminator);
         let impl_discriminator = quote! {
@@ -71,40 +71,8 @@ fn gen_internal_args_mod(idl: &Idl) -> proc_macro2::TokenStream {
             }
         };
 
-        // Generate conditional derives based on field types
-        let copy_attr = ix
-            .args
-            .iter()
-            .map(|field| &field.ty)
-            .all(|ty| can_derive_copy_ty(ty, &idl.types))
-            .then_some(quote!(#[derive(Copy)]));
-        let clone_attr = ix
-            .args
-            .iter()
-            .map(|field| &field.ty)
-            .all(|ty| can_derive_clone_ty(ty, &idl.types))
-            .then_some(quote!(#[derive(Clone)]));
-        let debug_attr = ix
-            .args
-            .iter()
-            .map(|field| &field.ty)
-            .all(|ty| can_derive_debug_ty(ty, &idl.types))
-            .then_some(quote!(#[derive(Debug)]));
-        let default_attr = ix
-            .args
-            .iter()
-            .map(|field| &field.ty)
-            .all(|ty| can_derive_default_ty(ty, &idl.types))
-            .then_some(quote!(#[derive(Default)]));
-
         quote! {
-            /// Instruction argument
-            #[derive(AnchorSerialize, AnchorDeserialize)]
-            #copy_attr
-            #clone_attr
-            #debug_attr
-            #default_attr
-            #ix_struct
+            #ty_def
 
             #impl_discriminator
             #impl_ix_data

--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -99,6 +99,44 @@
       ]
     },
     {
+      "name": "test_compilation_generic_types",
+      "discriminator": [
+        2,
+        200,
+        154,
+        199,
+        119,
+        208,
+        171,
+        225
+      ],
+      "accounts": [
+        {
+          "name": "account_with_generic_field"
+        }
+      ],
+      "args": [
+        {
+          "name": "generic_struct",
+          "type": {
+            "defined": {
+              "name": "GenericStruct",
+              "generics": [
+                {
+                  "kind": "type",
+                  "type": "u32"
+                },
+                {
+                  "kind": "const",
+                  "value": "8"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "test_compilation_initialize_with_token_2022",
       "discriminator": [
         230,
@@ -398,6 +436,19 @@
   ],
   "accounts": [
     {
+      "name": "AccountWithGenericField",
+      "discriminator": [
+        3,
+        245,
+        8,
+        220,
+        119,
+        168,
+        105,
+        172
+      ]
+    },
+    {
       "name": "MyAccount",
       "discriminator": [
         246,
@@ -455,6 +506,64 @@
     }
   ],
   "types": [
+    {
+      "name": "AccountWithGenericField",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "field",
+            "type": {
+              "defined": {
+                "name": "GenericStruct",
+                "generics": [
+                  {
+                    "kind": "type",
+                    "type": "u32"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "8"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GenericStruct",
+      "generics": [
+        {
+          "kind": "type",
+          "name": "T"
+        },
+        {
+          "kind": "const",
+          "name": "N",
+          "type": "usize"
+        }
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "field",
+            "type": {
+              "array": [
+                {
+                  "generic": "T"
+                },
+                {
+                  "generic": "N"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "MyAccount",
       "type": {

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -98,13 +98,3 @@ pub struct Cpi<'info> {
     pub cpi_my_account: Account<'info, external::accounts::MyAccount>,
     pub external_program: Program<'info, External>,
 }
-
-#[derive(Accounts)]
-pub struct Utils<'info> {
-    pub authority: Signer<'info>,
-}
-
-#[derive(Accounts)]
-pub struct Proxy<'info> {
-    pub program: Program<'info, External>,
-}

--- a/tests/declare-program/programs/declare-program/tests/generics.rs
+++ b/tests/declare-program/programs/declare-program/tests/generics.rs
@@ -1,0 +1,18 @@
+use anchor_lang::prelude::*;
+
+declare_program!(external);
+use external::types::GenericStruct;
+
+#[test]
+fn structs() {
+    let _ = GenericStruct { field: [1; 2] };
+}
+
+#[test]
+fn args() {
+    let _ = external::client::args::TestCompilationGenericTypes {
+        generic_struct: GenericStruct {
+            field: Default::default(),
+        },
+    };
+}

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -132,6 +132,14 @@ pub mod external {
     ) -> Result<()> {
         Ok(())
     }
+
+    // Compilation test for generic types (both arguments and account fields)
+    pub fn test_compilation_generic_types(
+        _ctx: Context<TestCompilationGeneric>,
+        generic_struct: GenericStruct<u32, 8>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[error_code]
@@ -154,6 +162,11 @@ pub struct TestCompilationPackedAccount<'info> {
 
 #[derive(Accounts)]
 pub struct TestCompilationNoAccounts {}
+
+#[derive(Accounts)]
+pub struct TestCompilationGeneric<'info> {
+    pub account_with_generic_field: Account<'info, AccountWithGenericField>,
+}
 
 #[derive(Accounts)]
 pub struct Init<'info> {
@@ -231,7 +244,17 @@ pub struct PackedAccount {
     pub b: [u16; 8],
 }
 
+#[account]
+pub struct AccountWithGenericField {
+    pub field: GenericStruct<u32, 8>,
+}
+
 #[event]
 pub struct MyEvent {
     pub value: u32,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct GenericStruct<T, const N: usize> {
+    pub field: [T; N],
 }


### PR DESCRIPTION
### Problem

Instruction argument structs and regular types have different derive logic after https://github.com/otter-sec/anchor/pull/4085.

### Summary of changes

- Use the [`can_derive_debug`](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/lang/attribute/program/src/declare_program/common.rs#L342) and [`can_derive_clone`](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/lang/attribute/program/src/declare_program/common.rs#L330) functions in [`convert_idl_type_def_to_ts`](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/lang/attribute/program/src/declare_program/common.rs#L128) to decide whether `Debug` and `Clone` can be derived on the type
- Use `convert_idl_type_def_to_ts` to create args structs
- Make the `can_derive_*_ty` functions private

**Note:** I'm not sure if these new checks are even required tbh. They currently only disable derivation if the field is a generic type. I think we should be able to add the missing trait bounds as necessary, but that's outside the scope of this PR.