### PR TITLE
fix(asm-v2): derive asm enum constants from Rust discriminants

### DIFF
--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -372,4 +372,52 @@ mod tests {
         assert!(expanded.contains("DISC_START = const Disc :: Start as u32"));
         assert!(expanded.contains("DISC_NEXT = const Disc :: Next as u32"));
     }
+
+    #[test]
+    fn test_error_enum_auto_increment_tracks_explicit_gaps() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            #[error_enum(prefix = "ERR")]
+            pub enum Errors {
+                Alpha = 41,
+                Beta,
+                Gamma = 90,
+                Delta,
+            }
+
+            asm { "" }
+            "#,
+        )
+        .unwrap();
+
+        let expanded = expand_asm_program(program).to_string();
+        assert!(expanded.contains("ERR_ALPHA = const Errors :: Alpha as i32"));
+        assert!(expanded.contains("ERR_BETA = const Errors :: Beta as i32"));
+        assert!(expanded.contains("ERR_GAMMA = const Errors :: Gamma as i32"));
+        assert!(expanded.contains("ERR_DELTA = const Errors :: Delta as i32"));
+    }
+
+    #[test]
+    fn test_discriminant_auto_increment_tracks_explicit_gaps() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            #[discriminant(prefix = "DISC")]
+            pub enum Instruction {
+                Init = 4,
+                Update,
+                Close = 12,
+                Sweep,
+            }
+
+            asm { "" }
+            "#,
+        )
+        .unwrap();
+
+        let expanded = expand_asm_program(program).to_string();
+        assert!(expanded.contains("DISC_INIT = const Instruction :: Init as u32"));
+        assert!(expanded.contains("DISC_UPDATE = const Instruction :: Update as u32"));
+        assert!(expanded.contains("DISC_CLOSE = const Instruction :: Close as u32"));
+        assert!(expanded.contains("DISC_SWEEP = const Instruction :: Sweep as u32"));
+    }
 }

--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -36,6 +36,9 @@ use syn::{
     Expr, Fields, Ident, Item, Lit, Meta,
 };
 
+/// Default first custom error code. Mirrors `anchor_lang_v2::error_code`.
+const DEFAULT_ERROR_CODE_OFFSET: u32 = 6000;
+
 // ---------------------------------------------------------------------------
 // asm_program! — the single entry point
 // ---------------------------------------------------------------------------
@@ -202,7 +205,7 @@ fn expand_asm_program(program: AsmProgram) -> TokenStream2 {
                     );
                     let variant = &v.ident;
                     const_operands.push(quote! {
-                        #name = const #enum_name::#variant as u32,
+                        #name = const (#enum_name::#variant as u32 + #DEFAULT_ERROR_CODE_OFFSET),
                     });
                 }
             }
@@ -366,9 +369,9 @@ mod tests {
         .unwrap();
 
         let expanded = expand_asm_program(program).to_string();
-        assert!(expanded.contains("E_ALPHA = const Errors :: Alpha as u32"));
-        assert!(expanded.contains("E_BETA = const Errors :: Beta as u32"));
-        assert!(expanded.contains("E_GAMMA = const Errors :: Gamma as u32"));
+        assert!(expanded.contains("E_ALPHA = const (Errors :: Alpha as u32 + 6000u32)"));
+        assert!(expanded.contains("E_BETA = const (Errors :: Beta as u32 + 6000u32)"));
+        assert!(expanded.contains("E_GAMMA = const (Errors :: Gamma as u32 + 6000u32)"));
         assert!(expanded.contains("DISC_START = const Disc :: Start as u32"));
         assert!(expanded.contains("DISC_NEXT = const Disc :: Next as u32"));
     }
