### PR TITLE
fix(cli): avoid cwd-dependent cargo metadata discovery

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -294,20 +294,25 @@ fn close_buffer_for_resize(
     Ok(())
 }
 
+fn find_nearest_manifest_path(start_dir: &Path) -> Option<PathBuf> {
+    start_dir
+        .ancestors()
+        .map(|path| path.join("Cargo.toml"))
+        .find(|manifest_path| manifest_path.is_file())
+}
+
 fn discover_cargo_metadata(start_dir: &Path) -> Result<Option<Metadata>> {
+    let Some(manifest_path) = find_nearest_manifest_path(start_dir) else {
+        return Ok(None);
+    };
+
     match MetadataCommand::new()
-        .current_dir(start_dir)
+        .manifest_path(manifest_path)
         .no_deps()
         .exec()
     {
         Ok(metadata) => Ok(Some(metadata)),
-        Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
-            if stderr.contains("could not find `Cargo.toml`") {
-                Ok(None)
-            } else {
-                bail!(stderr);
-            }
-        }
+        Err(cargo_metadata::Error::CargoMetadata { stderr }) => bail!(stderr),
         Err(err) => Err(err.into()),
     }
 }
@@ -2783,6 +2788,20 @@ resolver = "2"
         );
         create_program(&root.join("programs").join("foo"), "foo");
         create_program(&root.join("programs").join("bar"), "bar");
+    }
+
+    #[test]
+    fn find_nearest_manifest_path_finds_closest_cargo_toml() {
+        let dir = tempdir().unwrap();
+        create_workspace(dir.path());
+
+        let program_dir = dir.path().join("programs").join("foo");
+        let nested_dir = program_dir.join("src");
+
+        assert_eq!(
+            find_nearest_manifest_path(&nested_dir),
+            Some(program_dir.join("Cargo.toml"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #4751.

`discover_cargo_metadata` previously ran `cargo metadata` with the subprocess working directory set to the requested start directory. In sandboxed macOS environments such as Nix builds, that temporary directory can be unresolvable to the subprocess and `cargo metadata` can fail before reading the manifest.

This change resolves the nearest `Cargo.toml` in-process and passes it to `cargo metadata` via `--manifest-path` instead. That preserves nested workspace discovery while avoiding the fragile subprocess cwd dependency.

Added a regression test for finding the closest manifest from a nested workspace member path.


Verification:
- `cargo test -p anchor-cli program::tests::find_nearest_manifest_path_finds_closest_cargo_toml --lib`
- `cargo test -p anchor-cli program::tests::discover_solana_programs --lib`
- `cargo test -p anchor-cli --lib`
- `cargo clippy -p anchor-cli --all-targets -- -D warnings`
- `rustfmt +nightly --edition 2021 --check cli/src/program.rs`


## Branch Target

If this contains breaking changes, it should target the `anchor-next` branch.
