### PR TITLE
Add NO_DNA support to Anchor CLI

### DIFF
--- a/cli/src/legacy_idl.rs
+++ b/cli/src/legacy_idl.rs
@@ -9,7 +9,7 @@ use {
         abs_path::AbsolutePath,
         cluster_url,
         config::{Config, ConfigOverride, WithPath},
-        create_client, prepend_compute_unit_ix, with_workspace,
+        create_client, no_dna_enabled, prepend_compute_unit_ix, with_workspace,
     },
     anchor_cli_macros::AbsolutePath,
     anchor_lang::{
@@ -17,7 +17,7 @@ use {
         AccountDeserialize, AnchorDeserialize, AnchorSerialize, Discriminator,
     },
     anchor_lang_idl::types::Idl,
-    anyhow::{anyhow, Result},
+    anyhow::{anyhow, bail, Result},
     clap::Parser,
     flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression},
     solana_instruction::{AccountMeta, Instruction},
@@ -33,6 +33,13 @@ use {
 ///
 /// These commands interact with the old Anchor IDL instruction protocol stored
 /// on-chain. They will be removed in a future Anchor release.
+const NO_DNA_LEGACY_IDL_ERASE_AUTHORITY_HELP: &str =
+    "NO_DNA disables the interactive confirmation. Pass --bypass-warning explicitly to erase the \
+     IDL authority non-interactively.";
+const NO_DNA_LEGACY_IDL_ERASE_AUTHORITY_ERROR: &str =
+    "Cannot prompt for confirmation because NO_DNA is set. Re-run with --bypass-warning to erase \
+     the IDL authority.";
+
 #[derive(Debug, Parser, AbsolutePath)]
 pub enum LegacyIdlCommand {
     /// [DEPRECATED] Close the legacy IDL account and recover rent.
@@ -86,9 +93,13 @@ pub enum LegacyIdlCommand {
         priority_fee: Option<u64>,
     },
     /// [DEPRECATED] Remove the ability to modify the legacy IDL account.
+    #[clap(after_help = NO_DNA_LEGACY_IDL_ERASE_AUTHORITY_HELP)]
     EraseAuthority {
         #[clap(short, long)]
         program_id: Pubkey,
+        /// Bypass warning prompts
+        #[clap(long)]
+        bypass_warning: bool,
         #[clap(long)]
         priority_fee: Option<u64>,
     },
@@ -184,8 +195,9 @@ pub fn handle_legacy_idl_command(
         ),
         LegacyIdlCommand::EraseAuthority {
             program_id,
+            bypass_warning,
             priority_fee,
-        } => idl_erase_authority(cfg_override, program_id, priority_fee),
+        } => idl_erase_authority(cfg_override, program_id, bypass_warning, priority_fee),
         LegacyIdlCommand::Authority { program_id } => idl_authority(cfg_override, program_id),
         LegacyIdlCommand::Init {
             program_id,
@@ -480,17 +492,21 @@ fn idl_set_authority(
 fn idl_erase_authority(
     cfg_override: &ConfigOverride,
     program_id: Pubkey,
+    bypass_warning: bool,
     priority_fee: Option<u64>,
 ) -> Result<()> {
-    println!("Are you sure you want to erase the IDL authority: [y/n]");
+    if should_prompt_for_idl_erase_authority(no_dna_enabled(), bypass_warning)? {
+        println!("Are you sure you want to erase the IDL authority: [y/n]");
 
-    let stdin = std::io::stdin();
-    let mut stdin_lines = stdin.lock().lines();
-    let input = stdin_lines.next().unwrap().unwrap();
-    if input != "y" {
-        println!("Not erasing.");
-        return Ok(());
+        let stdin = std::io::stdin();
+        let mut stdin_lines = stdin.lock().lines();
+        let input = stdin_lines.next().unwrap().unwrap();
+        if input != "y" {
+            println!("Not erasing.");
+            return Ok(());
+        }
     }
+
     idl_set_authority(
         cfg_override,
         program_id,
@@ -499,6 +515,19 @@ fn idl_erase_authority(
         false,
         priority_fee,
     )
+}
+
+fn should_prompt_for_idl_erase_authority(
+    no_dna_enabled: bool,
+    bypass_warning: bool,
+) -> Result<bool> {
+    if bypass_warning {
+        return Ok(false);
+    }
+    if no_dna_enabled {
+        bail!(NO_DNA_LEGACY_IDL_ERASE_AUTHORITY_ERROR);
+    }
+    Ok(true)
 }
 
 fn idl_close_account(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -137,10 +137,6 @@ fn command_output(command: &str, args: &[&str]) -> Option<String> {
         .filter(|line| !line.is_empty())
 }
 
-fn env_var_present(value: Option<&str>) -> bool {
-    value.is_some_and(|value| !value.trim().is_empty())
-}
-
 pub(crate) fn no_dna_enabled() -> bool {
     std::env::var(NO_DNA_ENV).is_ok()
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -141,16 +141,6 @@ pub(crate) fn no_dna_enabled() -> bool {
     std::env::var(NO_DNA_ENV).is_ok()
 }
 
-pub(crate) fn propagate_no_dna(
-    cmd: &mut std::process::Command,
-    enabled: bool,
-) -> &mut std::process::Command {
-    if enabled {
-        cmd.env(NO_DNA_ENV, "1");
-    }
-    cmd
-}
-
 fn os_version() -> String {
     #[cfg(target_os = "macos")]
     if let Some(version) = macos_version() {
@@ -4658,9 +4648,7 @@ fn run_test_suite(
         };
         let cmd = cmd.clone();
         let script_args = format!("{cmd} {}", extra_args.join(" "));
-        let mut command = std::process::Command::new("bash");
-        propagate_no_dna(&mut command, no_dna_enabled());
-        command
+        std::process::Command::new("bash")
             .arg("-c")
             .arg(script_args)
             .env("ANCHOR_PROVIDER_URL", url)
@@ -5705,9 +5693,7 @@ fn start_surfpool_validator(
         false => Stdio::null(),
     };
 
-    let mut validator_command = std::process::Command::new("surfpool");
-    propagate_no_dna(&mut validator_command, no_dna_enabled());
-    let mut validator_handle = validator_command
+    let mut validator_handle = std::process::Command::new("surfpool")
         .arg("start")
         .args(flags.unwrap_or_default())
         .stdout(test_validator_stdout)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -79,7 +79,7 @@ pub const DOCKER_BUILDER_VERSION: &str = VERSION;
 /// Default RPC port
 pub const DEFAULT_RPC_PORT: u16 = 8899;
 const DEFAULT_FAUCET_PORT: u16 = 9900;
-/// Environment variable for NO_DNA mode & Relevent Help Messages.
+/// Environment variable for NO_DNA mode & relevant help messages.
 pub(crate) const NO_DNA_ENV: &str = "NO_DNA";
 const NO_DNA_TOP_LEVEL_HELP: &str =
     "Set NO_DNA=1 when running Anchor in CI, scripts, or AI agents. This disables supported \
@@ -4648,6 +4648,7 @@ fn run_test_suite(
         };
         let cmd = cmd.clone();
         let script_args = format!("{cmd} {}", extra_args.join(" "));
+
         std::process::Command::new("bash")
             .arg("-c")
             .arg(script_args)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -138,7 +138,7 @@ fn command_output(command: &str, args: &[&str]) -> Option<String> {
 }
 
 pub(crate) fn no_dna_enabled() -> bool {
-    std::env::var(NO_DNA_ENV).is_ok()
+    std::env::var(NO_DNA_ENV).is_ok_and(|value| !value.trim().is_empty())
 }
 
 fn os_version() -> String {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -79,6 +79,17 @@ pub const DOCKER_BUILDER_VERSION: &str = VERSION;
 /// Default RPC port
 pub const DEFAULT_RPC_PORT: u16 = 8899;
 const DEFAULT_FAUCET_PORT: u16 = 9900;
+/// Environment variable for NO_DNA mode & Relevent Help Messages.
+pub(crate) const NO_DNA_ENV: &str = "NO_DNA";
+const NO_DNA_TOP_LEVEL_HELP: &str =
+    "Set NO_DNA=1 when running Anchor in CI, scripts, or AI agents. This disables supported \
+     interactive prompts, but destructive commands still require their explicit bypass flags.";
+const NO_DNA_TEST_HELP: &str =
+    "Set NO_DNA=1 to run tests without waiting for supported interactive input.";
+const NO_DNA_LOCALNET_HELP: &str = "With NO_DNA=1, Anchor starts the local validator and \
+                                    continues immediately without waiting for interactive input.";
+const NO_DNA_PROGRAM_CLOSE_HELP: &str = "NO_DNA disables the interactive confirmation. Pass \
+                                         --bypass-warning explicitly to close non-interactively.";
 
 /// WebSocket port offset for solana-test-validator (RPC port + 1)
 pub const WEBSOCKET_PORT_OFFSET: u16 = 1;
@@ -126,6 +137,24 @@ fn command_output(command: &str, args: &[&str]) -> Option<String> {
         .filter(|line| !line.is_empty())
 }
 
+fn env_var_present(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
+}
+
+pub(crate) fn no_dna_enabled() -> bool {
+    env_var_present(std::env::var(NO_DNA_ENV).ok().as_deref())
+}
+
+pub(crate) fn propagate_no_dna(
+    cmd: &mut std::process::Command,
+    enabled: bool,
+) -> &mut std::process::Command {
+    if enabled {
+        cmd.env(NO_DNA_ENV, "1");
+    }
+    cmd
+}
+
 fn os_version() -> String {
     #[cfg(target_os = "macos")]
     if let Some(version) = macos_version() {
@@ -168,7 +197,7 @@ fn linux_os_release() -> Option<String> {
 }
 
 #[derive(Debug, Parser, AbsolutePath)]
-#[clap(version = VERSION)]
+#[clap(version = VERSION, after_help = NO_DNA_TOP_LEVEL_HELP)]
 pub struct Opts {
     #[clap(flatten)]
     pub cfg_override: ConfigOverride,
@@ -296,7 +325,7 @@ pub enum Command {
         #[clap(raw = true)]
         args: Vec<String>,
     },
-    #[clap(name = "test", alias = "t")]
+    #[clap(name = "test", alias = "t", after_help = NO_DNA_TEST_HELP)]
     /// Runs integration tests.
     Test {
         /// Build and test only this program
@@ -483,6 +512,7 @@ pub enum Command {
         subcmd: KeysCommand,
     },
     /// Localnet commands.
+    #[clap(after_help = NO_DNA_LOCALNET_HELP)]
     Localnet {
         /// Flag to skip building the program in the workspace,
         /// use this to save time when running test and the program code is not altered.
@@ -771,6 +801,7 @@ pub enum ProgramCommand {
         output_file: String,
     },
     /// Close a program or buffer account and withdraw all lamports
+    #[clap(after_help = NO_DNA_PROGRAM_CLOSE_HELP)]
     Close {
         /// Account address to close (buffer or program).
         /// If not provided, discovers program from workspace using program_name
@@ -4631,8 +4662,9 @@ fn run_test_suite(
         };
         let cmd = cmd.clone();
         let script_args = format!("{cmd} {}", extra_args.join(" "));
-
-        std::process::Command::new("bash")
+        let mut command = std::process::Command::new("bash");
+        propagate_no_dna(&mut command, no_dna_enabled());
+        command
             .arg("-c")
             .arg(script_args)
             .env("ANCHOR_PROVIDER_URL", url)
@@ -4647,7 +4679,17 @@ fn run_test_suite(
 
     // Keep validator running if needed.
     if test_result.is_ok() && detach {
-        println!("Local validator still running. Press Ctrl + C quit.");
+        if no_dna_enabled() {
+            println!("Local validator still running.");
+            if let Some(log_streams) = log_streams {
+                for handle in log_streams {
+                    handle.shutdown();
+                }
+            }
+            return Ok(());
+        } else {
+            println!("Local validator still running. Press Ctrl + C quit.");
+        }
         std::io::stdin().lock().lines().next().unwrap().unwrap();
     }
 
@@ -5667,7 +5709,9 @@ fn start_surfpool_validator(
         false => Stdio::null(),
     };
 
-    let mut validator_handle = std::process::Command::new("surfpool")
+    let mut validator_command = std::process::Command::new("surfpool");
+    propagate_no_dna(&mut validator_command, no_dna_enabled());
+    let mut validator_handle = validator_command
         .arg("start")
         .args(flags.unwrap_or_default())
         .stdout(test_validator_stdout)
@@ -6699,6 +6743,17 @@ fn localnet(
             }
         };
 
+        if no_dna_enabled() {
+            println!("Local validator still running.");
+            if let Some(log_streams) = log_streams {
+                for handle in log_streams {
+                    handle.shutdown();
+                }
+            }
+            return Ok(());
+        } else {
+            println!("Local validator still running. Press Ctrl + C quit.");
+        }
         std::io::stdin().lock().lines().next().unwrap().unwrap();
 
         // Check all errors and shut down.
@@ -7227,6 +7282,30 @@ mod tests {
             panic!("expected localnet command");
         };
         assert_eq!(validator, ValidatorType::Surfpool);
+    }
+
+    #[test]
+    fn test_no_dna_present_and_non_empty() {
+        assert!(env_var_present(Some("1")));
+        assert!(env_var_present(Some("true")));
+        assert!(env_var_present(Some("0")));
+        assert!(env_var_present(Some("random")));
+        assert!(!env_var_present(None));
+        assert!(!env_var_present(Some("")));
+        assert!(!env_var_present(Some("   ")));
+    }
+
+    #[test]
+    fn test_propagate_no_dna_normalizes_child_env() {
+        let mut command = std::process::Command::new("true");
+        propagate_no_dna(&mut command, true);
+
+        let propagated = command
+            .get_envs()
+            .find_map(|(key, value)| (key == std::ffi::OsStr::new(NO_DNA_ENV)).then_some(value))
+            .flatten();
+
+        assert_eq!(propagated, Some(std::ffi::OsStr::new("1")));
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -142,7 +142,7 @@ fn env_var_present(value: Option<&str>) -> bool {
 }
 
 pub(crate) fn no_dna_enabled() -> bool {
-    env_var_present(std::env::var(NO_DNA_ENV).ok().as_deref())
+    std::env::var(NO_DNA_ENV).is_ok()
 }
 
 pub(crate) fn propagate_no_dna(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7285,30 +7285,6 @@ mod tests {
     }
 
     #[test]
-    fn test_no_dna_present_and_non_empty() {
-        assert!(env_var_present(Some("1")));
-        assert!(env_var_present(Some("true")));
-        assert!(env_var_present(Some("0")));
-        assert!(env_var_present(Some("random")));
-        assert!(!env_var_present(None));
-        assert!(!env_var_present(Some("")));
-        assert!(!env_var_present(Some("   ")));
-    }
-
-    #[test]
-    fn test_propagate_no_dna_normalizes_child_env() {
-        let mut command = std::process::Command::new("true");
-        propagate_no_dna(&mut command, true);
-
-        let propagated = command
-            .get_envs()
-            .find_map(|(key, value)| (key == std::ffi::OsStr::new(NO_DNA_ENV)).then_some(value))
-            .flatten();
-
-        assert_eq!(propagated, Some(std::ffi::OsStr::new("1")));
-    }
-
-    #[test]
     fn test_codama_command_parses() {
         let opts = Opts::try_parse_from([
             "anchor",

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -58,6 +58,20 @@ const WRITE_COMPUTE_UNIT_LIMIT: u32 = 3_000;
 /// the latest snapshot.
 const BUFFER_STABILIZE_MAX_WAIT_SECS: u64 = 60;
 
+/// Error returned when `NO_DNA` disables the destructive confirmation prompt.
+const NO_DNA_PROGRAM_CLOSE_ERROR: &str = "Cannot prompt for confirmation because NO_DNA is set. \
+                                          Re-run with --bypass-warning to close the account.";
+
+fn should_prompt_for_program_close(no_dna_enabled: bool, bypass_warning: bool) -> Result<bool> {
+    if bypass_warning {
+        return Ok(false);
+    }
+    if no_dna_enabled {
+        bail!(NO_DNA_PROGRAM_CLOSE_ERROR);
+    }
+    Ok(true)
+}
+
 /// If `--buffer` is absent, inject a per-program persistent path at
 /// `target/deploy/{program_name}-upgrade-buffer.json`. Creates the keypair
 /// file on first run; subsequent runs reuse it so a failed deploy/upgrade
@@ -2158,7 +2172,7 @@ fn program_close(
     // Determine recipient
     let recipient_pubkey = recipient.unwrap_or_else(|| authority_keypair.pubkey());
 
-    if !bypass_warning {
+    if should_prompt_for_program_close(crate::no_dna_enabled(), bypass_warning)? {
         println!();
         println!(
             "WARNING: This will close the {} account and reclaim all lamports.",
@@ -2836,5 +2850,17 @@ resolver = "2"
             .to_string();
 
         assert!(err.contains("current package believes it's in a workspace when it's not"));
+    }
+
+    #[test]
+    fn program_close_requires_explicit_bypass_under_no_dna() {
+        let err = should_prompt_for_program_close(true, false).unwrap_err();
+        assert!(
+            err.to_string().contains("--bypass-warning"),
+            "unexpected error: {err}"
+        );
+
+        assert!(!should_prompt_for_program_close(true, true).unwrap());
+        assert!(should_prompt_for_program_close(false, false).unwrap());
     }
 }

--- a/docs-v2/src/content/docs/v1/reference/_meta.ts
+++ b/docs-v2/src/content/docs/v1/reference/_meta.ts
@@ -8,8 +8,9 @@ export default {
     'account-constraints': { order: 1 },
     'anchor-toml': { order: 2 },
     cli: { label: 'Anchor CLI', order: 3 },
-    avm: { label: 'Anchor version manager', order: 4 },
-    'rust-to-js-types': { label: 'Rust to JS type conversion', order: 5 },
-    examples: { order: 6 },
+    'no-dna': { label: 'NO_DNA', order: 4 },
+    avm: { label: 'Anchor version manager', order: 5 },
+    'rust-to-js-types': { label: 'Rust to JS type conversion', order: 6 },
+    examples: { order: 7 },
   },
 } satisfies MetaFile

--- a/docs-v2/src/content/docs/v1/reference/cli.mdx
+++ b/docs-v2/src/content/docs/v1/reference/cli.mdx
@@ -5,6 +5,8 @@ description: Anchor CLI reference documentation.
 
 The Anchor CLI manages an Anchor workspace: scaffolding projects, building programs, deploying to a cluster, running tests, and interacting with on-chain IDLs. Run `$ <blue>anchor</blue> <dim>--help</dim>` on any subcommand for the full list of flags:
 
+For non-human or agent-driven usage, see [NO_DNA](/docs/v1/reference/no-dna/).
+
 ```console
 $ <blue>anchor</blue> <dim>--help</dim>
 <bold>Usage:</bold> <bold>anchor-1.0.1</bold> [OPTIONS] <COMMAND>

--- a/docs-v2/src/content/docs/v1/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v1/reference/no-dna.mdx
@@ -44,14 +44,6 @@ Anchor currently supports `NO_DNA` in the following CLI flows:
 `anchor program close`, pass the existing explicit bypass flag yourself.
 </Callout>
 
-## Behavior contract
-
-- Any present, non-empty `NO_DNA` value enables this mode.
-- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
-  child tools.
-- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
-  non-interactive mode is visible downstream.
-- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 
 ## Checking support from the CLI
 

--- a/docs-v2/src/content/docs/v1/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v1/reference/no-dna.mdx
@@ -28,16 +28,6 @@ anchor test --detach
 
 ## Supported behavior
 
-Anchor currently supports `NO_DNA` in the following CLI flows:
-
-- `anchor test --detach` returns immediately instead of waiting for Enter after
-  tests complete. The validator is left running.
-- `anchor localnet` returns immediately instead of waiting for Enter after the
-  local validator starts. The validator is left running.
-- `anchor program close` disables the interactive confirmation prompt. This
-  command fails unless `--bypass-warning` is passed explicitly.
-- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
-  including the test script shell and Surfpool validator startup.
 
 <Callout type="info" title="Destructive commands stay explicit">
 `NO_DNA` does not auto-confirm destructive actions. For commands such as

--- a/docs-v2/src/content/docs/v1/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v1/reference/no-dna.mdx
@@ -1,0 +1,81 @@
+---
+title: NO_DNA
+description: Reference documentation for Anchor's NO_DNA support
+---
+
+Anchor supports the `NO_DNA` convention for non-human CLI usage. See
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+invoking Anchor from an agent, automation, or another non-interactive
+workflow that should not block on supported stdin waits. `NO_DNA=1` is the
+standard example.
+
+## Usage
+
+Prefix the command:
+
+```bash
+NO_DNA=1 anchor test --detach
+NO_DNA=1 anchor localnet
+NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+```
+
+Or export it for a session:
+
+```bash
+export NO_DNA=1
+anchor test --detach
+```
+
+## Supported behavior
+
+Anchor currently supports `NO_DNA` in the following CLI flows:
+
+- `anchor test --detach` returns immediately instead of waiting for Enter after
+  tests complete. The validator is left running.
+- `anchor localnet` returns immediately instead of waiting for Enter after the
+  local validator starts. The validator is left running.
+- `anchor program close` disables the interactive confirmation prompt. This
+  command fails unless `--bypass-warning` is passed explicitly.
+- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
+  including the test script shell and Surfpool validator startup.
+
+<Callout type="info" title="Destructive commands stay explicit">
+`NO_DNA` does not auto-confirm destructive actions. For commands such as
+`anchor program close`, pass the existing explicit bypass flag yourself.
+</Callout>
+
+## Behavior contract
+
+- Any present, non-empty `NO_DNA` value enables this mode.
+- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
+  child tools.
+- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
+  non-interactive mode is visible downstream.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+
+## Checking support from the CLI
+
+The CLI help text documents `NO_DNA` where it applies:
+
+```bash
+anchor --help
+anchor test --help
+anchor localnet --help
+anchor program close --help
+```
+
+## Notes
+
+`NO_DNA` support is additive and currently scoped to the supported flows above.
+If a command is not documented as `NO_DNA`-aware, do not assume it has
+non-interactive behavior beyond its existing flags.
+
+## Current limitations
+
+Dangerous operations still require extra explicit confirmation in automation
+flows.
+
+- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
+  you must still pass `--bypass-warning` explicitly.
+- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
+  to automate it, you must still provide the confirmation input yourself.

--- a/docs-v2/src/content/docs/v1/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v1/reference/no-dna.mdx
@@ -4,10 +4,10 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
 invoking Anchor from an agent, automation, or another non-interactive
-workflow that should not block on supported stdin waits. `NO_DNA=1` is the
-standard example.
+workflow that should not block on supported interactive waits or confirmation
+prompts. `NO_DNA=1` is the standard example.
 
 ## Usage
 
@@ -17,6 +17,7 @@ Prefix the command:
 NO_DNA=1 anchor test --detach
 NO_DNA=1 anchor localnet
 NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+NO_DNA=1 anchor legacy-idl erase-authority --program-id <PROGRAM_ID> --bypass-warning
 ```
 
 Or export it for a session:
@@ -26,15 +27,11 @@ export NO_DNA=1
 anchor test --detach
 ```
 
-## Supported behavior
-
-
 <Callout type="info" title="Destructive commands stay explicit">
 `NO_DNA` does not auto-confirm destructive actions. For commands such as
-`anchor program close`, pass the existing explicit bypass flag yourself.
+`anchor program close` and `anchor legacy-idl erase-authority`, pass the
+existing explicit bypass flag yourself.
 </Callout>
-
-
 ## Checking support from the CLI
 
 The CLI help text documents `NO_DNA` where it applies:
@@ -44,20 +41,12 @@ anchor --help
 anchor test --help
 anchor localnet --help
 anchor program close --help
+anchor legacy-idl erase-authority --help
 ```
 
 ## Notes
 
-`NO_DNA` support is additive and currently scoped to the supported flows above.
-If a command is not documented as `NO_DNA`-aware, do not assume it has
-non-interactive behavior beyond its existing flags.
-
-## Current limitations
-
-Dangerous operations still require extra explicit confirmation in automation
-flows.
-
-- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
-  you must still pass `--bypass-warning` explicitly.
-- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
-  to automate it, you must still provide the confirmation input yourself.
+- Any present `NO_DNA` value enables this mode.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+- If a command is not documented as `NO_DNA`-aware, do not assume it has
+  non-interactive behavior beyond its existing flags.

--- a/docs-v2/src/content/docs/v1/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v1/reference/no-dna.mdx
@@ -4,7 +4,7 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to a non-empty value when
 invoking Anchor from an agent, automation, or another non-interactive
 workflow that should not block on supported interactive waits or confirmation
 prompts. `NO_DNA=1` is the standard example.
@@ -46,7 +46,7 @@ anchor legacy-idl erase-authority --help
 
 ## Notes
 
-- Any present `NO_DNA` value enables this mode.
+- A non-empty `NO_DNA` value enables this mode.
 - Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 - If a command is not documented as `NO_DNA`-aware, do not assume it has
   non-interactive behavior beyond its existing flags.

--- a/docs-v2/src/content/docs/v2/reference/_meta.ts
+++ b/docs-v2/src/content/docs/v2/reference/_meta.ts
@@ -11,7 +11,8 @@ export default {
     'feature-flags': { order: 4 },
     'anchor-toml': { label: 'Anchor.toml', order: 5 },
     cli: { label: 'Anchor CLI', order: 6 },
-    'examples-and-benchmarks': { order: 7 },
-    'alpha-limitations': { order: 8 },
+    'no-dna': { label: 'NO_DNA', order: 7 },
+    'examples-and-benchmarks': { order: 8 },
+    'alpha-limitations': { order: 9 },
   },
 } satisfies MetaFile

--- a/docs-v2/src/content/docs/v2/reference/cli.mdx
+++ b/docs-v2/src/content/docs/v2/reference/cli.mdx
@@ -5,6 +5,8 @@ description: CLI reference for project scaffolding, builds, tests, profiling, de
 
 The Anchor CLI is the workspace toolchain. It scaffolds projects, builds programs, runs tests, generates IDLs, deploys, and drives the trace tooling.
 
+For non-human or agent-driven usage, see [NO_DNA](/docs/v2/reference/no-dna/).
+
 This alpha is installed from git:
 
 ```console showLineNumbers=false

--- a/docs-v2/src/content/docs/v2/reference/index.mdx
+++ b/docs-v2/src/content/docs/v2/reference/index.mdx
@@ -28,6 +28,10 @@ Lookup pages for macros, constraints, account wrappers, feature flags, CLI comma
   CLI commands and flags.
 </Card>
 
+<Card title="NO_DNA" href="/docs/v2/reference/no-dna/">
+  Non-human CLI usage, supported behavior, and current automation limitations.
+</Card>
+
 <Card title="Alpha limitations" href="/docs/v2/reference/alpha-limitations/">
   Known alpha caveats before depending on this version.
 </Card>

--- a/docs-v2/src/content/docs/v2/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v2/reference/no-dna.mdx
@@ -4,7 +4,7 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to a non-empty value when
 invoking Anchor from an agent, automation, or another non-interactive
 workflow that should not block on supported interactive waits or confirmation
 prompts. `NO_DNA=1` is the standard example.
@@ -44,7 +44,7 @@ anchor program close --help
 
 ## Notes
 
-- Any present `NO_DNA` value enables this mode.
+- A non-empty `NO_DNA` value enables this mode.
 - Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 - If a command is not documented as `NO_DNA`-aware, do not assume it has
   non-interactive behavior beyond its existing flags.

--- a/docs-v2/src/content/docs/v2/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v2/reference/no-dna.mdx
@@ -17,7 +17,6 @@ Prefix the command:
 NO_DNA=1 anchor test --detach
 NO_DNA=1 anchor localnet
 NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
-NO_DNA=1 anchor legacy-idl erase-authority --program-id <PROGRAM_ID> --bypass-warning
 ```
 
 Or export it for a session:
@@ -29,8 +28,7 @@ anchor test --detach
 
 <Callout type="info" title="Destructive commands stay explicit">
 `NO_DNA` does not auto-confirm destructive actions. For commands such as
-`anchor program close` and `anchor legacy-idl erase-authority`, pass the
-existing explicit bypass flag yourself.
+`anchor program close`, pass the existing explicit bypass flag yourself.
 </Callout>
 
 ## Checking support from the CLI
@@ -42,7 +40,6 @@ anchor --help
 anchor test --help
 anchor localnet --help
 anchor program close --help
-anchor legacy-idl erase-authority --help
 ```
 
 ## Notes

--- a/docs-v2/src/content/docs/v2/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v2/reference/no-dna.mdx
@@ -1,0 +1,81 @@
+---
+title: NO_DNA
+description: Reference documentation for Anchor's NO_DNA support
+---
+
+Anchor supports the `NO_DNA` convention for non-human CLI usage. See
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+invoking Anchor from an agent, automation, or another non-interactive
+workflow that should not block on supported stdin waits. `NO_DNA=1` is the
+standard example.
+
+## Usage
+
+Prefix the command:
+
+```bash
+NO_DNA=1 anchor test --detach
+NO_DNA=1 anchor localnet
+NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+```
+
+Or export it for a session:
+
+```bash
+export NO_DNA=1
+anchor test --detach
+```
+
+## Supported behavior
+
+Anchor currently supports `NO_DNA` in the following CLI flows:
+
+- `anchor test --detach` returns immediately instead of waiting for Enter after
+  tests complete. The validator is left running.
+- `anchor localnet` returns immediately instead of waiting for Enter after the
+  local validator starts. The validator is left running.
+- `anchor program close` disables the interactive confirmation prompt. This
+  command fails unless `--bypass-warning` is passed explicitly.
+- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
+  including the test script shell and Surfpool validator startup.
+
+<Callout type="info" title="Destructive commands stay explicit">
+`NO_DNA` does not auto-confirm destructive actions. For commands such as
+`anchor program close`, pass the existing explicit bypass flag yourself.
+</Callout>
+
+## Behavior contract
+
+- Any present, non-empty `NO_DNA` value enables this mode.
+- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
+  child tools.
+- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
+  non-interactive mode is visible downstream.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+
+## Checking support from the CLI
+
+The CLI help text documents `NO_DNA` where it applies:
+
+```bash
+anchor --help
+anchor test --help
+anchor localnet --help
+anchor program close --help
+```
+
+## Notes
+
+`NO_DNA` support is additive and currently scoped to the supported flows above.
+If a command is not documented as `NO_DNA`-aware, do not assume it has
+non-interactive behavior beyond its existing flags.
+
+## Current limitations
+
+Dangerous operations still require extra explicit confirmation in automation
+flows.
+
+- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
+  you must still pass `--bypass-warning` explicitly.
+- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
+  to automate it, you must still provide the confirmation input yourself.

--- a/docs-v2/src/content/docs/v2/reference/no-dna.mdx
+++ b/docs-v2/src/content/docs/v2/reference/no-dna.mdx
@@ -4,10 +4,10 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
 invoking Anchor from an agent, automation, or another non-interactive
-workflow that should not block on supported stdin waits. `NO_DNA=1` is the
-standard example.
+workflow that should not block on supported interactive waits or confirmation
+prompts. `NO_DNA=1` is the standard example.
 
 ## Usage
 
@@ -17,6 +17,7 @@ Prefix the command:
 NO_DNA=1 anchor test --detach
 NO_DNA=1 anchor localnet
 NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+NO_DNA=1 anchor legacy-idl erase-authority --program-id <PROGRAM_ID> --bypass-warning
 ```
 
 Or export it for a session:
@@ -26,32 +27,11 @@ export NO_DNA=1
 anchor test --detach
 ```
 
-## Supported behavior
-
-Anchor currently supports `NO_DNA` in the following CLI flows:
-
-- `anchor test --detach` returns immediately instead of waiting for Enter after
-  tests complete. The validator is left running.
-- `anchor localnet` returns immediately instead of waiting for Enter after the
-  local validator starts. The validator is left running.
-- `anchor program close` disables the interactive confirmation prompt. This
-  command fails unless `--bypass-warning` is passed explicitly.
-- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
-  including the test script shell and Surfpool validator startup.
-
 <Callout type="info" title="Destructive commands stay explicit">
 `NO_DNA` does not auto-confirm destructive actions. For commands such as
-`anchor program close`, pass the existing explicit bypass flag yourself.
+`anchor program close` and `anchor legacy-idl erase-authority`, pass the
+existing explicit bypass flag yourself.
 </Callout>
-
-## Behavior contract
-
-- Any present, non-empty `NO_DNA` value enables this mode.
-- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
-  child tools.
-- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
-  non-interactive mode is visible downstream.
-- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 
 ## Checking support from the CLI
 
@@ -62,20 +42,12 @@ anchor --help
 anchor test --help
 anchor localnet --help
 anchor program close --help
+anchor legacy-idl erase-authority --help
 ```
 
 ## Notes
 
-`NO_DNA` support is additive and currently scoped to the supported flows above.
-If a command is not documented as `NO_DNA`-aware, do not assume it has
-non-interactive behavior beyond its existing flags.
-
-## Current limitations
-
-Dangerous operations still require extra explicit confirmation in automation
-flows.
-
-- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
-  you must still pass `--bypass-warning` explicitly.
-- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
-  to automate it, you must still provide the confirmation input yourself.
+- Any present `NO_DNA` value enables this mode.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+- If a command is not documented as `NO_DNA`-aware, do not assume it has
+  non-interactive behavior beyond its existing flags.

--- a/docs/content/docs/references/cli.mdx
+++ b/docs/content/docs/references/cli.mdx
@@ -7,6 +7,8 @@ A CLI is provided to support building and managing an Anchor workspace. For a
 comprehensive list of commands and options, run `anchor -h` on any of the
 following subcommands.
 
+For non-human or agent-driven usage, see [NO_DNA](/docs/references/no-dna).
+
 ---
 
 ```shell

--- a/docs/content/docs/references/meta.json
+++ b/docs/content/docs/references/meta.json
@@ -5,6 +5,7 @@
     "account-constraints",
     "anchor-toml",
     "cli",
+    "no-dna",
     "avm",
     "space",
     "type-conversion",

--- a/docs/content/docs/references/no-dna.mdx
+++ b/docs/content/docs/references/no-dna.mdx
@@ -1,0 +1,81 @@
+---
+title: NO_DNA
+description: Reference documentation for Anchor's NO_DNA support
+---
+
+Anchor supports the `NO_DNA` convention for non-human CLI usage. See
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+invoking Anchor from an agent, automation, or another non-interactive
+workflow that should not block on supported stdin waits. `NO_DNA=1` is the
+standard example.
+
+## Usage
+
+Prefix the command:
+
+```bash
+NO_DNA=1 anchor test --detach
+NO_DNA=1 anchor localnet
+NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+```
+
+Or export it for a session:
+
+```bash
+export NO_DNA=1
+anchor test --detach
+```
+
+## Supported behavior
+
+Anchor currently supports `NO_DNA` in the following CLI flows:
+
+- `anchor test --detach` returns immediately instead of waiting for Enter after
+  tests complete. The validator is left running.
+- `anchor localnet` returns immediately instead of waiting for Enter after the
+  local validator starts. The validator is left running.
+- `anchor program close` disables the interactive confirmation prompt. This
+  command fails unless `--bypass-warning` is passed explicitly.
+- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
+  including the test script shell and Surfpool validator startup.
+
+<Callout type="info" title="Destructive commands stay explicit">
+`NO_DNA` does not auto-confirm destructive actions. For commands such as
+`anchor program close`, pass the existing explicit bypass flag yourself.
+</Callout>
+
+## Behavior contract
+
+- Any present, non-empty `NO_DNA` value enables this mode.
+- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
+  child tools.
+- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
+  non-interactive mode is visible downstream.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+
+## Checking support from the CLI
+
+The CLI help text documents `NO_DNA` where it applies:
+
+```bash
+anchor --help
+anchor test --help
+anchor localnet --help
+anchor program close --help
+```
+
+## Notes
+
+`NO_DNA` support is additive and currently scoped to the supported flows above.
+If a command is not documented as `NO_DNA`-aware, do not assume it has
+non-interactive behavior beyond its existing flags.
+
+## Current limitations
+
+Dangerous operations still require extra explicit confirmation in automation
+flows.
+
+- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
+  you must still pass `--bypass-warning` explicitly.
+- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
+  to automate it, you must still provide the confirmation input yourself.

--- a/docs/content/docs/references/no-dna.mdx
+++ b/docs/content/docs/references/no-dna.mdx
@@ -4,10 +4,10 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
-invoking Anchor from an agent, automation, or another non-interactive
-workflow that should not block on supported interactive waits or confirmation
-prompts. `NO_DNA=1` is the standard example.
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to a non-empty value when
+invoking Anchor from an agent, automation, or another non-interactive workflow
+that should not block on supported interactive waits or confirmation prompts.
+`NO_DNA=1` is the standard example.
 
 ## Usage
 
@@ -28,9 +28,9 @@ anchor test --detach
 ```
 
 <Callout type="info" title="Destructive commands stay explicit">
-`NO_DNA` does not auto-confirm destructive actions. For commands such as
-`anchor program close` and `anchor legacy-idl erase-authority`, pass the
-existing explicit bypass flag yourself.
+  `NO_DNA` does not auto-confirm destructive actions. For commands such as
+  `anchor program close` and `anchor legacy-idl erase-authority`, pass the
+  existing explicit bypass flag yourself.
 </Callout>
 
 ## Checking support from the CLI
@@ -47,7 +47,7 @@ anchor legacy-idl erase-authority --help
 
 ## Notes
 
-- Any present `NO_DNA` value enables this mode.
+- A non-empty `NO_DNA` value enables this mode.
 - Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 - If a command is not documented as `NO_DNA`-aware, do not assume it has
   non-interactive behavior beyond its existing flags.

--- a/docs/content/docs/references/no-dna.mdx
+++ b/docs/content/docs/references/no-dna.mdx
@@ -4,10 +4,10 @@ description: Reference documentation for Anchor's NO_DNA support
 ---
 
 Anchor supports the `NO_DNA` convention for non-human CLI usage. See
-[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any non-empty value when
+[no-dna.org](https://no-dna.org/). Set `NO_DNA` to any value when
 invoking Anchor from an agent, automation, or another non-interactive
-workflow that should not block on supported stdin waits. `NO_DNA=1` is the
-standard example.
+workflow that should not block on supported interactive waits or confirmation
+prompts. `NO_DNA=1` is the standard example.
 
 ## Usage
 
@@ -17,6 +17,7 @@ Prefix the command:
 NO_DNA=1 anchor test --detach
 NO_DNA=1 anchor localnet
 NO_DNA=1 anchor program close <ACCOUNT> --bypass-warning
+NO_DNA=1 anchor legacy-idl erase-authority --program-id <PROGRAM_ID> --bypass-warning
 ```
 
 Or export it for a session:
@@ -26,32 +27,11 @@ export NO_DNA=1
 anchor test --detach
 ```
 
-## Supported behavior
-
-Anchor currently supports `NO_DNA` in the following CLI flows:
-
-- `anchor test --detach` returns immediately instead of waiting for Enter after
-  tests complete. The validator is left running.
-- `anchor localnet` returns immediately instead of waiting for Enter after the
-  local validator starts. The validator is left running.
-- `anchor program close` disables the interactive confirmation prompt. This
-  command fails unless `--bypass-warning` is passed explicitly.
-- Child processes launched from the touched test workflow inherit `NO_DNA=1`,
-  including the test script shell and Surfpool validator startup.
-
 <Callout type="info" title="Destructive commands stay explicit">
 `NO_DNA` does not auto-confirm destructive actions. For commands such as
-`anchor program close`, pass the existing explicit bypass flag yourself.
+`anchor program close` and `anchor legacy-idl erase-authority`, pass the
+existing explicit bypass flag yourself.
 </Callout>
-
-## Behavior contract
-
-- Any present, non-empty `NO_DNA` value enables this mode.
-- `NO_DNA=1` is the standard example and the value Anchor forwards to supported
-  child tools.
-- When enabled, Anchor forwards `NO_DNA=1` to supported child tools so the same
-  non-interactive mode is visible downstream.
-- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
 
 ## Checking support from the CLI
 
@@ -62,20 +42,12 @@ anchor --help
 anchor test --help
 anchor localnet --help
 anchor program close --help
+anchor legacy-idl erase-authority --help
 ```
 
 ## Notes
 
-`NO_DNA` support is additive and currently scoped to the supported flows above.
-If a command is not documented as `NO_DNA`-aware, do not assume it has
-non-interactive behavior beyond its existing flags.
-
-## Current limitations
-
-Dangerous operations still require extra explicit confirmation in automation
-flows.
-
-- `anchor program close` does not auto-confirm under `NO_DNA`. For automation,
-  you must still pass `--bypass-warning` explicitly.
-- `anchor legacy-idl erase-authority` is not yet `NO_DNA`-aware. If you need
-  to automate it, you must still provide the confirmation input yourself.
+- Any present `NO_DNA` value enables this mode.
+- Default human-driven CLI behavior is unchanged when `NO_DNA` is unset.
+- If a command is not documented as `NO_DNA`-aware, do not assume it has
+  non-interactive behavior beyond its existing flags.


### PR DESCRIPTION
Adds agent-friendly `NO_DNA` handling for supported CLI flows, propagates `NO_DNA` to child tools, documents current limitations, and updates docs in both docs versions.

Closes #4309 