### PR TITLE
cli: Warn unused `Anchor.toml` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `AccountLoader::new_unchecked` for constructing an `AccountLoader` without performing owner or discriminator checks ([#4162](https://github.com/solana-foundation/anchor/pull/4162)).
 - lang: Provide better error messages for `token` constraints ([#4698](https://github.com/solana-foundation/anchor/pull/4698)).
 - ts: Improve account resolution error of self-referencing PDAs ([#4711](https://github.com/solana-foundation/anchor/pull/4711)).
+- cli: Warn unused `Anchor.toml` fields ([#4749](https://github.com/solana-foundation/anchor/pull/4749)).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "rustc-demangle",
  "semver",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sha2 0.10.9",
  "shellexpand",
@@ -4192,6 +4193,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,6 +48,7 @@ reqwest = { workspace = true, default-features = false, features = [
 ] }
 semver = "1.0.4"
 serde = { version = "1.0.130", features = ["derive"] }
+serde_ignored = "0.1.14"
 serde_json = "1.0"
 shellexpand = "2.1.0"
 solana-cli-config.workspace = true

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -732,7 +732,7 @@ impl Config {
 
         // File path -> unused field paths
         static CACHE: LazyLock<Mutex<HashMap<PathBuf, BTreeSet<String>>>> =
-            LazyLock::new(|| Default::default());
+            LazyLock::new(Default::default);
         let mut cache = CACHE
             .lock()
             .map_err(|e| anyhow!("Failed to acquire the cache lock ({path:?}): {e}"))?;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -940,7 +940,7 @@ impl FromStr for Config {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         toml::from_str::<_Config>(s)
             .map_err(|e| anyhow!("Unable to deserialize config: {e}"))
-            .map(TryInto::<Self>::try_into)?
+            .map(TryFrom::try_from)?
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -19,7 +19,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     std::{
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, BTreeSet, HashMap},
         convert::TryFrom,
         fmt,
         fs::{self, File},
@@ -29,7 +29,6 @@ use {
         path::{Path, PathBuf},
         process::Command,
         str::FromStr,
-        sync::Once,
     },
     walkdir::WalkDir,
 };
@@ -719,10 +718,31 @@ impl Config {
         Ok(None)
     }
 
-    fn from_path(p: impl AsRef<Path>) -> Result<Self> {
-        fs::read_to_string(&p)
-            .with_context(|| format!("Error reading the file with path: {}", p.as_ref().display()))?
-            .parse::<Self>()
+    fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let cfg = fs::read_to_string(path)
+            .with_context(|| format!("Error reading configuration file: {path:?}"))?;
+
+        let mut unused = BTreeSet::new();
+        let de = toml::Deserializer::new(&cfg);
+        let cfg: _Config = serde_ignored::deserialize(de, |path| {
+            unused.insert(path.to_string());
+        })?;
+
+        if let Some(paths) = unused.into_iter().reduce(|mut acc, path| {
+            if !acc.is_empty() {
+                acc.push_str(", ");
+            }
+
+            acc.push('`');
+            acc.push_str(&path);
+            acc.push('`');
+            acc
+        }) {
+            eprintln!("Warning: Unused Anchor.toml field(s): {paths}");
+        }
+
+        Self::try_from(cfg)
     }
 
     pub fn wallet_kp(&self) -> Result<Keypair> {
@@ -771,8 +791,6 @@ struct _Config {
     skip_local_validator: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     clients: Option<ClientsConfig>,
-    #[serde(flatten)]
-    unused: HashMap<String, toml::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -884,7 +902,6 @@ impl fmt::Display for Config {
                     && clients.go.is_none();
                 (!empty).then(|| clients.clone())
             },
-            unused: Default::default(),
         };
 
         let cfg = toml::to_string(&cfg).expect("Must be well formed");
@@ -892,33 +909,10 @@ impl fmt::Display for Config {
     }
 }
 
-impl FromStr for Config {
-    type Err = Error;
+impl TryFrom<_Config> for Config {
+    type Error = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let cfg: _Config =
-            toml::from_str(s).map_err(|e| anyhow!("Unable to deserialize config: {e}"))?;
-
-        static WARN_UNUSED: Once = Once::new();
-        WARN_UNUSED.call_once(|| {
-            let s = match cfg.unused.len() {
-                0 => return,
-                1 => "",
-                _ => "s",
-            };
-            let keys = cfg.unused.keys().fold(String::new(), |mut acc, key| {
-                if !acc.is_empty() {
-                    acc.push_str(", ");
-                }
-
-                acc.push('`');
-                acc.push_str(key);
-                acc.push('`');
-                acc
-            });
-            eprintln!("Warning: Unused Anchor.toml field{s}: {keys}");
-        });
-
+    fn try_from(cfg: _Config) -> std::result::Result<Self, Self::Error> {
         Ok(Config {
             toolchain: cfg.toolchain.unwrap_or_default(),
             features: cfg.features.unwrap_or_default(),
@@ -937,6 +931,16 @@ impl FromStr for Config {
             skip_local_validator: cfg.skip_local_validator,
             clients: cfg.clients.unwrap_or_default(),
         })
+    }
+}
+
+impl FromStr for Config {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        toml::from_str::<_Config>(s)
+            .map_err(|e| anyhow!("Unable to deserialize config: {e}"))
+            .map(TryInto::<Self>::try_into)?
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -29,6 +29,7 @@ use {
         path::{Path, PathBuf},
         process::Command,
         str::FromStr,
+        sync::{LazyLock, Mutex},
     },
     walkdir::WalkDir,
 };
@@ -728,6 +729,17 @@ impl Config {
         let cfg: _Config = serde_ignored::deserialize(de, |path| {
             unused.insert(path.to_string());
         })?;
+
+        // File path -> unused field paths
+        static CACHE: LazyLock<Mutex<HashMap<PathBuf, BTreeSet<String>>>> =
+            LazyLock::new(|| Default::default());
+        let mut cache = CACHE
+            .lock()
+            .map_err(|e| anyhow!("Failed to acquire the cache lock ({path:?}): {e}"))?;
+        match cache.get(path) {
+            Some(cached_unused) if *cached_unused == unused => return Self::try_from(cfg),
+            _ => cache.insert(path.to_path_buf(), unused.clone()),
+        };
 
         if let Some(paths) = unused.into_iter().reduce(|mut acc, path| {
             if !acc.is_empty() {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -29,6 +29,7 @@ use {
         path::{Path, PathBuf},
         process::Command,
         str::FromStr,
+        sync::Once,
     },
     walkdir::WalkDir,
 };
@@ -770,6 +771,8 @@ struct _Config {
     skip_local_validator: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     clients: Option<ClientsConfig>,
+    #[serde(flatten)]
+    unused: HashMap<String, toml::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -881,6 +884,7 @@ impl fmt::Display for Config {
                     && clients.go.is_none();
                 (!empty).then(|| clients.clone())
             },
+            unused: Default::default(),
         };
 
         let cfg = toml::to_string(&cfg).expect("Must be well formed");
@@ -894,6 +898,27 @@ impl FromStr for Config {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let cfg: _Config =
             toml::from_str(s).map_err(|e| anyhow!("Unable to deserialize config: {e}"))?;
+
+        static WARN_UNUSED: Once = Once::new();
+        WARN_UNUSED.call_once(|| {
+            let s = match cfg.unused.len() {
+                0 => return,
+                1 => "",
+                _ => "s",
+            };
+            let keys = cfg.unused.keys().fold(String::new(), |mut acc, key| {
+                if !acc.is_empty() {
+                    acc.push_str(", ");
+                }
+
+                acc.push('`');
+                acc.push_str(key);
+                acc.push('`');
+                acc
+            });
+            eprintln!("Warning: Unused Anchor.toml field{s}: {keys}");
+        });
+
         Ok(Config {
             toolchain: cfg.toolchain.unwrap_or_default(),
             features: cfg.features.unwrap_or_default(),


### PR DESCRIPTION
### Problem

Users get no indication about having redundant `Anchor.toml` fields.

For example, if a user has a typo (`script` instead of `scripts`):

```toml
[script]
test = "..."
```

then user-defined scripts (or override of the default `test` script) will not work.

### Summary of changes

Warn when there are unused `Anchor.toml` fields.

Example output for typos:

```
Warning: Unused Anchor.toml field(s): `feture`, `script`
```

Example output for inner unused fields:

```
Warning: Unused Anchor.toml field(s): features.?.seeds
```
