### PR TITLE
fix(cli): fail npm wrapper without anchor

### DIFF
--- a/cli/npm-package/anchor.js
+++ b/cli/npm-package/anchor.js
@@ -74,7 +74,7 @@ function trySystemAnchor() {
 
   if (!absolutePath) {
     console.error(`Could not find globally installed anchor, install with cargo.`);
-    process.exit();
+    process.exit(1);
   }
 
   const absoluteBinaryPath = `${absolutePath}/anchor`;
@@ -82,13 +82,13 @@ function trySystemAnchor() {
   const [error, binaryVersion] = getBinaryVersion(absoluteBinaryPath);
   if (error !== null) {
     console.error(`Failed to get version of global binary: ${error}`);
-    return;
+    process.exit(1);
   }
   if (binaryVersion !== PACKAGE_VERSION) {
     console.error(
       `Globally installed anchor version is not correct. Expected "${PACKAGE_VERSION}", found "${binaryVersion}".`
     );
-    return;
+    process.exit(1);
   }
 
   runAnchor(absoluteBinaryPath);

--- a/cli/npm-package/anchor.test.js
+++ b/cli/npm-package/anchor.test.js
@@ -1,0 +1,100 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const PACKAGE_VERSION = `anchor-cli ${require("./package.json").version}`;
+
+function makePackage() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "anchor-npm-"));
+  const wrapperPath = path.join(dir, "anchor.js");
+  const preloadPath = path.join(dir, "mock-os.js");
+
+  fs.copyFileSync(path.join(__dirname, "anchor.js"), wrapperPath);
+  fs.copyFileSync(path.join(__dirname, "package.json"), path.join(dir, "package.json"));
+  fs.chmodSync(wrapperPath, 0o755);
+
+  fs.writeFileSync(
+    preloadPath,
+    `
+const os = require("node:os");
+os.arch = () => "arm64";
+os.platform = () => "darwin";
+`
+  );
+
+  return { dir, preloadPath, wrapperPath };
+}
+
+function writeFakeAnchor(filePath, { version = PACKAGE_VERSION, runOutput, runExit = 0 } = {}) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "--version" ]; then',
+      `  printf '%s\\n' ${JSON.stringify(version)}`,
+      "  exit 0",
+      "fi",
+      runOutput ? `printf '%s\\n' ${JSON.stringify(runOutput)}` : ":",
+      `exit ${runExit}`,
+      "",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+}
+
+function runWrapper(npmPackage, { args = [], pathValue = "" } = {}) {
+  return spawnSync(
+    process.execPath,
+    ["--require", npmPackage.preloadPath, npmPackage.wrapperPath, ...args],
+    {
+      encoding: "utf8",
+      env: { PATH: pathValue },
+    }
+  );
+}
+
+test("exits non-zero if global anchor fallback is missing", () => {
+  const npmPackage = makePackage();
+
+  const result = runWrapper(npmPackage);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Trying globally installed anchor/);
+  assert.match(result.stderr, /Could not find globally installed anchor/);
+});
+
+test("exits non-zero if global anchor fallback has the wrong version", () => {
+  const npmPackage = makePackage();
+  const globalBin = fs.mkdtempSync(path.join(os.tmpdir(), "anchor-global-"));
+  writeFakeAnchor(path.join(globalBin, "anchor"), {
+    version: "anchor-cli 0.0.0",
+  });
+
+  const result = runWrapper(npmPackage, { pathValue: globalBin });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Trying globally installed anchor/);
+  assert.match(result.stderr, /Globally installed anchor version is not correct/);
+});
+
+test("runs matching global anchor fallback", () => {
+  const npmPackage = makePackage();
+  const globalBin = fs.mkdtempSync(path.join(os.tmpdir(), "anchor-global-"));
+  writeFakeAnchor(path.join(globalBin, "anchor"), {
+    runExit: 7,
+    runOutput: "global anchor ran",
+  });
+
+  const result = runWrapper(npmPackage, {
+    args: ["build"],
+    pathValue: globalBin,
+  });
+
+  assert.equal(result.status, 7);
+  assert.match(result.stderr, /Trying globally installed anchor/);
+  assert.match(result.stdout, /global anchor ran/);
+});


### PR DESCRIPTION
## Summary
- Keep the existing automatic global `anchor` fallback behavior.
- Make global fallback failures exit non-zero when no global binary exists, the global version cannot be read, or the version does not match.
- Add focused Node tests for the missing, mismatched, and matching global fallback paths.

## Why
The wrapper could finish successfully without running Anchor: missing global fallback used a bare `process.exit()`, and global version errors returned from the function. That could let CI pass while no real Anchor command ran.

## Validation
- `node --test cli/npm-package/anchor.test.js`
- `node --check cli/npm-package/anchor.js && node --check cli/npm-package/anchor.test.js`
- Manual repros for no global fallback and stale global fallback now print `exit=1`; matching global fallback still runs.