### PR TITLE
fix(asm-v2): recurse through nested modules in preamble generatio

### DIFF
--- a/asm-v2/src/lib.rs
+++ b/asm-v2/src/lib.rs
@@ -79,7 +79,9 @@ macro_rules! include_asm {
 /// and writes the concatenated result to `$OUT_DIR/combined.s`.
 ///
 /// If `src/lib.rs` contains `#[repr(C)]` or `#[account]` structs,
-/// `.equ` constants for field offsets are prepended automatically.
+/// `.equ` constants for field offsets are prepended automatically. Any Rust
+/// modules parsed while generating that preamble are also registered as
+/// `cargo:rerun-if-changed` inputs.
 pub fn build(asm_dir: &str) {
     let manifest_dir = PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"),
@@ -90,11 +92,7 @@ pub fn build(asm_dir: &str) {
     let asm_path = manifest_dir.join(asm_dir);
     let lib_rs = manifest_dir.join("src").join("lib.rs");
 
-    let preamble = if lib_rs.exists() {
-        preamble::generate(&lib_rs)
-    } else {
-        String::new()
-    };
+    let (preamble, preamble_files) = preamble_for_build(&lib_rs);
 
     let combined = collect_asm(&asm_path);
 
@@ -107,8 +105,8 @@ pub fn build(asm_dir: &str) {
     std::fs::write(out_dir.join("combined.s"), output).expect("write combined.s");
 
     println!("cargo:rerun-if-changed={asm_dir}");
-    if lib_rs.exists() {
-        println!("cargo:rerun-if-changed=src/lib.rs");
+    for path in preamble_files {
+        println!("cargo:rerun-if-changed={}", path.display());
     }
 }
 
@@ -125,6 +123,14 @@ pub fn build_to(asm_dir: &Path, output_path: &Path) {
 // ---------------------------------------------------------------------------
 
 mod preamble;
+
+fn preamble_for_build(lib_rs: &Path) -> (String, Vec<PathBuf>) {
+    if lib_rs.exists() {
+        preamble::generate_tracked(lib_rs)
+    } else {
+        (String::new(), Vec::new())
+    }
+}
 
 fn collect_asm(dir: &Path) -> String {
     let mut files: Vec<PathBuf> = Vec::new();
@@ -215,5 +221,63 @@ fn walk_dir(dir: &Path, out: &mut Vec<PathBuf>) {
         } else if path.extension().and_then(|e| e.to_str()) == Some("s") {
             out.push(path);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("anchor-asm-v2-lib-{name}-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_preamble_for_build_tracks_nested_module_files() {
+        let dir = temp_test_dir("tracked-preamble");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let lib_rs = src_dir.join("lib.rs");
+        let state_rs = src_dir.join("state.rs");
+        let custom_rs = src_dir.join("custom.rs");
+
+        std::fs::write(&lib_rs, "mod state;\n").unwrap();
+        std::fs::write(
+            &state_rs,
+            r#"
+            #[path = "custom.rs"]
+            mod child;
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            &custom_rs,
+            r#"
+            #[repr(C)]
+            pub struct BuildTracked {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let (preamble, tracked_files) = preamble_for_build(&lib_rs);
+        assert!(preamble.contains(".equ BuildTracked__value, 0"));
+
+        let canon = |path: &Path| std::fs::canonicalize(path).unwrap();
+        assert!(tracked_files.contains(&canon(&lib_rs)));
+        assert!(tracked_files.contains(&canon(&state_rs)));
+        assert!(tracked_files.contains(&canon(&custom_rs)));
+
+        std::fs::remove_dir_all(dir).ok();
     }
 }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -17,10 +17,21 @@ use std::{
 use syn::{Meta, Token, punctuated::Punctuated};
 
 /// Parse `lib.rs` and generate `.equ` preamble for all `#[account]` structs.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn generate(lib_rs: &Path) -> String {
+    generate_tracked(lib_rs).0
+}
+
+/// Like [`generate`], but also returns every Rust source file that was parsed
+/// while walking the module tree. Callers can use the returned paths to emit
+/// `cargo:rerun-if-changed=` directives.
+pub(crate) fn generate_tracked(lib_rs: &Path) -> (String, Vec<PathBuf>) {
     let root_dir = lib_rs.parent().unwrap_or_else(|| Path::new("."));
     let mut visited = HashSet::new();
-    generate_file(lib_rs, root_dir, &mut visited)
+    let output = generate_file(lib_rs, root_dir, &mut visited);
+    let mut visited_files: Vec<_> = visited.into_iter().collect();
+    visited_files.sort();
+    (output, visited_files)
 }
 
 fn generate_file(path: &Path, module_dir: &Path, visited: &mut HashSet<PathBuf>) -> String {
@@ -841,6 +852,44 @@ mod tests {
 
         let result = generate(&lib_rs);
         assert!(result.contains(".equ InlinePathState__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_generate_tracks_nested_module_dependencies() {
+        let dir = temp_test_dir("tracked-deps");
+        let lib_rs = dir.join("lib.rs");
+        let state_rs = dir.join("state.rs");
+        let custom_rs = dir.join("custom.rs");
+
+        std::fs::write(&lib_rs, "mod state;\n").unwrap();
+        std::fs::write(
+            &state_rs,
+            r#"
+            #[path = "custom.rs"]
+            mod child;
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            &custom_rs,
+            r#"
+            #[repr(C)]
+            pub struct NestedTracked {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let (result, visited_files) = generate_tracked(&lib_rs);
+        assert!(result.contains(".equ NestedTracked__value, 0"));
+
+        let canon = |path: &Path| std::fs::canonicalize(path).unwrap();
+        assert!(visited_files.contains(&canon(&lib_rs)));
+        assert!(visited_files.contains(&canon(&state_rs)));
+        assert!(visited_files.contains(&canon(&custom_rs)));
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -10,49 +10,80 @@
 //! enforces via bytemuck Pod). Fields must be primitive numeric types or
 //! fixed-size arrays of them — no generics, no references.
 
-use std::path::Path;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 /// Parse `lib.rs` and generate `.equ` preamble for all `#[account]` structs.
 pub fn generate(lib_rs: &Path) -> String {
-    let source = std::fs::read_to_string(lib_rs)
-        .unwrap_or_else(|e| panic!("read {}: {e}", lib_rs.display()));
+    let root_dir = lib_rs.parent().unwrap_or_else(|| Path::new("."));
+    let mut visited = HashSet::new();
+    generate_file(lib_rs, root_dir, &mut visited)
+}
+
+fn generate_file(path: &Path, module_dir: &Path, visited: &mut HashSet<PathBuf>) -> String {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical) {
+        return String::new();
+    }
+
+    let source = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     let file = match syn::parse_file(&source) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("anchor-asm: warning: can't parse {}: {e}", lib_rs.display());
+            eprintln!("anchor-asm: warning: can't parse {}: {e}", path.display());
             return String::new();
         }
     };
 
     let mut out = String::new();
+    visit_items(&file.items, module_dir, visited, &mut out);
+    out
+}
 
-    for item in &file.items {
-        // Also check mod items for structs defined in submodules
-        // that are inlined with `mod foo { ... }`.
+fn visit_items(
+    items: &[syn::Item],
+    module_dir: &Path,
+    visited: &mut HashSet<PathBuf>,
+    out: &mut String,
+) {
+    for item in items {
         match item {
             syn::Item::Struct(s) if has_account_attr(s) => {
                 if let Some(block) = emit_struct(s) {
                     out.push_str(&block);
                 }
             }
-            syn::Item::Mod(m) => {
-                if let Some((_, items)) = &m.content {
-                    for item in items {
-                        if let syn::Item::Struct(s) = item {
-                            if has_account_attr(s) {
-                                if let Some(block) = emit_struct(s) {
-                                    out.push_str(&block);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            syn::Item::Mod(m) => visit_module(m, module_dir, visited, out),
             _ => {}
         }
     }
+}
 
-    out
+fn visit_module(
+    module: &syn::ItemMod,
+    module_dir: &Path,
+    visited: &mut HashSet<PathBuf>,
+    out: &mut String,
+) {
+    let child_dir = module_dir.join(module.ident.to_string());
+    if let Some((_, items)) = &module.content {
+        visit_items(items, &child_dir, visited, out);
+    } else if let Some(path) = resolve_module_file(module_dir, &module.ident.to_string()) {
+        out.push_str(&generate_file(&path, &child_dir, visited));
+    }
+}
+
+fn resolve_module_file(module_dir: &Path, module_name: &str) -> Option<PathBuf> {
+    let file = module_dir.join(format!("{module_name}.rs"));
+    if file.exists() {
+        return Some(file);
+    }
+
+    let mod_rs = module_dir.join(module_name).join("mod.rs");
+    mod_rs.exists().then_some(mod_rs)
 }
 
 /// Check if a struct should have assembly constants generated.
@@ -250,6 +281,18 @@ fn align_up(offset: usize, align: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("anchor-asm-v2-{name}-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
 
     #[test]
     fn test_simple_struct() {
@@ -380,5 +423,59 @@ mod tests {
         assert!(!result.contains("SplitAlignedPod__value"));
         assert!(!result.contains("SplitPackedPod__value"));
         std::fs::remove_file(tmp).ok();
+    }
+
+    #[test]
+    fn test_generate_recurses_inline_and_file_backed_modules() {
+        let dir = temp_test_dir("mods");
+        let lib_rs = dir.join("lib.rs");
+        let outer_dir = dir.join("outer");
+        std::fs::create_dir_all(&outer_dir).unwrap();
+
+        std::fs::write(
+            &lib_rs,
+            r#"
+            mod outer {
+                pub mod inline_leaf {
+                    #[account]
+                    pub struct NestedInline {
+                        pub value: u64,
+                    }
+                }
+
+                pub mod file_leaf;
+            }
+
+            mod state;
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            outer_dir.join("file_leaf.rs"),
+            r#"
+            #[repr(C)]
+            pub struct NestedFile {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("state.rs"),
+            r#"
+            #[account]
+            pub struct RootFile {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let result = generate(&lib_rs);
+        assert!(result.contains(".equ NestedInline__value, 0"));
+        assert!(result.contains(".equ NestedFile__value, 0"));
+        assert!(result.contains(".equ RootFile__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
     }
 }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -478,4 +478,29 @@ mod tests {
 
         std::fs::remove_dir_all(dir).ok();
     }
+
+    #[test]
+    fn test_generate_resolves_mod_rs_modules() {
+        let dir = temp_test_dir("mod-rs");
+        let lib_rs = dir.join("lib.rs");
+        let outer_dir = dir.join("outer");
+        std::fs::create_dir_all(&outer_dir).unwrap();
+
+        std::fs::write(&lib_rs, "mod outer;\n").unwrap();
+        std::fs::write(
+            outer_dir.join("mod.rs"),
+            r#"
+            #[repr(C)]
+            pub struct NestedFromModRs {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let result = generate(&lib_rs);
+        assert!(result.contains(".equ NestedFromModRs__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
 }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -40,12 +40,14 @@ fn generate_file(path: &Path, module_dir: &Path, visited: &mut HashSet<PathBuf>)
     };
 
     let mut out = String::new();
-    visit_items(&file.items, module_dir, visited, &mut out);
+    let source_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    visit_items(&file.items, source_dir, module_dir, visited, &mut out);
     out
 }
 
 fn visit_items(
     items: &[syn::Item],
+    source_dir: &Path,
     module_dir: &Path,
     visited: &mut HashSet<PathBuf>,
     out: &mut String,
@@ -57,7 +59,9 @@ fn visit_items(
                     out.push_str(&block);
                 }
             }
-            syn::Item::Mod(m) if cfg_enabled(&m.attrs) => visit_module(m, module_dir, visited, out),
+            syn::Item::Mod(m) if cfg_enabled(&m.attrs) => {
+                visit_module(m, source_dir, module_dir, visited, out)
+            }
             _ => {}
         }
     }
@@ -65,34 +69,64 @@ fn visit_items(
 
 fn visit_module(
     module: &syn::ItemMod,
+    source_dir: &Path,
     module_dir: &Path,
     visited: &mut HashSet<PathBuf>,
     out: &mut String,
 ) {
-    let child_dir = module_dir.join(module.ident.to_string());
     if let Some((_, items)) = &module.content {
-        visit_items(items, &child_dir, visited, out);
-    } else if let Some(path) = resolve_module_file(module_dir, module) {
+        let child_dir = inline_module_dir(source_dir, module_dir, module);
+        visit_items(items, &child_dir, &child_dir, visited, out);
+    } else if let Some((path, child_dir)) = resolve_module_file(source_dir, module_dir, module) {
         out.push_str(&generate_file(&path, &child_dir, visited));
     }
 }
 
-fn resolve_module_file(module_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf> {
-    if let Some(path) = module_path_attr(module_dir, module) {
-        return path.exists().then_some(path);
+fn inline_module_dir(source_dir: &Path, module_dir: &Path, module: &syn::ItemMod) -> PathBuf {
+    module_path_attr(source_dir, module)
+        .map(|path| explicit_module_dir(&path))
+        .unwrap_or_else(|| module_dir.join(module.ident.to_string()))
+}
+
+fn resolve_module_file(
+    source_dir: &Path,
+    module_dir: &Path,
+    module: &syn::ItemMod,
+) -> Option<(PathBuf, PathBuf)> {
+    if let Some(path) = module_path_attr(source_dir, module) {
+        return (path.exists() && path.is_file()).then(|| {
+            let child_dir = explicit_module_dir(&path);
+            (path, child_dir)
+        });
     }
 
     let module_name = module.ident.to_string();
     let file = module_dir.join(format!("{module_name}.rs"));
     if file.exists() {
-        return Some(file);
+        return Some((file, module_dir.join(module_name)));
     }
 
     let mod_rs = module_dir.join(module_name).join("mod.rs");
-    mod_rs.exists().then_some(mod_rs)
+    if mod_rs.exists() {
+        let child_dir = mod_rs
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        Some((mod_rs, child_dir))
+    } else {
+        None
+    }
 }
 
-fn module_path_attr(module_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf> {
+fn explicit_module_dir(path: &Path) -> PathBuf {
+    if path.is_dir() || path.extension().is_none() {
+        path.to_path_buf()
+    } else {
+        path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf()
+    }
+}
+
+fn module_path_attr(source_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf> {
     module
         .attrs
         .iter()
@@ -113,7 +147,7 @@ fn module_path_attr(module_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf>
             Some(path.value())
         })
         .map(PathBuf::from)
-        .map(|path| if path.is_absolute() { path } else { module_dir.join(path) })
+        .map(|path| if path.is_absolute() { path } else { source_dir.join(path) })
 }
 
 /// Check if a struct should have assembly constants generated.
@@ -741,6 +775,72 @@ mod tests {
 
         let result = generate(&lib_rs);
         assert!(result.contains(".equ PathAttrState__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_generate_resolves_path_attr_relative_to_non_mod_rs_declaring_file() {
+        let dir = temp_test_dir("path-attr-non-mod-rs");
+        let lib_rs = dir.join("lib.rs");
+
+        std::fs::write(&lib_rs, "mod state;\n").unwrap();
+        std::fs::write(
+            dir.join("state.rs"),
+            r#"
+            #[path = "custom.rs"]
+            mod child;
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("custom.rs"),
+            r#"
+            #[repr(C)]
+            pub struct CustomState {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let result = generate(&lib_rs);
+        assert!(result.contains(".equ CustomState__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_generate_resolves_nested_path_attrs_inside_inline_path_modules() {
+        let dir = temp_test_dir("inline-path-attr");
+        let lib_rs = dir.join("lib.rs");
+        let thread_files_dir = dir.join("thread_files");
+        std::fs::create_dir_all(&thread_files_dir).unwrap();
+
+        std::fs::write(
+            &lib_rs,
+            r#"
+            #[path = "thread_files"]
+            mod thread {
+                #[path = "tls.rs"]
+                mod local_data;
+            }
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            thread_files_dir.join("tls.rs"),
+            r#"
+            #[repr(C)]
+            pub struct InlinePathState {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let result = generate(&lib_rs);
+        assert!(result.contains(".equ InlinePathState__value, 0"));
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -441,6 +441,12 @@ mod tests {
                     pub struct NestedInline {
                         pub value: u64,
                     }
+
+                    #[account]
+                    #[repr(packed)]
+                    pub struct NestedPacked {
+                        pub value: u64,
+                    }
                 }
 
                 pub mod file_leaf;
@@ -455,6 +461,11 @@ mod tests {
             r#"
             #[repr(C)]
             pub struct NestedFile {
+                pub value: u64,
+            }
+
+            #[account(borsh)]
+            pub struct NestedBorsh {
                 pub value: u64,
             }
             "#,
@@ -475,6 +486,8 @@ mod tests {
         assert!(result.contains(".equ NestedInline__value, 0"));
         assert!(result.contains(".equ NestedFile__value, 0"));
         assert!(result.contains(".equ RootFile__value, 0"));
+        assert!(!result.contains("NestedPacked__value"));
+        assert!(!result.contains("NestedBorsh__value"));
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/asm-v2/src/preamble.rs
+++ b/asm-v2/src/preamble.rs
@@ -14,6 +14,7 @@ use std::{
     collections::HashSet,
     path::{Path, PathBuf},
 };
+use syn::{Meta, Token, punctuated::Punctuated};
 
 /// Parse `lib.rs` and generate `.equ` preamble for all `#[account]` structs.
 pub fn generate(lib_rs: &Path) -> String {
@@ -51,12 +52,12 @@ fn visit_items(
 ) {
     for item in items {
         match item {
-            syn::Item::Struct(s) if has_account_attr(s) => {
+            syn::Item::Struct(s) if cfg_enabled(&s.attrs) && has_account_attr(s) => {
                 if let Some(block) = emit_struct(s) {
                     out.push_str(&block);
                 }
             }
-            syn::Item::Mod(m) => visit_module(m, module_dir, visited, out),
+            syn::Item::Mod(m) if cfg_enabled(&m.attrs) => visit_module(m, module_dir, visited, out),
             _ => {}
         }
     }
@@ -71,12 +72,17 @@ fn visit_module(
     let child_dir = module_dir.join(module.ident.to_string());
     if let Some((_, items)) = &module.content {
         visit_items(items, &child_dir, visited, out);
-    } else if let Some(path) = resolve_module_file(module_dir, &module.ident.to_string()) {
+    } else if let Some(path) = resolve_module_file(module_dir, module) {
         out.push_str(&generate_file(&path, &child_dir, visited));
     }
 }
 
-fn resolve_module_file(module_dir: &Path, module_name: &str) -> Option<PathBuf> {
+fn resolve_module_file(module_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf> {
+    if let Some(path) = module_path_attr(module_dir, module) {
+        return path.exists().then_some(path);
+    }
+
+    let module_name = module.ident.to_string();
     let file = module_dir.join(format!("{module_name}.rs"));
     if file.exists() {
         return Some(file);
@@ -84,6 +90,30 @@ fn resolve_module_file(module_dir: &Path, module_name: &str) -> Option<PathBuf> 
 
     let mod_rs = module_dir.join(module_name).join("mod.rs");
     mod_rs.exists().then_some(mod_rs)
+}
+
+fn module_path_attr(module_dir: &Path, module: &syn::ItemMod) -> Option<PathBuf> {
+    module
+        .attrs
+        .iter()
+        .find_map(|attr| {
+            let Meta::NameValue(nv) = &attr.meta else {
+                return None;
+            };
+            if !nv.path.is_ident("path") {
+                return None;
+            }
+            let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(path),
+                ..
+            }) = &nv.value
+            else {
+                return None;
+            };
+            Some(path.value())
+        })
+        .map(PathBuf::from)
+        .map(|path| if path.is_absolute() { path } else { module_dir.join(path) })
 }
 
 /// Check if a struct should have assembly constants generated.
@@ -129,6 +159,85 @@ fn is_exact_repr_c(attr: &syn::Attribute) -> bool {
     args.len() == 1 && matches!(args.first(), Some(syn::Meta::Path(path)) if path.is_ident("C"))
 }
 
+fn cfg_enabled(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().filter(|attr| attr.path().is_ident("cfg")).all(eval_cfg_attr)
+}
+
+fn eval_cfg_attr(attr: &syn::Attribute) -> bool {
+    let Ok(meta) = attr.parse_args::<Meta>() else {
+        return false;
+    };
+    eval_cfg_meta(&meta)
+}
+
+fn eval_cfg_meta(meta: &Meta) -> bool {
+    match meta {
+        Meta::Path(path) => path
+            .get_ident()
+            .map(|ident| cfg_flag_is_set(&ident.to_string()))
+            .unwrap_or(false),
+        Meta::NameValue(nv) => {
+            let Some(key) = nv.path.get_ident().map(|ident| ident.to_string()) else {
+                return false;
+            };
+            let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(value),
+                ..
+            }) = &nv.value
+            else {
+                return false;
+            };
+            cfg_key_matches(&key, &value.value())
+        }
+        Meta::List(list) if list.path.is_ident("all") => parse_cfg_list(list)
+            .map(|items| items.iter().all(eval_cfg_meta))
+            .unwrap_or(false),
+        Meta::List(list) if list.path.is_ident("any") => parse_cfg_list(list)
+            .map(|items| items.iter().any(eval_cfg_meta))
+            .unwrap_or(false),
+        Meta::List(list) if list.path.is_ident("not") => parse_cfg_list(list)
+            .map(|items| items.len() == 1 && !eval_cfg_meta(&items[0]))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn parse_cfg_list(list: &syn::MetaList) -> Option<Vec<Meta>> {
+    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .ok()
+        .map(|items| items.into_iter().collect())
+}
+
+fn cfg_flag_is_set(flag: &str) -> bool {
+    let env_key = format!("CARGO_CFG_{}", cfg_env_name(flag));
+    std::env::var_os(&env_key).is_some()
+}
+
+fn cfg_key_matches(key: &str, value: &str) -> bool {
+    if key == "feature" {
+        let feature_key = format!("CARGO_FEATURE_{}", cfg_env_name(value));
+        if std::env::var_os(&feature_key).is_some() {
+            return true;
+        }
+    }
+
+    let env_key = format!("CARGO_CFG_{}", cfg_env_name(key));
+    let Some(raw) = std::env::var_os(&env_key) else {
+        return false;
+    };
+    raw.to_string_lossy()
+        .split(',')
+        .any(|entry| entry == value)
+}
+
+fn cfg_env_name(value: &str) -> String {
+    value
+        .replace('-', "_")
+        .chars()
+        .flat_map(|ch| ch.to_uppercase())
+        .collect()
+}
+
 /// Emit `.equ` constants for a single struct.
 fn emit_struct(s: &syn::ItemStruct) -> Option<String> {
     let name = &s.ident;
@@ -150,6 +259,10 @@ fn emit_struct(s: &syn::ItemStruct) -> Option<String> {
     let mut max_align: usize = 1;
 
     for field in fields {
+        if !cfg_enabled(&field.attrs) {
+            continue;
+        }
+
         let field_name = field.ident.as_ref()?;
 
         // Skip fields starting with _ (padding).
@@ -281,7 +394,15 @@ fn align_up(offset: usize, align: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::{Mutex, OnceLock},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
 
     fn temp_test_dir(name: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -292,6 +413,23 @@ mod tests {
             std::env::temp_dir().join(format!("anchor-asm-v2-{name}-{}-{unique}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn with_env_var<F>(key: &str, value: Option<&str>, f: F)
+    where
+        F: FnOnce(),
+    {
+        let _guard = env_lock();
+        let previous = std::env::var_os(key);
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+        f();
+        match previous {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 
     #[test]
@@ -426,6 +564,39 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_respects_cfg_gated_fields() {
+        let source = r#"
+            #[repr(C)]
+            pub struct CfgFieldLayout {
+                pub tag: u8,
+                #[cfg(feature = "asm_cfg_field")]
+                pub gated: u64,
+                pub bump: u8,
+            }
+        "#;
+        let tmp = std::env::temp_dir().join("anchor_asm_test_cfg_field.rs");
+        std::fs::write(&tmp, source).unwrap();
+
+        with_env_var("CARGO_FEATURE_ASM_CFG_FIELD", None, || {
+            let result = generate(&tmp);
+            assert!(result.contains(".equ CfgFieldLayout__tag, 0"));
+            assert!(result.contains(".equ CfgFieldLayout__bump, 1"));
+            assert!(result.contains(".equ CfgFieldLayout__SIZE, 2"));
+            assert!(!result.contains("CfgFieldLayout__gated"));
+        });
+
+        with_env_var("CARGO_FEATURE_ASM_CFG_FIELD", Some("1"), || {
+            let result = generate(&tmp);
+            assert!(result.contains(".equ CfgFieldLayout__tag, 0"));
+            assert!(result.contains(".equ CfgFieldLayout__gated, 8"));
+            assert!(result.contains(".equ CfgFieldLayout__bump, 16"));
+            assert!(result.contains(".equ CfgFieldLayout__SIZE, 24"));
+        });
+
+        std::fs::remove_file(tmp).ok();
+    }
+
+    #[test]
     fn test_generate_recurses_inline_and_file_backed_modules() {
         let dir = temp_test_dir("mods");
         let lib_rs = dir.join("lib.rs");
@@ -493,6 +664,38 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_respects_cfg_on_nested_modules() {
+        let dir = temp_test_dir("cfg-mod");
+        let lib_rs = dir.join("lib.rs");
+
+        std::fs::write(
+            &lib_rs,
+            r#"
+            #[cfg(feature = "asm_cfg_module")]
+            mod gated {
+                #[account]
+                pub struct NestedEnabled {
+                    pub value: u64,
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        with_env_var("CARGO_FEATURE_ASM_CFG_MODULE", None, || {
+            let result = generate(&lib_rs);
+            assert!(!result.contains("NestedEnabled__value"));
+        });
+
+        with_env_var("CARGO_FEATURE_ASM_CFG_MODULE", Some("1"), || {
+            let result = generate(&lib_rs);
+            assert!(result.contains(".equ NestedEnabled__value, 0"));
+        });
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
     fn test_generate_resolves_mod_rs_modules() {
         let dir = temp_test_dir("mod-rs");
         let lib_rs = dir.join("lib.rs");
@@ -513,6 +716,31 @@ mod tests {
 
         let result = generate(&lib_rs);
         assert!(result.contains(".equ NestedFromModRs__value, 0"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_generate_resolves_path_attr_modules() {
+        let dir = temp_test_dir("path-attr");
+        let lib_rs = dir.join("lib.rs");
+        let alt_dir = dir.join("alt");
+        std::fs::create_dir_all(&alt_dir).unwrap();
+
+        std::fs::write(&lib_rs, "#[path = \"alt/custom_state.rs\"] mod state;\n").unwrap();
+        std::fs::write(
+            alt_dir.join("custom_state.rs"),
+            r#"
+            #[repr(C)]
+            pub struct PathAttrState {
+                pub value: u64,
+            }
+            "#,
+        )
+        .unwrap();
+
+        let result = generate(&lib_rs);
+        assert!(result.contains(".equ PathAttrState__value, 0"));
 
         std::fs::remove_dir_all(dir).ok();
     }


### PR DESCRIPTION
**Finding**
Preamble generation only walked `src/lib.rs`, so nested inline and file-backed modules could be skipped. It also only watched `src/lib.rs`, so edits in nested module files could leave stale `.equ` offsets in `combined.s`.

**Fix**
This PR recursively walks nested modules, resolves `#[path]` modules, respects `#[cfg]`, and tracks every parsed Rust file with `rerun-if-changed` so nested edits rebuild the preamble. Also adds regression tests for nested modules and rebuild tracking.