### PR TITLE
docs: fix the syntax error in the rust example of Time travel section

### DIFF
--- a/docs-v2/src/content/docs/v1/testing/litesvm.mdx
+++ b/docs-v2/src/content/docs/v1/testing/litesvm.mdx
@@ -312,7 +312,7 @@ fn test_set_clock() {
     let msg = Message::new_with_blockhash(&ixs, Some(&payer_address), &blockhash);
     let versioned_msg = VersionedMessage::Legacy(msg);
     let tx = VersionedTransaction::try_new(versioned_msg, &[&payer]).unwrap();
-    // set the time to January 1st 2000
+    // set the time to January 1st 2025
     let mut initial_clock = svm.get_sysvar::<Clock>();
     initial_clock.unix_timestamp = 1735689600;
     svm.set_sysvar::<Clock>(&initial_clock);
@@ -360,7 +360,7 @@ test('clock', () => {
   tx.recentBlockhash = blockhash
   tx.add(...ixs)
   tx.sign(payer)
-  // set the time to January 1st 2000
+  // set the time to January 1st 2025
   const initialClock = svm.getClock()
   initialClock.unixTimestamp = 1735689600n
   svm.setClock(initialClock)
@@ -419,7 +419,7 @@ def test_set_clock() -> None:
     ixs = [Instruction(program_id=program_id, data=b"", accounts=[])]
     msg = Message.new_with_blockhash(ixs, payer.pubkey(), blockhash)
     tx = VersionedTransaction(msg, [payer])
-    # set the time to January 1st 2000
+    # set the time to January 1st 2025
     initial_clock = client.get_clock()
     initial_clock.unix_timestamp = 1735689600
     client.set_clock(initial_clock)

--- a/docs/content/docs/testing/litesvm.mdx
+++ b/docs/content/docs/testing/litesvm.mdx
@@ -283,7 +283,7 @@ use {
     litesvm::LiteSVM,
     solana_clock::Clock,
     solana_instruction::Instruction,
-    use solana_keypair::Keypair,
+    solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_pubkey::Pubkey,
     solana_signer::Signer,
@@ -307,7 +307,7 @@ fn test_set_clock() {
     let msg = Message::new_with_blockhash(&ixs, Some(&payer_address), &blockhash);
     let versioned_msg = VersionedMessage::Legacy(msg);
     let tx = VersionedTransaction::try_new(versioned_msg, &[&payer]).unwrap();
-    // set the time to January 1st 2000
+    // set the time to January 1st 2025
     let mut initial_clock = svm.get_sysvar::<Clock>();
     initial_clock.unix_timestamp = 1735689600;
     svm.set_sysvar::<Clock>(&initial_clock);
@@ -359,7 +359,7 @@ test("clock", () => {
   tx.recentBlockhash = blockhash;
   tx.add(...ixs);
   tx.sign(payer);
-  // set the time to January 1st 2000
+  // set the time to January 1st 2025
   const initialClock = svm.getClock();
   initialClock.unixTimestamp = 1735689600n;
   svm.setClock(initialClock);
@@ -416,7 +416,7 @@ def test_set_clock() -> None:
     ixs = [Instruction(program_id=program_id, data=b"", accounts=[])]
     msg = Message.new_with_blockhash(ixs, payer.pubkey(), blockhash)
     tx = VersionedTransaction(msg, [payer])
-    # set the time to January 1st 2000
+    # set the time to January 1st 2025
     initial_clock = client.get_clock()
     initial_clock.unix_timestamp = 1735689600
     client.set_clock(initial_clock)


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

Fix two issues in the `test_set_clock` LiteSVM example in the docs:

1. **Stray `use` keyword**  removed the extra `use` on the `solana_keypair::Keypair` import line inside the brace-group import block, which was a syntax error.
2. **Incorrect timestamp comment**  the comment claimed `1735689600` was "January 1st 2000", but this Unix timestamp corresponds to **January 1, 2025**. Updated all Rust, TypeScript, and Python example comments to say "January 1st 2025". For verification I did
 ```bash
> date -u -d @1735689600
Wed Jan  1 12:00:00 AM UTC 2025
```

## Branch Target

No breaking changes ,docs-only fixes.

