### PR TITLE
fix(lang-v2): handle non-derivable seeds program fields

### DIFF
--- a/lang-v2/derive/Cargo.toml
+++ b/lang-v2/derive/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+syn = { version = "2", features = ["full", "parsing", "extra-traits", "visit"] }
 # Host-only deps used at macro-expansion time to precompute the canonical
 # PDA bump when `#[account(seeds = [b"..."], bump)]` has all byte-literal
 # seeds, or to assemble IDL JSON. Not part of user programs' runtime —

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -17,7 +17,7 @@ use {
     proc_macro2::TokenStream as TokenStream2,
     quote::quote,
     serde_json::{json, Value},
-    syn::{Expr, Lit, Type},
+    syn::{visit::Visit, Expr, Lit, Type},
 };
 
 /// Convert a Rust type to its IDL JSON representation (as a `serde_json`
@@ -650,11 +650,62 @@ pub fn classify_program_seed(
 ) -> SeedJson {
     let seed = classify_seed_inner(expr, field_names, ix_arg_names);
     match seed {
-        SeedJson::Static(ref s) if s == r#"{"kind":"expr"}"# => SeedJson::Runtime(quote! {
-            anchor_lang_v2::idl_build::__idl_const_seed_json(#expr)
-        }),
+        SeedJson::Static(ref s) if s == r#"{"kind":"expr"}"# => {
+            if expr_references_local_binding(expr, field_names, ix_arg_names) {
+                seed
+            } else {
+                SeedJson::Runtime(quote! {
+                    anchor_lang_v2::idl_build::__idl_const_seed_json(#expr)
+                })
+            }
+        }
         _ => seed,
     }
+}
+
+pub fn expr_references_local_binding(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> bool {
+    struct LocalBindingFinder<'a> {
+        field_names: &'a [String],
+        ix_arg_names: &'a [String],
+        found: bool,
+    }
+
+    impl LocalBindingFinder<'_> {
+        fn is_local_name(&self, ident: &str) -> bool {
+            self.field_names.iter().any(|name| name == ident)
+                || self.ix_arg_names.iter().any(|name| name == ident)
+        }
+    }
+
+    impl<'ast> Visit<'ast> for LocalBindingFinder<'_> {
+        fn visit_expr_path(&mut self, expr: &'ast syn::ExprPath) {
+            if self.found {
+                return;
+            }
+            if expr.qself.is_none()
+                && expr.path.leading_colon.is_none()
+                && expr.path.segments.len() == 1
+                && expr.path.segments[0].arguments.is_empty()
+                && self.is_local_name(&expr.path.segments[0].ident.to_string())
+            {
+                self.found = true;
+                return;
+            }
+            syn::visit::visit_expr_path(self, expr);
+        }
+    }
+
+    let mut finder = LocalBindingFinder {
+        field_names,
+        ix_arg_names,
+        found: false,
+    };
+    finder.visit_expr(expr);
+    finder.found
 }
 
 fn static_seed(value: Value) -> SeedJson {
@@ -1034,6 +1085,34 @@ mod tests {
         ));
         assert!(ts.contains("__idl_const_seed_json"), "got: {ts}");
         assert!(ts.contains("System :: id"), "got: {ts}");
