### PR TITLE
fix(client): reject non-http custom cluster URL schemes

### DIFF
--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -19,13 +19,14 @@ pub enum Cluster {
 impl FromStr for Cluster {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Cluster> {
-        match s.to_lowercase().as_str() {
+        let cluster = s.to_lowercase();
+        match cluster.as_str() {
             "t" | "testnet" => Ok(Cluster::Testnet),
             "m" | "mainnet" => Ok(Cluster::Mainnet),
             "d" | "devnet" => Ok(Cluster::Devnet),
             "l" | "localnet" => Ok(Cluster::Localnet),
             "g" | "debug" => Ok(Cluster::Debug),
-            _ if s.starts_with("http") => {
+            _ if cluster.starts_with("http://") || cluster.starts_with("https://") => {
                 let http_url = s;
 
                 // Taken from:
@@ -122,6 +123,12 @@ mod tests {
     }
 
     #[test]
+    fn test_reject_non_http_scheme_with_http_prefix() {
+        let bad_url = "httpx://my_custom_url.test.net";
+        assert!(Cluster::from_str(bad_url).is_err());
+    }
+
+    #[test]
     fn test_http_port() {
         let url = "http://my-url.com:7000/";
         let cluster = Cluster::from_str(url).unwrap();
@@ -173,6 +180,16 @@ mod tests {
         let cluster = Cluster::from_str(url).unwrap();
         assert_eq!(
             Cluster::Custom(url.to_string(), "ws://my-url.com/FooBar".to_string()),
+            cluster
+        );
+    }
+
+    #[test]
+    fn test_upper_case_scheme() {
+        let url = "HTTPS://my-url.com/";
+        let cluster = Cluster::from_str(url).unwrap();
+        assert_eq!(
+            Cluster::Custom(url.to_string(), "wss://my-url.com/".to_string()),
             cluster
         );
     }

--- a/client/src/cluster.rs
+++ b/client/src/cluster.rs
@@ -19,20 +19,25 @@ pub enum Cluster {
 impl FromStr for Cluster {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Cluster> {
-        let cluster = s.to_lowercase();
-        match cluster.as_str() {
+        match s.to_lowercase().as_str() {
             "t" | "testnet" => Ok(Cluster::Testnet),
             "m" | "mainnet" => Ok(Cluster::Mainnet),
             "d" | "devnet" => Ok(Cluster::Devnet),
             "l" | "localnet" => Ok(Cluster::Localnet),
             "g" | "debug" => Ok(Cluster::Debug),
-            _ if cluster.starts_with("http://") || cluster.starts_with("https://") => {
+            _ => {
                 let http_url = s;
 
                 // Taken from:
                 // https://github.com/solana-labs/solana/blob/aea8f0df1610248d29d8ca3bc0d60e9fabc99e31/web3.js/src/util/url.ts
 
                 let mut ws_url = Url::parse(http_url)?;
+                if !matches!(ws_url.scheme(), "http" | "https") {
+                    return Err(anyhow::Error::msg(
+                        "Cluster must be one of [localnet, testnet, mainnet, devnet] or be an \
+                         http or https url\n",
+                    ));
+                }
                 if let Some(port) = ws_url.port() {
                     let ws_port = port
                         .checked_add(1)
@@ -53,10 +58,6 @@ impl FromStr for Cluster {
 
                 Ok(Cluster::Custom(http_url.to_string(), ws_url.to_string()))
             }
-            _ => Err(anyhow::Error::msg(
-                "Cluster must be one of [localnet, testnet, mainnet, devnet] or be an http or \
-                 https url\n",
-            )),
         }
     }
 }


### PR DESCRIPTION
## Summary

`Cluster::from_str` previously accepted any custom URL whose input started with `http`, which allowed non-HTTP(S) schemes such as `httpx://...` to be parsed as custom RPC URLs and converted into websocket URLs.

This change tightens the custom cluster URL check to only accept `http://` and `https://` prefixes. The comparison uses the lowercased input, so valid uppercase schemes like `HTTPS://...` continue to work.

Regression tests cover both rejecting a non-HTTP scheme with an `http` prefix and accepting an uppercase HTTPS scheme.


## Branch Target

If this contains breaking changes, it should target the `anchor-next` branch.