@@ -391,10 +394,10 @@ mod tests {
         .unwrap();
 
         let expanded = expand_asm_program(program).to_string();
-        assert!(expanded.contains("ERR_ALPHA = const Errors :: Alpha as u32"));
-        assert!(expanded.contains("ERR_BETA = const Errors :: Beta as u32"));
-        assert!(expanded.contains("ERR_GAMMA = const Errors :: Gamma as u32"));
-        assert!(expanded.contains("ERR_DELTA = const Errors :: Delta as u32"));
+        assert!(expanded.contains("ERR_ALPHA = const (Errors :: Alpha as u32 + 6000u32)"));
+        assert!(expanded.contains("ERR_BETA = const (Errors :: Beta as u32 + 6000u32)"));
+        assert!(expanded.contains("ERR_GAMMA = const (Errors :: Gamma as u32 + 6000u32)"));
+        assert!(expanded.contains("ERR_DELTA = const (Errors :: Delta as u32 + 6000u32)"));
     }
 
     #[test]
@@ -414,9 +417,30 @@ mod tests {
         .unwrap();
 
         let expanded = expand_asm_program(program).to_string();
-        assert!(expanded.contains("ERR_SMALL = const Errors :: Small as u32"));
-        assert!(expanded.contains("ERR_LARGE = const Errors :: Large as u32"));
+        assert!(expanded.contains("ERR_SMALL = const (Errors :: Small as u32 + 6000u32)"));
+        assert!(expanded.contains("ERR_LARGE = const (Errors :: Large as u32 + 6000u32)"));
         assert!(!expanded.contains("Errors :: Large as i32"));
+    }
+
+    #[test]
+    fn test_error_enum_default_first_variant_is_not_success() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            #[error_enum(prefix = "ERR")]
+            pub enum Errors {
+                InvalidSignature,
+                Unauthorized,
+            }
+
+            asm { "" }
+            "#,
+        )
+        .unwrap();
+
+        let expanded = expand_asm_program(program).to_string();
+        assert!(expanded.contains("ERR_INVALID_SIGNATURE = const (Errors :: InvalidSignature as u32 + 6000u32)"));
+        assert!(expanded.contains("ERR_UNAUTHORIZED = const (Errors :: Unauthorized as u32 + 6000u32)"));
+        assert!(!expanded.contains("ERR_INVALID_SIGNATURE = const Errors :: InvalidSignature as u32"));
     }
 
     #[test]

