### PR TITLE
fix(client): avoid port overflow when deriving websocket URLs

### DIFF
--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -33,8 +33,11 @@ impl FromStr for Cluster {
 
                 let mut ws_url = Url::parse(http_url)?;
                 if let Some(port) = ws_url.port() {
+                    let ws_port = port
+                        .checked_add(1)
+                        .ok_or_else(|| anyhow!("Unable to infer websocket port from {port}"))?;
                     ws_url
-                        .set_port(Some(port + 1))
+                        .set_port(Some(ws_port))
                         .map_err(|_| anyhow!("Unable to set port"))?;
                 }
                 if ws_url.scheme() == "https" {
@@ -147,6 +150,13 @@ mod tests {
             cluster
         );
     }
+
+    #[test]
+    fn test_http_max_port() {
+        let url = "http://my-url.com:65535/";
+        assert!(Cluster::from_str(url).is_err());
+    }
+
     #[test]
     fn test_https_no_port() {
         let url = "https://my-url.com/";


### PR DESCRIPTION
## Summary

When parsing a custom HTTP RPC URL, `Cluster::from_str` derives the websocket URL by incrementing the HTTP port by one. For a URL using port `65535`, this addition overflows in debug builds and can produce an invalid wrapped port in release builds.

This change uses `checked_add(1)` when inferring the websocket port and returns an error if the HTTP port cannot be incremented. Existing valid custom URLs keep the same behavior, and a regression test covers the max-port edge case.


## Branch Target

If this contains breaking changes, it should target the `anchor-next` branch.
