### PR TITLE
fix(lang-v2): restore cross-field account constraint validation

### DIFF
--- a/bench/programs/multisig/anchor-v2/src/instructions/create.rs
+++ b/bench/programs/multisig/anchor-v2/src/instructions/create.rs
@@ -9,7 +9,12 @@ use crate::{
 pub struct Create {
     #[account(mut)]
     pub creator: Signer,
-    #[account(init, payer = creator, seeds = [b"multisig", creator.address().as_ref()])]
+    #[account(
+        init,
+        payer = creator,
+        seeds = [b"multisig", creator.address().as_ref()],
+        bump
+    )]
     pub config: Account<MultisigConfig>,
     pub system_program: Program<System>,
 }

--- a/bench/programs/multisig/anchor-v2/src/instructions/deposit.rs
+++ b/bench/programs/multisig/anchor-v2/src/instructions/deposit.rs
@@ -7,7 +7,7 @@ pub struct Deposit {
     #[account(mut)]
     pub depositor: Signer,
     pub config: Account<MultisigConfig>,
-    #[account(mut, seeds = [b"vault", config.address().as_ref()])]
+    #[account(mut, seeds = [b"vault", config.address().as_ref()], bump)]
     pub vault: UncheckedAccount,
     pub system_program: Program<System>,
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1016,6 +1016,9 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         Ok(fields) => fields,
         Err(err) => return err.to_compile_error(),
     };
+    if let Err(err) = parse::validate_account_fields(&field_summaries) {
+        return err.to_compile_error();
+    }
 
     let fields: Vec<parse::AccountField> = match named_fields
         .named
@@ -1036,30 +1039,6 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         Ok(fields) => fields,
         Err(err) => return err.to_compile_error(),
     };
-
-    for field in fields.iter().filter(|f| f.init_payer.is_some()) {
-        let payer = field.init_payer.as_ref().unwrap();
-        match fields
-            .iter()
-            .find(|candidate| candidate.name == payer.as_str())
-        {
-            Some(payer_field) if payer_field.idl_writable => {}
-            Some(_) => {
-                return syn::Error::new(
-                    field.name.span(),
-                    "the payer specified for an init constraint must be mutable",
-                )
-                .to_compile_error();
-            }
-            None => {
-                return syn::Error::new(
-                    field.name.span(),
-                    "the payer specified for an init constraint does not exist",
-                )
-                .to_compile_error();
-            }
-        }
-    }
 
     let field_names: Vec<_> = fields.iter().map(|f| &f.name).collect();
     let loads: Vec<_> = fields.iter().map(|f| &f.load).collect();

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1024,9 +1024,11 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .named
         .iter()
         .zip(offset_exprs)
-        .map(|(f, offset)| {
+        .zip(&field_summaries)
+        .map(|((f, offset), summary)| {
             parse::parse_field(
                 f,
+                &summary.attrs,
                 &raw_field_names,
                 &field_offsets,
                 offset,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -132,6 +132,10 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         namespaced: Vec::new(),
     };
 
+    let duplicate_singleton = |span: proc_macro2::Span, name: &str| -> syn::Error {
+        syn::Error::new(span, format!("`{name}` already provided"))
+    };
+
     for attr in attrs {
         if !attr.path().is_ident("account") {
             continue;
@@ -142,20 +146,50 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                 match ident.to_string().as_str() {
                     "mut" => result.is_mut = true,
                     "init" => {
+                        if result.is_init {
+                            return Err(duplicate_singleton(ident.span(), "init"));
+                        }
+                        if result.is_init_if_needed || result.is_zeroed {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "only one of `init`, `init_if_needed`, and `zeroed` may be used",
+                            ));
+                        }
                         result.is_init = true;
                         result.is_mut = true;
                         result.init_span = Some(ident.span());
                     }
                     "init_if_needed" => {
+                        if result.is_init_if_needed {
+                            return Err(duplicate_singleton(ident.span(), "init_if_needed"));
+                        }
+                        if result.is_init || result.is_zeroed {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "only one of `init`, `init_if_needed`, and `zeroed` may be used",
+                            ));
+                        }
                         result.is_init_if_needed = true;
                         result.is_mut = true;
                         result.init_if_needed_span = Some(ident.span());
                     }
                     "zeroed" => {
+                        if result.is_zeroed {
+                            return Err(duplicate_singleton(ident.span(), "zeroed"));
+                        }
+                        if result.is_init || result.is_init_if_needed {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "only one of `init`, `init_if_needed`, and `zeroed` may be used",
+                            ));
+                        }
                         result.is_zeroed = true;
                         result.is_mut = true;
                     }
                     "bump" => {
+                        if result.bump.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "bump"));
+                        }
                         if input.peek(Token![=]) {
                             input.parse::<Token![=]>()?;
                             result.bump = Some(Some(input.parse()?));
@@ -204,10 +238,19 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                             let key_ident: Ident = Ident::parse_any(&content)?;
                             content.parse::<Token![=]>()?;
                             let value: Expr = content.parse()?;
+                            let namespace = ns_ident.to_string();
                             let raw_key = key_ident.to_string();
+                            if result.namespaced.iter().any(|nc| {
+                                nc.is_update && nc.namespace == namespace && nc.raw_key == raw_key
+                            }) {
+                                return Err(syn::Error::new(
+                                    key_ident.span(),
+                                    format!("duplicate `{namespace}::{raw_key}` constraint"),
+                                ));
+                            }
                             let key = constraint_key_ident(&raw_key);
                             result.namespaced.push(NamespacedConstraint {
-                                namespace: ns_ident.to_string(),
+                                namespace,
                                 key,
                                 raw_key,
                                 value,
@@ -220,14 +263,23 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "payer" => {
                         input.parse::<Token![=]>()?;
+                        if result.payer.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "payer"));
+                        }
                         result.payer = Some(input.parse()?);
                     }
                     "space" => {
                         input.parse::<Token![=]>()?;
+                        if result.space.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "space"));
+                        }
                         result.space = Some(input.parse()?);
                     }
                     "seeds" if input.peek(Token![=]) => {
                         input.parse::<Token![=]>()?;
+                        if result.seeds.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "seeds"));
+                        }
                         result.seeds = Some(input.parse()?);
                     }
                     // `seeds::program = expr` falls through to the
@@ -238,6 +290,16 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                         let keyword_span = ident.span();
                         input.parse::<Token![=]>()?;
                         let target: Ident = input.parse()?;
+                        if result
+                            .has_one
+                            .iter()
+                            .any(|(_, existing, _)| *existing == target)
+                        {
+                            return Err(syn::Error::new(
+                                target.span(),
+                                format!("duplicate `has_one = {target}` constraint"),
+                            ));
+                        }
                         let err = if input.peek(Token![@]) {
                             input.parse::<Token![@]>()?;
                             Some(input.parse()?)
@@ -248,6 +310,9 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "address" => {
                         input.parse::<Token![=]>()?;
+                        if result.address.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "address"));
+                        }
                         result.address = Some(input.parse()?);
                         if input.peek(Token![@]) {
                             input.parse::<Token![@]>()?;
@@ -256,6 +321,9 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "owner" => {
                         input.parse::<Token![=]>()?;
+                        if result.owner.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "owner"));
+                        }
                         result.owner = Some(input.parse()?);
                         if input.peek(Token![@]) {
                             input.parse::<Token![@]>()?;
@@ -264,12 +332,18 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "realloc" => {
                         input.parse::<Token![=]>()?;
+                        if result.realloc.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "realloc"));
+                        }
                         result.realloc = Some(input.parse()?);
                         result.realloc_span = Some(ident.span());
                         result.is_mut = true;
                     }
                     "realloc_payer" => {
                         input.parse::<Token![=]>()?;
+                        if result.realloc_payer.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "realloc_payer"));
+                        }
                         result.realloc_payer = Some(input.parse()?);
                     }
                     "realloc_zero" => {
@@ -279,6 +353,9 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "close" => {
                         input.parse::<Token![=]>()?;
+                        if result.close.is_some() {
+                            return Err(duplicate_singleton(ident.span(), "close"));
+                        }
                         result.close = Some(input.parse()?);
                     }
                     "constraint" => {
@@ -333,6 +410,12 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                                     ));
                                 }
                                 input.parse::<Token![=]>()?;
