### PR TITLE
fix(cli): serialize Option::None as JSON null

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3903,7 +3903,7 @@ fn deserialize_idl_type_to_json(
             let is_present = <u8 as AnchorDeserialize>::deserialize(data)?;
 
             if is_present == 0 {
-                JsonValue::String("None".to_string())
+                JsonValue::Null
             } else {
                 deserialize_idl_type_to_json(ty, data, parent_idl)?
             }
@@ -7160,6 +7160,18 @@ mod tests {
         std::collections::{HashMap, HashSet},
         tempfile::tempdir,
     };
+
+    #[test]
+    fn test_deserialize_idl_option_none_to_json_null() {
+        let idl_type = IdlType::Option(Box::new(IdlType::String));
+        let mut data: &[u8] = &[0]; // is_present = 0, meaning None
+        let idl: Idl = serde_json::from_str(
+            r#"{"address":"","metadata":{"name":"","version":"","spec":""},"instructions":[]}"#,
+        )
+        .unwrap();
+        let json = deserialize_idl_type_to_json(&idl_type, &mut data, &idl).unwrap();
+        assert_eq!(json, JsonValue::Null);
+    }
 
     #[test]
     fn test_init_accepts_anchor_version() {

--- a/tests/anchor-cli-account/programs/account-command/src/lib.rs
+++ b/tests/anchor-cli-account/programs/account-command/src/lib.rs
@@ -21,6 +21,7 @@ pub mod account_command {
             values,
             state: State::Confirmed { amount, memo },
         };
+        my_account.opt_field = None;
 
         Ok(())
     }
@@ -43,6 +44,7 @@ pub struct MyAccount {
     pub balance: f32,
     pub delegate_pubkey: Pubkey,
     pub sub: Sub,
+    pub opt_field: Option<String>,
 }
 
 #[derive(Accounts)]

--- a/tests/anchor-cli-account/tests/account.ts
+++ b/tests/anchor-cli-account/tests/account.ts
@@ -74,5 +74,9 @@ describe("Test CLI account commands", () => {
         "Values deserialized incorrectly"
       );
     }
+    assert(
+      output.opt_field === null,
+      "Option::None deserialized incorrectly (expected null)"
+    );
   });
 });


### PR DESCRIPTION
## Summary

The Anchor CLI currently serializes `Option::None` values as the JSON string `"None"` when decoding account state or instruction data.

This is inconsistent with how `serde_json` represents `Option::None`, which serializes to `null`. Returning `"None"` also makes it difficult for downstream consumers to distinguish an absent value from a string whose value happens to be `"None"`.

This PR updates the CLI to serialize `Option::None` as `JsonValue::Null`.

### Example

**Before**

```json
{
  "opt_field": "None"
}
```

**After**

```json
{
  "opt_field": null
}
```

## Changes

- Return `JsonValue::Null` for `Option::None`.
- Add a unit test covering `Option::None` serialization.
- Add an integration test verifying the CLI outputs `null` for optional fields.

## Verification

- `cargo test --lib` passes.
- The `anchor-cli-account` integration test passes.
- `Option::Some` behavior is unchanged.