### PR TITLE
client: Remove the `CompileError` and `NotLegacyTransaction` variants of `ClientError`

### DIFF
--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -150,9 +150,9 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> RequestBuilder<'a, C, Box<dyn S
     pub fn signed_transaction(&self) -> Result<Transaction, ClientError> {
         self.handle
             .block_on(self.signed_transaction_internal(TxVersion::Legacy))
-            .and_then(|tx| {
+            .map(|tx| {
                 tx.into_legacy_transaction()
-                    .ok_or(ClientError::NotLegacyTransaction)
+                    .expect("Signed transaction with `TxVersion::Legacy`")
             })
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -520,8 +520,6 @@ pub enum ClientError {
     IOError(#[from] std::io::Error),
     #[error("{0}")]
     SignerError(#[from] SignerError),
-    #[error("Expected a legacy transaction but got a versioned transaction")]
-    NotLegacyTransaction,
 }
 
 pub trait AsSigner {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -520,8 +520,6 @@ pub enum ClientError {
     IOError(#[from] std::io::Error),
     #[error("{0}")]
     SignerError(#[from] SignerError),
-    #[error("{0}")]
-    CompileError(#[from] solana_message::CompileError),
     #[error("Expected a legacy transaction but got a versioned transaction")]
     NotLegacyTransaction,
 }
@@ -713,7 +711,8 @@ impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, 
                     &instructions,
                     address_lookup_table_accounts,
                     recent_blockhash,
-                )?;
+                )
+                .map_err(|e| ClientError::IOError(std::io::Error::other(e)))?;
                 Ok(solana_transaction::versioned::VersionedTransaction {
                     signatures: vec![
                         solana_signature::Signature::default();
@@ -752,7 +751,8 @@ impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, 
                     &instructions,
                     address_lookup_table_accounts,
                     latest_hash,
-                )?;
+                )
+                .map_err(|e| ClientError::IOError(std::io::Error::other(e)))?;
                 solana_message::VersionedMessage::V0(msg)
             }
         };

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -522,6 +522,17 @@ pub enum ClientError {
     SignerError(#[from] SignerError),
 }
 
+impl ClientError {
+    /// Adding a new variant to [`ClientError`] is a breaking change in v1. To mitigate this issue,
+    /// use this helper method for all errors that cannot be precisely described by [`ClientError`].
+    fn other<E>(e: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self::IOError(std::io::Error::other(e))
+    }
+}
+
 pub trait AsSigner {
     fn as_signer(&self) -> &dyn Signer;
 }
@@ -710,7 +721,7 @@ impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, 
                     address_lookup_table_accounts,
                     recent_blockhash,
                 )
-                .map_err(|e| ClientError::IOError(std::io::Error::other(e)))?;
+                .map_err(ClientError::other)?;
                 Ok(solana_transaction::versioned::VersionedTransaction {
                     signatures: vec![
                         solana_signature::Signature::default();
@@ -750,7 +761,7 @@ impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, 
                     address_lookup_table_accounts,
                     latest_hash,
                 )
-                .map_err(|e| ClientError::IOError(std::io::Error::other(e)))?;
+                .map_err(ClientError::other)?;
                 solana_message::VersionedMessage::V0(msg)
             }
         };

--- a/client/src/nonblocking.rs
+++ b/client/src/nonblocking.rs
@@ -156,9 +156,9 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> RequestBuilder<'a, C, Arc<dyn T
     pub async fn signed_transaction(&self) -> Result<Transaction, ClientError> {
         self.signed_transaction_internal(TxVersion::Legacy)
             .await
-            .and_then(|tx| {
+            .map(|tx| {
                 tx.into_legacy_transaction()
-                    .ok_or(ClientError::NotLegacyTransaction)
+                    .expect("Signed transaction with `TxVersion::Legacy`")
             })
     }
 


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/otter-sec/anchor/pull/4207#discussion_r3410453091, [the recent variants](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/client/src/lib.rs#L523-L526) added to [the `ClientError` enum](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/client/src/lib.rs#L506) will result in breakage in v1.

### Summary of changes

- Remove `ClientError::CompileError` (replace with `ClientError::IOError`)
- Remove `ClientError::NotLegacyTransaction` (replace with `expect`, since that path should be unreachable)
- Add `ClientError::other` (a method to be used with non-supported errors)