### PR TITLE
fix(lang-v2): validate payer constraints early

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -179,7 +179,6 @@ fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt>
         )),
     }
 }
-
 fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
     let fields = match &input.data {
         Data::Struct(s) => match &s.fields {

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -846,6 +846,39 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn realloc_payer_cannot_be_optional() {
+    compile_fail_case(
+        "realloc_payer_optional_account_is_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: Account<Data>,
+    #[account(mut)]
+    pub payer: Option<SystemAccount>,
+}
+"#,
+        &[
+            "optional accounts cannot be used as realloc payers",
+            "realloc_payer",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn pda_init_payer_must_be_system_account() {
     compile_fail_case(
         "pda_init_payer_must_be_system_account",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -820,6 +820,25 @@ pub struct MissingReallocPayer {
         &["`realloc` requires `realloc_payer`"],
         &["proc-macro derive panicked"],
     );
+
+    compile_fail_case(
+        "realloc_payer_missing_field_is_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
+    pub data: Account<Data>,
+}
+"#,
+        &["the payer specified for a realloc constraint does not exist"],
+    );
 }
 
 #[test]

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -763,7 +763,7 @@ pub struct Bad {
     pub system_program: Program<System>,
 }
 "#,
-        &["the payer specified for the init constraint must be mutable"],
+        &["the payer specified for an init constraint must be mutable"],
     );
 
     compile_fail_case(

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -763,7 +763,7 @@ pub struct Bad {
     pub system_program: Program<System>,
 }
 "#,
-        &["the payer specified for an init constraint must be mutable"],
+        &["the payer specified for the init constraint must be mutable"],
     );
 
     compile_fail_case(
@@ -843,25 +843,6 @@ pub struct MissingReallocPayer {
 "#,
         &["`realloc` requires `realloc_payer`"],
         &["proc-macro derive panicked"],
-    );
-
-    compile_fail_case(
-        "realloc_payer_missing_field_is_rejected",
-        r#"
-use anchor_lang_v2::prelude::*;
-
-#[account]
-pub struct Data {
-    pub value: u64,
-}
-
-#[derive(Accounts)]
-pub struct Bad {
-    #[account(mut, realloc = 16, realloc_payer = payer, realloc_zero = false)]
-    pub data: Account<Data>,
-}
-"#,
-        &["the payer specified for a realloc constraint does not exist"],
     );
 }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -765,6 +765,30 @@ pub struct Bad {
 "#,
         &["the payer specified for an init constraint must be mutable"],
     );
+
+    compile_fail_case(
+        "init_payer_optional_account_is_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(init, payer = payer, space = 8 + core::mem::size_of::<Data>())]
+    pub data: Account<Data>,
+    #[account(mut)]
+    pub payer: Option<SystemAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["optional accounts cannot be used as init payers"],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Finding

A `realloc_payer` could reference a readonly, optional, or nonexistent field, producing unusable account metas or late failures.

## Fix

Require realloc payers to reference an existing, non-optional mutable account during derive validation. Macro diagnostics cover readonly, missing, and optional payers.