### PR TITLE
reject close constraints on unchecked accounts

### DIFF
--- a/lang-v2/README.md
+++ b/lang-v2/README.md
@@ -106,7 +106,7 @@ None of these carry an `'info` lifetime — pinocchio's account model is static-
 | `Signer` | Transaction signer. Validates `is_signer`. (v1 compat) |
 | `Program<T>` | CPI targets (`Program<System>`, `Program<Token>`, …). Validates executable + program ID via `T: Id`. (v1 compat) |
 | `SystemAccount` | System-owned account. Owner check only. (v1 compat) |
-| `UncheckedAccount` | Escape hatch. No validation. (v1 compat) |
+| `UncheckedAccount` | Escape hatch. No validation. No generic `close` support. (v1 compat) |
 | `Sysvar<T>` | `Sysvar<Clock>`, `Sysvar<Rent>`. Prefer `Clock::get()` / `Rent::get()` syscalls where possible. (v1 compat) |
 
 ## CPI Semantics

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -642,6 +642,29 @@ pub fn extract_option_inner(ty: &Type) -> Option<&Type> {
     None
 }
 
+fn contains_unchecked_account(ty: &Type) -> bool {
+    match ty {
+        Type::Path(tp) => {
+            let Some(seg) = tp.path.segments.last() else {
+                return false;
+            };
+            if seg.ident == "UncheckedAccount" {
+                return true;
+            }
+            if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                return args.args.iter().any(|arg| match arg {
+                    syn::GenericArgument::Type(inner) => contains_unchecked_account(inner),
+                    _ => false,
+                });
+            }
+            false
+        }
+        Type::Paren(paren) => contains_unchecked_account(&paren.elem),
+        Type::Reference(reference) => contains_unchecked_account(&reference.elem),
+        _ => false,
+    }
+}
+
 pub struct AccountField {
     pub name: Ident,
     /// The field's original `syn::Type` — used by `impl_accounts` to build
@@ -1415,6 +1438,13 @@ pub fn parse_field(
         return Err(syn::Error::new(
             field_name.span(),
             "mut must be provided when using close",
+        ));
+    }
+    if attrs.close.is_some() && contains_unchecked_account(field_ty) {
+        return Err(syn::Error::new(
+            field_name.span(),
+            "`#[account(close = ...)]` is not supported on `UncheckedAccount`; use a typed \
+             account wrapper or close the raw account manually",
         ));
     }
     let associated_token = parse_associated_token_init(&attrs, field_names)?;

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -642,29 +642,6 @@ pub fn extract_option_inner(ty: &Type) -> Option<&Type> {
     None
 }
 
-fn contains_unchecked_account(ty: &Type) -> bool {
-    match ty {
-        Type::Path(tp) => {
-            let Some(seg) = tp.path.segments.last() else {
-                return false;
-            };
-            if seg.ident == "UncheckedAccount" {
-                return true;
-            }
-            if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
-                return args.args.iter().any(|arg| match arg {
-                    syn::GenericArgument::Type(inner) => contains_unchecked_account(inner),
-                    _ => false,
-                });
-            }
-            false
-        }
-        Type::Paren(paren) => contains_unchecked_account(&paren.elem),
-        Type::Reference(reference) => contains_unchecked_account(&reference.elem),
-        _ => false,
-    }
-}
-
 pub struct AccountField {
     pub name: Ident,
     /// The field's original `syn::Type` — used by `impl_accounts` to build
@@ -1438,13 +1415,6 @@ pub fn parse_field(
         return Err(syn::Error::new(
             field_name.span(),
             "mut must be provided when using close",
-        ));
-    }
-    if attrs.close.is_some() && contains_unchecked_account(field_ty) {
-        return Err(syn::Error::new(
-            field_name.span(),
-            "`#[account(close = ...)]` is not supported on `UncheckedAccount`; use a typed \
-             account wrapper or close the raw account manually",
         ));
     }
     let associated_token = parse_associated_token_init(&attrs, field_names)?;
@@ -2287,7 +2257,7 @@ pub fn parse_field(
         });
         Some(quote! {
             #(#constraint_exits)*
-            anchor_lang_v2::AnchorAccount::close(
+            anchor_lang_v2::AccountClose::close(
                 &mut self.#field_name,
                 *self.#close_target.account(),
             )?;
@@ -2312,7 +2282,8 @@ pub fn parse_field(
     // unwrapped inner — we wrap it in `if let Some(#field_name) = #field_name`
     // so `#field_name.account()`, `#field_name.authority`, etc. resolve on the
     // inner `T` (via autoderef). The exit/close path regenerates against the
-    // unwrapped `&mut T` so `AnchorAccount::exit/close` get the right type.
+    // unwrapped `&mut T` so `AnchorAccount::exit` / `AccountClose::close`
+    // get the right type.
     //
     // Mutable fields use `ref mut` so constraint bodies that need `&mut self`
     // (e.g. BorshAccount::release_borrow in the realloc path) can work.
@@ -2394,7 +2365,7 @@ pub fn parse_field(
                 quote! {
                     if let Some(__inner) = self.#field_name.as_mut() {
                         #(#inner_constraint_exits)*
-                        anchor_lang_v2::AnchorAccount::close(
+                        anchor_lang_v2::AccountClose::close(
                             __inner,
                             *self.#close_target.account(),
                         )?;

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -39,10 +39,6 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
     fn exit(&mut self) -> pinocchio::ProgramResult {
         (**self).exit()
     }
-
-    fn close(&mut self, destination: AccountView) -> pinocchio::ProgramResult {
-        (**self).close(destination)
-    }
 }
 
 impl<T: crate::ToCpiHandle + ?Sized> crate::ToCpiHandle for Box<T> {
@@ -70,6 +66,13 @@ impl<T: crate::AccountRealloc> crate::AccountRealloc for Box<T> {
         zero: bool,
     ) -> pinocchio::ProgramResult {
         self.as_mut().realloc_account(new_space, payer, zero)
+    }
+}
+
+impl<T: crate::AccountClose> crate::AccountClose for Box<T> {
+    #[inline(always)]
+    fn close(&mut self, destination: AccountView) -> pinocchio::ProgramResult {
+        self.as_mut().close(destination)
     }
 }
 

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -279,6 +279,35 @@ where
         Ok(crate::CpiHandleMut::writable(&mut self.view))
     }
 
+    fn exit(&mut self) -> pinocchio::ProgramResult {
+        // Skip serialization only after close() has cleared the account header.
+        // A zero lamport balance can be transient when a later exit refunds this
+        // account, so lamports alone do not prove that write-back is unnecessary.
+        if super::slab::is_closed(&self.view) {
+            return Ok(());
+        }
+        // Belt-and-braces: the derive's `realloc` constraint does
+        // release_borrow + reacquire after resize, but if someone resizes
+        // through a non-derive path the guard's length would be stale.
+        // Detect and fix before serializing.
+        let stale = matches!(&self.borrow, SerializedAccountBorrow::Mutable { guard } if guard.len() != self.view.data_len());
+        if stale {
+            // Drop the stale guard directly rather than via release_borrow:
+            // serializing through a stale-length guard would OOB on shrink.
+            // The serialize below runs through the freshly reacquired guard.
+            self.borrow = SerializedAccountBorrow::Released;
+            self.reacquire_guard_only()?;
+        }
+        Self::serialize_mutable_borrow(&self.data, &mut self.borrow, &mut self.serialized_len)?;
+        Ok(())
+    }
+}
+
+impl<T, S> crate::AccountClose for SerializedAccount<T, S>
+where
+    T: Owner + Discriminator,
+    S: AnchorAccountSerialize<T>,
+{
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
         let mut self_view = self.view;
         let dest_lamports = destination
@@ -316,29 +345,6 @@ where
         }
 
         self_view.close()?;
-        Ok(())
-    }
-
-    fn exit(&mut self) -> pinocchio::ProgramResult {
-        // Skip serialization only after close() has cleared the account header.
-        // A zero lamport balance can be transient when a later exit refunds this
-        // account, so lamports alone do not prove that write-back is unnecessary.
-        if super::slab::is_closed(&self.view) {
-            return Ok(());
-        }
-        // Belt-and-braces: the derive's `realloc` constraint does
-        // release_borrow + reacquire after resize, but if someone resizes
-        // through a non-derive path the guard's length would be stale.
-        // Detect and fix before serializing.
-        let stale = matches!(&self.borrow, SerializedAccountBorrow::Mutable { guard } if guard.len() != self.view.data_len());
-        if stale {
-            // Drop the stale guard directly rather than via release_borrow:
-            // serializing through a stale-length guard would OOB on shrink.
-            // The serialize below runs through the freshly reacquired guard.
-            self.borrow = SerializedAccountBorrow::Released;
-            self.reacquire_guard_only()?;
-        }
-        Self::serialize_mutable_borrow(&self.data, &mut self.borrow, &mut self.serialized_len)?;
         Ok(())
     }
 }

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -811,7 +811,12 @@ where
     fn account(&self) -> &AccountView {
         &self.view
     }
+}
 
+impl<H, T> crate::AccountClose for Slab<H, T>
+where
+    H: Pod + Zeroable + SlabSchema,
+{
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
         self.assert_mutable();
         let mut self_view = self.view;

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -4,6 +4,10 @@ use {
     solana_program_error::ProgramError,
 };
 
+/// Escape hatch account wrapper with no owner/layout/discriminator validation.
+///
+/// Because the wrapper provides no lifecycle guarantees, it intentionally
+/// does not support Anchor's generic `#[account(close = ...)]` path.
 pub struct UncheckedAccount {
     view: AccountView,
 }

--- a/lang-v2/src/accounts/unchecked_account.rs
+++ b/lang-v2/src/accounts/unchecked_account.rs
@@ -7,7 +7,9 @@ use {
 /// Escape hatch account wrapper with no owner/layout/discriminator validation.
 ///
 /// Because the wrapper provides no lifecycle guarantees, it intentionally
-/// does not support Anchor's generic `#[account(close = ...)]` path.
+/// does not implement [`crate::AccountClose`], so Anchor's generic
+/// `#[account(close = ...)]` path (and manual close) will not compile
+/// against it.
 pub struct UncheckedAccount {
     view: AccountView,
 }
@@ -29,10 +31,6 @@ impl AnchorAccount for UncheckedAccount {
     #[inline(always)]
     fn account(&self) -> &AccountView {
         &self.view
-    }
-
-    fn close(&mut self, _destination: AccountView) -> pinocchio::ProgramResult {
-        Err(ProgramError::InvalidArgument)
     }
 }
 

--- a/lang-v2/src/prelude.rs
+++ b/lang-v2/src/prelude.rs
@@ -47,6 +47,8 @@ pub use crate::{
     system_program,
     // Core trait
     AccountAddress,
+    // Close trait
+    AccountClose,
     // Constraints
     AccountConstraint,
     // Loader & dispatch

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -196,18 +196,6 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
         *self.account().address()
     }
 
-    fn close(&mut self, mut destination: AccountView) -> ProgramResult {
-        let mut self_view = *self.account();
-        let dest_lamports = destination
-            .lamports()
-            .checked_add(self_view.lamports())
-            .ok_or(ProgramError::ArithmeticOverflow)?;
-        destination.set_lamports(dest_lamports);
-        self_view.set_lamports(0);
-        self_view.close()?;
-        Ok(())
-    }
-
     /// Obtain a read-only CPI handle for this account.
     ///
     /// The handle borrows `self`, preventing mutable typed access while
@@ -260,6 +248,20 @@ pub trait AccountRealloc: AnchorAccount {
         payer: AccountView,
         zero: bool,
     ) -> ProgramResult;
+}
+
+/// Account wrapper capability for `#[account(close = ...)]`.
+///
+/// The derive emits a call to this trait instead of deciding close support
+/// from syntactic type names. That lets rustc resolve aliases and wrapper
+/// forwards normally: unsupported wrappers (notably `UncheckedAccount`)
+/// simply do not implement the trait.
+#[diagnostic::on_unimplemented(
+    message = "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
+    note = "use a typed account wrapper or close the raw account manually"
+)]
+pub trait AccountClose: AnchorAccount {
+    fn close(&mut self, destination: AccountView) -> ProgramResult;
 }
 
 /// Account-like value that can be passed into a CPI account struct.

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -101,14 +101,6 @@ impl Discriminator for LongDiscCounter {
     ];
 }
 