+    }
+
+    #[test]
+    fn local_field_program_seed_stays_opaque_expr() {
+        let fields = vec!["config".to_string()];
+        let args = Vec::new();
+        let s = expect_static(classify_program_seed(
+            &syn::parse_quote!(config.program_id),
+            &fields,
+            &args,
+        ));
+        assert_eq!(s, r#"{"kind":"expr"}"#);
+    }
+
+    #[test]
+    fn local_binding_detector_sees_sibling_field_access() {
+        let fields = vec!["config".to_string()];
+        let args = Vec::new();
+        assert!(expr_references_local_binding(
+            &syn::parse_quote!(config.program_id),
+            &fields,
+            &args,
+        ));
+        assert!(!expr_references_local_binding(
+            &syn::parse_quote!(System::id()),
+            &fields,
+            &args,
+        ));
     }
 
     #[test]

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -651,7 +651,9 @@ pub fn classify_program_seed(
     let seed = classify_seed_inner(expr, field_names, ix_arg_names);
     match seed {
         SeedJson::Static(ref s) if s == r#"{"kind":"expr"}"# => {
-            if expr_references_local_binding(expr, field_names, ix_arg_names) {
+            if expr_contains_macro(expr)
+                || expr_references_local_binding(expr, field_names, ix_arg_names)
+            {
                 seed
             } else {
                 SeedJson::Runtime(quote! {
@@ -661,6 +663,22 @@ pub fn classify_program_seed(
         }
         _ => seed,
     }
+}
+
+pub fn expr_contains_macro(expr: &Expr) -> bool {
+    struct MacroFinder {
+        found: bool,
+    }
+
+    impl<'ast> Visit<'ast> for MacroFinder {
+        fn visit_expr_macro(&mut self, _expr: &'ast syn::ExprMacro) {
+            self.found = true;
+        }
+    }
+
+    let mut finder = MacroFinder { found: false };
+    finder.visit_expr(expr);
+    finder.found
 }
 
 pub fn expr_references_local_binding(
@@ -1100,6 +1118,18 @@ mod tests {
     }
 
     #[test]
+    fn macro_wrapped_local_field_program_seed_stays_opaque_expr() {
+        let fields = vec!["config".to_string()];
+        let args = Vec::new();
+        let s = expect_static(classify_program_seed(
+            &syn::parse_quote!(wrap!(config.program_id)),
+            &fields,
+            &args,
+        ));
+        assert_eq!(s, r#"{"kind":"expr"}"#);
+    }
+
+    #[test]
     fn local_binding_detector_sees_sibling_field_access() {
         let fields = vec!["config".to_string()];
         let args = Vec::new();
@@ -1113,6 +1143,14 @@ mod tests {
             &fields,
             &args,
         ));
+    }
+
+    #[test]
+    fn macro_detector_sees_expr_macro() {
+        assert!(expr_contains_macro(&syn::parse_quote!(wrap!(
+            config.program_id
+        ))));
+        assert!(!expr_contains_macro(&syn::parse_quote!(System::id())));
     }
 
     #[test]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1270,6 +1270,14 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                                 } else {
                                     quote! { &#program }
                                 }
+                            } else if idl::expr_contains_macro(program) {
+                                // Nested macros are opaque to this proc macro.
+                                // A macro may expand to sibling account data
+                                // access (e.g. `wrap!(config.program_id)`),
+                                // which cannot be derived from the resolved
+                                // builder's address-only inputs.
+                                all_derivable = false;
+                                quote! {}
                             } else if idl::expr_references_local_binding(
                                 program,
                                 &raw_field_names,
@@ -1527,6 +1535,8 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                         } else {
                             quote! { &#program }
                         }
+                    } else if idl::expr_contains_macro(program) {
+                        return None;
                     } else if idl::expr_references_local_binding(
                         program,
                         &raw_field_names,

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1270,6 +1270,18 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                                 } else {
                                     quote! { &#program }
                                 }
+                            } else if idl::expr_references_local_binding(
+                                program,
+                                &raw_field_names,
+                                &ix_arg_names,
+                            ) {
+                                // The client-side resolved accounts struct only
+                                // carries sibling account ADDRESSES. If
+                                // `seeds::program` depends on sibling account
+                                // DATA (e.g. `config.program_id`), this PDA is
+                                // not auto-derivable off-chain.
+                                all_derivable = false;
+                                quote! {}
                             } else {
                                 quote! { &#program }
                             }
@@ -1515,6 +1527,12 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                         } else {
                             quote! { &#program }
                         }
+                    } else if idl::expr_references_local_binding(
+                        program,
+                        &raw_field_names,
+                        &ix_arg_names,
+                    ) {
+                        return None;
                     } else {
                         quote! { &#program }
                     }

--- a/tests-v2/programs/client-builders/src/lib.rs
+++ b/tests-v2/programs/client-builders/src/lib.rs
@@ -18,6 +18,16 @@ pub struct UserState {
     pub value: u64,
 }
 
+#[account]
+pub struct Config {
+    pub program_id: Address,
+}
+
+#[account]
+pub struct DynamicProgramPda {
+    pub value: u64,
+}
+
 #[program]
 pub mod client_builders {
     use super::*;
@@ -63,6 +73,11 @@ pub mod client_builders {
     pub fn check_external_pda(_ctx: &mut Context<CheckExternalPda>) -> Result<()> {
         Ok(())
     }
+
+    #[discrim = 6]
+    pub fn check_dynamic_program_pda(_ctx: &mut Context<CheckDynamicProgramPda>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -104,4 +119,11 @@ pub struct OptionalBuilderCase {
 pub struct CheckExternalPda {
     #[account(seeds = [b"external"], bump, seeds::program = OTHER_PROGRAM)]
     pub external_pda: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct CheckDynamicProgramPda {
+    pub config: Account<Config>,
+    #[account(seeds = [b"other"], bump, seeds::program = config.program_id)]
+    pub dynamic_pda: Account<DynamicProgramPda>,
 }

--- a/tests-v2/programs/client-builders/src/lib.rs
+++ b/tests-v2/programs/client-builders/src/lib.rs
@@ -28,6 +28,17 @@ pub struct DynamicProgramPda {
     pub value: u64,
 }
 
+#[account]
+pub struct MacroProgramPda {
+    pub value: u64,
+}
+
+macro_rules! wrap_program_expr {
+    ($expr:expr) => {
+        $expr
+    };
+}
+
 #[program]
 pub mod client_builders {
     use super::*;
@@ -78,6 +89,11 @@ pub mod client_builders {
     pub fn check_dynamic_program_pda(_ctx: &mut Context<CheckDynamicProgramPda>) -> Result<()> {
         Ok(())
     }
+
+    #[discrim = 7]
+    pub fn check_macro_program_pda(_ctx: &mut Context<CheckMacroProgramPda>) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -126,4 +142,15 @@ pub struct CheckDynamicProgramPda {
     pub config: Account<Config>,
     #[account(seeds = [b"other"], bump, seeds::program = config.program_id)]
     pub dynamic_pda: Account<DynamicProgramPda>,
+}
+
+#[derive(Accounts)]
+pub struct CheckMacroProgramPda {
+    pub config: Account<Config>,
+    #[account(
+        seeds = [b"macro"],
+        bump,
+        seeds::program = wrap_program_expr!(config.program_id)
+    )]
+    pub macro_pda: Account<MacroProgramPda>,
 }

--- a/tests-v2/tests/client_builders.rs
+++ b/tests-v2/tests/client_builders.rs
@@ -69,6 +69,10 @@ fn dynamic_program_pda(program: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"other"], program).0
 }
 
+fn macro_program_pda(program: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"macro"], program).0
+}
+
 fn set_program_owned_account(svm: &mut LiteSVM, pubkey: Pubkey, data: Vec<u8>) {
     let account = solana_account::Account {
         lamports: 1_000_000,
@@ -90,6 +94,12 @@ fn config_account_data(program: &Pubkey) -> Vec<u8> {
 fn dynamic_program_pda_data() -> Vec<u8> {
     let mut data = vec![0u8; 16];
     data[..8].copy_from_slice(<client_builders::DynamicProgramPda as Discriminator>::DISCRIMINATOR);
+    data
+}
+
+fn macro_program_pda_data() -> Vec<u8> {
+    let mut data = vec![0u8; 16];
+    data[..8].copy_from_slice(<client_builders::MacroProgramPda as Discriminator>::DISCRIMINATOR);
     data
 }
 
@@ -161,6 +171,28 @@ fn seeds_program_from_account_data_uses_manual_client_account() {
     assert_eq!(ix.accounts[0].pubkey, config);
     assert_eq!(ix.accounts[1].pubkey, dynamic_pda);
     send_ix(&mut svm, ix, &payer, &[]).expect("dynamic seeds::program should validate");
+}
+
+#[test]
+fn macro_wrapped_seeds_program_from_account_data_uses_manual_client_account() {
+    let (mut svm, payer, _) = setup();
+    let config = Pubkey::new_unique();
+    let program = other_program();
+    let macro_pda = macro_program_pda(&program);
+
+    set_program_owned_account(&mut svm, config, config_account_data(&program));
+    set_program_owned_account(&mut svm, macro_pda, macro_program_pda_data());
+
+    // The proc macro cannot see through nested macros in `seeds::program`, so
+    // helper generation must conservatively fall back to the manual accounts
+    // struct instead of trying to auto-derive from address-only sibling inputs.
+    let ix = instruction::CheckMacroProgramPda {}
+        .to_instruction(accounts::CheckMacroProgramPda { config, macro_pda });
+
+    assert_eq!(ix.accounts[0].pubkey, config);
+    assert_eq!(ix.accounts[1].pubkey, macro_pda);
+    send_ix(&mut svm, ix, &payer, &[])
+        .expect("macro-wrapped dynamic seeds::program should validate");
 }
 
 #[test]

--- a/tests-v2/tests/client_builders.rs
+++ b/tests-v2/tests/client_builders.rs
@@ -1,5 +1,5 @@
 use {
-    anchor_lang_v2::{InstructionData, ToAccountMetas},
+    anchor_lang_v2::{Discriminator, InstructionData, ToAccountMetas},
     client_builders::{accounts, instruction},
     litesvm::{types::TransactionResult, LiteSVM},
     solana_keypair::Keypair,
@@ -65,6 +65,34 @@ fn external_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"external"], &other_program()).0
 }
 
+fn dynamic_program_pda(program: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"other"], program).0
+}
+
+fn set_program_owned_account(svm: &mut LiteSVM, pubkey: Pubkey, data: Vec<u8>) {
+    let account = solana_account::Account {
+        lamports: 1_000_000,
+        data,
+        owner: program_id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    svm.set_account(pubkey, account).expect("set account");
+}
+
+fn config_account_data(program: &Pubkey) -> Vec<u8> {
+    let mut data = vec![0u8; 40];
+    data[..8].copy_from_slice(<client_builders::Config as Discriminator>::DISCRIMINATOR);
+    data[8..40].copy_from_slice(program.as_ref());
+    data
+}
+
+fn dynamic_program_pda_data() -> Vec<u8> {
+    let mut data = vec![0u8; 16];
+    data[..8].copy_from_slice(<client_builders::DynamicProgramPda as Discriminator>::DISCRIMINATOR);
+    data
+}
+
 #[test]
 fn resolved_builder_derives_pda_program_id_and_sends_instruction() {
     let (mut svm, payer, authority) = setup();
@@ -109,6 +137,30 @@ fn seeds_program_override_drives_client_pda_derivation() {
     assert_eq!(ix.accounts[0].pubkey, external_pda);
 
     send_ix(&mut svm, ix, &payer, &[]).expect("external PDA derived with seeds::program");
+}
+
+#[test]
+fn seeds_program_from_account_data_uses_manual_client_account() {
+    let (mut svm, payer, _) = setup();
+    let config = Pubkey::new_unique();
+    let program = other_program();
+    let dynamic_pda = dynamic_program_pda(&program);
+
+    set_program_owned_account(&mut svm, config, config_account_data(&program));
+    set_program_owned_account(&mut svm, dynamic_pda, dynamic_program_pda_data());
+
+    // The client-side resolved builder cannot derive this PDA because the
+    // seeds::program value lives in config ACCOUNT DATA rather than in an
+    // address-only sibling account input.
+    let ix =
+        instruction::CheckDynamicProgramPda {}.to_instruction(accounts::CheckDynamicProgramPda {
+            config,
+            dynamic_pda,
+        });
+
+    assert_eq!(ix.accounts[0].pubkey, config);
+    assert_eq!(ix.accounts[1].pubkey, dynamic_pda);
+    send_ix(&mut svm, ix, &payer, &[]).expect("dynamic seeds::program should validate");
 }
 
 #[test]


### PR DESCRIPTION
Now handles non-derivable seeds program fields; 
Note: the important review note is that this is a helper-generation fix, not a runtime PDA-validation fix.