### PR TITLE
spl: fix metadata feature failing to build standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- spl: Fix `anchor-spl` failing to build with only the `metadata` feature ([#4742](https://github.com/solana-foundation/anchor/pull/4742)).
 - client: Fix ignored commitment level ([#4666](https://github.com/solana-foundation/anchor/pull/4666)).
 - lang: Remove cloning `AccountInfo` to read lamports in `init_if_needed` codegen ([#4675](https://github.com/solana-foundation/anchor/pull/4675)).
 - lang: Guard `AccountLoader<T>::exit` against zero-copy buffer truncation and bail with `AccountDidNotDeserialize` instead of rewriting the discriminator over an undersized buffer ([#4633](https://github.com/otter-sec/anchor/pull/4633)).

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -19,7 +19,12 @@ devnet = []
 governance = []
 idl-build = ["anchor-lang/idl-build"]
 memo = ["spl-memo-interface"]
-metadata = ["mpl-token-metadata", "dep:solana-sysvar"]
+metadata = [
+    "mpl-token-metadata",
+    "dep:solana-sysvar",
+    "spl-token-interface",
+    "spl-associated-token-account-interface",
+]
 mint = []
 stake = ["dep:borsh", "dep:solana-stake-interface"]
 token = ["spl-token-interface"]


### PR DESCRIPTION
Fixes #3291.

`cargo build -p anchor-spl --no-default-features --features metadata` fails because `metadata.rs` uses `spl_token_interface::ID` and `spl_associated_token_account_interface::program::ID`, which are only pulled in by the `token`/`associated_token` features. This enables those two (already optional) crates from the `metadata` feature so it builds standalone. No code changes.

Verified `--features metadata` builds and the default build is unchanged.

@acheroncrypto you suggested using the lighter `spl-associated-token-account-client` instead. I went with the existing interface crates since it's a one-line change with no new deps, but can switch to the client crates if you'd prefer.
