### PR TITLE
chore: Unpin `solana-transaction-error` in tests

### DIFF
--- a/tests/zero-copy/programs/zero-copy/Cargo.toml
+++ b/tests/zero-copy/programs/zero-copy/Cargo.toml
@@ -23,6 +23,3 @@ bytemuck = {version = "1.4.0", features = ["derive", "min_const_generics"]}
 anchor-client = { path = "../../../../client", features = ["debug", "async"] }
 solana-program-test = "3.1"
 solana-sdk = "3.0"
-# FIXME: `solana-runtime` 3.1.12 (via `solana-program-test`) is broken by newer versions of `solana-transaction-error`
-# https://github.com/anza-xyz/solana-sdk/pull/765
-solana-transaction-error = "=3.2.0"


### PR DESCRIPTION
Reverts https://github.com/otter-sec/anchor/pull/4728

Upstream change reverted: https://github.com/anza-xyz/solana-sdk/pull/765#discussion_r3507995780