-#[derive(Accounts)]
-struct CloseUnchecked {
-    #[account(mut, close = receiver)]
-    data: UncheckedAccount,
-    #[account(mut)]
-    receiver: UncheckedAccount,
-}
-
 fn setup_borsh_counter_buf(
     buf: &mut AccountBuffer<128>,
     owner: [u8; 32],
@@ -322,19 +314,16 @@ fn unchecked_account_load_mut_accepts_writable() {
 }
 
 #[test]
-fn unchecked_account_close_constraint_fails_at_runtime() {
+fn unchecked_account_close_method_fails_at_runtime() {
     let data_buf = AccountBuffer::<128>::new();
     data_buf.init([0xAB; 32], [0x99; 32], 0, false, true, false);
+    let mut data = unsafe { UncheckedAccount::load_mut(data_buf.view()) }.unwrap();
 
     let receiver_buf = AccountBuffer::<128>::new();
     receiver_buf.init([0xCD; 32], [0x99; 32], 0, false, true, false);
+    let receiver = unsafe { receiver_buf.view() };
 
-    let views = [unsafe { data_buf.view() }, unsafe { receiver_buf.view() }];
-    let (mut accounts, _, _) =
-        CloseUnchecked::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
-            .unwrap();
-
-    let err = expect_err(accounts.exit_accounts());
+    let err = expect_err(anchor_lang_v2::AnchorAccount::close(&mut data, receiver));
     assert_eq!(err, ProgramError::InvalidArgument);
 }
 

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -313,20 +313,6 @@ fn unchecked_account_load_mut_accepts_writable() {
     assert_eq!(ua.address().to_bytes(), [0xAB; 32]);
 }
 
-#[test]
-fn unchecked_account_close_method_fails_at_runtime() {
-    let data_buf = AccountBuffer::<128>::new();
-    data_buf.init([0xAB; 32], [0x99; 32], 0, false, true, false);
-    let mut data = unsafe { UncheckedAccount::load_mut(data_buf.view()) }.unwrap();
-
-    let receiver_buf = AccountBuffer::<128>::new();
-    receiver_buf.init([0xCD; 32], [0x99; 32], 0, false, true, false);
-    let receiver = unsafe { receiver_buf.view() };
-
-    let err = expect_err(anchor_lang_v2::AnchorAccount::close(&mut data, receiver));
-    assert_eq!(err, ProgramError::InvalidArgument);
-}
-
 // -- Program<T> ---------------------------------------------------------
 
 #[test]

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -51,7 +51,7 @@ use {
         prelude::BorshAccount,
         testing::AccountBuffer,
         wincode::{SchemaRead, SchemaWrite},
-        AccountRealloc, AnchorAccount, Discriminator, Owner,
+        AccountClose, AccountRealloc, AnchorAccount, Discriminator, Owner,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::{account::RuntimeAccount, address::Address},

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -800,6 +800,34 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn close_on_unchecked_account_is_rejected() {
+    compile_fail_case(
+        "close_on_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut, close = receiver)]
+    pub raw: UncheckedAccount,
+    #[account(mut)]
+    pub receiver: SystemAccount,
+}
+"#,
+        &[
+            "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
+            "close the raw account manually",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn init_owner_override_rejects_typed_accounts() {
     fn case(name: &str, account_attr: &str, field_ty: &str) {
         let source = format!(

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -92,7 +92,7 @@ pub mod accounts_test {
         Ok(())
     }
 
-    /// Closes a boxed counter, forwarding through `AnchorAccount::close`.
+    /// Closes a boxed counter, forwarding through `AccountClose::close`.
     #[discrim = 4]
     pub fn close_boxed(_ctx: &mut Context<CloseBoxed>) -> Result<()> {
         Ok(())

--- a/tests-v2/programs/custom-constraints/src/lib.rs
+++ b/tests-v2/programs/custom-constraints/src/lib.rs
@@ -66,7 +66,7 @@ pub mod custom_constraints {
         Ok(())
     }
 
-    /// Close a boxed counter to exercise `AnchorAccount::close` forwarding.
+    /// Close a boxed counter to exercise `AccountClose::close` forwarding.
     pub fn handle_boxed_close(_ctx: &mut Context<HandleBoxedClose>) -> Result<()> {
         Ok(())
     }

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1048,7 +1048,7 @@ pub struct Bad {
 }
 
 #[test]
-fn close_on_unchecked_account_compiles() {
+fn close_on_unchecked_account_does_not_compile() {
     CompileCase::new(
         "close_on_unchecked_account",
         r#"
@@ -1076,11 +1076,14 @@ pub struct Close {
 }
 "#,
     )
-    .expect_pass();
+    .expect_fail(&[
+        "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
+        "close the raw account manually",
+    ]);
 }
 
 #[test]
-fn close_on_boxed_unchecked_account_compiles() {
+fn close_on_boxed_unchecked_account_does_not_compile() {
     CompileCase::new(
         "close_on_boxed_unchecked_account",
         r#"
@@ -1108,11 +1111,14 @@ pub struct Close {
 }
 "#,
     )
-    .expect_pass();
+    .expect_fail(&[
+        "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
+        "close the raw account manually",
+    ]);
 }
 
 #[test]
-fn close_on_optional_unchecked_account_compiles() {
+fn close_on_optional_unchecked_account_does_not_compile() {
     CompileCase::new(
         "close_on_optional_unchecked_account",
         r#"
@@ -1140,7 +1146,10 @@ pub struct Close {
 }
 "#,
     )
-    .expect_pass();
+    .expect_fail(&[
+        "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
+        "close the raw account manually",
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
Finding

`#[account(close = ...)]` was accepted on `UncheckedAccount` in lang-v2, even though `UncheckedAccount::close` only fails at runtime with `InvalidArgument`. That turned a misuse that v1 rejected early into a late runtime error.

Fix

~This PR rejects `close` constraints on `UncheckedAccount` at derive time, matching the earlier enforcement model and improving diagnostics. It also adds regression coverage for the macro diagnostic and wrapper behavior.~

Updated Fix:
- Introduced the `AccountClose` trait to handle account closing semantics.
- Updated various account types (Box, SerializedAccount, Slab) to implement `AccountClose`.
- Removed the close method from `UncheckedAccount`.
- Adjusted related tests and documentation to reflect these changes