### PR TITLE
fix(asm-v2): reject multiple asm blocks in asm_program

### DIFF
--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -81,6 +81,7 @@ impl Parse for AsmProgram {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut items = Vec::new();
         let mut asm_tokens = Vec::new();
+        let mut saw_asm = false;
 
         while !input.is_empty() {
             // Check for `asm { ... }` block
@@ -88,11 +89,18 @@ impl Parse for AsmProgram {
                 let lookahead = input.fork();
                 let ident: Ident = lookahead.parse()?;
                 if ident == "asm" {
+                    if saw_asm {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            "multiple `asm { ... }` blocks are not allowed",
+                        ));
+                    }
                     let _: Ident = input.parse()?;
                     let content;
                     braced!(content in input);
                     // Collect all tokens verbatim
                     asm_tokens = content.parse::<proc_macro2::TokenStream>()?.into_iter().collect();
+                    saw_asm = true;
                     continue;
                 }
             }
@@ -691,5 +699,21 @@ mod tests {
         assert!(expanded.contains("DISC_UPDATE = const Instruction :: Update as u32"));
         assert!(expanded.contains("DISC_CLOSE = const Instruction :: Close as u32"));
         assert!(expanded.contains("DISC_SWEEP = const Instruction :: Sweep as u32"));
+    }
+
+    #[test]
+    fn test_multiple_asm_blocks_are_rejected() {
+        let err = syn::parse_str::<AsmProgram>(
+            r#"
+            asm { "" }
+            asm { "" }
+            "#,
+        )
+        .err()
+        .expect("multiple asm blocks should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("multiple `asm { ... }` blocks are not allowed"));
     }
 }

--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -716,4 +716,20 @@ mod tests {
             .to_string()
             .contains("multiple `asm { ... }` blocks are not allowed"));
     }
+
+    #[test]
+    fn test_single_asm_block_is_accepted() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            pub struct Helper;
+
+            asm { include_str!("asm/errors.s"), }
+            "#,
+        )
+        .unwrap();
+
+        let asm_tokens = proc_macro2::TokenStream::from_iter(program.asm_tokens);
+        assert_eq!(program.items.len(), 1);
+        assert_eq!(asm_tokens.to_string(), "include_str ! (\"asm/errors.s\") ,");
+    }
 }

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -216,8 +216,8 @@ fn slab_realloc_shrink_refund_is_capped_by_available_lamports_above_new_floor() 
 }
 
 #[test]
-fn slab_realloc_shrink_with_self_payer_preserves_lamports_and_still_resizes() {
-    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+fn slab_realloc_shrink_with_self_payer_is_rejected() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
     let old_space = ITEMS_OFFSET + 4 * ITEM_SIZE;
     let new_space = ITEMS_OFFSET + ITEM_SIZE;
@@ -230,17 +230,21 @@ fn slab_realloc_shrink_with_self_payer_preserves_lamports_and_still_resizes() {
     let view = unsafe { buf.view() };
     let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
 
-    slab.realloc_account(new_space, payer_view, false).unwrap();
-
+    // #4692: realloc rejects payer == target before any resize / lamport
+    // transfer.
+    let err = slab
+        .realloc_account(new_space, payer_view, false)
+        .expect_err("realloc must reject using the target account as the payer");
+    assert_eq!(err, ProgramError::InvalidArgument);
     assert_eq!(
         slab.view().lamports(),
         old_required + vault_balance,
-        "when payer == account, shrinking should not burn lamports while refunding to self",
+        "rejected self-payer realloc must leave lamports unchanged",
     );
     assert_eq!(
         slab.current_space(),
-        new_space,
-        "self-payer shrink should still resize the account",
+        old_space,
+        "rejected self-payer realloc must leave account size unchanged",
     );
 }
 
@@ -436,9 +440,7 @@ fn swap_remove_panics_when_index_geq_effective_len() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
-)]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
     let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
 
@@ -448,9 +450,7 @@ fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
-)]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn resize_to_capacity_panics_when_loaded_read_only() {
     let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
 
@@ -599,9 +599,7 @@ fn refund_moves_excess_lamports_to_recipient() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
-)]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn refund_panics_when_loaded_read_only() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
@@ -641,9 +639,7 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Tried to mutate `Slab<H, T>` through a read-only load"
-)]
+#[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn top_up_panics_when_loaded_read_only() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 


### PR DESCRIPTION
Reject multiple `asm { ... }` blocks in a `single asm_program! `invocation to avoid ambiguous input handling. Adds tests for both duplicate-block rejection and valid single-block acceptance.