### PR TITLE
cli: make init template MSRV-aware via .cargo/config.toml (#4770)

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -18,7 +18,7 @@ use {
     },
 };
 
-const ANCHOR_MSRV: &str = "1.89.0";
+const ANCHOR_MSRV: &str = "1.84.0";
 const ANCHOR_V2_TEMPLATE_VERSION: &str = "2.0.0";
 
 /// Anchor template version to generate.
@@ -52,6 +52,7 @@ pub fn create_program(
     let lib_rs_path = program_path.join("src").join("lib.rs");
     let common_files = vec![
         ("Cargo.toml".into(), workspace_manifest()),
+        (".cargo/config.toml".into(), cargo_config()),
         ("rust-toolchain.toml".into(), rust_toolchain_toml()),
         (
             program_path.join("Cargo.toml"),
@@ -547,6 +548,14 @@ pub struct Counter {
             .into(),
         ),
     ]
+}
+
+/// Cargo config enabling MSRV-aware dependency resolution.
+fn cargo_config() -> String {
+    r#"[resolver]
+incompatible-rust-versions = "fallback"
+"#
+    .into()
 }
 
 fn workspace_manifest() -> String {


### PR DESCRIPTION
Fixes #4770.

A fresh `anchor init` project fails `anchor build` because transitive deps now ship `edition2024` (rustc 1.85+) releases, while platform-tools is frozen at rustc 1.84.1. The generated workspace didn't steer cargo away from those versions, producing a cascade of `feature 'edition2024' is required` / `requires rustc 1.85.0` errors.

This makes `anchor init` emit MSRV-aware dependency resolution keyed to the platform-tools rustc:

- New generated **`.cargo/config.toml`** with `[resolver]` `incompatible-rust-versions = "fallback"`, so cargo avoids versions requiring a newer rustc than the declared MSRV.
- **`ANCHOR_MSRV` `"1.89.0"` → `"1.84.0"`** to match the rustc shipped by platform-tools (feeds `[workspace.package] rust-version`, which the program crate already inherits via `rust-version.workspace = true`).

Both are stable as of cargo 1.84 (what platform-tools ships), so no toolchain bump is needed. Both are required together: fallback resolution only helps once the MSRV reflects the real 1.84 toolchain.

The config lives in `.cargo/config.toml` rather than `resolver = "3"` in `Cargo.toml` on purpose — Anchor's own manifest parser only accepts resolver `1`/`2`, so `resolver = "3"` breaks `anchor build` before cargo runs.

Verified: a fresh `anchor init` project with these changes builds out of the box (no manual pins), and `cargo tree -i toml_datetime` resolves to the pre-`edition2024` `0.6.x` line. This self-heals once platform-tools ships a newer rustc (bump `ANCHOR_MSRV` accordingly).
