### PR TITLE
fix(lang-v2): enforce slab min data len on realloc

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -145,3 +145,7 @@ required-features = ["testing"]
 [[test]]
 name = "address_idl_surface"
 required-features = ["testing"]
+
+[[test]]
+name = "slab_min_data_len_realloc"
+required-features = ["testing"]

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -708,6 +708,11 @@ where
     /// touching lamports. Compose with `top_up` / `refund` afterward to
     /// settle rent. Re-derives `header_ptr` after the resize; `guard_bytes*`
     /// pick up the new size from `view.data_len()` automatically.
+    ///
+    /// No `self.view = view_mut` write-back is needed here. `AccountView` is
+    /// a raw-pointer wrapper over the shared `RuntimeAccount` header; Pinocchio
+    /// resizes by mutating that header's `data_len` in place, so all
+    /// `AccountView` copies observe the updated length.
     pub fn resize_to_capacity(&mut self, new_capacity: u32) -> Result<(), ProgramError> {
         use pinocchio::Resize;
 
@@ -846,6 +851,10 @@ where
             if new_space < Self::MIN_DATA_LEN {
                 return Err(ProgramError::AccountDataTooSmall);
             }
+            // No `self.view = view` write-back is needed: `AccountView` is a
+            // raw-pointer wrapper over the shared `RuntimeAccount` header, and
+            // `crate::realloc_account` updates that header's `data_len` in
+            // place. All `AccountView` copies therefore observe the new size.
             crate::realloc_account(&mut view, new_space, &payer, zero)?;
             self.header_ptr = unsafe { view.data_mut_ptr().add(Self::HEADER_OFFSET) } as *mut H;
             if Self::HAS_TAIL {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -843,7 +843,7 @@ where
     ) -> pinocchio::ProgramResult {
         let mut view = *self.account();
         if new_space != view.data_len() {
-            if new_space < Self::ITEMS_OFFSET {
+            if new_space < Self::MIN_DATA_LEN {
                 return Err(ProgramError::AccountDataTooSmall);
             }
             crate::realloc_account(&mut view, new_space, &payer, zero)?;

--- a/lang-v2/tests/slab_min_data_len_realloc.rs
+++ b/lang-v2/tests/slab_min_data_len_realloc.rs
@@ -1,0 +1,70 @@
+use {
+    anchor_lang_v2::{
+        accounts::{Account, SlabSchema},
+        testing::AccountBuffer,
+        AccountRealloc, AnchorAccount,
+    },
+    bytemuck::{Pod, Zeroable},
+    pinocchio::account::AccountView,
+    solana_program_error::ProgramError,
+};
+
+const DATA_OFFSET: usize = 8;
+const PHYSICAL_MIN_DATA_LEN: usize = DATA_OFFSET + core::mem::size_of::<CustomHeader>();
+const DECLARED_MIN_DATA_LEN: usize = PHYSICAL_MIN_DATA_LEN + 16;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct CustomHeader {
+    counter: u64,
+    bump: u64,
+}
+
+impl SlabSchema for CustomHeader {
+    const DATA_OFFSET: usize = DATA_OFFSET;
+    const MIN_DATA_LEN: usize = DECLARED_MIN_DATA_LEN;
+
+    fn validate(_view: &AccountView, data: &[u8]) -> Result<(), ProgramError> {
+        if data.len() < Self::MIN_DATA_LEN {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        Ok(())
+    }
+}
+
+type CustomAccount = Account<CustomHeader>;
+
+fn setup_account(data_len: usize) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    buf.init([0x44; 32], [0x55; 32], data_len, false, true, false);
+    let data = [0u8; 128];
+    buf.write_data(&data[..data_len]);
+    buf
+}
+
+#[test]
+fn custom_schema_minimum_exceeds_physical_layout() {
+    assert_eq!(PHYSICAL_MIN_DATA_LEN, 24);
+    assert_eq!(<CustomAccount as AnchorAccount>::MIN_DATA_LEN, DECLARED_MIN_DATA_LEN);
+    assert!(DECLARED_MIN_DATA_LEN > PHYSICAL_MIN_DATA_LEN);
+}
+
+#[test]
+fn realloc_rejects_shrink_below_custom_schema_minimum() {
+    let buf = setup_account(DECLARED_MIN_DATA_LEN);
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0x99; 32], [0x11; 32], 0, true, true, false);
+
+    let view = unsafe { buf.view() };
+    let mut account = unsafe { CustomAccount::load_mut(view) }.unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    let err = account
+        .realloc_account(PHYSICAL_MIN_DATA_LEN, payer_view, false)
+        .expect_err("realloc must reject spaces below the schema minimum");
+    assert_eq!(err, ProgramError::AccountDataTooSmall);
+    assert_eq!(account.current_space(), DECLARED_MIN_DATA_LEN);
+    drop(account);
+
+    CustomAccount::load(unsafe { buf.view() }).expect("account should stay reloadable");
+}

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -399,6 +399,61 @@ fn slab_resize_to_capacity_clamps_len() {
     drop(slab);
 }
 
+#[test]
+fn slab_resize_to_capacity_updates_live_capacity_and_supports_push() {
+    let buf = setup_ledger(/*capacity*/ 1, /*len*/ 1);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+
+    slab.resize_to_capacity(3).unwrap();
+
+    assert_eq!(slab.current_space(), ITEMS_OFFSET + 3 * ITEM_SIZE);
+    assert_eq!(slab.capacity(), 3);
+
+    slab.try_push([0x11; 8]).unwrap();
+    slab.try_push([0x22; 8]).unwrap();
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab.capacity(), 3);
+
+    drop(slab);
+
+    let reloaded = CounterLedger::load(view).unwrap();
+    assert_eq!(reloaded.current_space(), ITEMS_OFFSET + 3 * ITEM_SIZE);
+    assert_eq!(reloaded.capacity(), 3);
+    assert_eq!(reloaded.len(), 3);
+}
+
+#[test]
+fn slab_realloc_growth_updates_live_capacity_and_supports_push() {
+    let buf = setup_ledger(/*capacity*/ 1, /*len*/ 1);
+    let payer = AccountBuffer::<128>::new();
+    payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
+    payer.set_lamports(1_000_000_000);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    let payer_view = unsafe { payer.view() };
+
+    slab.realloc_account(ITEMS_OFFSET + 3 * ITEM_SIZE, payer_view, false)
+        .unwrap();
+
+    assert_eq!(slab.current_space(), ITEMS_OFFSET + 3 * ITEM_SIZE);
+    assert_eq!(slab.capacity(), 3);
+
+    slab.try_push([0x33; 8]).unwrap();
+    slab.try_push([0x44; 8]).unwrap();
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab.capacity(), 3);
+
+    drop(slab);
+
+    let reloaded = CounterLedger::load(view).unwrap();
+    assert_eq!(reloaded.current_space(), ITEMS_OFFSET + 3 * ITEM_SIZE);
+    assert_eq!(reloaded.capacity(), 3);
+    assert_eq!(reloaded.len(), 3);
+}
+
 // -- Rent helpers -----------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Finding

Slab reallocation accepted sizes below the schema’s required minimum length, and the resize path could leave cached slab view state stale after a buffer move. That could leave the account in an invalid state or make later capacity/length reads inconsistent.

Fix

This PR enforces `MIN_DATA_LEN` during slab reallocation, refreshes the cached slab view/header after resize, and adds regression tests for both the minimum-length and resize-coherence cases.