+                                if result.seeds_program.is_some() {
+                                    return Err(duplicate_singleton(
+                                        key_ident.span(),
+                                        "seeds::program",
+                                    ));
+                                }
                                 result.seeds_program = Some(input.parse()?);
                                 if !input.is_empty() {
                                     input.parse::<Token![,]>()?;
@@ -341,10 +424,19 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                             }
                             input.parse::<Token![=]>()?;
                             let value: Expr = input.parse()?;
+                            let namespace = ident.to_string();
                             let raw_key = key_ident.to_string();
+                            if result.namespaced.iter().any(|nc| {
+                                !nc.is_update && nc.namespace == namespace && nc.raw_key == raw_key
+                            }) {
+                                return Err(syn::Error::new(
+                                    key_ident.span(),
+                                    format!("duplicate `{namespace}::{raw_key}` constraint"),
+                                ));
+                            }
                             let key = constraint_key_ident(&raw_key);
                             result.namespaced.push(NamespacedConstraint {
-                                namespace: ident.to_string(),
+                                namespace,
                                 key,
                                 raw_key,
                                 value,
@@ -395,11 +487,68 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         }
     }
 
+    if result.close.is_some() && (result.is_init || result.is_init_if_needed || result.is_zeroed) {
+        return Err(syn::Error::new(
+            result.close.as_ref().unwrap().span(),
+            "`close` cannot be used with `init`, `init_if_needed`, or `zeroed`",
+        ));
+    }
+
+    if result.realloc.is_some() && (result.is_init || result.is_init_if_needed || result.is_zeroed)
+    {
+        return Err(syn::Error::new(
+            result.realloc.as_ref().unwrap().span(),
+            "`realloc` cannot be used with `init`, `init_if_needed`, or `zeroed`",
+        ));
+    }
+
+    if result.payer.is_some() && !(result.is_init || result.is_init_if_needed) {
+        return Err(syn::Error::new(
+            result.payer.as_ref().unwrap().span(),
+            "`payer` requires `init` or `init_if_needed`",
+        ));
+    }
+
+    if result.space.is_some() && !(result.is_init || result.is_init_if_needed) {
+        return Err(syn::Error::new(
+            result.space.as_ref().unwrap().span(),
+            "`space` requires `init` or `init_if_needed`",
+        ));
+    }
+
+    if result.bump.is_some() && result.seeds.is_none() {
+        let span = match result.bump.as_ref().unwrap() {
+            Some(expr) => syn::spanned::Spanned::span(expr),
+            None => proc_macro2::Span::call_site(),
+        };
+        return Err(syn::Error::new(span, "`bump` requires `seeds`"));
+    }
+
+    if result.seeds.is_some() && result.bump.is_none() {
+        return Err(syn::Error::new(
+            result.seeds.as_ref().unwrap().span(),
+            "`seeds` requires `bump`",
+        ));
+    }
     if result.seeds_program.is_some() && result.seeds.is_none() {
         return Err(syn::Error::new(
             result.seeds_program.as_ref().unwrap().span(),
             "`seeds::program` requires `seeds`",
         ));
+    }
+    if let Some(program) = result.seeds_program.as_ref() {
+        if result.is_init_if_needed {
+            return Err(syn::Error::new(
+                syn::spanned::Spanned::span(program),
+                "`seeds::program` cannot be used with `init_if_needed`",
+            ));
+        }
+        if result.is_init {
+            return Err(syn::Error::new(
+                syn::spanned::Spanned::span(program),
+                "`seeds::program` cannot be used with `init`",
+            ));
+        }
     }
 
     if result.payer.is_none() {
@@ -425,7 +574,46 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
             "`realloc` requires `realloc_payer = <target>`",
         ));
     }
+    if result.realloc_payer.is_some() && result.realloc.is_none() {
+        return Err(syn::Error::new(
+            result.realloc_payer.as_ref().unwrap().span(),
+            "`realloc_payer` requires `realloc`",
+        ));
+    }
 
+    let has_init = result.is_init || result.is_init_if_needed;
+    let has_namespaced = |ns: &str, key: &str| {
+        result
+            .namespaced
+            .iter()
+            .any(|nc| !nc.is_update && nc.namespace == ns && nc.raw_key == key)
+    };
+    if has_init {
+        if has_namespaced("token", "mint") && !has_namespaced("token", "authority") {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "when initializing, `token::authority` must be provided if `token::mint` is",
+            ));
+        }
+        if has_namespaced("token", "authority") && !has_namespaced("token", "mint") {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "when initializing, `token::mint` must be provided if `token::authority` is",
+            ));
+        }
+        if has_namespaced("mint", "decimals") && !has_namespaced("mint", "authority") {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "when initializing, `mint::authority` must be provided if `mint::decimals` is",
+            ));
+        }
+        if has_namespaced("mint", "authority") && !has_namespaced("mint", "decimals") {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "when initializing, `mint::decimals` must be provided if `mint::authority` is",
+            ));
+        }
+    }
     Ok(result)
 }
 

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1349,7 +1349,7 @@ fn dotted_address_hint(
     } else {
         None
     }
-
+}
 
 fn require_summary_field<'a>(
     fields: &'a [FieldSummary],
@@ -1501,17 +1501,6 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
     }
 
     Ok(())
-}
-
-/// Turn the RHS of `#[account(address = <expr>)]` into the string form the
-/// IDL emits. Whitespace from `quote!`'s token reassembly is stripped so
-/// `crate :: ID` → `crate::ID`, `data . authority` → `data.authority`, and
-/// `crate :: id ()` → `crate::id()` — matching what a user would hand-write
-/// and what downstream tooling (the Anchor CLI resolver, TS client path
-/// walkers) expect to parse.
-fn stringify_address_expr(expr: &Expr) -> String {
-    let s = quote!(#expr).to_string();
-    s.split_whitespace().collect()
 }
 
 /// If `expr` is the v1-encodable shape `<sibling>.<field>` where both:
@@ -3587,7 +3576,7 @@ mod tests {
                 pub program: UncheckedAccount
             })
             .unwrap();
-        let parsed = parse_field(&field, &[], &[], quote::quote!(0usize), &[], &[]).unwrap();
+        let parsed = parse_test_field(&field).unwrap();
 
         assert!(parsed.idl_address.is_none());
         assert!(parsed.idl_address_expr.is_some());
@@ -3604,8 +3593,10 @@ mod tests {
                 pub program: UncheckedAccount
             })
             .unwrap();
