### PR TITLE
fix(lang-v2): disambiguate declare_program account groups

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2407,12 +2407,13 @@ fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<To
     let events = gen_declare_program_events(idl)?;
     let errors = gen_declare_program_errors(idl, name.span())?;
     let mut account_groups = std::collections::BTreeMap::<String, Vec<DeclareAccountField>>::new();
+    let mut account_group_variants =
+        std::collections::BTreeMap::<String, Vec<DeclareAccountGroupVariant>>::new();
     let mut handlers = Vec::new();
     for ix in instructions {
         let ix_name = json_str(ix, "name", name.span())?;
         let ix_ident = Ident::new(&to_snake_case(ix_name), name.span());
         let accounts_name = to_type_name(ix_name);
-        let accounts_ident = Ident::new(&accounts_name, name.span());
         let accounts = ix
             .get("accounts")
             .and_then(serde_json::Value::as_array)
@@ -2422,7 +2423,14 @@ fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<To
                     format!("instruction `{ix_name}` is missing accounts array"),
                 )
             })?;
-        collect_declare_account_group(&accounts_name, accounts, &mut account_groups, name.span())?;
+        let generated_accounts_name = collect_declare_account_group(
+            &accounts_name,
+            accounts,
+            &mut account_groups,
+            &mut account_group_variants,
+            name.span(),
+        )?;
+        let accounts_ident = Ident::new(&generated_accounts_name, name.span());
 
         let discrim = ix
             .get("discriminator")
@@ -2682,16 +2690,89 @@ impl DeclareAccountField {
     }
 }
 
