### PR TITLE
lang: Remove cloning `AccountInfo` to read lamports in `init_if_needed` codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- lang: Remove cloning `AccountInfo` to read lamports in `init_if_needed` codegen ([#4675](https://github.com/solana-foundation/anchor/pull/4675)).
 - ts: Remove `cross-fetch` dependency ([#4671](https://github.com/solana-foundation/anchor/pull/4671)).
 - lang: Guard `AccountLoader<T>::exit` against zero-copy buffer truncation and bail with `AccountDidNotDeserialize` instead of rewriting the discriminator over an undersized buffer ([#4633](https://github.com/otter-sec/anchor/pull/4633)).
 - lang: Set `anchor-lang` Minimum Supported Rust Version to `1.89` ([#4638](https://github.com/otter-sec/anchor/pull/4638)).

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1196,7 +1196,7 @@ fn generate_constraint_init_group(
 
                         {
                             let required_lamports = __anchor_rent.minimum_balance(space);
-                            if anchor_lang::Lamports::get_lamports(&pa) < required_lamports {
+                            if anchor_lang::Lamports::get_lamports(actual_field) < required_lamports {
                                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintRentExempt).with_account_name(#name_str));
                             }
                         }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1196,7 +1196,7 @@ fn generate_constraint_init_group(
 
                         {
                             let required_lamports = __anchor_rent.minimum_balance(space);
-                            if pa.to_account_info().lamports() < required_lamports {
+                            if anchor_lang::Lamports::get_lamports(&pa) < required_lamports {
                                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintRentExempt).with_account_name(#name_str));
                             }
                         }


### PR DESCRIPTION
### Problem

Similar to https://github.com/otter-sec/anchor/pull/4642, we clone the `AccountInfo` just to check its lamports in the `init_if_needed` constraint codegen:

https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/lang/syn/src/codegen/accounts/constraints.rs#L1199

### Summary of changes

Remove the unnecessary cloning in the `init_if_needed` codegen by using [`Lamports::get_lamports`](https://github.com/otter-sec/anchor/blob/e47eda0a5b35a7182ba4cabae64a8b9bf8a93049/lang/src/lib.rs#L280).

This change results in 41 less CU per `init_if_needed`.

**Note:** This check seems fully redundant currently, but this PR is not concerned with getting rid of the rent exemption logic (https://github.com/otter-sec/anchor/pull/2708). Plus, not cloning here is *comparable* to not having the check at all (perf-wise).