+        let attrs = parse_account_attrs(&field.attrs).unwrap();
         let parsed = parse_field(
             &field,
+            &attrs,
             &["data".into(), "program".into()],
             &[],
             quote::quote!(0usize),

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -607,19 +607,22 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         ));
     }
 
-    let has_namespaced = |ns: &str, key: &str| {
+    let has_namespaced = |ns: &str, key: &str, allow_update: bool| {
         result
             .namespaced
             .iter()
-            .any(|nc| !nc.is_update && nc.namespace == ns && nc.raw_key == key)
+            .any(|nc| (allow_update || !nc.is_update) && nc.namespace == ns && nc.raw_key == key)
     };
     if result.is_init || result.is_init_if_needed {
-        for (namespace, left, right) in [
-            ("token", "mint", "authority"),
-            ("mint", "decimals", "authority"),
+        for (namespace, left, right, allow_update) in [
+            ("token", "mint", "authority", false),
+            // `update(mint::...)` constraints should still compile on init
+            // accounts; they are applied later and must not leak into the
+            // init params that `Mint::create_and_initialize` consumes.
+            ("mint", "decimals", "authority", true),
         ] {
-            let has_left = has_namespaced(namespace, left);
-            let has_right = has_namespaced(namespace, right);
+            let has_left = has_namespaced(namespace, left, allow_update);
+            let has_right = has_namespaced(namespace, right, allow_update);
             if has_left != has_right {
                 let (missing, present) = if has_left {
                     (right, left)
@@ -1453,8 +1456,7 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 .realloc_payer
                 .as_ref()
                 .expect("realloc payer is validated while parsing account attributes");
-            let payer_field =
-                require_summary_field(fields, payer, target, "realloc payer", false)?;
+            let payer_field = require_summary_field(fields, payer, target, "realloc payer", false)?;
             if extract_option_inner(&payer_field.ty).is_some() {
                 return Err(syn::Error::new(
                     payer_field.name.span(),

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -103,7 +103,7 @@ pub struct IdlPdaMeta {
 }
 
 pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
-    let mut explicit_mut = false;
+    let mut explicit_mut = None;
     let mut realloc_zero_seen = false;
     let mut result = AccountAttrs {
         is_mut: false,
@@ -147,10 +147,10 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                 let ident = Ident::parse_any(input)?;
                 match ident.to_string().as_str() {
                     "mut" => {
-                        if explicit_mut {
+                        if explicit_mut.is_some() {
                             return Err(duplicate_singleton(ident.span(), "mut"));
                         }
-                        explicit_mut = true;
+                        explicit_mut = Some(ident.span());
                         result.is_mut = true;
                     }
                     "init" => {
@@ -512,6 +512,15 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         }
     }
 
+    if let Some(span) = explicit_mut {
+        if result.is_init || result.is_init_if_needed {
+            return Err(syn::Error::new(span, "mut cannot be provided with init"));
+        }
+        if result.is_zeroed {
+            return Err(syn::Error::new(span, "mut cannot be provided with zeroed"));
+        }
+    }
+
     if result.close.is_some() && (result.is_init || result.is_init_if_needed || result.is_zeroed) {
         return Err(syn::Error::new(
             result.close.as_ref().unwrap().span(),
@@ -617,6 +626,13 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         return Err(syn::Error::new(
             result.realloc.as_ref().unwrap().span(),
             "`realloc` requires `realloc_payer`",
+        ));
+    }
+
+    if result.realloc.is_some() && !realloc_zero_seen {
+        return Err(syn::Error::new(
+            result.realloc.as_ref().unwrap().span(),
+            "`realloc` requires `realloc_zero`",
         ));
     }
 

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1387,7 +1387,7 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 .as_ref()
                 .expect("init payer is validated while parsing account attributes");
             let payer_field = require_summary_field(fields, payer, target, "init payer", false)?;
-            if required && extract_option_inner(&payer_field.ty).is_some() {
+            if extract_option_inner(&payer_field.ty).is_some() {
                 return Err(syn::Error::new(
                     payer_field.name.span(),
                     "optional accounts cannot be used as init payers",
@@ -1485,7 +1485,7 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 .expect("realloc payer is validated while parsing account attributes");
             let payer_field =
                 require_summary_field(fields, payer, target, "realloc payer", false)?;
-            if required && extract_option_inner(&payer_field.ty).is_some() {
+            if extract_option_inner(&payer_field.ty).is_some() {
                 return Err(syn::Error::new(
                     payer_field.name.span(),
                     "optional accounts cannot be used as realloc payers",

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -643,37 +643,33 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         ));
     }
 
-    let has_init = result.is_init || result.is_init_if_needed;
     let has_namespaced = |ns: &str, key: &str| {
         result
             .namespaced
             .iter()
             .any(|nc| !nc.is_update && nc.namespace == ns && nc.raw_key == key)
     };
-    if has_init {
-        if has_namespaced("token", "mint") && !has_namespaced("token", "authority") {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "when initializing, `token::authority` must be provided if `token::mint` is",
-            ));
-        }
-        if has_namespaced("token", "authority") && !has_namespaced("token", "mint") {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "when initializing, `token::mint` must be provided if `token::authority` is",
-            ));
-        }
-        if has_namespaced("mint", "decimals") && !has_namespaced("mint", "authority") {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "when initializing, `mint::authority` must be provided if `mint::decimals` is",
-            ));
-        }
-        if has_namespaced("mint", "authority") && !has_namespaced("mint", "decimals") {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "when initializing, `mint::decimals` must be provided if `mint::authority` is",
-            ));
+    if result.is_init || result.is_init_if_needed {
+        for (namespace, left, right) in [
+            ("token", "mint", "authority"),
+            ("mint", "decimals", "authority"),
+        ] {
+            let has_left = has_namespaced(namespace, left);
+            let has_right = has_namespaced(namespace, right);
+            if has_left != has_right {
+                let (missing, present) = if has_left {
+                    (right, left)
+                } else {
+                    (left, right)
+                };
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    format!(
+                        "when initializing, `{namespace}::{missing}` must be provided if \
+                         `{namespace}::{present}` is"
+                    ),
+                ));
+            }
         }
     }
     Ok(result)
@@ -1360,9 +1356,6 @@ fn dotted_address_hint(
         None
     }
 
-fn find_summary_field<'a>(fields: &'a [FieldSummary], name: &Ident) -> Option<&'a FieldSummary> {
-    fields.iter().find(|field| field.name == *name)
-}
 
 fn require_summary_field<'a>(
     fields: &'a [FieldSummary],
@@ -1371,12 +1364,15 @@ fn require_summary_field<'a>(
     purpose: &str,
     required: bool,
 ) -> syn::Result<&'a FieldSummary> {
-    let field = find_summary_field(fields, name).ok_or_else(|| {
-        syn::Error::new(
-            name.span(),
-            format!("the {purpose} account `{name}` does not exist"),
-        )
-    })?;
+    let field = fields
+        .iter()
+        .find(|field| field.name == *name)
+        .ok_or_else(|| {
+            syn::Error::new(
+                name.span(),
+                format!("the {purpose} account `{name}` does not exist"),
+            )
+        })?;
     if required && extract_option_inner(&field.ty).is_some() {
         return Err(syn::Error::new(
             target.name.span(),
@@ -1425,11 +1421,11 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 })
                 .collect();
             if !spl_constraints.is_empty() {
-                let token_program_constraints: Vec<_> = spl_constraints
+                let mut token_program_constraints = spl_constraints
                     .iter()
                     .filter(|constraint| constraint.raw_key == "token_program")
-                    .collect();
-                if token_program_constraints.is_empty() {
+                    .peekable();
+                if token_program_constraints.peek().is_none() {
                     let token_program = Ident::new("token_program", proc_macro2::Span::call_site());
                     require_summary_field(
                         fields,
@@ -2185,6 +2181,7 @@ fn emit_init_if_needed_reuse_validation(
 
 pub fn parse_field(
     field: &syn::Field,
+    attrs: &AccountAttrs,
     field_names: &[String],
     field_offsets: &[(String, TokenStream2)],
     offset_expr: proc_macro2::TokenStream,
@@ -2193,22 +2190,7 @@ pub fn parse_field(
 ) -> syn::Result<AccountField> {
     let field_name = field.ident.as_ref().expect("named field");
     let field_ty = &field.ty;
-    let attrs = parse_account_attrs(&field.attrs)?;
-    if attrs.seeds_program.is_some() {
-        if attrs.is_init {
-            return Err(syn::Error::new(
-                attrs.seeds_program.as_ref().unwrap().span(),
-                "`seeds::program` cannot be used with `init`",
-            ));
-        }
-        if attrs.is_init_if_needed {
-            return Err(syn::Error::new(
-                attrs.seeds_program.as_ref().unwrap().span(),
-                "`seeds::program` cannot be used with `init_if_needed`",
-            ));
-        }
-    }
-    validate_init_constraint_refs(field_name, &attrs, field_summaries)?;
+    validate_init_constraint_refs(field_name, attrs, field_summaries)?;
     if attrs.close.is_some() && !attrs.is_mut {
         return Err(syn::Error::new(
             field_name.span(),
@@ -3290,6 +3272,11 @@ pub fn parse_field(
 mod tests {
     use super::*;
 
+    fn parse_test_field(field: &syn::Field) -> syn::Result<AccountField> {
+        let attrs = parse_account_attrs(&field.attrs)?;
+        parse_field(field, &attrs, &[], &[], quote!(0usize), &[], &[])
+    }
+
     #[test]
     fn test_parse_account_attrs() {
         let attrs: Vec<Attribute> = vec![syn::parse_quote!(
@@ -3351,7 +3338,7 @@ mod tests {
                 pub inner: Nested<Inner>
             })
             .unwrap();
-        let err = match parse_field(&field, &[], &[], quote::quote!(0usize), &[], &[]) {
+        let err = match parse_test_field(&field) {
             Ok(_) => panic!("account attrs on Nested<T> must be rejected"),
             Err(err) => err,
         };
@@ -3377,7 +3364,7 @@ mod tests {
                 pub my_acc: Account<MyAcc>
             })
             .unwrap();
-        let parsed = parse_field(&field, &[], &[], quote::quote!(0usize), &[], &[]).unwrap();
+        let parsed = parse_test_field(&field).unwrap();
         let joined = parsed
             .constraints
             .iter()

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -103,6 +103,8 @@ pub struct IdlPdaMeta {
 }
 
 pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
+    let mut explicit_mut = false;
+    let mut realloc_zero_seen = false;
     let mut result = AccountAttrs {
         is_mut: false,
         is_signer: false,
@@ -144,7 +146,13 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
             while !input.is_empty() {
                 let ident = Ident::parse_any(input)?;
                 match ident.to_string().as_str() {
-                    "mut" => result.is_mut = true,
+                    "mut" => {
+                        if explicit_mut {
+                            return Err(duplicate_singleton(ident.span(), "mut"));
+                        }
+                        explicit_mut = true;
+                        result.is_mut = true;
+                    }
                     "init" => {
                         if result.is_init {
                             return Err(duplicate_singleton(ident.span(), "init"));
@@ -197,8 +205,18 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                             result.bump = Some(None);
                         }
                     }
-                    "signer" => result.is_signer = true,
-                    "executable" => result.is_executable = true,
+                    "signer" => {
+                        if result.is_signer {
+                            return Err(duplicate_singleton(ident.span(), "signer"));
+                        }
+                        result.is_signer = true;
+                    }
+                    "executable" => {
+                        if result.is_executable {
+                            return Err(duplicate_singleton(ident.span(), "executable"));
+                        }
+                        result.is_executable = true;
+                    }
                     "dup" => {
                         return Err(syn::Error::new(
                             ident.span(),
@@ -212,6 +230,9 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                         let inner: Ident = content.parse()?;
                         match inner.to_string().as_str() {
                             "dup" => {
+                                if result.is_dup {
+                                    return Err(duplicate_singleton(inner.span(), "unsafe(dup)"));
+                                }
                                 result.is_dup = true;
                                 result.is_mut = true;
                             }
@@ -348,6 +369,10 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     }
                     "realloc_zero" => {
                         input.parse::<Token![=]>()?;
+                        if realloc_zero_seen {
+                            return Err(duplicate_singleton(ident.span(), "realloc_zero"));
+                        }
+                        realloc_zero_seen = true;
                         let val: syn::LitBool = input.parse()?;
                         result.realloc_zero = val.value;
                     }
@@ -509,6 +534,13 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         ));
     }
 
+    if (result.is_init || result.is_init_if_needed) && result.payer.is_none() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`init` and `init_if_needed` require `payer`",
+        ));
+    }
+
     if result.space.is_some() && !(result.is_init || result.is_init_if_needed) {
         return Err(syn::Error::new(
             result.space.as_ref().unwrap().span(),
@@ -578,6 +610,20 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         return Err(syn::Error::new(
             result.realloc_payer.as_ref().unwrap().span(),
             "`realloc_payer` requires `realloc`",
+        ));
+    }
+
+    if result.realloc.is_some() && result.realloc_payer.is_none() {
+        return Err(syn::Error::new(
+            result.realloc.as_ref().unwrap().span(),
+            "`realloc` requires `realloc_payer`",
+        ));
+    }
+
+    if realloc_zero_seen && result.realloc.is_none() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`realloc_zero` requires `realloc`",
         ));
     }
 
@@ -1135,9 +1181,6 @@ pub struct AccountField {
     /// `true` iff this optional field contributes to the runtime active
     /// mutable mask when it loads as `Some`.
     pub contributes_active_mut_bit: bool,
-    /// The local payer field named by this field's `init`/`init_if_needed`
-    /// constraint, if present.
-    pub init_payer: Option<String>,
     // IDL metadata
     pub idl_writable: bool,
     /// True when this is a fresh-keypair init site (attrs: `init` or
@@ -1300,6 +1343,169 @@ fn dotted_address_hint(
     } else {
         None
     }
+
+fn find_summary_field<'a>(fields: &'a [FieldSummary], name: &Ident) -> Option<&'a FieldSummary> {
+    fields.iter().find(|field| field.name == *name)
+}
+
+fn require_summary_field<'a>(
+    fields: &'a [FieldSummary],
+    name: &Ident,
+    target: &FieldSummary,
+    purpose: &str,
+    required: bool,
+) -> syn::Result<&'a FieldSummary> {
+    let field = find_summary_field(fields, name).ok_or_else(|| {
+        syn::Error::new(
+            name.span(),
+            format!("the {purpose} account `{name}` does not exist"),
+        )
+    })?;
+    if required && extract_option_inner(&field.ty).is_some() {
+        return Err(syn::Error::new(
+            target.name.span(),
+            format!("the {purpose} account `{name}` must be non-optional"),
+        ));
+    }
+    Ok(field)
+}
+
+pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
+    for target in fields {
+        let attrs = &target.attrs;
+        let required = extract_option_inner(&target.ty).is_none();
+
+        if attrs.is_init || attrs.is_init_if_needed {
+            let payer = attrs
+                .payer
+                .as_ref()
+                .expect("init payer is validated while parsing account attributes");
+            let payer_field = require_summary_field(fields, payer, target, "init payer", false)?;
+            if required && extract_option_inner(&payer_field.ty).is_some() {
+                return Err(syn::Error::new(
+                    payer_field.name.span(),
+                    "optional accounts cannot be used as init payers",
+                ));
+            }
+            if !payer_field.attrs.is_mut {
+                return Err(syn::Error::new(
+                    target.name.span(),
+                    "the payer specified for an init constraint must be mutable",
+                ));
+            }
+
+            let system_program = Ident::new("system_program", proc_macro2::Span::call_site());
+            require_summary_field(fields, &system_program, target, "init program", required)?;
+
+            let spl_constraints: Vec<_> = attrs
+                .namespaced
+                .iter()
+                .filter(|constraint| {
+                    !constraint.is_update
+                        && matches!(
+                            constraint.namespace.as_str(),
+                            "token" | "mint" | "associated_token"
+                        )
+                })
+                .collect();
+            if !spl_constraints.is_empty() {
+                let token_program_constraints: Vec<_> = spl_constraints
+                    .iter()
+                    .filter(|constraint| constraint.raw_key == "token_program")
+                    .collect();
+                if token_program_constraints.is_empty() {
+                    let token_program = Ident::new("token_program", proc_macro2::Span::call_site());
+                    require_summary_field(
+                        fields,
+                        &token_program,
+                        target,
+                        "SPL token program",
+                        required,
+                    )?;
+                } else {
+                    for constraint in token_program_constraints {
+                        let token_program =
+                            expr_as_field_ident(&constraint.value).ok_or_else(|| {
+                                syn::Error::new(
+                                    constraint.value.span(),
+                                    "SPL token program constraints must reference an account field",
+                                )
+                            })?;
+                        require_summary_field(
+                            fields,
+                            &token_program,
+                            target,
+                            "SPL token program",
+                            required,
+                        )?;
+                    }
+                }
+            }
+
+            for constraint in spl_constraints.iter().filter(|constraint| {
+                constraint.raw_key == "mint"
+                    && matches!(constraint.namespace.as_str(), "token" | "associated_token")
+            }) {
+                let mint = expr_as_field_ident(&constraint.value).ok_or_else(|| {
+                    syn::Error::new(
+                        constraint.value.span(),
+                        "the mint constraint must reference an account field for token \
+                         initialization",
+                    )
+                })?;
+                require_summary_field(fields, &mint, target, "token mint", false)?;
+            }
+
+            if spl_constraints
+                .iter()
+                .any(|constraint| constraint.namespace == "associated_token")
+            {
+                let associated_token_program =
+                    Ident::new("associated_token_program", proc_macro2::Span::call_site());
+                require_summary_field(
+                    fields,
+                    &associated_token_program,
+                    target,
+                    "associated token program",
+                    required,
+                )?;
+            }
+        }
+
+        if attrs.realloc.is_some() {
+            let payer = attrs
+                .realloc_payer
+                .as_ref()
+                .expect("realloc payer is validated while parsing account attributes");
+            let payer_field =
+                require_summary_field(fields, payer, target, "realloc payer", false)?;
+            if required && extract_option_inner(&payer_field.ty).is_some() {
+                return Err(syn::Error::new(
+                    payer_field.name.span(),
+                    "optional accounts cannot be used as realloc payers",
+                ));
+            }
+            if !payer_field.attrs.is_mut {
+                return Err(syn::Error::new(
+                    target.name.span(),
+                    "the payer specified for a realloc constraint must be mutable",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Turn the RHS of `#[account(address = <expr>)]` into the string form the
+/// IDL emits. Whitespace from `quote!`'s token reassembly is stripped so
+/// `crate :: ID` → `crate::ID`, `data . authority` → `data.authority`, and
+/// `crate :: id ()` → `crate::id()` — matching what a user would hand-write
+/// and what downstream tooling (the Anchor CLI resolver, TS client path
+/// walkers) expect to parse.
+fn stringify_address_expr(expr: &Expr) -> String {
+    let s = quote!(#expr).to_string();
+    s.split_whitespace().collect()
 }
 
 /// If `expr` is the v1-encodable shape `<sibling>.<field>` where both:
@@ -2141,7 +2347,6 @@ pub fn parse_field(
             // own offset.
             contributes_mut_bit: false,
             contributes_active_mut_bit: false,
-            init_payer: None,
             idl_writable: false,
             idl_init_signer: false,
             idl_has_one: vec![],
@@ -3040,10 +3245,6 @@ pub fn parse_field(
 
     let contributes_mut_bit = attrs.is_mut && !attrs.is_dup && !is_optional;
     let contributes_active_mut_bit = attrs.is_mut && !attrs.is_dup && is_optional;
-    let init_payer = (attrs.is_init || attrs.is_init_if_needed)
-        .then(|| attrs.payer.as_ref().map(ToString::to_string))
-        .flatten();
-
     Ok(AccountField {
         name: field_name.clone(),
         ty: field.ty.clone(),
@@ -3057,7 +3258,6 @@ pub fn parse_field(
         offset_expr,
         contributes_mut_bit,
         contributes_active_mut_bit,
-        init_payer,
         idl_writable,
         idl_init_signer,
         idl_has_one,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -435,12 +435,6 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                                     ));
                                 }
                                 input.parse::<Token![=]>()?;
-                                if result.seeds_program.is_some() {
-                                    return Err(duplicate_singleton(
-                                        key_ident.span(),
-                                        "seeds::program",
-                                    ));
-                                }
                                 result.seeds_program = Some(input.parse()?);
                                 if !input.is_empty() {
                                     input.parse::<Token![,]>()?;

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -565,12 +565,6 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
             "`seeds` requires `bump`",
         ));
     }
-    if result.seeds_program.is_some() && result.seeds.is_none() {
-        return Err(syn::Error::new(
-            result.seeds_program.as_ref().unwrap().span(),
-            "`seeds::program` requires `seeds`",
-        ));
-    }
     if let Some(program) = result.seeds_program.as_ref() {
         if result.is_init_if_needed {
             return Err(syn::Error::new(
@@ -584,30 +578,6 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                 "`seeds::program` cannot be used with `init`",
             ));
         }
-    }
-
-    if result.payer.is_none() {
-        if let Some(init_span) = result.init_span {
-            return Err(syn::Error::new(
-                init_span,
-                "`init` requires `payer = <target>`",
-            ));
-        }
-        if let Some(init_if_needed_span) = result.init_if_needed_span {
-            return Err(syn::Error::new(
-                init_if_needed_span,
-                "`init_if_needed` requires `payer = <target>`",
-            ));
-        }
-    }
-
-    if result.realloc.is_some() && result.realloc_payer.is_none() {
-        return Err(syn::Error::new(
-            result
-                .realloc_span
-                .unwrap_or_else(proc_macro2::Span::call_site),
-            "`realloc` requires `realloc_payer = <target>`",
-        ));
     }
     if result.realloc_payer.is_some() && result.realloc.is_none() {
         return Err(syn::Error::new(
@@ -3021,7 +2991,7 @@ pub fn parse_field(
         let realloc_payer = attrs.realloc_payer.as_ref().ok_or_else(|| {
             syn::Error::new(
                 attrs.realloc_span.unwrap_or_else(|| field_name.span()),
-                "`realloc` requires `realloc_payer = <target>`",
+                "`realloc` requires `realloc_payer`",
             )
         })?;
         let zero_fill = attrs.realloc_zero;
@@ -3289,16 +3259,18 @@ mod tests {
     }
 
     #[test]
-    fn empty_seed_array_with_seeds_program_is_accepted() {
+    fn empty_seed_array_with_seeds_program_requires_bump() {
         let attrs: Vec<Attribute> = vec![syn::parse_quote!(
             #[account(seeds = [], seeds::program = other_program.key())]
         )];
-        let parsed = parse_account_attrs(&attrs).expect("empty seeds array remains valid");
-        let Expr::Array(arr) = parsed.seeds.expect("seed array should be preserved") else {
-            panic!("expected parsed seeds to stay as an array expression");
+        let err = match parse_account_attrs(&attrs) {
+            Ok(_) => panic!("empty seeds array without bump must be rejected"),
+            Err(err) => err,
         };
-        assert!(arr.elems.is_empty());
-        assert!(parsed.seeds_program.is_some());
+        assert!(
+            err.to_string().contains("`seeds` requires `bump`"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -3413,7 +3385,7 @@ mod tests {
         };
         assert!(
             err.to_string()
-                .contains("`init` requires `payer = <target>`"),
+                .contains("`init` and `init_if_needed` require `payer`"),
             "unexpected error: {err}"
         );
     }
@@ -3429,7 +3401,7 @@ mod tests {
         };
         assert!(
             err.to_string()
-                .contains("`init_if_needed` requires `payer = <target>`"),
+                .contains("`init` and `init_if_needed` require `payer`"),
             "unexpected error: {err}"
         );
     }
@@ -3445,7 +3417,7 @@ mod tests {
         };
         assert!(
             err.to_string()
-                .contains("`realloc` requires `realloc_payer = <target>`"),
+                .contains("`realloc` requires `realloc_payer`"),
             "unexpected error: {err}"
         );
     }

--- a/lang-v2/tests/init_if_needed_reuse_validation.rs
+++ b/lang-v2/tests/init_if_needed_reuse_validation.rs
@@ -1,7 +1,8 @@
 use {
     anchor_lang_v2::{
-        accounts::{Signer, UncheckedAccount},
+        accounts::{Program, Signer, UncheckedAccount},
         cpi::rent_exempt_lamports,
+        programs::{System, Token},
         testing::AccountBuffer,
         AccountInitialize, Accounts, AnchorAccount, Error, ErrorCode, Id, TryAccounts,
     },
@@ -21,6 +22,7 @@ struct SeedlessReuseUnchecked {
     target: UncheckedAccount,
     #[account(mut)]
     payer: Signer,
+    system_program: Program<System>,
 }
 
 #[derive(Clone, Copy)]
@@ -306,6 +308,8 @@ struct ReuseFakeMint {
     authority: UncheckedAccount,
     #[account(mut)]
     payer: Signer,
+    token_program: Program<Token>,
+    system_program: Program<System>,
 }
 
 #[derive(Accounts)]
@@ -323,6 +327,8 @@ struct ReuseFakeMintWithFreezeAuthority {
     freeze_authority: UncheckedAccount,
     #[account(mut)]
     payer: Signer,
+    token_program: Program<Token>,
+    system_program: Program<System>,
 }
 
 #[derive(Accounts)]
@@ -339,6 +345,8 @@ struct ReuseFakeToken {
     authority: UncheckedAccount,
     #[account(mut)]
     payer: Signer,
+    token_program: Program<Token>,
+    system_program: Program<System>,
 }
 
 fn expect_err<T>(result: Result<T, ProgramError>) -> ProgramError {
@@ -369,6 +377,12 @@ fn payer_account() -> AccountBuffer<128> {
 fn authority_account(address: [u8; 32]) -> AccountBuffer<128> {
     let buf = AccountBuffer::<128>::new();
     buf.init(address, PROGRAM_ID, 0, false, false, false);
+    buf
+}
+
+fn program_account(address: Address) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    buf.init(address.to_bytes(), [0u8; 32], 0, false, false, true);
     buf
 }
 
@@ -408,7 +422,12 @@ fn fake_token_account(
 }
 
 fn try_reuse(target: &AccountBuffer<128>, payer: &AccountBuffer<128>) -> Result<(), ProgramError> {
-    let views = [unsafe { target.view() }, unsafe { payer.view() }];
+    let system_program = program_account(System::id());
+    let views = [
+        unsafe { target.view() },
+        unsafe { payer.view() },
+        unsafe { system_program.view() },
+    ];
     SeedlessReuseUnchecked::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
         .map(|_| ())
 }
@@ -418,10 +437,14 @@ fn try_reuse_fake_mint(
     authority: &AccountBuffer<128>,
     payer: &AccountBuffer<128>,
 ) -> Result<(), ProgramError> {
+    let token_program = program_account(Token::id());
+    let system_program = program_account(System::id());
     let views = [
         unsafe { target.view() },
         unsafe { authority.view() },
         unsafe { payer.view() },
+        unsafe { token_program.view() },
+        unsafe { system_program.view() },
     ];
     ReuseFakeMint::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
         .map(|_| ())
@@ -433,11 +456,15 @@ fn try_reuse_fake_mint_with_freeze_authority(
     freeze_authority: &AccountBuffer<128>,
     payer: &AccountBuffer<128>,
 ) -> Result<(), ProgramError> {
+    let token_program = program_account(Token::id());
+    let system_program = program_account(System::id());
     let views = [
         unsafe { target.view() },
         unsafe { authority.view() },
         unsafe { freeze_authority.view() },
         unsafe { payer.view() },
+        unsafe { token_program.view() },
+        unsafe { system_program.view() },
     ];
     ReuseFakeMintWithFreezeAuthority::try_accounts(
         &Address::new_from_array(PROGRAM_ID),
@@ -455,11 +482,15 @@ fn try_reuse_fake_token(
     authority: &AccountBuffer<128>,
     payer: &AccountBuffer<128>,
 ) -> Result<(), ProgramError> {
+    let token_program = program_account(Token::id());
+    let system_program = program_account(System::id());
     let views = [
         unsafe { target.view() },
         unsafe { mint.view() },
         unsafe { authority.view() },
         unsafe { payer.view() },
+        unsafe { token_program.view() },
+        unsafe { system_program.view() },
     ];
     ReuseFakeToken::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
         .map(|_| ())

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1027,6 +1027,80 @@ pub struct Bad {
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
 fn account_attrs_reject_duplicate_singletons_and_conflicts() {
+    for (name, attrs, message) in [
+        (
+            "duplicate_mut",
+            "#[account(mut)] #[account(mut)]",
+            "`mut` already provided",
+        ),
+        (
+            "duplicate_signer",
+            "#[account(signer)] #[account(signer)]",
+            "`signer` already provided",
+        ),
+        (
+            "duplicate_executable",
+            "#[account(executable)] #[account(executable)]",
+            "`executable` already provided",
+        ),
+        (
+            "duplicate_unsafe_dup",
+            "#[account(unsafe(dup))] #[account(unsafe(dup))]",
+            "`unsafe(dup)` already provided",
+        ),
+    ] {
+        compile_fail_case(
+            name,
+            &format!(
+                r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {{
+    {attrs}
+    pub data: UncheckedAccount,
+}}
+"#
+            ),
+            &[message],
+        );
+    }
+
+    compile_fail_case(
+        "duplicate_realloc_zero",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(
+        realloc = 16,
+        realloc_payer = payer,
+        realloc_zero = false,
+        realloc_zero = true,
+    )]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc_zero` already provided"],
+    );
+
+    compile_fail_case(
+        "duplicate_namespaced_constraint",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(example::value = 1, example::value = 2)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["duplicate `example::value` constraint"],
+    );
+
     compile_fail_case(
         "duplicate_owner_across_account_attrs",
         r#"
@@ -1152,6 +1226,34 @@ pub struct Bad {
 )]
 fn account_attrs_enforce_local_dependency_pairs() {
     compile_fail_case(
+        "init_without_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(init, space = 8)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`init` and `init_if_needed` require `payer`"],
+    );
+
+    compile_fail_case(
+        "init_if_needed_without_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(init_if_needed, space = 8)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`init` and `init_if_needed` require `payer`"],
+    );
+
+    compile_fail_case(
         "payer_without_init",
         r#"
 use anchor_lang_v2::prelude::*;
@@ -1243,6 +1345,256 @@ pub struct Bad {
 "#,
         &["`realloc_payer` requires `realloc`"],
     );
+
+    compile_fail_case(
+        "realloc_without_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(realloc = 16)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`realloc` requires `realloc_payer`"],
+    );
+
+    compile_fail_case(
+        "realloc_zero_without_realloc",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(realloc_zero = true)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`realloc_zero` requires `realloc`"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn accounts_derive_enforces_referenced_account_invariants() {
+    compile_fail_case(
+        "required_init_rejects_optional_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Option<Signer>,
+    #[account(init, payer = payer, space = 8)]
+    pub data: UncheckedAccount,
+    pub system_program: Program<System>,
+}
+"#,
+        &["optional accounts cannot be used as init payers"],
+    );
+
+    compile_fail_case(
+        "required_init_requires_system_program",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, space = 8)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["the init program account `system_program` does not exist"],
+    );
+
+    compile_fail_case(
+        "required_init_rejects_optional_system_program",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, space = 8)]
+    pub data: UncheckedAccount,
+    pub system_program: Option<Program<System>>,
+}
+"#,
+        &["the init program account `system_program` must be non-optional"],
+    );
+
+    compile_fail_case(
+        "required_spl_init_requires_token_program",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::{Mint, TokenAccount},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: UncheckedAccount,
+    #[account(
+        init,
+        payer = payer,
+        token::mint = mint,
+        token::authority = authority,
+    )]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["the SPL token program account `token_program` does not exist"],
+    );
+
+    compile_fail_case(
+        "token_init_mint_must_reference_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::{TokenAccount, TokenInterface},
+};
+
+pub const MINT: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: UncheckedAccount,
+    pub token_program: Interface<'static, TokenInterface>,
+    #[account(
+        init,
+        payer = payer,
+        token::mint = MINT,
+        token::authority = authority,
+    )]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["the token mint account `MINT` does not exist"],
+    );
+
+    compile_fail_case(
+        "required_spl_init_rejects_optional_token_program",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: UncheckedAccount,
+    pub token_program: Option<Interface<'static, TokenInterface>>,
+    #[account(
+        init,
+        payer = payer,
+        token::mint = mint,
+        token::authority = authority,
+    )]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["the SPL token program account `token_program` must be non-optional"],
+    );
+
+    compile_fail_case(
+        "associated_token_init_requires_program",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    associated_token::{self},
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: UncheckedAccount,
+    pub token_program: Interface<'static, TokenInterface>,
+    #[account(
+        init,
+        payer = payer,
+        associated_token::mint = mint,
+        associated_token::authority = authority,
+    )]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["the associated token program account `associated_token_program` does not exist"],
+    );
+
+    compile_fail_case(
+        "realloc_payer_must_be_mutable",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    pub payer: Signer,
+    #[account(realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["the payer specified for a realloc constraint must be mutable"],
+    );
+
+    compile_fail_case(
+        "required_realloc_rejects_optional_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Option<Signer>,
+    #[account(realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["optional accounts cannot be used as realloc payers"],
+    );
+
+    compile_fail_case(
+        "realloc_payer_must_exist",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["the realloc payer account `payer` does not exist"],
+    );
 }
 
 #[test]
@@ -1251,6 +1603,62 @@ pub struct Bad {
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
 fn spl_init_constraints_require_pairs() {
+    compile_fail_case(
+        "associated_token_requires_authority",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    associated_token::{self},
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<'static, TokenInterface>,
+    pub associated_token_program: Program<AssociatedToken>,
+    #[account(init, payer = payer, associated_token::mint = mint)]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`associated_token::authority` is required when using associated_token constraints"],
+    );
+
+    compile_fail_case(
+        "associated_token_rejects_seeds",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    associated_token::{self},
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: UncheckedAccount,
+    pub token_program: Interface<'static, TokenInterface>,
+    pub associated_token_program: Program<AssociatedToken>,
+    #[account(
+        init,
+        payer = payer,
+        seeds = [b"token"],
+        bump,
+        associated_token::mint = mint,
+        associated_token::authority = authority,
+    )]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`associated_token` constraints cannot be used with `seeds`"],
+    );
+
     compile_fail_case(
         "init_token_requires_authority_with_mint",
         r#"

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1821,7 +1821,7 @@ use anchor_lang_v2::prelude::*;
 use anchor_spl_v2::{
     mint::{self},
     token::{self},
-    token_interface::Mint,
+    token_interface::{Mint, TokenInterface},
 };
 
 #[derive(Accounts)]
@@ -1829,6 +1829,7 @@ pub struct Good {
     #[account(mut)]
     pub payer: Signer,
     pub authority: UncheckedAccount,
+    pub token_program: Interface<'static, TokenInterface>,
     #[account(
         init,
         payer = payer,

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -778,7 +778,7 @@ pub struct MissingInitPayer {
     pub system_program: Program<System>,
 }
 "#,
-        &["`init` requires `payer = <target>`"],
+        &["`init` and `init_if_needed` require `payer`"],
         &["proc-macro derive panicked"],
     );
 
@@ -803,7 +803,7 @@ pub struct MissingReallocPayer {
     pub system_program: Program<System>,
 }
 "#,
-        &["`realloc` requires `realloc_payer = <target>`"],
+        &["`realloc` requires `realloc_payer`"],
         &["proc-macro derive panicked"],
     );
 }
@@ -1342,7 +1342,7 @@ pub struct Bad {
     pub data: UncheckedAccount,
 }
 "#,
-        &["`seeds::program` requires `seeds`"],
+        &["seeds must be provided before seeds::program"],
     );
 
     compile_fail_case(

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -21,6 +21,7 @@ publish = false
 
 [dependencies]
 anchor-lang-v2 = {{ path = "{}" }}
+anchor-spl-v2 = {{ path = "{}" }}
 wincode = {{ version = "0.5", features = ["derive"] }}
 
 [features]
@@ -30,7 +31,8 @@ live = []
 
 [workspace]
 "#,
-            manifest_dir.display()
+            manifest_dir.display(),
+            manifest_dir.parent().unwrap().join("spl-v2").display()
         ),
     )
     .unwrap();
@@ -1016,6 +1018,330 @@ pub struct Bad {
             "`#[account(close = ...)]` is not supported on `UncheckedAccount`",
             "close the raw account manually",
         ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn account_attrs_reject_duplicate_singletons_and_conflicts() {
+    compile_fail_case(
+        "duplicate_owner_across_account_attrs",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(owner = System::id())]
+    #[account(owner = System::id())]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`owner` already provided"],
+    );
+
+    compile_fail_case(
+        "duplicate_has_one_target",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[account]
+pub struct Data {
+    pub authority: Address,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    pub authority: UncheckedAccount,
+    #[account(has_one = authority, has_one = authority)]
+    pub data: Account<Data>,
+}
+"#,
+        &["duplicate `has_one = authority` constraint"],
+    );
+
+    compile_fail_case(
+        "init_and_zeroed_conflict",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, zeroed, payer = payer, space = 8 + core::mem::size_of::<Data>())]
+    pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["only one of `init`, `init_if_needed`, and `zeroed` may be used"],
+    );
+
+    compile_fail_case(
+        "init_and_close_conflict",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut)]
+    pub receiver: SystemAccount,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        close = receiver,
+    )]
+    pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`close` cannot be used with `init`, `init_if_needed`, or `zeroed`"],
+    );
+
+    compile_fail_case(
+        "init_if_needed_and_realloc_conflict",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init_if_needed,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        realloc = 64,
+        realloc_payer = payer,
+        realloc_zero = false,
+    )]
+    pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`realloc` cannot be used with `init`, `init_if_needed`, or `zeroed`"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn account_attrs_enforce_local_dependency_pairs() {
+    compile_fail_case(
+        "payer_without_init",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(payer = payer)]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`payer` requires `init` or `init_if_needed`"],
+    );
+
+    compile_fail_case(
+        "space_without_init",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(space = 16)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`space` requires `init` or `init_if_needed`"],
+    );
+
+    compile_fail_case(
+        "bump_without_seeds",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(bump)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`bump` requires `seeds`"],
+    );
+
+    compile_fail_case(
+        "seeds_without_bump",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(seeds = [b"data"])]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`seeds` requires `bump`"],
+    );
+
+    compile_fail_case(
+        "seeds_program_without_seeds",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(seeds::program = OTHER_PROGRAM)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["`seeds::program` requires `seeds`"],
+    );
+
+    compile_fail_case(
+        "realloc_payer_without_realloc",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(realloc_payer = payer)]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc_payer` requires `realloc`"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn spl_init_constraints_require_pairs() {
+    compile_fail_case(
+        "init_token_requires_authority_with_mint",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::{Mint, TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<'static, TokenInterface>,
+    #[account(init, payer = payer, token::mint = mint)]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["when initializing, `token::authority` must be provided if `token::mint` is"],
+    );
+
+    compile_fail_case(
+        "init_token_requires_mint_with_authority",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::{TokenAccount, TokenInterface},
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: UncheckedAccount,
+    pub token_program: Interface<'static, TokenInterface>,
+    #[account(init, payer = payer, token::authority = authority)]
+    pub token_account: InterfaceAccount<TokenAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["when initializing, `token::mint` must be provided if `token::authority` is"],
+    );
+
+    compile_fail_case(
+        "init_mint_requires_authority_with_decimals",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::Mint,
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, mint::decimals = 6)]
+    pub mint: InterfaceAccount<Mint>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["when initializing, `mint::authority` must be provided if `mint::decimals` is"],
+    );
+
+    compile_fail_case(
+        "init_mint_requires_decimals_with_authority",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::Mint,
+};
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: UncheckedAccount,
+    #[account(init, payer = payer, mint::authority = authority)]
+    pub mint: InterfaceAccount<Mint>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["when initializing, `mint::decimals` must be provided if `mint::authority` is"],
     );
 }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1048,6 +1048,21 @@ fn account_attrs_reject_duplicate_singletons_and_conflicts() {
             "#[account(unsafe(dup))] #[account(unsafe(dup))]",
             "`unsafe(dup)` already provided",
         ),
+        (
+            "mut_with_init",
+            "#[account(mut, init)]",
+            "mut cannot be provided with init",
+        ),
+        (
+            "mut_with_init_if_needed",
+            "#[account(mut, init_if_needed)]",
+            "mut cannot be provided with init",
+        ),
+        (
+            "mut_with_zeroed",
+            "#[account(mut, zeroed)]",
+            "mut cannot be provided with zeroed",
+        ),
     ] {
         compile_fail_case(
             name,
@@ -1372,6 +1387,22 @@ pub struct Bad {
 }
 "#,
         &["`realloc_zero` requires `realloc`"],
+    );
+
+    compile_fail_case(
+        "realloc_without_zero",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(realloc = 16, realloc_payer = payer)]
+    pub data: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+}
+"#,
+        &["`realloc` requires `realloc_zero`"],
     );
 }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1430,6 +1430,23 @@ pub struct Bad {
     );
 
     compile_fail_case(
+        "optional_init_target_rejects_optional_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Option<Signer>,
+    #[account(init_if_needed, payer = payer, space = 8)]
+    pub data: Option<UncheckedAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["optional accounts cannot be used as init payers"],
+    );
+
+    compile_fail_case(
         "required_init_requires_system_program",
         r#"
 use anchor_lang_v2::prelude::*;
@@ -1608,6 +1625,22 @@ pub struct Bad {
     pub payer: Option<Signer>,
     #[account(realloc = 16, realloc_payer = payer, realloc_zero = false)]
     pub data: UncheckedAccount,
+}
+"#,
+        &["optional accounts cannot be used as realloc payers"],
+    );
+
+    compile_fail_case(
+        "optional_realloc_target_rejects_optional_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Option<Signer>,
+    #[account(realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: Option<UncheckedAccount>,
 }
 "#,
         &["optional accounts cannot be used as realloc payers"],

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -447,9 +447,7 @@ pub struct Bad {
     pub data: Option<UncheckedAccount>,
 }
 "#,
-        &[
-            "instruction argument names beginning with `__` are reserved for generated code",
-        ],
+        &["instruction argument names beginning with `__` are reserved for generated code"],
     );
 }
 
@@ -1814,6 +1812,33 @@ pub struct Bad {
 }
 "#,
         &["when initializing, `mint::decimals` must be provided if `mint::authority` is"],
+    );
+
+    compile_pass_case(
+        "init_mint_allows_update_only_decimals",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self},
+    token::{self},
+    token_interface::Mint,
+};
+
+#[derive(Accounts)]
+pub struct Good {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: UncheckedAccount,
+    #[account(
+        init,
+        payer = payer,
+        update(mint::decimals = 9),
+        mint::authority = authority,
+    )]
+    pub mint: InterfaceAccount<Mint>,
+    pub system_program: Program<System>,
+}
+"#,
     );
 }
 


### PR DESCRIPTION
## Finding

Lang-v2 omitted several v1 cross-field checks, accepting duplicate constraints, lifecycle conflicts, missing dependencies, and incomplete SPL initialization pairs.

## Fix

Restore derive-level validation for singleton constraints, lifecycle rules, local dependencies, SPL pairs, and referenced account requirements. Macro diagnostics cover lifecycle, dependency, and SPL conflicts.