### PR TITLE
fix(cli): validate deploy program id keypair match

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -713,6 +713,26 @@ fn get_payer_keypair(
     }
 }
 
+/// Resolve the deploy target from the loaded program keypair, treating an
+/// explicit `--program-id` as an assertion that it matches the keypair pubkey.
+fn resolve_program_id(
+    loaded_program_keypair: &Keypair,
+    program_id: Option<Pubkey>,
+) -> Result<Pubkey> {
+    let loaded_program_id = loaded_program_keypair.pubkey();
+    match program_id {
+        Some(expected_program_id) if expected_program_id != loaded_program_id => {
+            bail!(
+                "--program-id {} does not match --program-keypair pubkey {}",
+                expected_program_id,
+                loaded_program_id
+            );
+        }
+        Some(expected_program_id) => Ok(expected_program_id),
+        None => Ok(loaded_program_id),
+    }
+}
+
 /// Deploy a single program (either from explicit filepath or workspace) - private implementation
 #[allow(clippy::too_many_arguments)]
 pub fn program_deploy(
@@ -729,8 +749,11 @@ pub fn program_deploy(
     make_final: bool,
     solana_args: Vec<String>,
 ) -> Result<()> {
-    let (rpc_client, config) = get_rpc_client_and_config(cfg_override)?;
-    let payer = get_payer_keypair(cfg_override, &config)?;
+    if program_id.is_some() && program_keypair.is_none() {
+        return Err(anyhow!(
+            "When --program-id is specified, --program-keypair must also be provided"
+        ));
+    }
 
     // Determine the program filepath
     let program_filepath = if let Some(filepath) = program_filepath {
@@ -759,10 +782,6 @@ pub fn program_deploy(
                 e
             )
         })?
-    } else if let Some(_program_id) = program_id {
-        return Err(anyhow!(
-            "When --program-id is specified, --program-keypair must also be provided"
-        ));
     } else {
         // Auto-detect from target/deploy/{program_name}-keypair.json
         let program_name = Path::new(&program_filepath)
@@ -783,7 +802,10 @@ pub fn program_deploy(
         })?
     };
 
-    let program_id = loaded_program_keypair.pubkey();
+    let program_id = resolve_program_id(&loaded_program_keypair, program_id)?;
+
+    let (rpc_client, config) = get_rpc_client_and_config(cfg_override)?;
+    let payer = get_payer_keypair(cfg_override, &config)?;
 
     // Inject per-program --buffer keypair so retries
     // within and across runs share the same on-chain buffer.
@@ -2747,13 +2769,107 @@ fn send_messages_in_batches(
 mod tests {
     use {
         super::*,
-        std::{collections::BTreeSet, fs, path::Path},
+        std::{
+            collections::BTreeSet,
+            fs,
+            path::{Path, PathBuf},
+        },
         tempfile::tempdir,
     };
 
     fn write_file(path: &Path, contents: &str) {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn resolve_program_id_accepts_matching_keypair() {
+        let program_keypair = Keypair::new();
+        let expected_program_id = program_keypair.pubkey();
+
+        let program_id = resolve_program_id(&program_keypair, Some(expected_program_id)).unwrap();
+
+        assert_eq!(program_id, expected_program_id);
+    }
+
+    #[test]
+    fn resolve_program_id_rejects_mismatching_keypair() {
+        let program_keypair = Keypair::new();
+        let expected_program_id = Pubkey::new_unique();
+
+        let err = resolve_program_id(&program_keypair, Some(expected_program_id))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains(&format!(
+            "--program-id {} does not match --program-keypair pubkey {}",
+            expected_program_id,
+            program_keypair.pubkey()
+        )));
+    }
+
+    #[test]
+    fn program_deploy_rejects_mismatching_program_id_before_deploy() {
+        let dir = tempdir().unwrap();
+        let keypair_path = dir.path().join("program-keypair.json");
+        let program_keypair = Keypair::new();
+        program_keypair.write_to_file(&keypair_path).unwrap();
+        let mismatching_program_id = Pubkey::new_unique();
+
+        let err = program_deploy(
+            &ConfigOverride {
+                cluster: None,
+                wallet: None,
+                commitment: None,
+            },
+            Some(dir.path().join("program.so")),
+            None,
+            Some(keypair_path),
+            None,
+            Some(mismatching_program_id),
+            None,
+            None,
+            false,
+            true,
+            false,
+            vec![],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains(&format!(
+            "--program-id {} does not match --program-keypair pubkey {}",
+            mismatching_program_id,
+            program_keypair.pubkey()
+        )));
+    }
+
+    #[test]
+    fn program_deploy_rejects_program_id_without_program_keypair() {
+        let err = program_deploy(
+            &ConfigOverride {
+                cluster: None,
+                wallet: None,
+                commitment: None,
+            },
+            Some(PathBuf::from("program.so")),
+            None,
+            None,
+            None,
+            Some(Pubkey::new_unique()),
+            None,
+            None,
+            false,
+            true,
+            false,
+            vec![],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("When --program-id is specified, --program-keypair must also be provided")
+        );
     }
 
     fn create_program(root: &Path, name: &str) {


### PR DESCRIPTION
## Summary
- Treat `--program-id` as an assertion when `anchor program deploy` also receives `--program-keypair`.
- Reject mismatched values before RPC, wallet, or deployment work starts.
- Keep the existing explicit error for `--program-id` without `--program-keypair` and add focused tests for both cases.

## Why
The native deploy path loaded the requested program keypair and then unconditionally used that keypair pubkey as the target program ID. That meant a command with `--program-id X --program-keypair Y` silently targeted `Y`, even if the user was expecting `X`.

## Validation
- `cargo fmt --package anchor-cli`
- `cargo test -p anchor-cli program_id`
- `cargo test -p anchor-cli program::tests::`
