### PR TITLE
fix(asm-v2): narrow preamble attribute matching

### DIFF
--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -288,6 +288,11 @@ mod tests {
                 pub value: u64,
             }
 
+            #[account(zero_copy)]
+            pub struct MacroArgs {
+                pub value: u64,
+            }
+
             #[repr(C)]
             pub struct PlainPod {
                 pub value: u64,
@@ -297,6 +302,16 @@ mod tests {
             pub struct PackedPod {
                 pub value: u64,
             }
+
+            #[repr(transparent)]
+            pub struct TransparentPod {
+                pub value: u64,
+            }
+
+            #[repr(C, packed)]
+            pub struct MixedReprPod {
+                pub value: u64,
+            }
         "#;
         let tmp = std::env::temp_dir().join("anchor_asm_test_attrs.rs");
         std::fs::write(&tmp, source).unwrap();
@@ -304,7 +319,10 @@ mod tests {
         assert!(result.contains(".equ ZeroCopy__value, 0"));
         assert!(result.contains(".equ PlainPod__value, 0"));
         assert!(!result.contains("BorshBacked__value"));
+        assert!(!result.contains("MacroArgs__value"));
         assert!(!result.contains("PackedPod__value"));
+        assert!(!result.contains("TransparentPod__value"));
+        assert!(!result.contains("MixedReprPod__value"));
         std::fs::remove_file(tmp).ok();
     }
 }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -63,15 +63,17 @@ fn has_account_attr(s: &syn::ItemStruct) -> bool {
         .iter()
         .filter(|attr| attr.path().is_ident("account"))
         .collect();
-    if !account_attrs.is_empty() {
-        return account_attrs.len() == 1 && is_plain_account_attr(account_attrs[0]);
-    }
-
     let repr_attrs: Vec<_> = s
         .attrs
         .iter()
         .filter(|attr| attr.path().is_ident("repr"))
         .collect();
+
+    if !account_attrs.is_empty() {
+        return account_attrs.len() == 1
+            && is_plain_account_attr(account_attrs[0])
+            && repr_attrs.is_empty();
+    }
     repr_attrs.len() == 1 && is_exact_repr_c(repr_attrs[0])
 }
 
@@ -311,6 +313,24 @@ mod tests {
                 pub value: u64,
             }
 
+            #[account]
+            #[repr(C)]
+            pub struct ZeroCopyWithUserReprC {
+                pub value: u64,
+            }
+
+            #[account]
+            #[repr(packed)]
+            pub struct ZeroCopyPacked {
+                pub value: u64,
+            }
+
+            #[account]
+            #[repr(align(8))]
+            pub struct ZeroCopyAligned {
+                pub value: u64,
+            }
+
             #[repr(C)]
             pub struct PlainPod {
                 pub value: u64,
@@ -351,6 +371,9 @@ mod tests {
         assert!(!result.contains("BorshBacked__value"));
         assert!(!result.contains("MacroArgs__value"));
         assert!(!result.contains("BorshReprC__value"));
+        assert!(!result.contains("ZeroCopyWithUserReprC__value"));
+        assert!(!result.contains("ZeroCopyPacked__value"));
+        assert!(!result.contains("ZeroCopyAligned__value"));
         assert!(!result.contains("PackedPod__value"));
         assert!(!result.contains("TransparentPod__value"));
         assert!(!result.contains("MixedReprPod__value"));

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -58,9 +58,21 @@ pub fn generate(lib_rs: &Path) -> String {
 /// Check if a struct should have assembly constants generated.
 /// Matches `#[account]` (anchor v2) or `#[repr(C)]` (plain Pod).
 fn has_account_attr(s: &syn::ItemStruct) -> bool {
-    s.attrs
+    let account_attrs: Vec<_> = s
+        .attrs
         .iter()
-        .any(|attr| is_plain_account_attr(attr) || is_exact_repr_c(attr))
+        .filter(|attr| attr.path().is_ident("account"))
+        .collect();
+    if !account_attrs.is_empty() {
+        return account_attrs.len() == 1 && is_plain_account_attr(account_attrs[0]);
+    }
+
+    let repr_attrs: Vec<_> = s
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("repr"))
+        .collect();
+    repr_attrs.len() == 1 && is_exact_repr_c(repr_attrs[0])
 }
 
 fn is_plain_account_attr(attr: &syn::Attribute) -> bool {
@@ -293,6 +305,12 @@ mod tests {
                 pub value: u64,
             }
 
+            #[account(borsh)]
+            #[repr(C)]
+            pub struct BorshReprC {
+                pub value: u64,
+            }
+
             #[repr(C)]
             pub struct PlainPod {
                 pub value: u64,
@@ -312,6 +330,18 @@ mod tests {
             pub struct MixedReprPod {
                 pub value: u64,
             }
+
+            #[repr(C)]
+            #[repr(align(8))]
+            pub struct SplitAlignedPod {
+                pub value: u64,
+            }
+
+            #[repr(C)]
+            #[repr(packed)]
+            pub struct SplitPackedPod {
+                pub value: u64,
+            }
         "#;
         let tmp = std::env::temp_dir().join("anchor_asm_test_attrs.rs");
         std::fs::write(&tmp, source).unwrap();
@@ -320,9 +350,12 @@ mod tests {
         assert!(result.contains(".equ PlainPod__value, 0"));
         assert!(!result.contains("BorshBacked__value"));
         assert!(!result.contains("MacroArgs__value"));
+        assert!(!result.contains("BorshReprC__value"));
         assert!(!result.contains("PackedPod__value"));
         assert!(!result.contains("TransparentPod__value"));
         assert!(!result.contains("MixedReprPod__value"));
+        assert!(!result.contains("SplitAlignedPod__value"));
+        assert!(!result.contains("SplitPackedPod__value"));
         std::fs::remove_file(tmp).ok();
     }
 }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -58,11 +58,30 @@ pub fn generate(lib_rs: &Path) -> String {
 /// Check if a struct should have assembly constants generated.
 /// Matches `#[account]` (anchor v2) or `#[repr(C)]` (plain Pod).
 fn has_account_attr(s: &syn::ItemStruct) -> bool {
-    s.attrs.iter().any(|attr| {
-        let path = attr.path();
-        let last = path.segments.last().map(|s| s.ident.to_string());
-        matches!(last.as_deref(), Some("account" | "repr"))
-    })
+    s.attrs
+        .iter()
+        .any(|attr| is_plain_account_attr(attr) || is_exact_repr_c(attr))
+}
+
+fn is_plain_account_attr(attr: &syn::Attribute) -> bool {
+    matches!(&attr.meta, syn::Meta::Path(path) if path.is_ident("account"))
+}
+
+fn is_exact_repr_c(attr: &syn::Attribute) -> bool {
+    let syn::Meta::List(list) = &attr.meta else {
+        return false;
+    };
+    if !attr.path().is_ident("repr") {
+        return false;
+    }
+
+    let Ok(args) =
+        list.parse_args_with(syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated)
+    else {
+        return false;
+    };
+
+    args.len() == 1 && matches!(args.first(), Some(syn::Meta::Path(path)) if path.is_ident("C"))
 }
 
 /// Emit `.equ` constants for a single struct.
@@ -253,6 +272,39 @@ mod tests {
         // Address is 32 bytes, align 1
         assert!(result.contains(".equ Config__admin, 0"));
         assert!(result.contains(".equ Config__bump, 32"));
+        std::fs::remove_file(tmp).ok();
+    }
+
+    #[test]
+    fn test_account_attr_must_be_plain_or_exact_repr_c() {
+        let source = r#"
+            #[account]
+            pub struct ZeroCopy {
+                pub value: u64,
+            }
+
+            #[account(borsh)]
+            pub struct BorshBacked {
+                pub value: u64,
+            }
+
+            #[repr(C)]
+            pub struct PlainPod {
+                pub value: u64,
+            }
+
+            #[repr(packed)]
+            pub struct PackedPod {
+                pub value: u64,
+            }
+        "#;
+        let tmp = std::env::temp_dir().join("anchor_asm_test_attrs.rs");
+        std::fs::write(&tmp, source).unwrap();
+        let result = generate(&tmp);
+        assert!(result.contains(".equ ZeroCopy__value, 0"));
+        assert!(result.contains(".equ PlainPod__value, 0"));
+        assert!(!result.contains("BorshBacked__value"));
+        assert!(!result.contains("PackedPod__value"));
         std::fs::remove_file(tmp).ok();
     }
 }


### PR DESCRIPTION
Restrict preamble generation to plain `#[account]` and exact `#[repr(C)]` so layout constants are only emitted for supported layouts. 

Adds invalid-entry coverage for `#[account(borsh)]`, `#[account(...)]`, and unsupported repr forms.