### PR TITLE
fix(cli): wait for deployed programs before running tests

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1095,7 +1095,7 @@ impl From<SurfpoolConfig> for _SurfpoolConfig {
         }
     }
 }
-pub const STARTUP_WAIT: i32 = 5000;
+pub const STARTUP_WAIT: i32 = 30000;
 pub const SHUTDOWN_WAIT: i32 = 2000;
 
 impl From<_TestValidator> for TestValidator {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -990,14 +990,14 @@ fn deser_programs(
 pub struct TestValidator {
     pub genesis: Option<Vec<GenesisEntry>>,
     pub validator: Option<Validator>,
-    pub startup_wait: i32,
+    pub startup_wait: u64,
     pub shutdown_wait: i32,
     pub upgradeable: bool,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SurfpoolConfig {
-    pub startup_wait: i32,
+    pub startup_wait: u64,
     pub shutdown_wait: i32,
     pub rpc_port: u16,
     pub ws_port: Option<u16>,
@@ -1019,7 +1019,7 @@ pub struct _TestValidator {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validator: Option<_Validator>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub startup_wait: Option<i32>,
+    pub startup_wait: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shutdown_wait: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1029,7 +1029,7 @@ pub struct _TestValidator {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct _SurfpoolConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub startup_wait: Option<i32>,
+    pub startup_wait: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shutdown_wait: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1095,7 +1095,7 @@ impl From<SurfpoolConfig> for _SurfpoolConfig {
         }
     }
 }
-pub const STARTUP_WAIT: i32 = 30000;
+pub const STARTUP_WAIT: u64 = 30000;
 pub const SHUTDOWN_WAIT: i32 = 2000;
 
 impl From<_TestValidator> for TestValidator {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5734,7 +5734,7 @@ fn start_surfpool_validator(
 }
 
 fn start_solana_test_validator(
-    cfg: &Config,
+    cfg: &WithPath<Config>,
     test_validator: &Option<TestValidator>,
     flags: Option<Vec<String>>,
     test_log_stdout: bool,
@@ -5802,11 +5802,17 @@ fn start_solana_test_validator(
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
 
-    if wait_for_validator_ready(&client, ms_wait).is_err() {
+    let program_ids: Vec<Pubkey> = cfg
+        .get_programs(None)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|p| p.pubkey().ok())
+        .collect();
+
+    if let Err(e) = wait_for_validator_ready(&client, ms_wait, &program_ids) {
         eprintln!(
-            "Unable to get latest blockhash. Test validator does not look started. Check \
-             {test_ledger_log_filename:?} for errors. Consider increasing [test.startup_wait] in \
-             Anchor.toml."
+            "Test validator setup failed: {e}. Check {test_ledger_log_filename:?} for errors. \
+             Consider increasing [test.startup_wait] in Anchor.toml."
         );
         validator_handle.kill()?;
         std::process::exit(1);
@@ -5814,17 +5820,43 @@ fn start_solana_test_validator(
     Ok(validator_handle)
 }
 
-fn wait_for_validator_ready(client: &RpcClient, ms_wait: i32) -> Result<()> {
-    let mut count = 0;
-    while count < ms_wait {
-        let r = client.get_latest_blockhash();
-        if r.is_ok() {
-            return Ok(());
+fn wait_for_validator_ready(
+    client: &RpcClient,
+    ms_wait: i32,
+    program_ids: &[Pubkey],
+) -> Result<()> {
+    let start = std::time::Instant::now();
+    let max_wait = std::time::Duration::from_millis(ms_wait as u64);
+
+    // Wait for RPC to be up
+    loop {
+        if client.get_latest_blockhash().is_ok() {
+            break;
+        }
+        if start.elapsed() >= max_wait {
+            return Err(anyhow!(
+                "Timeout waiting for validator to start (RPC not ready)"
+            ));
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
-        count += 100;
     }
-    Err(anyhow!("Timeout waiting for validator to start"))
+
+    // Wait for programs to be deployed and executable
+    for pubkey in program_ids {
+        loop {
+            if let Ok(account) = client.get_account(pubkey) {
+                if account.executable {
+                    break;
+                }
+            }
+            if start.elapsed() >= max_wait {
+                return Err(anyhow!("Timeout waiting for program {} to deploy", pubkey));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+
+    Ok(())
 }
 
 // Return the URL that solana-test-validator should be running on given the
@@ -7117,7 +7149,13 @@ mod tests {
             IdlGenericArg, IdlInstructionAccount, IdlInstructionAccountItem, IdlPda, IdlSeed,
             IdlSeedAccount, IdlTypeDef, IdlTypeDefGeneric,
         },
-        std::collections::{HashMap, HashSet},
+        solana_pubkey::Pubkey,
+        std::{
+            collections::{HashMap, HashSet},
+            io::{Read, Write},
+            net::TcpListener,
+            str::FromStr,
+        },
         tempfile::tempdir,
     };
 
@@ -7841,5 +7879,86 @@ mod tests {
 
         assert_eq!(generated_accounts.len(), 2);
         assert_ne!(generated_accounts[0].pubkey, generated_accounts[1].pubkey);
+    }
+
+    #[test]
+    fn test_wait_for_validator_ready_success() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        std::thread::spawn(move || {
+            let mut expected_requests = 2; // blockhash, then getAccount
+            while expected_requests > 0 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buf = [0; 1024];
+                    let size = stream.read(&mut buf).unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..size]);
+
+                    let response_body = if req.contains("getLatestBlockhash") {
+                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1}},"id":1}"#
+                    } else if req.contains("getAccountInfo") {
+                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"data":["","base64"],"executable":true,"lamports":1,"owner":"11111111111111111111111111111111","rentEpoch":1}},"id":1}"#
+                    } else {
+                        r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"#
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    expected_requests -= 1;
+                }
+            }
+        });
+
+        let client = create_client(format!("http://127.0.0.1:{}", port));
+        let program_id = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+
+        let result = wait_for_validator_ready(&client, 5000, &[program_id]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_wait_for_validator_ready_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Server only replies to blockhash, not getAccountInfo
+        std::thread::spawn(move || {
+            // Keep listening until the timeout
+            for _ in 0..10 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buf = [0; 1024];
+                    let size = stream.read(&mut buf).unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..size]);
+
+                    let response_body = if req.contains("getLatestBlockhash") {
+                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1}},"id":1}"#
+                    } else {
+                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":null},"id":1}"#
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            }
+        });
+
+        let client = create_client(format!("http://127.0.0.1:{}", port));
+        let program_id = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+
+        // Wait 300ms, will timeout because getAccountInfo returns null
+        let result = wait_for_validator_ready(&client, 300, &[program_id]);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Timeout waiting for program"));
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5797,20 +5797,12 @@ fn start_solana_test_validator(
 
     // Wait for the validator to be ready.
     let client = create_client(rpc_url);
-    let mut count = 0;
     let ms_wait = test_validator
         .as_ref()
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
-    while count < ms_wait {
-        let r = client.get_latest_blockhash();
-        if r.is_ok() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        count += 100;
-    }
-    if count >= ms_wait {
+
+    if wait_for_validator_ready(&client, ms_wait).is_err() {
         eprintln!(
             "Unable to get latest blockhash. Test validator does not look started. Check \
              {test_ledger_log_filename:?} for errors. Consider increasing [test.startup_wait] in \
@@ -5820,6 +5812,19 @@ fn start_solana_test_validator(
         std::process::exit(1);
     }
     Ok(validator_handle)
+}
+
+fn wait_for_validator_ready(client: &RpcClient, ms_wait: i32) -> Result<()> {
+    let mut count = 0;
+    while count < ms_wait {
+        let r = client.get_latest_blockhash();
+        if r.is_ok() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        count += 100;
+    }
+    Err(anyhow!("Timeout waiting for validator to start"))
 }
 
 // Return the URL that solana-test-validator should be running on given the

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5786,7 +5786,7 @@ fn start_solana_test_validator(
     let program_ids: Vec<Pubkey> = flags
         .as_deref()
         .unwrap_or(&[])
-        .windows(3)
+        .windows(2)
         .filter_map(|w| {
             if w[0] == "--bpf-program" || w[0] == "--upgradeable-program" {
                 w[1].parse::<Pubkey>().ok()
@@ -5844,16 +5844,18 @@ fn wait_for_validator_ready(
     }
 
     // Wait for programs to be deployed and executable
-    loop {
-        match client.get_multiple_accounts(program_ids) {
-            Ok(accounts)
-                if accounts
-                    .iter()
-                    .all(|a| a.as_ref().is_some_and(|acc| acc.executable)) =>
-            {
-                break
+    let mut pending: Vec<Pubkey> = program_ids.to_vec();
+    while !pending.is_empty() {
+        if let Ok(accounts) = client.get_multiple_accounts(&pending) {
+            pending = pending
+                .iter()
+                .zip(accounts.iter())
+                .filter(|(_, acc)| !acc.as_ref().is_some_and(|a| a.executable))
+                .map(|(pk, _)| *pk)
+                .collect();
+            if pending.is_empty() {
+                break;
             }
-            _ => {}
         }
         if start.elapsed() >= max_wait {
             return Err(anyhow!("Timeout waiting for programs to deploy"));

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5783,6 +5783,18 @@ fn start_solana_test_validator(
             "Your configured faucet port: {faucet_port} is already in use"
         ));
     }
+    let program_ids: Vec<Pubkey> = flags
+        .as_deref()
+        .unwrap_or(&[])
+        .windows(3)
+        .filter_map(|w| {
+            if w[0] == "--bpf-program" || w[0] == "--upgradeable-program" {
+                w[1].parse::<Pubkey>().ok()
+            } else {
+                None
+            }
+        })
+        .collect();
 
     let mut validator_handle = std::process::Command::new("solana-test-validator")
         .arg("--ledger")
@@ -5801,13 +5813,6 @@ fn start_solana_test_validator(
         .as_ref()
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
-
-    let program_ids: Vec<Pubkey> = cfg
-        .get_programs(None)
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|p| p.pubkey().ok())
-        .collect();
 
     if let Err(e) = wait_for_validator_ready(&client, ms_wait, &program_ids) {
         eprintln!(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5813,6 +5813,8 @@ fn start_solana_test_validator(
         .as_ref()
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
+    let ms_wait =
+        u64::try_from(ms_wait).map_err(|_| anyhow!("startup_wait must be a non-negative value"))?;
 
     if let Err(e) = wait_for_validator_ready(&client, ms_wait, &program_ids) {
         eprintln!(
@@ -5827,17 +5829,14 @@ fn start_solana_test_validator(
 
 fn wait_for_validator_ready(
     client: &RpcClient,
-    ms_wait: i32,
+    ms_wait: u64,
     program_ids: &[Pubkey],
 ) -> Result<()> {
     let start = std::time::Instant::now();
-    let max_wait = std::time::Duration::from_millis(ms_wait.max(0) as u64);
+    let max_wait = std::time::Duration::from_millis(ms_wait);
 
     // Wait for RPC to be up
-    loop {
-        if client.get_latest_blockhash().is_ok() {
-            break;
-        }
+    while client.get_latest_blockhash().is_err() {
         if start.elapsed() >= max_wait {
             return Err(anyhow!(
                 "Timeout waiting for validator to start (RPC not ready)"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5847,18 +5847,21 @@ fn wait_for_validator_ready(
     }
 
     // Wait for programs to be deployed and executable
-    for pubkey in program_ids {
-        loop {
-            if let Ok(account) = client.get_account(pubkey) {
-                if account.executable {
-                    break;
-                }
+    loop {
+        match client.get_multiple_accounts(program_ids) {
+            Ok(accounts)
+                if accounts
+                    .iter()
+                    .all(|a| a.as_ref().map_or(false, |acc| acc.executable)) =>
+            {
+                break
             }
-            if start.elapsed() >= max_wait {
-                return Err(anyhow!("Timeout waiting for program {} to deploy", pubkey));
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            _ => {}
         }
+        if start.elapsed() >= max_wait {
+            return Err(anyhow!("Timeout waiting for programs to deploy"));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
     Ok(())
@@ -7154,13 +7157,7 @@ mod tests {
             IdlGenericArg, IdlInstructionAccount, IdlInstructionAccountItem, IdlPda, IdlSeed,
             IdlSeedAccount, IdlTypeDef, IdlTypeDefGeneric,
         },
-        solana_pubkey::Pubkey,
-        std::{
-            collections::{HashMap, HashSet},
-            io::{Read, Write},
-            net::TcpListener,
-            str::FromStr,
-        },
+        std::collections::{HashMap, HashSet},
         tempfile::tempdir,
     };
 
@@ -7884,86 +7881,5 @@ mod tests {
 
         assert_eq!(generated_accounts.len(), 2);
         assert_ne!(generated_accounts[0].pubkey, generated_accounts[1].pubkey);
-    }
-
-    #[test]
-    fn test_wait_for_validator_ready_success() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        std::thread::spawn(move || {
-            let mut expected_requests = 2; // blockhash, then getAccount
-            while expected_requests > 0 {
-                if let Ok((mut stream, _)) = listener.accept() {
-                    let mut buf = [0; 1024];
-                    let size = stream.read(&mut buf).unwrap_or(0);
-                    let req = String::from_utf8_lossy(&buf[..size]);
-
-                    let response_body = if req.contains("getLatestBlockhash") {
-                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1}},"id":1}"#
-                    } else if req.contains("getAccountInfo") {
-                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"data":["","base64"],"executable":true,"lamports":1,"owner":"11111111111111111111111111111111","rentEpoch":1}},"id":1}"#
-                    } else {
-                        r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"#
-                    };
-
-                    let response = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
-                        response_body.len(),
-                        response_body
-                    );
-                    let _ = stream.write_all(response.as_bytes());
-                    expected_requests -= 1;
-                }
-            }
-        });
-
-        let client = create_client(format!("http://127.0.0.1:{}", port));
-        let program_id = Pubkey::from_str("11111111111111111111111111111111").unwrap();
-
-        let result = wait_for_validator_ready(&client, 5000, &[program_id]);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_wait_for_validator_ready_timeout() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        // Server only replies to blockhash, not getAccountInfo
-        std::thread::spawn(move || {
-            // Keep listening until the timeout
-            for _ in 0..10 {
-                if let Ok((mut stream, _)) = listener.accept() {
-                    let mut buf = [0; 1024];
-                    let size = stream.read(&mut buf).unwrap_or(0);
-                    let req = String::from_utf8_lossy(&buf[..size]);
-
-                    let response_body = if req.contains("getLatestBlockhash") {
-                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1}},"id":1}"#
-                    } else {
-                        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":null},"id":1}"#
-                    };
-
-                    let response = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
-                        response_body.len(),
-                        response_body
-                    );
-                    let _ = stream.write_all(response.as_bytes());
-                }
-            }
-        });
-
-        let client = create_client(format!("http://127.0.0.1:{}", port));
-        let program_id = Pubkey::from_str("11111111111111111111111111111111").unwrap();
-
-        // Wait 300ms, will timeout because getAccountInfo returns null
-        let result = wait_for_validator_ready(&client, 300, &[program_id]);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Timeout waiting for program"));
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5852,7 +5852,7 @@ fn wait_for_validator_ready(
             Ok(accounts)
                 if accounts
                     .iter()
-                    .all(|a| a.as_ref().map_or(false, |acc| acc.executable)) =>
+                    .all(|a| a.as_ref().is_some_and(|acc| acc.executable)) =>
             {
                 break
             }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5813,8 +5813,6 @@ fn start_solana_test_validator(
         .as_ref()
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
-    let ms_wait =
-        u64::try_from(ms_wait).map_err(|_| anyhow!("startup_wait must be a non-negative value"))?;
 
     if let Err(e) = wait_for_validator_ready(&client, ms_wait, &program_ids) {
         eprintln!(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5831,7 +5831,7 @@ fn wait_for_validator_ready(
     program_ids: &[Pubkey],
 ) -> Result<()> {
     let start = std::time::Instant::now();
-    let max_wait = std::time::Duration::from_millis(ms_wait as u64);
+    let max_wait = std::time::Duration::from_millis(ms_wait.max(0) as u64);
 
     // Wait for RPC to be up
     loop {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5846,17 +5846,18 @@ fn wait_for_validator_ready(
     // Wait for programs to be deployed and executable
     let mut pending: Vec<Pubkey> = program_ids.to_vec();
     while !pending.is_empty() {
-        if let Ok(accounts) = client.get_multiple_accounts(&pending) {
-            pending = pending
-                .iter()
-                .zip(accounts.iter())
-                .filter(|(_, acc)| !acc.as_ref().is_some_and(|a| a.executable))
-                .map(|(pk, _)| *pk)
-                .collect();
-            if pending.is_empty() {
-                break;
-            }
-        }
+        pending = pending
+            .chunks(100)
+            .flat_map(|chunk| match client.get_multiple_accounts(chunk) {
+                Ok(accounts) => chunk
+                    .iter()
+                    .zip(accounts.iter())
+                    .filter(|(_, acc)| !acc.as_ref().is_some_and(|a| a.executable))
+                    .map(|(pk, _)| *pk)
+                    .collect::<Vec<_>>(),
+                Err(_) => chunk.to_vec(),
+            })
+            .collect();
         if start.elapsed() >= max_wait {
             return Err(anyhow!("Timeout waiting for programs to deploy"));
         }

--- a/docs-v2/src/content/docs/v1/reference/anchor-toml.mdx
+++ b/docs-v2/src/content/docs/v1/reference/anchor-toml.mdx
@@ -196,7 +196,7 @@ Configures the [Surfpool](https://github.com/solana-foundation/surfpool) validat
 
 ```toml
 [surfpool]
-startup_wait = 5000                                # Time (ms) to wait for Surfpool to start. Default: 5000.
+startup_wait = 30000                               # Time (ms) to wait for Surfpool to start. Default: 30000.
 shutdown_wait = 2000                               # Time (ms) to wait for Surfpool to shut down. Default: 2000.
 rpc_port = 8899                                    # JSON RPC port. Default: 8899.
 ws_port = 8900                                     # WebSocket port. If not set, derived automatically.
@@ -213,7 +213,7 @@ block_production_mode = "clock"                    # Block production mode. Defa
 
 ### `startup_wait`
 
-Time in milliseconds to wait for Surfpool to start up. Useful when loading many accounts or running runbooks at startup. Default: `5000`.
+Time in milliseconds to wait for Surfpool to start up. Useful when loading many accounts or running runbooks at startup. Default: `30000`.
 
 ### `shutdown_wait`
 

--- a/docs-v2/src/content/docs/v2/reference/anchor-toml.mdx
+++ b/docs-v2/src/content/docs/v2/reference/anchor-toml.mdx
@@ -217,7 +217,7 @@ Surfpool is the default local network backend for supported CLI flows. Configure
 
 ```toml showLineNumbers=false
 [surfpool]
-startup_wait = 5000
+startup_wait = 30000
 shutdown_wait = 2000
 rpc_port = 8899
 ws_port = 8900

--- a/docs/content/docs/references/anchor-toml.mdx
+++ b/docs/content/docs/references/anchor-toml.mdx
@@ -269,7 +269,7 @@ Example:
 
 ```toml
 [surfpool]
-startup_wait = 5000                                       # Time (ms) to wait for Surfpool to start. Default: 5000.
+startup_wait = 30000                                       # Time (ms) to wait for Surfpool to start. Default: 30000.
 shutdown_wait = 2000                                      # Time (ms) to wait for Surfpool to shut down. Default: 2000.
 rpc_port = 8899                                           # JSON RPC port. Default: 8899.
 ws_port = 8900                                            # WebSocket port. If not set, derived automatically.
@@ -287,7 +287,7 @@ block_production_mode = "clock"                            # Block production mo
 ### startup_wait
 
 Time in milliseconds to wait for Surfpool to start up. This is useful when
-loading many accounts or running runbooks at startup. Default: `5000`.
+loading many accounts or running runbooks at startup. Default: `30000`.
 
 ### shutdown_wait
 


### PR DESCRIPTION
Fixes #3624

Replaced the single `get_latest_blockhash()` readiness check with a two-phase wait: RPC liveness then `get_multiple_accounts()` polling until all deployed programs are executable. Programs are polled in chunks of 100 to respect Solana's RPC limit. Pubkeys are sourced from the actual `--bpf-program` flags (not keypair files) to respect `[programs.localnet]` overrides. `startup_wait` is now u64 and defaults to 30000ms.