### PR TITLE
fix(lang-v2): use wire size for byte discriminator minimum args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "min-ix-data-len"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang-v2",
+ "bytemuck",
+ "pinocchio",
+ "pinocchio-system",
+ "solana-program-error 3.0.0",
+ "wincode 0.5.4",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9280,6 +9292,7 @@ dependencies = [
  "init-space-usability",
  "ix-macro",
  "litesvm",
+ "min-ix-data-len",
  "optional-accounts",
  "pinocchio",
  "program-interface",

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4430,10 +4430,10 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
     // Returns u64 error code on failure (not Err) since __anchor_dispatch
     // returns u64 directly.
     // Build a const expression for the minimum ix_data length across all
-    // instructions: disc_size + min(serialized args size per ix). Uses
-    // `size_of` on a tuple of arg types — only when ALL args are owned
-    // fixed-size types (no references, no dynamic-size). Falls back to 0
-    // for instructions with references or complex types.
+    // instructions: disc_size + min(serialized args size per ix). Uses a
+    // per-argument scalar-size sum only when ALL args are owned fixed-size
+    // primitives (no references, no dynamic-size). Falls back to 0 for
+    // instructions with references or complex types.
     fn is_fixed_size_primitive(ty: &syn::Type) -> bool {
         match ty {
             syn::Type::Path(p) if p.path.segments.len() == 1 => {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4464,7 +4464,7 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                 if types.is_empty() || !types.iter().all(is_fixed_size_primitive) {
                     quote! { 0usize }
                 } else {
-                    quote! { core::mem::size_of::<(#(#types,)*)>() }
+                    quote! { 0usize #( + core::mem::size_of::<#types>() )* }
                 }
             })
             .collect();

--- a/tests-v2/Cargo.toml
+++ b/tests-v2/Cargo.toml
@@ -44,6 +44,7 @@ event-cpi-test = { path = "programs/event-cpi" }
 foreign-borsh-account = { path = "programs/foreign-borsh-account" }
 init-space-usability = { path = "programs/init-space-usability" }
 ix-macro = { path = "programs/ix-macro" }
+min-ix-data-len = { path = "programs/min-ix-data-len" }
 optional-accounts = { path = "programs/optional-accounts" }
 program-interface = { path = "programs/program-interface", features = ["cpi"] }
 seeds = { path = "programs/seeds" }

--- a/tests-v2/programs/min-ix-data-len/Cargo.toml
+++ b/tests-v2/programs/min-ix-data-len/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "min-ix-data-len"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+default = ["no-log-ix-name"]
+no-entrypoint = []
+cpi = ["no-entrypoint"]
+no-idl = []
+no-log-ix-name = []
+idl-build = []
+
+[dependencies]
+anchor-lang-v2 = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
+bytemuck = { version = "1", features = ["derive"] }
+pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
+pinocchio-system = "0.6"
+solana-program-error = "3.0"
+wincode = { version = "0.5", features = ["derive"] }
+
+[lints.rust.unexpected_cfgs]
+level = "allow"

--- a/tests-v2/programs/min-ix-data-len/src/lib.rs
+++ b/tests-v2/programs/min-ix-data-len/src/lib.rs
@@ -1,0 +1,19 @@
+use anchor_lang_v2::prelude::*;
+
+declare_id!("5s2e6TBgh2AYCEmW3DZi7WJYtNaLWS7M3e8dnNh4qLVA");
+
+#[program]
+pub mod min_ix_data_len {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn short_args(_ctx: &mut Context<Noop>, a: u8, b: u64) -> Result<()> {
+        if a != 7 || b != 0x0102_0304_0506_0708 {
+            return Err(ProgramError::InvalidInstructionData.into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Noop {}

--- a/tests-v2/tests/min_ix_data_len.rs
+++ b/tests-v2/tests/min_ix_data_len.rs
@@ -1,0 +1,45 @@
+use {
+    anchor_lang_v2::InstructionData,
+    litesvm::LiteSVM,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    tests_v2::{build_program, keypair_for, send_instruction},
+};
+
+fn program_id() -> Pubkey {
+    "5s2e6TBgh2AYCEmW3DZi7WJYtNaLWS7M3e8dnNh4qLVA"
+        .parse()
+        .unwrap()
+}
+
+fn setup() -> (LiteSVM, Keypair) {
+    let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let deploy_dir = test_dir.join("target/deploy");
+    build_program(
+        test_dir.join("programs/min-ix-data-len").to_str().unwrap(),
+        deploy_dir.to_str().unwrap(),
+    );
+
+    let mut svm = LiteSVM::new();
+    svm.add_program_from_file(program_id(), deploy_dir.join("min_ix_data_len.so"))
+        .expect("load min_ix_data_len program");
+    let payer = keypair_for("min-ix-data-len-payer");
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+    (svm, payer)
+}
+
+#[test]
+fn byte_discriminator_accepts_exact_wincode_payload_length() {
+    let (mut svm, payer) = setup();
+    let data = min_ix_data_len::instruction::ShortArgs {
+        a: 7,
+        b: 0x0102_0304_0506_0708,
+    }
+    .data();
+
+    assert_eq!(data.len(), 10, "1-byte discriminator + 9-byte payload");
+
+    send_instruction(&mut svm, program_id(), data, vec![], &payer, &[])
+        .expect("exact wire-length args should dispatch successfully");
+}


### PR DESCRIPTION
## Finding

Byte-discriminator minimum length used Rust tuple size instead of serialized width, rejecting valid compact instruction data.

## Fix

Calculate the minimum argument length from wincode wire widths rather than `size_of::<(Args,)>`. End-to-end regressions cover compact mixed-width arguments.