### PR TITLE
fix(asm-v2): correct asm_program include_str documentation

### DIFF
--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -745,4 +745,20 @@ mod tests {
         let asm_tokens = proc_macro2::TokenStream::from_iter(program.asm_tokens);
         assert_eq!(asm_tokens.to_string(), "include_str ! (\"asm/errors.s\") ,");
     }
+
+    #[test]
+    fn test_asm_block_accepts_include_str_concat_tokens() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            asm { include_str!(concat!(env!("OUT_DIR"), "/combined.s")), }
+            "#,
+        )
+        .unwrap();
+
+        let asm_tokens = proc_macro2::TokenStream::from_iter(program.asm_tokens);
+        assert_eq!(
+            asm_tokens.to_string(),
+            "include_str ! (concat ! (env ! (\"OUT_DIR\") , \"/combined.s\")) ,"
+        );
+    }
 }

--- a/asm-v2/macros/src/lib.rs
+++ b/asm-v2/macros/src/lib.rs
@@ -21,8 +21,8 @@
 //!     }
 //!
 //!     asm {
-//!         "asm/errors.s",
-//!         "asm/entrypoint.s",
+//!         include_str!("asm/errors.s"),
+//!         include_str!("asm/entrypoint.s"),
 //!     }
 //! }
 //! ```
@@ -730,6 +730,19 @@ mod tests {
 
         let asm_tokens = proc_macro2::TokenStream::from_iter(program.asm_tokens);
         assert_eq!(program.items.len(), 1);
+        assert_eq!(asm_tokens.to_string(), "include_str ! (\"asm/errors.s\") ,");
+    }
+
+    #[test]
+    fn test_asm_block_accepts_include_str_tokens() {
+        let program = syn::parse_str::<AsmProgram>(
+            r#"
+            asm { include_str!("asm/errors.s"), }
+            "#,
+        )
+        .unwrap();
+
+        let asm_tokens = proc_macro2::TokenStream::from_iter(program.asm_tokens);
         assert_eq!(asm_tokens.to_string(), "include_str ! (\"asm/errors.s\") ,");
     }
 }


### PR DESCRIPTION
Update the documented `asm_program! `example to pass assembly source text via `include_str!(...) `rather than a path string. Adds token-forwarding tests for both direct `include_str!` and the `OUT_DIR` concat form.