### PR TITLE
Fix bump-version for changelog changes

### DIFF
--- a/.github/scripts/publish-npmjs.sh
+++ b/.github/scripts/publish-npmjs.sh
@@ -28,10 +28,18 @@ publish() {
     return 0
   fi
 
+  local latest major_minor
+  latest="$(npm view "$name" dist-tags.latest 2>/dev/null || true)"
+  major_minor="$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")"
+
   local publish_args=()
   # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
   if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
     publish_args+=(--tag next)
+  # If we are releasing a backport, then we need to explicitly specify --tag as it can't be latest
+  elif [[ -n "$latest" ]] && [[ "$version" != "$latest" ]] &&
+     [[ "$(printf '%s\n%s\n' "$version" "$latest" | sort -V | tail -n1)" == "$latest" ]]; then
+    publish_args+=(--tag "back-$major_minor")
   fi
 
   if [[ "${DRY_RUN:-false}" == "true" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -386,15 +386,24 @@ jobs:
       - run: |
           set -xeuo pipefail
 
-          cp $DIST/anchor-*-x86_64-unknown-linux-gnu/anchor-*-x86_64-unknown-linux-gnu cli/npm-package/anchor
+          cp "$DIST"/anchor-*-x86_64-unknown-linux-gnu/anchor-*-x86_64-unknown-linux-gnu cli/npm-package/anchor
           cd cli/npm-package/
           chmod +x anchor
 
+          name="$(node -p "require('./package.json').name")"
           version="$(node -p "require('./package.json').version")"
+
+          latest="$(npm view "$name" dist-tags.latest 2>/dev/null || true)"
+          major_minor="$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")"
+
           publish_args=()
           # If version looks like X.Y.Z-<something> (e.g. 1.0.0-rc.2), publish under dist-tag "next"
           if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
             publish_args+=(--tag next)
+          # If we are releasing a backport, then we need to explicitly specify --tag as it can't be latest
+          elif [[ -n "$latest" ]] && [[ "$version" != "$latest" ]] &&
+            [[ "$(printf '%s\n%s\n' "$version" "$latest" | sort -V | tail -n1)" == "$latest" ]]; then
+            publish_args+=(--tag "back-$major_minor")
           fi
 
           echo "Publishing CLI"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -77,19 +77,60 @@ if [[ "$is_prerelease" -eq 0 ]]; then
     # If the release notes are missing from the website, we should at the minimum create a placeholder linking to the github release notes
     VERSION_URL=$(echo $version | sed 's/\./-/g')
     VERSION_CHANGELOG=$(echo $version | sed 's/\.//g')
-    if [[ ! -f "docs/content/docs/updates/release-notes/${VERSION_URL}.mdx" ]]; then
-        cat <<EOF > "docs/content/docs/updates/release-notes/${VERSION_URL}.mdx"
+    RELEASE_NOTE_PATH="docs/content/docs/updates/release-notes/${VERSION_URL}.mdx"
+    RELEASE_NOTE_META_PATH="docs/content/docs/updates/release-notes/meta.json"
+    CHANGELOG_TEXT="See the full [CHANGELOG](https://github.com/otter-sec/anchor/blob/v${version}/CHANGELOG.md#${VERSION_CHANGELOG}---$(date '+%Y-%m-%d'))."
+    if [[ ! -f "$RELEASE_NOTE_PATH" ]]; then
+        cat <<EOF > "$RELEASE_NOTE_PATH"
 ---
 title: $version
 description: Anchor - Release Notes $version
 ---
 
-See the full 
-[CHANGELOG](https://github.com/otter-sec/anchor/blob/v${version}/CHANGELOG.md#${VERSION_CHANGELOG}---$(date '+%Y-%m-%d')).
+$CHANGELOG_TEXT
 EOF
 
         # Insert the version into release notes meta, and sort the versions so the order is correct
-        jq --arg v "$VERSION_URL" '.pages |= (. + [$v] | sort_by(split("-") | map(tonumber)))' docs/content/docs/updates/release-notes/meta.json
+        tmp=$(mktemp)
+        jq --arg v "$VERSION_URL" '
+            .pages |= (
+                . + [$v]
+                | unique
+                | sort_by(split("-") | map(tonumber))
+                | reverse
+            )
+        ' "$RELEASE_NOTE_META_PATH" > "$tmp"
+        mv "$tmp" "$RELEASE_NOTE_META_PATH"
+    fi
+
+    # Additionally, add to the changelog the version if it's missing
+    CHANGELOG_PATH="docs/content/docs/updates/changelog.mdx"
+    if ! grep -qF "## [$version]" "$CHANGELOG_PATH"; then
+        PREVIOUS_VERSION_URL=$(
+            jq -r --arg v "$VERSION_URL" '
+                .pages
+                | map(select(. != $v))
+                | sort_by(split("-") | map(tonumber))
+                | reverse
+                | .[0]
+            ' "$RELEASE_NOTE_META_PATH"
+        )
+        PREVIOUS_VERSION=$(echo "$PREVIOUS_VERSION_URL" | sed 's/-/./g')
+        CHANGELOG_ENTRY=$(cat <<EOF
+## [$version]
+
+$CHANGELOG_TEXT
+EOF
+)
+
+        tmp=$(mktemp)
+        awk -v entry="$CHANGELOG_ENTRY" -v prev="## [$PREVIOUS_VERSION]" '
+            $0 == prev {
+                print entry
+                print ""
+            }
+            { print }
+        ' "$CHANGELOG_PATH" > "$tmp" && mv "$tmp" "$CHANGELOG_PATH"
     fi
 fi
 

--- a/cli/npm-package/package.json
+++ b/cli/npm-package/package.json
@@ -8,11 +8,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "license": "(MIT OR Apache-2.0)",
   "bin": {
-    "anchor": "./anchor.js"
+    "anchor": "anchor.js"
   },
   "scripts": {
     "prepack": "[ \"$(uname -op)\" != \"x86_64 GNU/Linux\" ] && (echo Can be packed only on x86_64 GNU/Linux && exit 1) || ([ \"$(./anchor --version)\" != \"anchor-cli $(jq -r .version package.json)\" ] && (echo Check anchor binary version && exit 2) || exit 0)"

--- a/examples/tutorial/basic-0/package.json
+++ b/examples/tutorial/basic-0/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/examples/tutorial/basic-1/package.json
+++ b/examples/tutorial/basic-1/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/examples/tutorial/basic-2/package.json
+++ b/examples/tutorial/basic-2/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/examples/tutorial/basic-3/package.json
+++ b/examples/tutorial/basic-3/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/examples/tutorial/basic-4/package.json
+++ b/examples/tutorial/basic-4/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/examples/tutorial/basic-5/package.json
+++ b/examples/tutorial/basic-5/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/tests/accountloader-realloc/package.json
+++ b/tests/accountloader-realloc/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=17"

--- a/tests/anchor-cli-account/package.json
+++ b/tests/anchor-cli-account/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/anchor-cli-idl/package.json
+++ b/tests/anchor-cli-idl/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/anchor-cli-legacy-idl/package.json
+++ b/tests/anchor-cli-legacy-idl/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/auction-house/package.json
+++ b/tests/auction-house/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/bench/package.json
+++ b/tests/bench/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/bpf-upgradeable-state/package.json
+++ b/tests/bpf-upgradeable-state/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/cashiers-check/package.json
+++ b/tests/cashiers-check/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/cfo/package.json
+++ b/tests/cfo/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/chat/package.json
+++ b/tests/chat/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/composite/package.json
+++ b/tests/composite/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/cpi-returns/package.json
+++ b/tests/cpi-returns/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/custom-coder/package.json
+++ b/tests/custom-coder/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/custom-discriminator/package.json
+++ b/tests/custom-discriminator/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/custom-program/package.json
+++ b/tests/custom-program/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/declare-id/package.json
+++ b/tests/declare-id/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/declare-program/package.json
+++ b/tests/declare-program/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/duplicate-mutable-accounts/package.json
+++ b/tests/duplicate-mutable-accounts/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/errors/package.json
+++ b/tests/errors/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/escrow/package.json
+++ b/tests/escrow/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/events/package.json
+++ b/tests/events/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/floats/package.json
+++ b/tests/floats/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/idl/package.json
+++ b/tests/idl/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/ido-pool/package.json
+++ b/tests/ido-pool/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/interface-account/package.json
+++ b/tests/interface-account/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/lazy-account/package.json
+++ b/tests/lazy-account/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/lockup/package.json
+++ b/tests/lockup/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/misc/package.json
+++ b/tests/misc/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/multiple-suites-run-single/package.json
+++ b/tests/multiple-suites-run-single/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/multiple-suites/package.json
+++ b/tests/multiple-suites/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/multisig/package.json
+++ b/tests/multisig/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/optional/package.json
+++ b/tests/optional/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/pda-derivation/package.json
+++ b/tests/pda-derivation/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/pyth/package.json
+++ b/tests/pyth/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/realloc/package.json
+++ b/tests/realloc/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/relations-derivation/package.json
+++ b/tests/relations-derivation/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/spl/metadata/package.json
+++ b/tests/spl/metadata/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/spl/token-extensions/package.json
+++ b/tests/spl/token-extensions/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/spl/token-proxy/package.json
+++ b/tests/spl/token-proxy/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/spl/token-wrapper/package.json
+++ b/tests/spl/token-wrapper/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/spl/transfer-hook/package.json
+++ b/tests/spl/transfer-hook/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/swap/package.json
+++ b/tests/swap/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/system-accounts/package.json
+++ b/tests/system-accounts/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/sysvars/package.json
+++ b/tests/sysvars/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/tictactoe/package.json
+++ b/tests/tictactoe/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/typescript/package.json
+++ b/tests/typescript/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/validator-clone/package.json
+++ b/tests/validator-clone/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/tests/zero-copy/package.json
+++ b/tests/zero-copy/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "engines": {
     "node": ">=20.18"

--- a/ts/packages/anchor-errors/package.json
+++ b/ts/packages/anchor-errors/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "publishConfig": {
     "access": "public"

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "publishConfig": {
     "access": "public"

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "publishConfig": {
     "access": "public"

--- a/ts/packages/spl-associated-token-account/package.json
+++ b/ts/packages/spl-associated-token-account/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-binary-option/package.json
+++ b/ts/packages/spl-binary-option/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-binary-oracle-pair/package.json
+++ b/ts/packages/spl-binary-oracle-pair/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-feature-proposal/package.json
+++ b/ts/packages/spl-feature-proposal/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-governance/package.json
+++ b/ts/packages/spl-governance/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-memo/package.json
+++ b/ts/packages/spl-memo/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-name-service/package.json
+++ b/ts/packages/spl-name-service/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-record/package.json
+++ b/ts/packages/spl-record/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-stake-pool/package.json
+++ b/ts/packages/spl-stake-pool/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-stateless-asks/package.json
+++ b/ts/packages/spl-stateless-asks/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token-lending/package.json
+++ b/ts/packages/spl-token-lending/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token-swap/package.json
+++ b/ts/packages/spl-token-swap/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"

--- a/ts/packages/spl-token/package.json
+++ b/ts/packages/spl-token/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/otter-sec/anchor.git"
+    "url": "git+https://github.com/otter-sec/anchor.git"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

When running prepare release, the bump-version script was not adding the required entry in meta.json for the new version due to an oversight. The changelog was missing the new version entry as well (even though it's mostly a placeholder, better than leaving gaps).

Also fixes the following warning during the release process:
```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/otter-sec/anchor.git"
```
and
```
npm warn publish "bin[anchor]" script name anchor.js was invalid and removed
```

Closes #4722