### PR TITLE
fix(lang-v2): reject init seeds program overrides

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -321,6 +321,12 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                             let key_ident = Ident::parse_any(input)?;
                             // seeds::program = expr — special case, stored separately
                             if ident == "seeds" && key_ident == "program" {
+                                if result.seeds_program.is_some() {
+                                    return Err(syn::Error::new(
+                                        key_ident.span(),
+                                        "`seeds::program` already provided",
+                                    ));
+                                }
                                 input.parse::<Token![=]>()?;
                                 result.seeds_program = Some(input.parse()?);
                                 if !input.is_empty() {
@@ -379,6 +385,13 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                  canonical bump (write `bump` without a value)",
             ));
         }
+    }
+
+    if result.seeds_program.is_some() && result.seeds.is_none() {
+        return Err(syn::Error::new(
+            result.seeds_program.as_ref().unwrap().span(),
+            "`seeds::program` requires `seeds`",
+        ));
     }
 
     Ok(result)

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1314,6 +1314,20 @@ pub fn parse_field(
     let field_name = field.ident.as_ref().expect("named field");
     let field_ty = &field.ty;
     let attrs = parse_account_attrs(&field.attrs)?;
+    if attrs.seeds_program.is_some() {
+        if attrs.is_init {
+            return Err(syn::Error::new(
+                attrs.seeds_program.as_ref().unwrap().span(),
+                "`seeds::program` cannot be used with `init`",
+            ));
+        }
+        if attrs.is_init_if_needed {
+            return Err(syn::Error::new(
+                attrs.seeds_program.as_ref().unwrap().span(),
+                "`seeds::program` cannot be used with `init_if_needed`",
+            ));
+        }
+    }
     if attrs.close.is_some() && !attrs.is_mut {
         return Err(syn::Error::new(
             field_name.span(),

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -376,6 +376,58 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn seeds_program_requires_seeds_and_rejects_duplicates() {
+    compile_fail_case(
+        "seeds_program_without_seeds",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(seeds::program = OTHER_PROGRAM)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`seeds::program` requires `seeds`"],
+    );
+
+    compile_fail_case(
+        "duplicate_seeds_program_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM_A: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+pub const OTHER_PROGRAM_B: Address =
+    Address::from_str_const("HmbTQ4MSEFuTMdM7x5TW5tsanTzQKB8CS7QdQ8qJbYQL");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(
+        seeds = [b"data"],
+        bump,
+        seeds::program = OTHER_PROGRAM_A,
+        seeds::program = OTHER_PROGRAM_B,
+    )]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`seeds::program` already provided"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn optional_pda_init_payer_is_rejected() {
     compile_fail_case(
         "optional_pda_init_payer_is_rejected",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -301,6 +301,81 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn init_and_init_if_needed_reject_seeds_program() {
+    compile_fail_case(
+        "init_seeds_program_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        seeds = [b"data"],
+        bump,
+        seeds::program = OTHER_PROGRAM,
+    )]
+    pub data: Account<Data>,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`seeds::program` cannot be used with `init`"],
+    );
+
+    compile_fail_case(
+        "init_if_needed_seeds_program_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(
+        init_if_needed,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        seeds = [b"data"],
+        bump,
+        seeds::program = OTHER_PROGRAM,
+    )]
+    pub data: Account<Data>,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`seeds::program` cannot be used with `init_if_needed`"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn optional_pda_init_payer_is_rejected() {
     compile_fail_case(
         "optional_pda_init_payer_is_rejected",


### PR DESCRIPTION
## Finding

`init` and `init_if_needed` accepted `seeds::program`, although the current program cannot initialize a PDA belonging to another program.

## Fix

Reject both combinations during Accounts parsing, matching v1 behavior and preventing invalid initialization codegen. Compile-fail regressions cover both initialization forms.