### PR TITLE
ci, tests: Fix `tictactoe` tests and include them in CI

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -536,6 +536,8 @@ jobs:
             path: tests/test-instruction-validation
           - cmd: cd tests/account-generation-test && anchor test
             path: tests/account-generation-test
+          - cmd: cd tests/tictactoe && anchor test
+            path: tests/tictactoe
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/tests/tictactoe/programs/tictactoe/src/lib.rs
+++ b/tests/tictactoe/programs/tictactoe/src/lib.rs
@@ -18,7 +18,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 pub mod tictactoe {
     use super::*;
 
-    pub fn initialize_dashboard(ctx: Context<Initializedashboard>) -> Result<()> {
+    pub fn initialize_dashboard(ctx: Context<InitializeDashboard>) -> Result<()> {
         let dashboard = &mut ctx.accounts.dashboard;
         dashboard.game_count = 0;
         dashboard.address = *dashboard.to_account_info().key;
@@ -34,15 +34,15 @@ pub mod tictactoe {
         Ok(())
     }
 
-    pub fn player_join(ctx: Context<Playerjoin>) -> Result<()> {
+    pub fn player_join(ctx: Context<PlayerJoin>) -> Result<()> {
         let game = &mut ctx.accounts.game;
         game.player_o = *ctx.accounts.player_o.key;
         game.game_state = 1;
         Ok(())
     }
 
-    #[access_control(Playermove::accounts(&ctx, x_or_o, player_move))]
-    pub fn player_move(ctx: Context<Playermove>, x_or_o: u8, player_move: u8) -> Result<()> {
+    #[access_control(PlayerMove::accounts(&ctx, x_or_o, player_move))]
+    pub fn player_move(ctx: Context<PlayerMove>, x_or_o: u8, player_move: u8) -> Result<()> {
         let game = &mut ctx.accounts.game;
         game.board[player_move as usize] = x_or_o;
         game.status(x_or_o);
@@ -55,13 +55,7 @@ pub mod tictactoe {
 }
 
 #[derive(Accounts)]
-pub struct Status<'info> {
-    dashboard: Account<'info, Dashboard>,
-    game: Account<'info, Game>,
-}
-
-#[derive(Accounts)]
-pub struct Initializedashboard<'info> {
+pub struct InitializeDashboard<'info> {
     #[account(zero)]
     dashboard: Account<'info, Dashboard>,
     authority: Signer<'info>,
@@ -77,34 +71,40 @@ pub struct Initialize<'info> {
 }
 
 #[derive(Accounts)]
-pub struct Playerjoin<'info> {
+pub struct PlayerJoin<'info> {
     player_o: Signer<'info>,
     #[account(mut, constraint = game.game_state != 0 && game.player_x != Pubkey::default())]
     game: Account<'info, Game>,
 }
 
 #[derive(Accounts)]
-pub struct Playermove<'info> {
+pub struct PlayerMove<'info> {
     player: Signer<'info>,
     #[account(mut)]
     game: Account<'info, Game>,
 }
 
-impl<'info> Playermove<'info> {
-    pub fn accounts(ctx: &Context<Playermove>, x_or_o: u8, player_move: u8) -> Result<()> {
+#[derive(Accounts)]
+pub struct Status<'info> {
+    dashboard: Account<'info, Dashboard>,
+    game: Account<'info, Game>,
+}
+
+impl<'info> PlayerMove<'info> {
+    pub fn accounts(ctx: &Context<PlayerMove>, x_or_o: u8, player_move: u8) -> Result<()> {
         if ctx.accounts.game.board[player_move as usize] != 0 {
             return Err(ErrorCode::Illegalmove.into());
         }
         if x_or_o == BOARD_ITEM_X {
-            return Playermove::player_x_checks(ctx);
+            return PlayerMove::player_x_checks(ctx);
         } else if x_or_o == BOARD_ITEM_O {
-            return Playermove::player_o_checks(ctx);
+            return PlayerMove::player_o_checks(ctx);
         } else {
             return Err(ErrorCode::UnexpectedValue.into());
         }
     }
 
-    pub fn player_x_checks(ctx: &Context<Playermove>) -> Result<()> {
+    pub fn player_x_checks(ctx: &Context<PlayerMove>) -> Result<()> {
         if ctx.accounts.game.player_x != *ctx.accounts.player.key {
             return Err(ErrorCode::Unauthorized.into());
         }
@@ -114,7 +114,7 @@ impl<'info> Playermove<'info> {
         Ok(())
     }
 
-    pub fn player_o_checks(ctx: &Context<Playermove>) -> Result<()> {
+    pub fn player_o_checks(ctx: &Context<PlayerMove>) -> Result<()> {
         if ctx.accounts.game.player_o != *ctx.accounts.player.key {
             return Err(ErrorCode::Unauthorized.into());
         }

--- a/tests/tictactoe/programs/tictactoe/src/lib.rs
+++ b/tests/tictactoe/programs/tictactoe/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Initialize<'info> {
 #[derive(Accounts)]
 pub struct PlayerJoin<'info> {
     player_o: Signer<'info>,
-    #[account(mut, constraint = game.game_state != 0 && game.player_x != Pubkey::default())]
+    #[account(mut, constraint = game.game_state == 0 && game.player_x != Pubkey::default())]
     game: Account<'info, Game>,
 }
 

--- a/tests/tictactoe/programs/tictactoe/src/lib.rs
+++ b/tests/tictactoe/programs/tictactoe/src/lib.rs
@@ -196,7 +196,7 @@ impl Game {
     }
 }
 
-#[error]
+#[error_code]
 pub enum ErrorCode {
     #[msg("You are not authorized to perform this action.")]
     Unauthorized,

--- a/tests/tictactoe/tests/tictactoe.js
+++ b/tests/tictactoe/tests/tictactoe.js
@@ -14,7 +14,6 @@ describe("tictactoe", () => {
       accounts: {
         authority: playerX.publicKey,
         dashboard: dashboard.publicKey,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       },
       signers: [dashboard],
       instructions: [
@@ -30,7 +29,6 @@ describe("tictactoe", () => {
         playerX: playerX.publicKey,
         dashboard: dashboard.publicKey,
         game: game.publicKey,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       },
       signers: [game],
       instructions: [await program.account.game.createInstruction(game)],

--- a/tests/tictactoe/tests/tictactoe.js
+++ b/tests/tictactoe/tests/tictactoe.js
@@ -3,14 +3,16 @@ const anchor = require("@anchor-lang/core");
 describe("tictactoe", () => {
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Tictactoe;
-  let dashboard = anchor.web3.Keypair.generate();
-  let game = anchor.web3.Keypair.generate();
-  let player_o = anchor.web3.Keypair.generate();
+
+  const dashboard = anchor.web3.Keypair.generate();
+  const game = anchor.web3.Keypair.generate();
+  const playerO = anchor.web3.Keypair.generate();
+  const playerX = program.provider.wallet;
 
   it("Initialize Dashboard", async () => {
     const tx = await program.rpc.initializeDashboard({
       accounts: {
-        authority: program.provider.wallet.publicKey,
+        authority: playerX.publicKey,
         dashboard: dashboard.publicKey,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       },
@@ -19,14 +21,13 @@ describe("tictactoe", () => {
         await program.account.dashboard.createInstruction(dashboard),
       ],
     });
-
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
   it("Initialize Game", async () => {
     const tx = await program.rpc.initialize({
       accounts: {
-        playerX: program.provider.wallet.publicKey,
+        playerX: playerX.publicKey,
         dashboard: dashboard.publicKey,
         game: game.publicKey,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
@@ -34,114 +35,112 @@ describe("tictactoe", () => {
       signers: [game],
       instructions: [await program.account.game.createInstruction(game)],
     });
-
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
   it("Player O joins", async () => {
     const tx = await program.rpc.playerJoin({
       accounts: {
-        playerO: player_o.publicKey,
+        playerO: playerO.publicKey,
         game: game.publicKey,
       },
-      signers: [player_o],
+      signers: [playerO],
     });
-
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player x plays", async () => {
+  it("Player X plays", async () => {
     const tx = await program.rpc.playerMove(1, 0, {
       accounts: {
-        player: program.provider.wallet.publicKey,
+        player: playerX.publicKey,
         game: game.publicKey,
       },
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player o plays", async () => {
+  it("Player O plays", async () => {
     const tx = await program.rpc.playerMove(2, 1, {
       accounts: {
-        player: player_o.publicKey,
+        player: playerO.publicKey,
         game: game.publicKey,
       },
-      signers: [player_o],
+      signers: [playerO],
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player x plays", async () => {
+  it("Player X plays", async () => {
     const tx = await program.rpc.playerMove(1, 3, {
       accounts: {
-        player: program.provider.wallet.publicKey,
+        player: playerX.publicKey,
         game: game.publicKey,
       },
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player o plays", async () => {
+  it("Player O plays", async () => {
     const tx = await program.rpc.playerMove(2, 6, {
       accounts: {
-        player: player_o.publicKey,
+        player: playerO.publicKey,
         game: game.publicKey,
       },
-      signers: [player_o],
+      signers: [playerO],
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player x plays", async () => {
+  it("Player X plays", async () => {
     const tx = await program.rpc.playerMove(1, 2, {
       accounts: {
-        player: program.provider.wallet.publicKey,
+        player: playerX.publicKey,
         game: game.publicKey,
       },
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player o plays", async () => {
+  it("Player O plays", async () => {
     const tx = await program.rpc.playerMove(2, 4, {
       accounts: {
-        player: player_o.publicKey,
+        player: playerO.publicKey,
         game: game.publicKey,
       },
-      signers: [player_o],
+      signers: [playerO],
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player x plays", async () => {
+  it("Player X plays", async () => {
     const tx = await program.rpc.playerMove(1, 5, {
       accounts: {
-        player: program.provider.wallet.publicKey,
+        player: playerX.publicKey,
         game: game.publicKey,
       },
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player o plays", async () => {
+  it("Player O plays", async () => {
     const tx = await program.rpc.playerMove(2, 8, {
       accounts: {
-        player: player_o.publicKey,
+        player: playerO.publicKey,
         game: game.publicKey,
       },
-      signers: [player_o],
+      signers: [playerO],
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
-  it("Player x plays", async () => {
+  it("Player X plays", async () => {
     const tx = await program.rpc.playerMove(1, 7, {
       accounts: {
-        player: program.provider.wallet.publicKey,
+        player: playerX.publicKey,
         game: game.publicKey,
       },
     });
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 
   it("Status", async () => {
@@ -151,7 +150,6 @@ describe("tictactoe", () => {
         game: game.publicKey,
       },
     });
-
-    console.log("transaction: ", tx);
+    console.log("transaction:", tx);
   });
 });


### PR DESCRIPTION
### Problem

One of the first Anchor examples, [the `tictactoe` tests](https://github.com/otter-sec/anchor/tree/82681c413f23147cbee76b691f25913fdac086dc/tests/tictactoe), are broken and are not checked in CI.

### Summary of changes

- Fix the `tictactoe` tests
- Include them in CI