### PR TITLE
Fix/v2 realloc payer target check

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -103,6 +103,10 @@ name = "lamports"
 required-features = ["testing"]
 
 [[test]]
+name = "realloc_payer_target_check"
+required-features = ["testing"]
+
+[[test]]
 name = "cursor_and_remaining_accounts"
 required-features = ["testing"]
 

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -569,6 +569,11 @@ pub fn realloc_account(
 ) -> Result<(), ProgramError> {
     use pinocchio::Resize;
 
+    require!(
+        !pinocchio::address::address_eq(payer.address(), account.address()),
+        ProgramError::InvalidArgument
+    );
+
     let old_space = account.data_len();
     let required = rent_exempt_lamports(new_space)?;
     let current_lamports = account.lamports();
@@ -635,6 +640,31 @@ mod const_rent_tests {
             rent_exempt_lamports(0).unwrap(),
             ACCOUNT_STORAGE_OVERHEAD * DEFAULT_LAMPORTS_PER_BYTE,
         );
+    }
+}
+
+#[cfg(all(test, feature = "testing"))]
+mod realloc_tests {
+    use {super::*, crate::testing::AccountBuffer};
+
+    const PROGRAM_ID: [u8; 32] = [0x42; 32];
+
+    #[test]
+    fn realloc_rejects_payer_equal_target_before_resize() {
+        let buf = AccountBuffer::<256>::new();
+        buf.init([0xAB; 32], PROGRAM_ID, 24, false, true, false);
+
+        let mut account = unsafe { buf.view() };
+        let payer = account;
+        let old_space = account.data_len();
+        let old_lamports = account.lamports();
+
+        let err = realloc_account(&mut account, 64, &payer, false)
+            .expect_err("realloc must reject using the target account as the payer");
+
+        assert_eq!(err, ProgramError::InvalidArgument);
+        assert_eq!(account.data_len(), old_space);
+        assert_eq!(account.lamports(), old_lamports);
     }
 }
 

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -643,31 +643,6 @@ mod const_rent_tests {
     }
 }
 
-#[cfg(all(test, feature = "testing"))]
-mod realloc_tests {
-    use {super::*, crate::testing::AccountBuffer};
-
-    const PROGRAM_ID: [u8; 32] = [0x42; 32];
-
-    #[test]
-    fn realloc_rejects_payer_equal_target_before_resize() {
-        let buf = AccountBuffer::<256>::new();
-        buf.init([0xAB; 32], PROGRAM_ID, 24, false, true, false);
-
-        let mut account = unsafe { buf.view() };
-        let payer = account;
-        let old_space = account.data_len();
-        let old_lamports = account.lamports();
-
-        let err = realloc_account(&mut account, 64, &payer, false)
-            .expect_err("realloc must reject using the target account as the payer");
-
-        assert_eq!(err, ProgramError::InvalidArgument);
-        assert_eq!(account.data_len(), old_space);
-        assert_eq!(account.lamports(), old_lamports);
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Kani proofs — CPI helper invariants
 // ---------------------------------------------------------------------------

--- a/lang-v2/tests/realloc_payer_target_check.rs
+++ b/lang-v2/tests/realloc_payer_target_check.rs
@@ -1,0 +1,24 @@
+use {
+    anchor_lang_v2::{cpi::realloc_account, testing::AccountBuffer},
+    solana_program_error::ProgramError,
+};
+
+const PROGRAM_ID: [u8; 32] = [0x42; 32];
+
+#[test]
+fn realloc_rejects_payer_equal_target_before_resize() {
+    let buf = AccountBuffer::<256>::new();
+    buf.init([0xAB; 32], PROGRAM_ID, 24, false, true, false);
+
+    let mut account = unsafe { buf.view() };
+    let payer = account;
+    let old_space = account.data_len();
+    let old_lamports = account.lamports();
+
+    let err = realloc_account(&mut account, 64, &payer, false)
+        .expect_err("realloc must reject using the target account as the payer");
+
+    assert_eq!(err, ProgramError::InvalidArgument);
+    assert_eq!(account.data_len(), old_space);
+    assert_eq!(account.lamports(), old_lamports);
+}


### PR DESCRIPTION
added an early `ProgramError::InvalidArgument` check, matching the existing guard style used in `create_account_with_signers`