### PR TITLE
fix(spl-v2): size interface token accounts from mint extensions

### DIFF
--- a/spl-v2/src/token_interface.rs
+++ b/spl-v2/src/token_interface.rs
@@ -35,7 +35,10 @@ use {
     solana_address::Address,
     solana_program_error::ProgramError,
     spl_token_2022_interface::{
-        extension::{BaseStateWithExtensions, PodStateWithExtensions},
+        extension::{
+            BaseStateWithExtensions, ExtensionType as Token2022ExtensionType,
+            PodStateWithExtensions,
+        },
         pod::{PodAccount, PodMint},
     },
 };
@@ -232,7 +235,7 @@ impl SlabInit for Interface<crate::TokenAccount> {
         let program_id = token_program.address();
         crate::token_shared::validate_token_interface_program(program_id)?;
 
-        let space = core::mem::size_of::<crate::TokenAccount>();
+        let space = token_account_init_space(mint, program_id)?;
         anchor_lang_v2::create_account_with_signers(
             payer,
             account,
@@ -250,6 +253,24 @@ impl SlabInit for Interface<crate::TokenAccount> {
         }
         .invoke()
     }
+}
+
+#[inline(always)]
+fn token_account_init_space(
+    mint: &AccountView,
+    token_program: &Address,
+) -> Result<usize, ProgramError> {
+    if !anchor_lang_v2::address_eq(token_program, &Token2022Program::id()) {
+        return Ok(core::mem::size_of::<crate::TokenAccount>());
+    }
+
+    let mint_data = unsafe { mint.borrow_unchecked() };
+    let mint_state = PodStateWithExtensions::<PodMint>::unpack(mint_data)?;
+    let mint_extensions = mint_state.get_extension_types()?;
+    let required_extensions =
+        Token2022ExtensionType::get_required_init_account_extensions(&mint_extensions);
+
+    Token2022ExtensionType::try_calculate_account_len::<PodAccount>(&required_extensions)
 }
 
 // ---------------------------------------------------------------------------

--- a/tests-v2/tests/token_interface.rs
+++ b/tests-v2/tests/token_interface.rs
@@ -3,12 +3,23 @@
 use {
     anchor_lang_v2::solana_program::instruction::AccountMeta,
     litesvm::LiteSVM,
+    solana_account::Account,
     solana_keypair::Keypair,
+    solana_program_option::COption,
+    solana_program_pack::Pack as _,
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     spl_token::{
         solana_program::program_pack::Pack,
         state::{Account as SplTokenAccount, Mint as SplMint},
+    },
+    spl_token_2022_interface::{
+        extension::{
+            non_transferable::{NonTransferable, NonTransferableAccount},
+            set_account_type, BaseStateWithExtensions, BaseStateWithExtensionsMut, ExtensionType,
+            StateWithExtensions, StateWithExtensionsMut,
+        },
+        state::{Account as Token2022Account, Mint as Token2022Mint},
     },
     tests_v2::{build_program, keypair_for, send_instruction},
 };
@@ -285,6 +296,76 @@ fn assert_token_state(
     assert_eq!(state.amount, amount);
 }
 
+fn seed_initialized_non_transferable_mint(svm: &mut LiteSVM, mint: Pubkey, authority: Pubkey) {
+    let len = ExtensionType::try_calculate_account_len::<Token2022Mint>(&[
+        ExtensionType::NonTransferable,
+    ])
+    .expect("calculate token-2022 mint length with non-transferable extension");
+    let mut data = vec![0; len];
+    {
+        let mut state = StateWithExtensionsMut::<Token2022Mint>::unpack_uninitialized(&mut data)
+            .expect("unpack uninitialized mint");
+        state
+            .init_extension::<NonTransferable>(false)
+            .expect("initialize non-transferable extension");
+    }
+    Token2022Mint {
+        mint_authority: COption::Some(authority),
+        supply: 0,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    }
+    .pack_into_slice(&mut data[..Token2022Mint::LEN]);
+    set_account_type::<Token2022Mint>(&mut data).expect("set token-2022 mint account type");
+
+    svm.set_account(
+        mint,
+        Account {
+            lamports: 10_000_000,
+            data,
+            owner: token_2022_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .expect("seed initialized token-2022 mint");
+}
+
+fn assert_non_transferable_token_2022_state(
+    svm: &LiteSVM,
+    token_account: Pubkey,
+    mint: Pubkey,
+    authority: Pubkey,
+) {
+    let account = svm
+        .get_account(&token_account)
+        .expect("token account exists");
+    assert_eq!(account.owner, token_2022_program_id());
+
+    let expected_len = ExtensionType::try_calculate_account_len::<Token2022Account>(&[
+        ExtensionType::NonTransferableAccount,
+        ExtensionType::ImmutableOwner,
+    ])
+    .expect("calculate token-2022 token account length");
+    assert_eq!(account.data.len(), expected_len);
+
+    let state =
+        StateWithExtensions::<Token2022Account>::unpack(&account.data).expect("unpack token-2022");
+    assert_eq!(state.base.mint.to_bytes(), mint.to_bytes());
+    assert_eq!(state.base.owner.to_bytes(), authority.to_bytes());
+    assert_eq!(state.base.amount, 0);
+
+    let extensions = state
+        .get_extension_types()
+        .expect("read token-2022 account extension types");
+    assert!(extensions.contains(&ExtensionType::NonTransferableAccount));
+    assert!(extensions.contains(&ExtensionType::ImmutableOwner));
+    state
+        .get_extension::<NonTransferableAccount>()
+        .expect("non-transferable account extension should be initialized");
+}
+
 #[test]
 fn token_interface_program_accepts_token_and_token_2022_only() {
     let (mut svm, payer) = setup();
@@ -357,6 +438,34 @@ fn interface_init_creates_token_2022_mint_and_token_account() {
         mint.pubkey(),
         token_owner.pubkey(),
         0,
+    );
+}
+
+#[test]
+fn interface_init_sizes_token_2022_accounts_from_mint_extensions() {
+    let (mut svm, payer) = setup();
+    let mint_authority = keypair_for("t22-interface-extended-mint-authority");
+    let token_owner = keypair_for("t22-interface-extended-token-owner");
+    let mint = Keypair::new();
+    let token_account = Keypair::new();
+
+    seed_initialized_non_transferable_mint(&mut svm, mint.pubkey(), mint_authority.pubkey());
+
+    init_token_account(
+        &mut svm,
+        &payer,
+        &mint.pubkey(),
+        &token_account,
+        &token_owner.pubkey(),
+        token_2022_program_id(),
+    )
+    .expect("interface token account init should size from required Token-2022 extensions");
+
+    assert_non_transferable_token_2022_state(
+        &svm,
+        token_account.pubkey(),
+        mint.pubkey(),
+        token_owner.pubkey(),
     );
 }
 


### PR DESCRIPTION
the init path now reads the mint’s extension set and computes required token-account space with `get_required_init_account_extensions(...)` plus `try_calculate_account_len::<PodAccount>(...)` before `InitializeAccount3`.