### PR TITLE
tests: Fix `ambiguous-discriminator` build test

### DIFF
--- a/tests/custom-discriminator/tests/ambiguous-discriminator.ts
+++ b/tests/custom-discriminator/tests/ambiguous-discriminator.ts
@@ -1,6 +1,24 @@
+import fs from "fs";
 import { spawnSync } from "child_process";
 
 describe("ambiguous-discriminator", () => {
+  const anchorTomlPath = "Anchor.toml";
+  const anchorToml = fs.readFileSync(anchorTomlPath, { encoding: "utf8" });
+
+  before(() => {
+    fs.writeFileSync(
+      anchorTomlPath,
+      anchorToml.replace(
+        'exclude = ["programs/ambiguous-discriminator"]',
+        (match) => "#" + match
+      )
+    );
+  });
+
+  after(() => {
+    fs.writeFileSync(anchorTomlPath, anchorToml);
+  });
+
   it("Returns ambiguous discriminator error on builds", () => {
     const result = spawnSync("anchor", [
       "idl",
@@ -14,7 +32,9 @@ describe("ambiguous-discriminator", () => {
 
     const output = result.output.toString();
     if (
-      !output.includes("Error: Program 'ambiguous-discriminator' not found")
+      !output.includes(
+        "Error: Ambiguous discriminators for accounts `AnotherAccount` and `SomeAccount`"
+      )
     ) {
       throw new Error(
         `Ambiguous discriminators did not return the expected error: "${output}"`


### PR DESCRIPTION
### Problem

[The `ambiguous-discriminator` test](https://github.com/otter-sec/anchor/blob/b446d8a2d190fce002ddd4d5d8f8a2af01869b38/tests/custom-discriminator/tests/ambiguous-discriminator.ts) does not actually verify the expected build error:

https://github.com/otter-sec/anchor/blob/b446d8a2d190fce002ddd4d5d8f8a2af01869b38/tests/custom-discriminator/tests/ambiguous-discriminator.ts#L16-L22

### Summary of changes

Fix the `ambiguous-discriminator` build test by:

- Commenting out the `workspace.exclude` field of `Anchor.toml` *before* the test(s)
- Restoring the `workspace.exclude` field of `Anchor.toml` *after* the test(s)
- Checking [the expected error message](https://github.com/otter-sec/anchor/blob/b446d8a2d190fce002ddd4d5d8f8a2af01869b38/idl/src/build.rs#L378)

    ```
    Error: Ambiguous discriminators for accounts `AnotherAccount` and `SomeAccount`