### PR TITLE
Docs: add links to extensive Anchor 1.0 / liteSVM example repo

### DIFF
--- a/.cspell-anchor-dictionary.txt
+++ b/.cspell-anchor-dictionary.txt
@@ -65,6 +65,7 @@ programdata
 projectserum
 pubkeys
 publickey
+Quicknode
 realizor
 reallocs
 repr

--- a/docs/content/docs/references/examples.mdx
+++ b/docs/content/docs/references/examples.mdx
@@ -3,9 +3,9 @@ title: Example Programs
 description: Example Anchor programs references
 ---
 
-There are extensive examples for individual Anchor features on [Solana Foundation Program Examples repo](https://github.com/solana-developers/program-examples).
+There are extensive examples for individual Anchor features on the [Solana Foundation Program Examples repo](https://github.com/solana-developers/program-examples).
 
-Additionally, the [Quicknode Solana Program Examples repo](https://github.com/quicknode/solana-program-examples) includes larger programs, including order books, loan markets, betting markets, and so on. The current Anchor stack, including Anchor 1.x, the multiple files layout, and LiteSVM for tests is used throughout.
+Additionally, the [Quicknode Solana Program Examples repo](https://github.com/quicknode/solana-program-examples) includes Anchor examples of larger programs, like order books, loan markets, betting markets, and so on. The current Anchor stack, including Anchor 1.x, the multiple files layout, and LiteSVM for tests is used throughout.
 
 ## Basics
 

--- a/docs/content/docs/references/examples.mdx
+++ b/docs/content/docs/references/examples.mdx
@@ -3,6 +3,10 @@ title: Example Programs
 description: Example Anchor programs references
 ---
 
+There are extensive examples for individual Anchor features on [Solana Foundation Program Examples repo](https://github.com/solana-developers/program-examples).
+
+Additionally, the [Quicknode Solana Program Examples repo](https://github.com/quicknode/solana-program-examples) includes larger programs, including order books, loan markets, betting markets, and so on. The current Anchor stack, including Anchor 1.x, the multiple files layout, and LiteSVM for tests is used throughout.
+
 ## Basics
 
 | Example                                                                                                                       | Description                                |


### PR DESCRIPTION
Add links to both the Solana Foundation Program Examples libaries and [Quicknode's Solana Program Examples](https://github.com/quicknode/solana-program-examples) (which has more examples, uses current Anchor, etc).