### PR TITLE
ci: Only run `nightly-attested-binaries` in the master repository

### DIFF
--- a/.github/workflows/nightly-attested-binaries.yaml
+++ b/.github/workflows/nightly-attested-binaries.yaml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.target }}
+    if: github.event.repository.fork == false
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -156,6 +157,7 @@ jobs:
 
   upload-to-cloud-bucket:
     name: Upload to cloud bucket
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     needs: build
     permissions:


### PR DESCRIPTION
### Problem

[The `nightly-attested-binaries` workflow](https://github.com/otter-sec/anchor/blob/b446d8a2d190fce002ddd4d5d8f8a2af01869b38/.github/workflows/nightly-attested-binaries.yaml) runs on all forks every single day ([example](https://github.com/acheroncrypto/anchor/actions/runs/27810881843)). This is highly wasteful and also results in a daily notification about CI failure.

### Summary of changes

Only run the `nightly-attested-binaries` workflow in the master repository (not forks).

**Note:** Technically, the workflow still runs on forks, but all its jobs will be skipped. I'm not sure if this is the best approach, so feel free to suggest better ways to achieve this.