--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -182,7 +182,10 @@ fn default_prefix(kind: &str) -> String {
 #[proc_macro]
 pub fn asm_program(input: TokenStream) -> TokenStream {
     let program = syn::parse_macro_input!(input as AsmProgram);
+    expand_asm_program(program).into()
+}
 
+fn expand_asm_program(program: AsmProgram) -> TokenStream2 {
     let mut rust_items = Vec::new();
     let mut const_operands: Vec<TokenStream2> = Vec::new();
 
@@ -190,26 +193,32 @@ pub fn asm_program(input: TokenStream) -> TokenStream {
         match item {
             AnnotatedItem::ErrorEnum { prefix, item } => {
                 rust_items.push(quote! { #item });
-                for (i, v) in item.variants.iter().enumerate() {
+                let enum_name = &item.ident;
+                for v in &item.variants {
                     let name = format_ident!(
                         "{}_{}",
                         prefix,
                         to_screaming_snake(&v.ident.to_string())
                     );
-                    let val = (i + 1) as i32;
-                    const_operands.push(quote! { #name = const #val, });
+                    let variant = &v.ident;
+                    const_operands.push(quote! {
+                        #name = const #enum_name::#variant as i32,
+                    });
                 }
             }
             AnnotatedItem::Discriminant { prefix, item } => {
                 rust_items.push(quote! { #item });
-                for (i, v) in item.variants.iter().enumerate() {
+                let enum_name = &item.ident;
+                for v in &item.variants {
                     let name = format_ident!(
                         "{}_{}",
                         prefix,
                         to_screaming_snake(&v.ident.to_string())
                     );
-                    let val = i as u32;
-                    const_operands.push(quote! { #name = const #val, });
+                    let variant = &v.ident;
+                    const_operands.push(quote! {
+                        #name = const #enum_name::#variant as u32,
+                    });
                 }
             }
             AnnotatedItem::Offsets { prefix, item } => {
@@ -298,7 +307,7 @@ pub fn asm_program(input: TokenStream) -> TokenStream {
         );
     };
 
-    expanded.into()
+    expanded
 }
 
 // ---------------------------------------------------------------------------
@@ -332,5 +341,35 @@ mod tests {
         assert_eq!(to_screaming_snake("RegisterMarket"), "REGISTER_MARKET");
         assert_eq!(to_screaming_snake("BaseVaultHasData"), "BASE_VAULT_HAS_DATA");
         assert_eq!(to_screaming_snake("UserHasData"), "USER_HAS_DATA");
+    }
+
+    #[test]
+    fn test_enum_constants_follow_rust_discriminants() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            #[error_enum(prefix = "E")]
+            pub enum Errors {
+                Alpha = 7,
+                Beta,
+                Gamma = 11,
+            }
+
+            #[discriminant(prefix = "DISC")]
+            pub enum Disc {
+                Start = 3,
+                Next,
+            }
+
+            asm { "" }
+            "#,
+        )
+        .unwrap();
+
+        let expanded = expand_asm_program(program).to_string();
+        assert!(expanded.contains("E_ALPHA = const Errors :: Alpha as i32"));
+        assert!(expanded.contains("E_BETA = const Errors :: Beta as i32"));
+        assert!(expanded.contains("E_GAMMA = const Errors :: Gamma as i32"));
+        assert!(expanded.contains("DISC_START = const Disc :: Start as u32"));
+        assert!(expanded.contains("DISC_NEXT = const Disc :: Next as u32"));
     }
 }

--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -202,7 +202,7 @@ fn expand_asm_program(program: AsmProgram) -> TokenStream2 {
                     );
                     let variant = &v.ident;
                     const_operands.push(quote! {
-                        #name = const #enum_name::#variant as i32,
+                        #name = const #enum_name::#variant as u32,
                     });
                 }
             }
@@ -366,9 +366,9 @@ mod tests {
         .unwrap();
 
         let expanded = expand_asm_program(program).to_string();
-        assert!(expanded.contains("E_ALPHA = const Errors :: Alpha as i32"));
-        assert!(expanded.contains("E_BETA = const Errors :: Beta as i32"));
-        assert!(expanded.contains("E_GAMMA = const Errors :: Gamma as i32"));
+        assert!(expanded.contains("E_ALPHA = const Errors :: Alpha as u32"));
+        assert!(expanded.contains("E_BETA = const Errors :: Beta as u32"));
+        assert!(expanded.contains("E_GAMMA = const Errors :: Gamma as u32"));
         assert!(expanded.contains("DISC_START = const Disc :: Start as u32"));
         assert!(expanded.contains("DISC_NEXT = const Disc :: Next as u32"));
     }
@@ -391,10 +391,32 @@ mod tests {
         .unwrap();
 
         let expanded = expand_asm_program(program).to_string();
-        assert!(expanded.contains("ERR_ALPHA = const Errors :: Alpha as i32"));
-        assert!(expanded.contains("ERR_BETA = const Errors :: Beta as i32"));
-        assert!(expanded.contains("ERR_GAMMA = const Errors :: Gamma as i32"));
-        assert!(expanded.contains("ERR_DELTA = const Errors :: Delta as i32"));
+        assert!(expanded.contains("ERR_ALPHA = const Errors :: Alpha as u32"));
+        assert!(expanded.contains("ERR_BETA = const Errors :: Beta as u32"));
+        assert!(expanded.contains("ERR_GAMMA = const Errors :: Gamma as u32"));
+        assert!(expanded.contains("ERR_DELTA = const Errors :: Delta as u32"));
+    }
+
+    #[test]
+    fn test_error_enum_preserves_u32_discriminants() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            #[error_enum(prefix = "ERR")]
+            #[repr(u32)]
+            pub enum Errors {
+                Small = 7,
+                Large = 0x8000_0000,
+            }
+
+            asm { "" }
+            "#,
+        )
+        .unwrap();
+
+        let expanded = expand_asm_program(program).to_string();
+        assert!(expanded.contains("ERR_SMALL = const Errors :: Small as u32"));
+        assert!(expanded.contains("ERR_LARGE = const Errors :: Large as u32"));
+        assert!(!expanded.contains("Errors :: Large as i32"));
     }
 
     #[test]


### PR DESCRIPTION
Make `#[error_enum]` and `#[discriminant]` derive assembly constants from actual Rust enum discriminants instead of variant position.