### PR TITLE
test(zero-zopy): Bump `solana-program-test`

### DIFF
--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -21,5 +21,5 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 
 [dev-dependencies]
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
-solana-program-test = "3.1"
-solana-sdk = "3.0"
+solana-program-test = "4.0"
+solana-sdk = "4.0"


### PR DESCRIPTION
https://github.com/anza-xyz/solana-sdk/pull/765 broke solana-runtime v3. Migrate to 4.0 crates to fix this.