### PR TITLE
lang: Provide better error messages for `token` constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - cli/idl: Add `fetch-historical` support to recover historical IDLs with the Anchor CLI ([#3992](https://github.com/solana-foundation/anchor/pull/3992)).
 - cli: `anchor init` refuses to create a new Anchor workspace inside an existing Cargo workspace to avoid broken nested layouts ([#4576](https://github.com/solana-foundation/anchor/pull/4576)).
 - cli: Add `r` as an alias to the `run` command ([#4643](https://github.com/solana-foundation/anchor/pull/4643)).
+- lang: Provide better error messages for `token` constraints ([#4698](https://github.com/solana-foundation/anchor/pull/4698)).
 
 ### Fixes
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -508,7 +508,6 @@ fn generate_constraint_init_group(
         quote! {false}
     };
     let space = &c.space;
-
     let payer = &c.payer;
 
     // Convert from account info to account context wrapper type.
@@ -1358,38 +1357,67 @@ fn generate_constraint_token_account(
     accs: &AccountsStruct,
 ) -> proc_macro2::TokenStream {
     let name = &f.ident;
+    let name_str = name.to_string();
     let account_ref = generate_account_ref(f);
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, name);
+
     let authority_check = match &c.authority {
         Some(authority) => {
             let authority_optional_check = optional_check_scope.generate_check(authority);
             quote! {
                 #authority_optional_check
-                if #name.owner != #authority.key() { return Err(anchor_lang::error::ErrorCode::ConstraintTokenOwner.into()); }
+                if #name.owner != #authority.key() {
+                    return Err(
+                        anchor_lang::error::Error::from(
+                            anchor_lang::error::ErrorCode::ConstraintTokenOwner
+                        )
+                        .with_account_name(#name_str)
+                        .with_pubkeys((#name.owner, #authority.key()))
+                    );
+                }
             }
         }
         None => quote! {},
     };
+
     let mint_check = match &c.mint {
         Some(mint) => {
             let mint_optional_check = optional_check_scope.generate_check(mint);
             quote! {
                 #mint_optional_check
-                if #name.mint != #mint.key() { return Err(anchor_lang::error::ErrorCode::ConstraintTokenMint.into()); }
+                if #name.mint != #mint.key() {
+                    return Err(
+                        anchor_lang::error::Error::from(
+                            anchor_lang::error::ErrorCode::ConstraintTokenMint
+                        )
+                        .with_account_name(#name_str)
+                        .with_pubkeys((#name.mint, #mint.key()))
+                    );
+                }
             }
         }
         None => quote! {},
     };
+
     let token_program_check = match &c.token_program {
         Some(token_program) => {
             let token_program_optional_check = optional_check_scope.generate_check(token_program);
             quote! {
                 #token_program_optional_check
-                if #account_ref.owner != &#token_program.key() { return Err(anchor_lang::error::ErrorCode::ConstraintTokenTokenProgram.into()); }
+                if #account_ref.owner != &#token_program.key() {
+                    return Err(
+                        anchor_lang::error::Error::from(
+                            anchor_lang::error::ErrorCode::ConstraintTokenTokenProgram
+                        )
+                        .with_account_name(#name_str)
+                        .with_pubkeys((*#account_ref.owner, #token_program.key()))
+                    );
+                }
             }
         }
         None => quote! {},
     };
+
     quote! {
         {
             #authority_check


### PR DESCRIPTION
### Problem

`associated_token` constraints provide better error messages with account name and pubkey values included, but `token` constraints don't.

### Summary of changes

Provide better error messages for token constraints.