### PR TITLE
fix(lang-v2): validate signer metas on checked invoke

### DIFF
--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -155,6 +155,9 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
         let mut handles = self.accounts.to_cpi_handles();
         handles.extend(self.remaining_accounts.iter().copied());
         crate::program::validate_handles(&ix, &handles)?;
+        if self.signer_seeds.is_empty() {
+            crate::program::validate_handle_signers(&ix, &handles)?;
+        }
 
         // SAFETY: `CpiContext` already ties every handle to a Rust borrow of
         // the caller's typed account. The account metas have been validated

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -154,10 +154,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
 
         let mut handles = self.accounts.to_cpi_handles();
         handles.extend(self.remaining_accounts.iter().copied());
-        crate::program::validate_handles(&ix, &handles)?;
-        if self.signer_seeds.is_empty() {
-            crate::program::validate_handle_signers(&ix, &handles)?;
-        }
+        crate::program::validate_handles(&ix, &handles, self.signer_seeds.is_empty())?;
 
         // SAFETY: `CpiContext` already ties every handle to a Rust borrow of
         // the caller's typed account. The account metas have been validated

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -38,10 +38,7 @@ pub fn invoke_signed<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
-    validate_handles(instruction, account_handles)?;
-    if signer_seeds.is_empty() {
-        validate_handle_signers(instruction, account_handles)?;
-    }
+    validate_handles(instruction, account_handles, signer_seeds.is_empty())?;
     validate_handle_borrows(instruction, account_handles)?;
 
     // SAFETY: Validation above proves every non-sentinel instruction account
@@ -109,6 +106,7 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
 pub(crate) fn validate_handles(
     instruction: &Instruction,
     account_handles: &[CpiHandle<'_>],
+    enforce_signers: bool,
 ) -> ProgramResult {
     let mut handle_index = 0;
 
@@ -128,29 +126,7 @@ pub(crate) fn validate_handles(
         if meta.is_writable {
             require!(handle.is_writable(), ProgramError::InvalidArgument);
         }
-
-        handle_index += 1;
-    }
-
-    Ok(())
-}
-
-pub(crate) fn validate_handle_signers(
-    instruction: &Instruction,
-    account_handles: &[CpiHandle<'_>],
-) -> ProgramResult {
-    let mut handle_index = 0;
-
-    for meta in &instruction.accounts {
-        if is_optional_account_sentinel(instruction, meta) {
-            continue;
-        }
-
-        let Some(handle) = account_handles.get(handle_index) else {
-            return Err(ProgramError::NotEnoughAccountKeys);
-        };
-
-        if meta.is_signer {
+        if enforce_signers && meta.is_signer {
             require!(handle.is_signer(), ProgramError::MissingRequiredSignature);
         }
 

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -39,6 +39,9 @@ pub fn invoke_signed<'a, 'seeds>(
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
     validate_handles(instruction, account_handles)?;
+    if signer_seeds.is_empty() {
+        validate_handle_signers(instruction, account_handles)?;
+    }
     validate_handle_borrows(instruction, account_handles)?;
 
     // SAFETY: Validation above proves every non-sentinel instruction account
@@ -124,6 +127,31 @@ pub(crate) fn validate_handles(
 
         if meta.is_writable {
             require!(handle.is_writable(), ProgramError::InvalidArgument);
+        }
+
+        handle_index += 1;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_handle_signers(
+    instruction: &Instruction,
+    account_handles: &[CpiHandle<'_>],
+) -> ProgramResult {
+    let mut handle_index = 0;
+
+    for meta in &instruction.accounts {
+        if is_optional_account_sentinel(instruction, meta) {
+            continue;
+        }
+
+        let Some(handle) = account_handles.get(handle_index) else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
+        if meta.is_signer {
+            require!(handle.is_signer(), ProgramError::MissingRequiredSignature);
         }
 
         handle_index += 1;

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -45,6 +45,20 @@ fn instruction(account: Address, writable: bool) -> Instruction {
     }
 }
 
+fn signer_instruction(account: Address, writable: bool) -> Instruction {
+    let meta = if writable {
+        AccountMeta::new(account, true)
+    } else {
+        AccountMeta::new_readonly(account, true)
+    };
+
+    Instruction {
+        program_id: ID,
+        accounts: vec![meta],
+        data: vec![9, 9, 9],
+    }
+}
+
 #[test]
 fn checked_invoke_accepts_matching_handles() {
     let buffer = account_view([1; 32], true);
@@ -121,6 +135,28 @@ fn checked_invoke_rejects_readonly_handle_for_writable_meta() {
 }
 
 #[test]
+fn checked_invoke_rejects_nonsigner_handle_for_signer_meta() {
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let ix = signer_instruction(*view.address(), false);
+    let handles = [CpiHandle::readonly(&view)];
+
+    let err = program::invoke(&ix, &handles).unwrap_err();
+
+    assert_eq!(err, ProgramError::MissingRequiredSignature);
+}
+
+#[test]
+fn checked_invoke_signed_allows_signer_meta_without_tx_signer_when_seeds_are_supplied() {
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let ix = signer_instruction(*view.address(), false);
+    let handles = [CpiHandle::readonly(&view)];
+
+    program::invoke_signed(&ix, &handles, &[&[b"pda", &[7]]]).unwrap();
+}
+
+#[test]
 fn invoke_ix_rejects_readonly_handle_for_writable_meta() {
     let program = ID;
     let buffer = account_view([1; 32], true);
@@ -139,6 +175,38 @@ fn invoke_ix_rejects_readonly_handle_for_writable_meta() {
         .unwrap_err();
 
     assert_eq!(err, ProgramError::InvalidArgument);
+}
+
+#[test]
+fn invoke_ix_rejects_nonsigner_handle_for_signer_meta_without_seeds() {
+    let program = ID;
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let accounts = ReadonlyCpi {
+        account: view.to_cpi_handle(),
+    };
+    let ix = signer_instruction(*view.address(), false);
+
+    let err = CpiContext::new(&program, accounts)
+        .invoke_ix(ix)
+        .unwrap_err();
+
+    assert_eq!(err, ProgramError::MissingRequiredSignature);
+}
+
+#[test]
+fn invoke_ix_allows_signer_meta_without_tx_signer_when_seeds_are_supplied() {
+    let program = ID;
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    let accounts = ReadonlyCpi {
+        account: view.to_cpi_handle(),
+    };
+    let ix = signer_instruction(*view.address(), false);
+
+    CpiContext::new_with_signer(&program, accounts, &[&[b"pda", &[7]]])
+        .invoke_ix(ix)
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
fixes by adding a signer check only on the no-seeds path