### PR TITLE
lang(lazy-account): Re-run ownership checks when reloading `LazyAccount`

### DIFF
--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -239,7 +239,8 @@ where
 
     /// Unload the deserialized account value by resetting the cache.
     ///
-    /// This is useful when observing side-effects of CPIs.
+    /// This is useful when observing side-effects of CPIs, and will re-check the account
+    /// owner and discriminator.
     ///
     /// # Usage
     ///
@@ -260,6 +261,8 @@ where
     ///
     /// If there is an existing reference (mutable or not) created by any of the `load` methods.
     pub fn unload(&self) -> Result<&Self> {
+        // Re-run load-time checks (owner, discriminator)
+        drop(Self::try_from(self.__info)?);
         // TODO: Should we drop the initialized fields manually?
         *self.__account.borrow_mut() = MaybeUninit::uninit();
         *self.__fields.borrow_mut() = None;

--- a/tests/lazy-account/programs/lazy-account/src/lib.rs
+++ b/tests/lazy-account/programs/lazy-account/src/lib.rs
@@ -36,6 +36,19 @@ pub mod lazy_account {
         *ctx.accounts.my_account.load_mut_authority()? = new_authority;
         Ok(())
     }
+
+    pub fn unload_after_account_change(ctx: Context<UnloadAfterAccountChange>) -> Result<()> {
+        // Populate the cache before imitating a CPI changing the account data.
+        drop(ctx.accounts.my_account.load_authority()?);
+
+        ctx.accounts
+            .my_account
+            .to_account_info()
+            .try_borrow_mut_data()?[0] ^= 0xff;
+
+        ctx.accounts.my_account.unload()?;
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -91,6 +104,12 @@ pub struct Write<'info> {
     /// This account imitates heavy stack usage in more complex programs
     #[account(seeds = [b"stack_heavy_account"], bump)]
     pub stack_heavy_account: Account<'info, StackHeavyAccount>,
+}
+
+#[derive(Accounts)]
+pub struct UnloadAfterAccountChange<'info> {
+    #[account(mut, seeds = [b"my_account"], bump)]
+    pub my_account: LazyAccount<'info, MyAccount>,
 }
 
 const MAX_DATA_LEN: usize = 256;

--- a/tests/lazy-account/tests/lazy-account.ts
+++ b/tests/lazy-account/tests/lazy-account.ts
@@ -21,6 +21,15 @@ describe("lazy-account", () => {
     await program.methods.read().rpc();
   });
 
+  it("Checks the discriminator when unloading after account data changes", async () => {
+    await assert.rejects(
+      program.methods.unloadAfterAccountChange().rpc(),
+      (err: anchor.AnchorError) =>
+        err.error.errorCode.number ===
+        anchor.LangErrorCode.AccountDiscriminatorMismatch
+    );
+  });
+
   it("Can write", async () => {
     const newAuthority = anchor.web3.PublicKey.default;
     const { pubkeys, signature } = await program.methods


### PR DESCRIPTION
`Account::reload()` re-runs the owner and discriminator checks in case these have been manipulated across a CPI. `LazyAccount::unload()` currently does not, so rerun `try_from` to perform these checks.

Another option here would be to introduce a `reload` method with the same API as on `Account`, but I don't think it's worth the churn