### PR TITLE
fix(accounts-resolver): return success when all accounts resolved at depth boundary

### DIFF
--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -95,12 +95,14 @@ export class AccountsResolver<IDL extends Idl> {
           .map((acc) => `\`${acc}\``)
           .join(", ");
 
-        throw new Error(
-          [
-            `Reached maximum depth for account resolution.`,
-            `Unresolved accounts: ${unresolvedAccs}`,
-          ].join(" ")
-        );
+        if (unresolvedAccs.length > 0) {
+          throw new Error(
+            [
+              `Reached maximum depth for account resolution.`,
+              `Unresolved accounts: ${unresolvedAccs}`,
+            ].join(" ")
+          );
+        }
       }
     }
   }

--- a/ts/packages/anchor/tests/accounts-resolver-depth.spec.ts
+++ b/ts/packages/anchor/tests/accounts-resolver-depth.spec.ts
@@ -1,0 +1,94 @@
+import { PublicKey } from "@solana/web3.js";
+import { AccountsResolver } from "../src/program/accounts-resolver";
+
+describe("accounts resolver depth", () => {
+  test("resolves successfully when all accounts resolved at depth boundary", async () => {
+    // Regression test for otter-sec/anchor#4663
+    // 17 accounts with reverse-ordered PDA chain: account16 has direct address,
+    // account15 depends on account16, ..., account0 depends on account1.
+    // This requires exactly 16 passes to resolve all accounts.
+    // Previously threw false max-depth error even though all accounts resolved.
+    const programId = new PublicKey("11111111111111111111111111111111");
+    const resolvedAccounts: Record<string, PublicKey> = {};
+    const accounts = Array.from({ length: 17 }, (_, index) => {
+      const name = `account${index}`;
+      if (index === 16) {
+        return { name, address: programId.toBase58() };
+      }
+
+      return {
+        name,
+        pda: {
+          seeds: [{ kind: "account", path: `account${index + 1}` }],
+        },
+      };
+    });
+
+    const resolver = new AccountsResolver(
+      [],
+      resolvedAccounts,
+      {} as any,
+      programId,
+      { name: "depthRegression", discriminator: [], accounts, args: [] } as any,
+      {} as any,
+      []
+    );
+
+    // Should NOT throw — all accounts resolve successfully
+    await expect(resolver.resolve()).resolves.toBeUndefined();
+
+    // Verify all 17 accounts were resolved
+    for (let index = 0; index < 17; index++) {
+      expect(resolvedAccounts[`account${index}`]).toBeInstanceOf(PublicKey);
+    }
+  });
+
+  test("throws when accounts remain unresolved at depth boundary", async () => {
+    // 18 accounts with circular dependency: cannot resolve all within 16 passes.
+    // account17 has no address and depends on account0 (circular).
+    const programId = new PublicKey("11111111111111111111111111111111");
+    const resolvedAccounts: Record<string, PublicKey> = {};
+    const accounts = Array.from({ length: 18 }, (_, index) => {
+      const name = `account${index}`;
+      if (index === 17) {
+        // No address, depends on account0 — creates circular dependency
+        return {
+          name,
+          pda: {
+            seeds: [{ kind: "account", path: "account0" }],
+          },
+        };
+      }
+      if (index === 16) {
+        return { name, address: programId.toBase58() };
+      }
+
+      return {
+        name,
+        pda: {
+          seeds: [{ kind: "account", path: `account${index + 1}` }],
+        },
+      };
+    });
+
+    const resolver = new AccountsResolver(
+      [],
+      resolvedAccounts,
+      {} as any,
+      programId,
+      { name: "depthCircular", discriminator: [], accounts, args: [] } as any,
+      {} as any,
+      []
+    );
+
+    let thrown: Error | undefined;
+    try {
+      await resolver.resolve();
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown?.message).toContain("Reached maximum depth");
+  });
+});


### PR DESCRIPTION
## Summary

The accounts resolver threw a max-depth error even when all accounts had already been resolved. Valid acyclic PDA dependency graphs that complete resolution on the final pass were failing with false errors.

## Root Cause

The depth check fires after the 16th resolution pass completes, but before verifying whether any accounts remain unresolved. If the last account resolves on the same pass that hits the depth limit, the error is thrown despite successful resolution.

```typescript
// Before (accounts-resolver.ts:98-103) — always throws at depth 16
if (depth === 16) {
  throw new Error('Reached maximum depth for account resolution...');
}

// After — only throws if accounts remain unresolved
if (depth === 16) {
  const unresolvedAccs = getUnresolvedAccounts();
  if (unresolvedAccs.length > 0) {
    throw new Error('Reached maximum depth for account resolution...');
  }
}
```

## Test

Added regression test with 17-account reverse-ordered PDA chain (requires exactly 16 passes). Previously threw false error; now resolves successfully.

Added negative test with circular dependency (18 accounts) to verify error still fires when accounts genuinely cannot be resolved.

## Related

Fixes otter-sec/anchor#4663