### PR TITLE
fix(lang): avoid unexpected_cfgs warnings for anchor-debug

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -971,3 +971,22 @@ macro_rules! source {
         }
     };
 }
+
+/// Helper macro for conditional compilation of debug code in anchor macros.
+#[cfg(feature = "anchor-debug")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! anchor_debug {
+    ($($arg:tt)*) => {
+        $($arg)*
+    };
+}
+
+/// Helper macro for conditional compilation of debug code in anchor macros.
+#[cfg(not(feature = "anchor-debug"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! anchor_debug {
+    ($($arg:tt)*) => {};
+}
+

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -26,8 +26,9 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     let name = &s.ident;
                     let ty = &s.raw_field.ty;
                     quote! {
-                        #[cfg(feature = "anchor-debug")]
-                        ::anchor_lang::solana_program::log::sol_log(stringify!(#name));
+                        ::anchor_lang::anchor_debug! {
+                            ::anchor_lang::solana_program::log::sol_log(stringify!(#name));
+                        }
                         let #name: #ty = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, &mut __bumps.#name, __reallocs)?;
                     }
                 }
@@ -81,8 +82,9 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                             quote! {}
                         };
                         quote! {
-                            #[cfg(feature = "anchor-debug")]
-                            ::anchor_lang::solana_program::log::sol_log(stringify!(#typed_name));
+                            ::anchor_lang::anchor_debug! {
+                                ::anchor_lang::solana_program::log::sol_log(stringify!(#typed_name));
+                            }
                             let #typed_name = anchor_lang::Accounts::try_accounts(__program_id, __accounts, __ix_data, __bumps, __reallocs)
                                 .map_err(|e| e.with_account_name(#name))?;
                             #warning

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -54,9 +54,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             accounts: &'info [AccountInfo<'info>],
             data: &'info [u8]
         ) -> anchor_lang::Result<()> {
-            #[cfg(feature = "anchor-debug")]
-            {
-                msg!("anchor-debug is active");
+            anchor_lang::anchor_debug! {
+                anchor_lang::solana_program::log::msg!("anchor-debug is active");
             }
             if *program_id != ID {
                 return Err(anchor_lang::error::ErrorCode::DeclaredProgramIdMismatch.into());


### PR DESCRIPTION
## Summary

Since Rust 1.80, `check-cfg` validates feature names used in `#[cfg(feature = "...")]` attributes.

Anchor currently emits `#[cfg(feature = "anchor-debug")]` in macro-generated code. Because these attributes are expanded in the downstream crate, the compiler evaluates them against the downstream crate's feature set instead of `anchor-lang`, resulting in warnings such as:

```text
warning: unexpected `cfg` condition value: `anchor-debug`
```

This PR moves the feature check into `anchor-lang` by introducing an internal `anchor_debug!` helper macro and updating the code generator to emit calls to that macro instead of generating raw `#[cfg(feature = "anchor-debug")]` attributes.

## Changes

### `anchor-lang`

- Add an internal `#[doc(hidden)]` `anchor_debug!` helper macro.
- Evaluate the `anchor-debug` feature within `anchor-lang` rather than the downstream crate.

### `anchor-syn`

Replace generated code like:

```rust
#[cfg(feature = "anchor-debug")]
msg!(...);
```

with:

```rust
::anchor_lang::anchor_debug! {
    msg!(...);
}
```

Updated code generation in:

- `lang/syn/src/codegen/program/entry.rs`
- `lang/syn/src/codegen/accounts/try_accounts.rs`

## Verification

Verified that:

- `cargo check` no longer emits the `unexpected cfg condition value: anchor-debug` warning.
- `cargo check --features anchor-lang/anchor-debug` compiles successfully, preserving the existing debug behavior.

## Backward Compatibility

This change is fully backward compatible.

- No changes to generated program behavior.
- No public API changes.
- The only change is where the `anchor-debug` feature is evaluated.