### PR TITLE
fix(lang-v2): defer account constraint updates until validation completes

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -966,6 +966,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .filter_map(|f| f.deferred_load.as_ref())
         .collect();
     let constraints: Vec<_> = fields.iter().flat_map(|f| &f.constraints).collect();
+    let updates: Vec<_> = fields.iter().flat_map(|f| &f.updates).collect();
     let exits: Vec<_> = fields.iter().filter_map(|f| f.exit.as_ref()).collect();
     // Bumps fields. Optional accounts get `Option<u8>` so the default
     // (`None`) maps cleanly to the sentinel-`None` load path; the seeds
@@ -1807,6 +1808,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 #(#loads)*
                 #(#deferred_loads)*
                 #(#constraints)*
+                #(#updates)*
                 Ok((Self { #(#field_names),* }, __bumps, #ix_args_return))
             }
 

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -651,6 +651,12 @@ pub struct AccountField {
     pub load: TokenStream2,
     pub deferred_load: Option<TokenStream2>,
     pub constraints: Vec<TokenStream2>,
+    pub updates: Vec<TokenStream2>,
+    /// Duplicate-mutable-account check. Collected separately from
+    /// `constraints` so all mut-field dup checks can share a single outer
+    /// `if let Some(__dups) = __duplicates` gate — non-dup txs pay one
+    /// Option-tag branch regardless of field count.
+    pub dup_check: Option<TokenStream2>,
     pub exit: Option<TokenStream2>,
     pub has_bump: bool,
     /// True when the field type is `Option<T>` (optional account).
@@ -1577,6 +1583,8 @@ pub fn parse_field(
             load,
             deferred_load: None,
             constraints: vec![],
+            updates: vec![],
+            dup_check: None,
             exit,
             has_bump: false,
             is_optional: false,
@@ -1857,6 +1865,7 @@ pub fn parse_field(
 
     // --- Constraints ---
     let mut constraints = Vec::new();
+    let mut updates = Vec::new();
 
     // Writable check is now owned by `AnchorAccount::load_mut` (default
     // impl in `lang-v2/src/traits.rs`), so the derive no longer emits a
@@ -2150,8 +2159,9 @@ pub fn parse_field(
     //
     // The `init` dispatch is embedded inline into the init body by
     // `wrap_init_body_with_constraints` above so the hook only fires on
-    // actual creation. Only `check` and `update` emit out here in the
-    // constraint phase.
+    // actual creation. `check` emits into the validation phase here;
+    // `update` is deferred into a later post-validation phase so sibling
+    // field constraints still observe the pre-update state.
     //
     // Field refs thread through `AsRef::as_ref` so the call-site's
     // `V` is inferred from the `AccountConstraint::Value` associated
@@ -2182,8 +2192,9 @@ pub fn parse_field(
             } else {
                 quote! { &mut #field_name }
             };
-            // `update(...)` — fires regardless of init state.
-            constraints.push(quote! {
+            // `update(...)` — fires regardless of init state, but only after
+            // all account validations have completed.
+            updates.push(quote! {
                 <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
                     #update_target, #expected,
                 )?;
@@ -2316,7 +2327,7 @@ pub fn parse_field(
     // Mutable fields use `ref mut` so constraint bodies that need `&mut self`
     // (e.g. BorshAccount::release_borrow in the realloc path) can work.
     // Read-only methods still resolve via auto-deref from `&mut T` to `&T`.
-    let (constraints, exit) = if is_optional {
+    let (constraints, updates, exit) = if is_optional {
         let constraints = constraints
             .into_iter()
             .map(|c| {
@@ -2341,6 +2352,17 @@ pub fn parse_field(
                             let _ = &#field_name;
                             #c
                         }
+                    }
+                }
+            })
+            .collect();
+        let updates = updates
+            .into_iter()
+            .map(|u| {
+                quote! {
+                    if let Some(ref mut #field_name) = #field_name {
+                        let _ = &#field_name;
+                        #u
                     }
                 }
             })
@@ -2403,9 +2425,9 @@ pub fn parse_field(
                 }
             }
         });
-        (constraints, exit)
+        (constraints, updates, exit)
     } else {
-        (constraints, exit)
+        (constraints, updates, exit)
     };
 
     let contributes_mut_bit = attrs.is_mut && !attrs.is_dup && !is_optional;
@@ -2420,6 +2442,8 @@ pub fn parse_field(
         load,
         deferred_load,
         constraints,
+        updates,
+        dup_check,
         exit,
         has_bump,
         is_optional,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2318,6 +2318,26 @@ pub fn parse_field(
         None
     };
 
+    // Dup-check emission: only `Option<_>` mut fields keep a gated
+    // per-field `get()` check — a `None` slot (the client encodes
+    // `program_id` as the address) must stay silent even when that slot
+    // is also the dup target of another account, and the
+    // `if let Some(...)` wrapper built below preserves that. Non-`Option`
+    // mut fields are folded into the enclosing struct's `MUT_MASK` const
+    // and checked once per dispatch by `run_handler`. Stored separately
+    // from `constraints` so the struct-level codegen can aggregate all
+    // mut fields' dup checks under a single outer
+    // `if let Some(__dups) = __duplicates { ... }` gate.
+    let dup_check = if attrs.is_mut && !attrs.is_dup && is_optional {
+        Some(quote! {
+            if __dups.get((__base_offset + #offset_expr) as u8) {
+                return Err(anchor_lang_v2::ErrorCode::ConstraintDuplicateMutableAccount.into());
+            }
+        })
+    } else {
+        None
+    };
+
     // For `Option<T>` fields, each constraint body was generated against the
     // unwrapped inner — we wrap it in `if let Some(#field_name) = #field_name`
     // so `#field_name.account()`, `#field_name.authority`, etc. resolve on the

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -570,7 +570,7 @@ pub trait ForeignOwnerInit: AccountInitialize {}
 /// | `init, ns::key = v`                                | `init`                |
 /// | `init_if_needed, ns::key = v` (creating)           | `init`, then `check`  |
 /// | `init_if_needed, ns::key = v` (already exists)     | `check`               |
-/// | `update(ns::key = v)`                              | `update`              |
+/// | `update(ns::key = v)`                              | `update` (post-validation) |
 /// | Any of the above                                    | `exit` (exit phase)  |
 ///
 /// There is deliberately **no blanket `impl<T: AccountConstraint<A>>
@@ -641,7 +641,8 @@ pub trait AccountConstraint<A> {
     /// inside an `update(...)` wrapper, e.g.
     /// `#[account(update(my_ns::field = value))]`. Intended for
     /// constraints that set / rewrite on-chain state rather than
-    /// validating it.
+    /// validating it. Runs after `try_accounts` has finished all
+    /// account validations, but before the instruction handler.
     #[inline(always)]
     fn update(_account: &mut A, _value: &Self::Value) -> core::result::Result<(), ProgramError> {
         Ok(())

--- a/tests-v2/programs/custom-constraints/src/lib.rs
+++ b/tests-v2/programs/custom-constraints/src/lib.rs
@@ -89,6 +89,15 @@ pub mod custom_constraints {
     ) -> Result<()> {
         Ok(())
     }
+
+    /// `update(...)` should not mutate `fresh` until later field
+    /// validations have completed. The integration test wires a later
+    /// `witness` constraint that expects the pre-update value.
+    pub fn handle_update_after_later_validation(
+        _ctx: &mut Context<HandleUpdateAfterLaterValidation>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -319,4 +328,22 @@ pub struct HandleOptionalInitIfNeeded {
     )]
     pub counter: Option<BorshAccount<Counter>>,
     pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct HandleUpdateAfterLaterValidation {
+    #[account(
+        zeroed,
+        counter_ns::min_value = 0u64,
+        update(counter_ns::set_value = 7u64)
+    )]
+    pub fresh: BorshAccount<Counter>,
+    #[account(constraint = fresh.value == 0 @ WErr::BadValue)]
+    pub witness: UncheckedAccount,
+}
+
+#[error_code]
+pub enum WErr {
+    #[msg("bad value")]
+    BadValue,
 }

--- a/tests-v2/tests/custom_constraints.rs
+++ b/tests-v2/tests/custom_constraints.rs
@@ -42,6 +42,10 @@ fn optional_init_if_needed_counter_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"optional-init-if-needed-counter"], &program_id()).0
 }
 
+fn fresh_zeroed_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"fresh-zeroed-counter"], &program_id()).0
+}
+
 fn setup() -> (LiteSVM, Keypair) {
     let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let deploy_dir = test_dir.join("target/deploy");
@@ -101,6 +105,17 @@ fn init_optional_if_needed_counter(svm: &mut LiteSVM, payer: &Keypair) {
     ];
     send_instruction(svm, program_id(), data, metas, payer, &[])
         .expect("handle_optional_init_if_needed should succeed");
+}
+
+fn set_zeroed_counter_account(svm: &mut LiteSVM, pda: Pubkey) {
+    let account = solana_account::Account {
+        lamports: 1_000_000,
+        data: vec![0u8; 16],
+        owner: program_id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    svm.set_account(pda, account).expect("set zeroed counter");
 }
 
 // ---- `init` method ---------------------------------------------------------
@@ -213,6 +228,27 @@ fn update_hook_writes_new_value() {
 
     // `SetValueConstraint::update` overwrote the value.
     assert_eq!(read_counter_value(&svm, &counter_pda()), 42);
+}
+
+#[test]
+fn update_hook_is_deferred_until_later_field_constraints_pass() {
+    let (mut svm, payer) = setup();
+    let fresh = fresh_zeroed_pda();
+    set_zeroed_counter_account(&mut svm, fresh);
+
+    let data = custom_constraints::instruction::HandleUpdateAfterLaterValidation {}.data();
+    let metas = vec![
+        AccountMeta::new(fresh, false),
+        AccountMeta::new_readonly(payer.pubkey(), true),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("later field constraint should see pre-update value");
+
+    assert_eq!(
+        read_counter_value(&svm, &fresh),
+        7,
+        "update hook should run after later validations succeed",
+    );
 }
 
 // ---- `exit` method ---------------------------------------------------------


### PR DESCRIPTION
this separates generated `update(...)` calls from validation checks and runs them only after all account validations pass, while still applying the updates before the instruction handler executes.