+struct DeclareAccountGroupVariant {
+    signature: String,
+    generated_name: String,
+}
+
+fn declare_account_group_signature(
+    accounts: &[serde_json::Value],
+    span: proc_macro2::Span,
+) -> syn::Result<String> {
+    let mut signature = String::new();
+    for account in accounts {
+        signature.push_str(&declare_account_signature(account, span)?);
+        signature.push(';');
+    }
+    Ok(signature)
+}
+
+fn declare_account_signature(
+    account: &serde_json::Value,
+    span: proc_macro2::Span,
+) -> syn::Result<String> {
+    let name = json_str(account, "name", span)?;
+    if let Some(nested) = account.get("accounts").and_then(serde_json::Value::as_array) {
+        return Ok(format!(
+            "nested:{name}:{}",
+            declare_account_group_signature(nested, span)?
+        ));
+    }
+
+    let writable = account
+        .get("writable")
+        .or_else(|| account.get("isMut"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let signer = account
+        .get("signer")
+        .or_else(|| account.get("isSigner"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let optional = account
+        .get("optional")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(format!("leaf:{name}:{writable}:{signer}:{optional}"))
+}
+
+fn next_declare_account_group_name(
+    base_name: &str,
+    groups: &std::collections::BTreeMap<String, Vec<DeclareAccountField>>,
+) -> String {
+    if !groups.contains_key(base_name) {
+        return base_name.to_string();
+    }
+
+    let mut suffix = 2usize;
+    loop {
+        let candidate = format!("{base_name}{suffix}");
+        if !groups.contains_key(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 fn collect_declare_account_group(
     group_name: &str,
     accounts: &[serde_json::Value],
     groups: &mut std::collections::BTreeMap<String, Vec<DeclareAccountField>>,
+    variants: &mut std::collections::BTreeMap<String, Vec<DeclareAccountGroupVariant>>,
     span: proc_macro2::Span,
-) -> syn::Result<()> {
-    if groups.contains_key(group_name) {
-        return Ok(());
+) -> syn::Result<String> {
+    let signature = declare_account_group_signature(accounts, span)?;
+    if let Some(existing_name) = variants.get(group_name).and_then(|group_variants| {
+        group_variants
+            .iter()
+            .find(|variant| variant.signature == signature)
+            .map(|variant| variant.generated_name.clone())
+    }) {
+        return Ok(existing_name);
     }
 
+    let generated_name = next_declare_account_group_name(group_name, groups);
     let mut fields = Vec::new();
     for account in accounts {
         let name = json_str(account, "name", span)?;
@@ -2701,8 +2782,9 @@ fn collect_declare_account_group(
             .and_then(serde_json::Value::as_array)
         {
             let nested_name = to_type_name(name);
-            collect_declare_account_group(&nested_name, nested, groups, span)?;
-            let nested_ident = Ident::new(&nested_name, span);
+            let generated_nested_name =
+                collect_declare_account_group(&nested_name, nested, groups, variants, span)?;
+            let nested_ident = Ident::new(&generated_nested_name, span);
             fields.push(DeclareAccountField {
                 name: ident,
                 ty: quote! { anchor_lang_v2::Nested<#nested_ident> },
@@ -2745,8 +2827,15 @@ fn collect_declare_account_group(
         });
     }
 
-    groups.insert(group_name.to_string(), fields);
-    Ok(())
+    groups.insert(generated_name.clone(), fields);
+    variants
+        .entry(group_name.to_string())
+        .or_default()
+        .push(DeclareAccountGroupVariant {
+            signature,
+            generated_name: generated_name.clone(),
+        });
+    Ok(generated_name)
 }
 
 fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenStream2>> {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2403,6 +2403,8 @@ fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<To
     let type_reexports = type_idents
         .iter()
         .map(|ident| quote! { pub use super::#ident; });
+    let reserved_account_group_names: std::collections::BTreeSet<String> =
+        type_idents.iter().map(ToString::to_string).collect();
     let constants = gen_declare_program_constants(idl)?;
     let events = gen_declare_program_events(idl)?;
     let errors = gen_declare_program_errors(idl, name.span())?;
@@ -2426,6 +2428,7 @@ fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<To
         let generated_accounts_name = collect_declare_account_group(
             &accounts_name,
             accounts,
+            &reserved_account_group_names,
             &mut account_groups,
             &mut account_group_variants,
             name.span(),
@@ -2739,16 +2742,17 @@ fn declare_account_signature(
 
 fn next_declare_account_group_name(
     base_name: &str,
+    reserved_names: &std::collections::BTreeSet<String>,
     groups: &std::collections::BTreeMap<String, Vec<DeclareAccountField>>,
 ) -> String {
-    if !groups.contains_key(base_name) {
+    if !groups.contains_key(base_name) && !reserved_names.contains(base_name) {
         return base_name.to_string();
     }
 
     let mut suffix = 2usize;
     loop {
         let candidate = format!("{base_name}{suffix}");
-        if !groups.contains_key(&candidate) {
+        if !groups.contains_key(&candidate) && !reserved_names.contains(&candidate) {
             return candidate;
         }
         suffix += 1;
@@ -2758,6 +2762,7 @@ fn next_declare_account_group_name(
 fn collect_declare_account_group(
     group_name: &str,
     accounts: &[serde_json::Value],
+    reserved_names: &std::collections::BTreeSet<String>,
     groups: &mut std::collections::BTreeMap<String, Vec<DeclareAccountField>>,
     variants: &mut std::collections::BTreeMap<String, Vec<DeclareAccountGroupVariant>>,
     span: proc_macro2::Span,
@@ -2772,7 +2777,7 @@ fn collect_declare_account_group(
         return Ok(existing_name);
     }
 
-    let generated_name = next_declare_account_group_name(group_name, groups);
+    let generated_name = next_declare_account_group_name(group_name, reserved_names, groups);
     let mut fields = Vec::new();
     for account in accounts {
         let name = json_str(account, "name", span)?;
@@ -2782,8 +2787,14 @@ fn collect_declare_account_group(
             .and_then(serde_json::Value::as_array)
         {
             let nested_name = to_type_name(name);
-            let generated_nested_name =
-                collect_declare_account_group(&nested_name, nested, groups, variants, span)?;
+            let generated_nested_name = collect_declare_account_group(
+                &nested_name,
+                nested,
+                reserved_names,
+                groups,
+                variants,
+                span,
+            )?;
             let nested_ident = Ident::new(&generated_nested_name, span);
             fields.push(DeclareAccountField {
                 name: ident,

--- a/tests-v2/programs/declare-program/surface/idls/surface.json
+++ b/tests-v2/programs/declare-program/surface/idls/surface.json
@@ -156,6 +156,46 @@
           }
         }
       ]
+    },
+    {
+      "name": "sharedAlpha",
+      "discriminator": [60, 61, 62],
+      "accounts": [
+        {
+          "name": "shared",
+          "accounts": [
+            {
+              "name": "firstSigner",
+              "signer": true
+            },
+            {
+              "name": "firstReadonly"
+            }
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "sharedBeta",
+      "discriminator": [63, 64, 65],
+      "accounts": [
+        {
+          "name": "shared",
+          "accounts": [
+            {
+              "name": "secondWritable",
+              "writable": true
+            },
+            {
+              "name": "secondSignerWritable",
+              "writable": true,
+              "signer": true
+            }
+          ]
+        }
+      ],
+      "args": []
     }
   ],
   "types": [

--- a/tests-v2/src/declare-program/surface.rs
+++ b/tests-v2/src/declare-program/surface.rs
@@ -87,6 +87,46 @@ fn declared_surface_deep_nested_accounts_flatten_in_idl_order() {
 }
 
 #[test]
+fn declared_surface_reuses_nested_group_names_only_when_shapes_match() {
+    let first_signer = Pubkey::new_unique();
+    let first_readonly = Pubkey::new_unique();
+    let metas = surface::accounts::SharedAlpha {
+        shared: surface::__client_accounts_shared::Shared {
+            first_signer,
+            first_readonly,
+        }
+        .into(),
+    }
+    .to_account_metas(None);
+
+    assert_eq!(metas.len(), 2);
+    assert_eq!(metas[0], AccountMeta::new_readonly(first_signer, true));
+    assert_eq!(metas[1], AccountMeta::new_readonly(first_readonly, false));
+
+    let second_writable = Pubkey::new_unique();
+    let second_signer_writable = Pubkey::new_unique();
+    let metas = surface::accounts::SharedBeta {
+        shared: surface::__client_accounts_shared2::Shared2 {
+            second_writable,
+            second_signer_writable,
+        }
+        .into(),
+    }
+    .to_account_metas(None);
+
+    assert_eq!(metas.len(), 2);
+    assert_eq!(metas[0], AccountMeta::new(second_writable, false));
+    assert_eq!(
+        metas[1],
+        AccountMeta {
+            pubkey: second_signer_writable,
+            is_writable: true,
+            is_signer: true,
+        }
+    );
+}
+
+#[test]
 fn declared_surface_complex_types_compile_and_serialize() {
     let owner = Pubkey::new_unique();
     let args = surface::SurfaceArgs {

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -425,6 +425,34 @@ pub fn build_ix(authority: Address, data: Address, owner: Address) -> anchor_lan
 }
 
 #[test]
+fn declare_program_account_group_variants_do_not_collide_with_existing_types() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let surface_idl_path = manifest_dir.join("programs/declare-program/surface/idls/surface.json");
+    let surface_idl = fs::read_to_string(&surface_idl_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", surface_idl_path.display()));
+    let mut surface: serde_json::Value =
+        serde_json::from_str(&surface_idl).expect("surface fixture should parse");
+    surface["types"]
+        .as_array_mut()
+        .expect("surface types should be an array")
+        .push(serde_json::json!({
+            "name": "Shared2",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "value",
+                        "type": "u64"
+                    }
+                ]
+            }
+        }));
+    let idl = Box::leak(surface.to_string().into_boxed_str());
+
+    declare_program_case("declare_program_account_group_type_name_collision", idl).expect_pass();
+}
+
+#[test]
 fn declare_program_missing_accounts_array_fails_clearly() {
     declare_program_compile_fail_case(
         "declare_program_missing_accounts_array",


### PR DESCRIPTION
## Finding

`declare_program!` cached nested account groups only by name, reusing incorrect layouts when same-name groups had different shapes.

## Fix

Include the complete account-group shape when deciding whether a generated nested struct can be reused. Compile regressions cover same-name, differently-shaped groups.