### PR TITLE
chore: Cleanup/enhance some repo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ resolver = "2"
 [workspace.package]
 version = "1.1.2"
 readme = "README.md"
+repository = "https://github.com/otter-sec/anchor"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 
 [workspace.package]
 version = "1.1.2"
+readme = "README.md"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To jump straight to examples, go [here](https://github.com/otter-sec/anchor/tree
 The recommended way to install the Anchor CLI is with the Anchor Version Manager (AVM).
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/solana-foundation/anchor/master/avm/install | sh
+curl -sSfL https://raw.githubusercontent.com/otter-sec/anchor/master/avm/install | sh
 ```
 
 The installer downloads the latest nightly AVM and Anchor CLI binaries, enables

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-cli"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 edition = "2021"
 repository = "https://github.com/otter-sec/anchor"
 description = "Anchor CLI"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "anchor-cli"
 version.workspace = true
 publish = true
 edition = "2021"
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 description = "Anchor CLI"
 license = "Apache-2.0"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-client"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 edition = "2021"
 license = "Apache-2.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-client"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "An RPC client to interact with Anchor programs"

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-lang-idl"
 version = "0.1.4"
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Anchor framework IDL"

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-lang-idl"
 version = "0.1.4"
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 edition = "2021"
 license = "Apache-2.0"

--- a/idl/spec/Cargo.toml
+++ b/idl/spec/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-lang-idl-spec"
 version = "0.1.0"
 publish = false
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 edition = "2021"
 license = "Apache-2.0"

--- a/idl/spec/Cargo.toml
+++ b/idl/spec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-lang-idl-spec"
 version = "0.1.0"
 publish = false
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Anchor framework IDL spec"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
 description = "Solana Sealevel eDSL"
+readme.workspace = true
 
 [package.metadata.docs.rs]
 workspace = true

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Solana Sealevel eDSL"
 readme.workspace = true
+homepage = "https://anchor-lang.com"
 
 [package.metadata.docs.rs]
 workspace = true

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-lang"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 edition = "2021"
 rust-version = "1.89"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-lang"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-access-control"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for instruction access control"

--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-access-control"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for instruction access control"
 edition = "2021"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-account"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining an account"
 edition = "2021"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-account"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining an account"

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-constant"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating constant types"

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-constant"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating constant types"
 edition = "2021"

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-error"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating error types"
 edition = "2021"

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-error"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for creating error types"

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-event"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining an event"

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-event"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining an event"
 rust-version = "1.60"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-attribute-program"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining a program"
 edition = "2021"

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-attribute-program"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor attribute macro for defining a program"

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-derive-accounts"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro for accounts"

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-derive-accounts"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor Derive macro for accounts"
 edition = "2021"

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-derive-serde"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro for serialization and deserialization"

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-derive-serde"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor Derive macro for serialization and deserialization"
 edition = "2021"

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-derive-space"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor Derive macro to automatically calculate the size of a structure or an enum"

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-derive-space"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor Derive macro to automatically calculate the size of a structure or an enum"
 edition = "2021"

--- a/lang/error/Cargo.toml
+++ b/lang/error/Cargo.toml
@@ -3,7 +3,7 @@ name = "anchor-lang-error"
 version.workspace = true
 publish = true
 edition = "2021"
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Error definitions for anchor-lang"
 

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-syn"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 license = "Apache-2.0"
 description = "Anchor syntax parsing and code generation tools"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-syn"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 license = "Apache-2.0"
 description = "Anchor syntax parsing and code generation tools"
 edition = "2021"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "anchor-spl"
 version.workspace = true
 publish = true
-repository = "https://github.com/otter-sec/anchor"
+repository.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "CPI clients for SPL programs"

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -2,7 +2,6 @@
 name = "anchor-spl"
 version.workspace = true
 publish = true
-authors = ["Anchor Maintainers <accounts@200ms.io>"]
 repository = "https://github.com/otter-sec/anchor"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
- Update AVM installer URL to the current repo
- Remove deprecated (and outdated) `authors` field
- Add `lang` README (to be displayed on crates.io)
- Inherit repo URL from workspace root
- Add homepage link to `lang`