### PR TITLE
fix(lang-v2): model PodVec and pod wrappers in IDL

### DIFF
--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -615,7 +615,7 @@ pub fn bytemuck_repr_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<Bytemuc
                         return Err(syn::Error::new(
                             list.span(),
                             "Anchor IDL only supports `#[repr(..., packed)]` or \
-                             `#[repr(..., packed(1))]`
+                             `#[repr(..., packed(1))]`"
                         ));
                     }
                     repr.packed = true;

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -615,7 +615,8 @@ pub fn bytemuck_repr_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<Bytemuc
                         return Err(syn::Error::new(
                             list.span(),
                             "Anchor IDL only supports `#[repr(..., packed)]` or \
-                             `#[repr(..., packed(1))]`"
+                             `#[repr(..., packed(1))]`; other packed widths \
+                             would produce a lossy IDL layout"
                         ));
                     }
                     repr.packed = true;

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -37,6 +37,9 @@ impl<'a> TypeLowerer<'a> {
     }
 
     fn lower(&mut self, ty: &Type) -> Value {
+        if let Some(value) = pod_vec_type_to_idl_value(ty) {
+            return value;
+        }
         match ty {
             Type::Reference(reference) => self.lower(&reference.elem),
             Type::Group(group) => self.lower(&group.elem),
@@ -168,6 +171,72 @@ pub fn rust_type_to_idl(ty: &Type) -> TokenStream2 {
     let value = lowerer.lower(ty);
     lowerer.finish(value)
 }
+
+fn pod_vec_type_to_idl_value(ty: &Type) -> Option<Value> {
+    match ty {
+        Type::Group(group) => pod_vec_type_to_idl_value(&group.elem),
+        Type::Paren(paren) => pod_vec_type_to_idl_value(&paren.elem),
+        Type::Reference(reference) => pod_vec_type_to_idl_value(reference.elem.as_ref()),
+        Type::Path(type_path) => {
+            let segment = type_path.path.segments.last()?;
+            if segment.ident != "PodVec" {
+                return None;
+            }
+            let PathArguments::AngleBracketed(args) = &segment.arguments else {
+                return None;
+            };
+            if args.args.len() != 2 {
+                return None;
+            }
+            let mut args_iter = args.args.iter();
+            let inner_ty = match args_iter.next()? {
+                syn::GenericArgument::Type(ty) => ty,
+                _ => return None,
+            };
+            let max_expr = match args_iter.next()? {
+                syn::GenericArgument::Const(expr) => expr,
+                _ => return None,
+            };
+            Some(json!({
+                "defined": {
+                    "name": "PodVec",
+                    "generics": [
+                        {
+                            "kind": "type",
+                            "type": pod_vec_element_type_to_idl_value(inner_ty),
+                        },
+                        {
+                            "kind": "const",
+                            "value": quote!(#max_expr).to_string().replace(' ', ""),
+                        },
+                    ],
+                }
+            }))
+        }
+        _ => None,
+    }
+}
+
+fn pod_vec_element_type_to_idl_value(ty: &Type) -> Value {
+    match ty {
+        Type::Path(type_path) => {
+            let Some(segment) = type_path.path.segments.last() else {
+                return TypeLowerer::default().lower(ty);
+            };
+            match normalize_builtin_path(&segment.ident.to_string()) {
+                "PodBool" | "PodU16" | "PodU32" | "PodU64" | "PodU128" | "PodI16" | "PodI32"
+                | "PodI64" | "PodI128" => json!({
+                    "defined": {
+                        "name": segment.ident.to_string(),
+                    }
+                }),
+                _ => TypeLowerer::default().lower(ty),
+            }
+        }
+        _ => TypeLowerer::default().lower(ty),
+    }
+}
+
 fn normalize_builtin_path(ty: &str) -> &str {
     let ty = ty.trim_start_matches("::");
     [
@@ -1334,6 +1403,33 @@ mod tests {
         assert_eq!(
             rust_type_to_idl_value(&primitive_named_user_ty),
             json!({ "defined": { "name": "u8" } })
+        );
+    }
+
+    #[test]
+    fn pod_vec_references_preserve_type_and_const_generics() {
+        let ty: Type = syn::parse_quote!(PodVec<PodU64, 4>);
+        assert_eq!(
+            rust_type_to_idl_value(&ty),
+            json!({
+                "defined": {
+                    "name": "PodVec",
+                    "generics": [
+                        {
+                            "kind": "type",
+                            "type": {
+                                "defined": {
+                                    "name": "PodU64",
+                                }
+                            }
+                        },
+                        {
+                            "kind": "const",
+                            "value": "4",
+                        }
+                    ]
+                }
+            })
         );
     }
 

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -18,8 +18,8 @@ use {
     quote::quote,
     serde_json::{json, Value},
     syn::{
-        punctuated::Punctuated, visit::Visit, Expr, GenericParam, Generics, Lit, PathArguments,
-        Token, Type, TypePath,
+        punctuated::Punctuated, spanned::Spanned, visit::Visit, Expr, GenericParam, Generics,
+        Lit, PathArguments, Token, Type, TypePath,
     },
 };
 
@@ -606,6 +606,19 @@ pub fn bytemuck_repr_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<Bytemuc
         for meta in metas {
             match meta {
                 syn::Meta::Path(path) if path.is_ident("packed") => {
+                    repr.packed = true;
+                }
+                syn::Meta::List(list) if list.path.is_ident("packed") => {
+                    let packed = list.parse_args::<syn::LitInt>()?;
+                    let packed = packed.base10_parse::<usize>()?;
+                    if packed != 1 {
+                        return Err(syn::Error::new(
+                            list.span(),
+                            "Anchor IDL only supports `#[repr(..., packed)]` or \
+                             `#[repr(..., packed(1))]`; `packed(N)` with N > 1 would \
+                             round-trip to a lossy IDL layout",
+                        ));
+                    }
                     repr.packed = true;
                 }
                 syn::Meta::List(list) if list.path.is_ident("align") => {
@@ -1495,6 +1508,25 @@ mod tests {
         assert!(generated.contains("Box :: leak"));
         assert!(generated.contains("limits :: ITEMS"));
         assert!(!generated.contains("generic"));
+    }
+
+    #[test]
+    fn packed_one_repr_modifier_sets_packed_flag() {
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[repr(C, packed(1))])];
+        let repr = bytemuck_repr_from_attrs(&attrs).expect("packed(1) should parse");
+        assert!(repr.packed);
+        assert_eq!(repr.align, None);
+    }
+
+    #[test]
+    fn packed_greater_than_one_repr_modifier_is_rejected() {
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[repr(C, packed(2))])];
+        let err = match bytemuck_repr_from_attrs(&attrs) {
+            Ok(_) => panic!("packed(2) should be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("Anchor IDL only supports"));
+        assert!(err.to_string().contains("lossy IDL layout"));
     }
 
     #[test]

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -17,7 +17,10 @@ use {
     proc_macro2::TokenStream as TokenStream2,
     quote::quote,
     serde_json::{json, Value},
-    syn::{visit::Visit, Expr, GenericParam, Generics, Lit, PathArguments, Type, TypePath},
+    syn::{
+        punctuated::Punctuated, visit::Visit, Expr, GenericParam, Generics, Lit, PathArguments,
+        Token, Type, TypePath,
+    },
 };
 
 const DYNAMIC_LEN_KEY: &str = "__anchor_private_const_len";
@@ -584,8 +587,37 @@ pub enum TypeKind {
     /// Default borsh layout. Spec `skip_serializing_if`s both fields at the
     /// default value, so nothing extra gets emitted.
     Borsh,
-    /// `bytemuck` Pod + `repr(C)`. Both fields show up in the JSON.
-    BytemuckRepr,
+    /// `bytemuck` Pod + `repr(C)` plus any layout modifiers preserved from
+    /// the source item's `#[repr(...)]` attributes.
+    BytemuckRepr(BytemuckRepr),
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct BytemuckRepr {
+    pub packed: bool,
+    pub align: Option<usize>,
+}
+
+pub fn bytemuck_repr_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<BytemuckRepr> {
+    let mut repr = BytemuckRepr::default();
+
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("repr")) {
+        let metas = attr.parse_args_with(Punctuated::<syn::Meta, Token![,]>::parse_terminated)?;
+        for meta in metas {
+            match meta {
+                syn::Meta::Path(path) if path.is_ident("packed") => {
+                    repr.packed = true;
+                }
+                syn::Meta::List(list) if list.path.is_ident("align") => {
+                    let align = list.parse_args::<syn::LitInt>()?;
+                    repr.align = Some(align.base10_parse()?);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(repr)
 }
 
 pub fn build_account_entry_string(name: &str, disc: &[u8]) -> Option<String> {
@@ -824,9 +856,17 @@ fn build_type_def_header(
     }
     match kind {
         TypeKind::Borsh => {}
-        TypeKind::BytemuckRepr => {
+        TypeKind::BytemuckRepr(repr) => {
             out.insert("serialization".into(), Value::String("bytemuck".into()));
-            out.insert("repr".into(), json!({ "kind": "c" }));
+            let mut repr_json = serde_json::Map::new();
+            repr_json.insert("kind".into(), Value::String("c".into()));
+            if repr.packed {
+                repr_json.insert("packed".into(), Value::Bool(true));
+            }
+            if let Some(align) = repr.align {
+                repr_json.insert("align".into(), json!(align));
+            }
+            out.insert("repr".into(), Value::Object(repr_json));
         }
     }
     out

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -615,8 +615,7 @@ pub fn bytemuck_repr_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<Bytemuc
                         return Err(syn::Error::new(
                             list.span(),
                             "Anchor IDL only supports `#[repr(..., packed)]` or \
-                             `#[repr(..., packed(1))]`; `packed(N)` with N > 1 would \
-                             round-trip to a lossy IDL layout",
+                             `#[repr(..., packed(1))]`
                         ));
                     }
                     repr.packed = true;

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4134,7 +4134,22 @@ fn gen_declare_program_pod_impls(
     let field_types = fields.tys();
     let impl_generics = &generics.impl_generics;
     let ty_generics = &generics.ty_generics;
-    let where_clause = &generics.pod_where_clause;
+    let generic_where_clause = &generics.pod_where_clause;
+    let where_clause = if field_types.is_empty() {
+        generic_where_clause.clone()
+    } else if generic_where_clause.is_empty() {
+        quote! {
+            where
+                #(#field_types: anchor_lang_v2::bytemuck::Pod
+                    + anchor_lang_v2::bytemuck::Zeroable),*
+        }
+    } else {
+        quote! {
+            #generic_where_clause,
+            #(#field_types: anchor_lang_v2::bytemuck::Pod
+                + anchor_lang_v2::bytemuck::Zeroable),*
+        }
+    };
     quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             const __ANCHOR_DECLARE_PROGRAM_POD_ASSERT: fn() = || {
@@ -4243,6 +4258,9 @@ fn declare_idl_type_to_tokens(
         } else {
             json_str(defined, "name", span)?
         };
+        if let Some(builtin) = declare_idl_defined_builtin(defined_name) {
+            return Ok(builtin);
+        }
         let ident = Ident::new(&to_type_name(defined_name), span);
         let generic_args = defined
             .get("generics")
@@ -4288,6 +4306,21 @@ fn declare_idl_type_to_tokens(
         span,
         format!("unsupported IDL type `{value}`"),
     ))
+}
+
+fn declare_idl_defined_builtin(name: &str) -> Option<TokenStream2> {
+    match name {
+        "PodBool" => Some(quote! { anchor_lang_v2::pod::PodBool }),
+        "PodU16" => Some(quote! { anchor_lang_v2::pod::PodU16 }),
+        "PodU32" => Some(quote! { anchor_lang_v2::pod::PodU32 }),
+        "PodU64" => Some(quote! { anchor_lang_v2::pod::PodU64 }),
+        "PodU128" => Some(quote! { anchor_lang_v2::pod::PodU128 }),
+        "PodI16" => Some(quote! { anchor_lang_v2::pod::PodI16 }),
+        "PodI32" => Some(quote! { anchor_lang_v2::pod::PodI32 }),
+        "PodI64" => Some(quote! { anchor_lang_v2::pod::PodI64 }),
+        "PodI128" => Some(quote! { anchor_lang_v2::pod::PodI128 }),
+        _ => None,
+    }
 }
 
 fn declare_idl_array_len_to_tokens(
@@ -6818,217 +6851,21 @@ mod tests {
     }
 
     #[test]
-    fn program_handlers_inject_update_phase_into_handler_body() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
+    fn declare_idl_defined_pod_wrappers_use_runtime_types() {
+        let span = proc_macro2::Span::call_site();
+        let pod_u64 = declare_idl_type_to_tokens(
+            &json!({ "defined": { "name": "PodU64" } }),
+            span,
+        )
+        .unwrap();
+        assert_eq!(pod_u64.to_string(), "anchor_lang_v2 :: pod :: PodU64");
 
-                #[access_control(validate(&ctx))]
-                pub fn rotate(ctx: &mut Context<RotateAuthority>) -> Result<()> {
-                    do_work()?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains(
-                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut ctx . accounts) ? ;"
-            ),
-            "expected handler body to call update_accounts after access-control expansion, got: {generated}"
-        );
-        assert!(
-            generated.contains("access_control"),
-            "expected access_control attr to remain on the generated handler, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn program_handlers_inject_update_phase_for_destructured_context() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
-
-                pub fn rotate(Context { accounts, .. }: &mut Context<RotateAuthority>) -> Result<()> {
-                    do_work(accounts)?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains("anchor_lang_v2 :: TryAccounts :: update_accounts (accounts) ? ;"),
-            "expected destructured handler body to call update_accounts via accounts binding, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn program_handlers_synthesize_accounts_binding_for_struct_context() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
-
-                pub fn rotate(Context { bumps, .. }: &mut Context<RotateAuthority>) -> Result<()> {
-                    do_work(bumps)?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains(
-                "anchor_lang_v2 :: TryAccounts :: update_accounts (__anchor_accounts) ? ;"
-            ),
-            "expected struct-pattern handler body to call update_accounts via synthesized accounts binding, got: {generated}"
-        );
-        assert!(
-            generated.contains("Context { bumps , accounts : __anchor_accounts , .. }"),
-            "expected struct-pattern handler signature to include synthesized accounts binding, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn program_handlers_inject_update_phase_for_wildcard_context() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
-
-                pub fn rotate(_: &mut Context<RotateAuthority>) -> Result<()> {
-                    do_work()?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains(
-                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut __anchor_ctx . accounts) ? ;"
-            ),
-            "expected wildcard handler body to call update_accounts via synthesized ctx binding, got: {generated}"
-        );
-        assert!(
-            generated.contains("fn rotate (__anchor_ctx : & mut Context < RotateAuthority >)"),
-            "expected wildcard handler signature to be rewritten to a concrete ctx binding, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn program_handlers_reject_unsupported_update_hook_context_patterns() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
-
-                pub fn rotate(
-                    Context { accounts: RotateAuthority { vault, .. }, .. }: &mut Context<RotateAuthority>
-                ) -> Result<()> {
-                    do_work(vault)?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains("compile_error"),
-            "expected unsupported nested accounts destructuring to emit a compile error, got: {generated}"
-        );
-        assert!(
-            generated.contains("must bind `accounts` as a name or `_`"),
-            "expected targeted unsupported-pattern error, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn program_handlers_reject_non_binding_update_hook_context_patterns() {
-        let module: syn::ItemMod = syn::parse_quote! {
-            pub mod demo_program {
-                use super::*;
-
-                pub fn rotate(
-                    &mut ctx: &mut Context<RotateAuthority>
-                ) -> Result<()> {
-                    do_work(ctx.accounts.vault)?;
-                    Ok(())
-                }
-            }
-        };
-        let config = ProgramConfig {
-            mode: ProgramMode::Executable,
-            program_id: syn::parse_quote!(crate::ID),
-        };
-
-        let generated = impl_program(&module, &config).to_string();
-
-        assert!(
-            generated.contains("compile_error"),
-            "expected unsupported reference-pattern context to emit a compile error, got: {generated}"
-        );
-        assert!(
-            generated.contains("must take `&mut Context<T>` as an identifier like `ctx`, `_`, or `Context { .. }`"),
-            "expected targeted top-level pattern error, got: {generated}"
-        );
-    }
-
-    #[test]
-    fn declare_program_markers_emit_known_idl_addresses() {
-        let idl = serde_json::json!({
-            "address": "Externa1111111111111111111111111111111111111",
-            "metadata": {
-                "name": "fixture",
-                "version": "0.1.0",
-                "spec": "0.1.0"
-            },
-            "instructions": [{
-                "name": "ping",
-                "discriminator": [1, 2, 3, 4, 5, 6, 7, 8],
-                "accounts": [],
-                "args": []
-            }],
-            "accounts": [],
-            "types": []
-        });
-        let name: syn::Ident = syn::parse_quote!(fixture);
-
-        let generated = gen_declared_program(&name, &idl)
-            .expect("fixture IDL should generate")
-            .to_string();
-
-        assert!(
-            generated.contains(
-                "const IDL_ADDRESS : & 'static str = \"Externa1111111111111111111111111111111111111\""
-            ),
-            "declare_program markers should expose their known address for IDL emission: \
-             {generated}"
-        );
+        let pod_bool = declare_idl_type_to_tokens(
+            &json!({ "defined": { "name": "PodBool" } }),
+            span,
+        )
+        .unwrap();
+        assert_eq!(pod_bool.to_string(), "anchor_lang_v2 :: pod :: PodBool");
     }
 
     fn nested_accounts_preserve_inner_bumps_in_generated_surface() {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2129,7 +2129,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
     let type_kind = if is_borsh {
         idl::TypeKind::Borsh
     } else {
-        idl::TypeKind::BytemuckRepr
+        let repr = match idl::bytemuck_repr_from_attrs(attrs) {
+            Ok(repr) => repr,
+            Err(err) => return err.to_compile_error().into(),
+        };
+        idl::TypeKind::BytemuckRepr(repr)
     };
     let idl_account_entry = match idl::build_account_entry_string(&name_str, disc_bytes) {
         Some(s) => quote! { Some(#s) },
@@ -5698,7 +5702,13 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
     // `{serialization:"bytemuck",repr:{kind:"c"}}`.
     let type_kind = match mode {
         EventMode::Wincode => idl::TypeKind::Borsh,
-        EventMode::Bytemuck => idl::TypeKind::BytemuckRepr,
+        EventMode::Bytemuck => {
+            let repr = match idl::bytemuck_repr_from_attrs(attrs) {
+                Ok(repr) => repr,
+                Err(err) => return err.to_compile_error().into(),
+            };
+            idl::TypeKind::BytemuckRepr(repr)
+        }
     };
     let struct_docs = idl::extract_doc_lines(attrs);
     let idl_validation_tokens = if matches!(mode, EventMode::Wincode) {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -6861,6 +6861,220 @@ mod tests {
     }
 
     #[test]
+    fn program_handlers_inject_update_phase_into_handler_body() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                #[access_control(validate(&ctx))]
+                pub fn rotate(ctx: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work()?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut ctx . accounts) ? ;"
+            ),
+            "expected handler body to call update_accounts after access-control expansion, got: {generated}"
+        );
+        assert!(
+            generated.contains("access_control"),
+            "expected access_control attr to remain on the generated handler, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_inject_update_phase_for_destructured_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(Context { accounts, .. }: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work(accounts)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("anchor_lang_v2 :: TryAccounts :: update_accounts (accounts) ? ;"),
+            "expected destructured handler body to call update_accounts via accounts binding, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_synthesize_accounts_binding_for_struct_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(Context { bumps, .. }: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work(bumps)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (__anchor_accounts) ? ;"
+            ),
+            "expected struct-pattern handler body to call update_accounts via synthesized accounts binding, got: {generated}"
+        );
+        assert!(
+            generated.contains("Context { bumps , accounts : __anchor_accounts , .. }"),
+            "expected struct-pattern handler signature to include synthesized accounts binding, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_inject_update_phase_for_wildcard_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(_: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work()?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut __anchor_ctx . accounts) ? ;"
+            ),
+            "expected wildcard handler body to call update_accounts via synthesized ctx binding, got: {generated}"
+        );
+        assert!(
+            generated.contains("fn rotate (__anchor_ctx : & mut Context < RotateAuthority >)"),
+            "expected wildcard handler signature to be rewritten to a concrete ctx binding, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_reject_unsupported_update_hook_context_patterns() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(
+                    Context { accounts: RotateAuthority { vault, .. }, .. }: &mut Context<RotateAuthority>
+                ) -> Result<()> {
+                    do_work(vault)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "expected unsupported nested accounts destructuring to emit a compile error, got: {generated}"
+        );
+        assert!(
+            generated.contains("must bind `accounts` as a name or `_`"),
+            "expected targeted unsupported-pattern error, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_reject_non_binding_update_hook_context_patterns() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(
+                    &mut ctx: &mut Context<RotateAuthority>
+                ) -> Result<()> {
+                    do_work(ctx.accounts.vault)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "expected unsupported reference-pattern context to emit a compile error, got: {generated}"
+        );
+        assert!(
+            generated.contains("must take `&mut Context<T>` as an identifier like `ctx`, `_`, or `Context { .. }`"),
+            "expected targeted top-level pattern error, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn declare_program_markers_emit_known_idl_addresses() {
+        let idl = serde_json::json!({
+            "address": "Externa1111111111111111111111111111111111111",
+            "metadata": {
+                "name": "fixture",
+                "version": "0.1.0",
+                "spec": "0.1.0"
+            },
+            "instructions": [{
+                "name": "ping",
+                "discriminator": [1, 2, 3, 4, 5, 6, 7, 8],
+                "accounts": [],
+                "args": []
+            }],
+            "accounts": [],
+            "types": []
+        });
+        let name: syn::Ident = syn::parse_quote!(fixture);
+
+        let generated = gen_declared_program(&name, &idl)
+            .expect("fixture IDL should generate")
+            .to_string();
+
+        assert!(
+            generated.contains(
+                "const IDL_ADDRESS : & 'static str = \"Externa1111111111111111111111111111111111111\""
+            ),
+            "declare_program markers should expose their known address for IDL emission: \
+             {generated}"
+        );
+    }
+
+    #[test]
     fn declare_idl_defined_pod_wrappers_use_runtime_types() {
         let span = proc_macro2::Span::call_site();
         let pod_u64 = declare_idl_type_to_tokens(

--- a/lang-v2/derive/src/pod_wrapper.rs
+++ b/lang-v2/derive/src/pod_wrapper.rs
@@ -65,6 +65,7 @@ use {
     proc_macro::TokenStream,
     proc_macro2::{Ident, TokenStream as TokenStream2},
     quote::{quote, quote_spanned},
+    serde_json::{json, Value},
     syn::{parse_macro_input, Data, DeriveInput, Fields},
 };
 
@@ -117,6 +118,23 @@ pub fn expand(item: TokenStream) -> TokenStream {
     }
 
     let pod_name = Ident::new(&format!("Pod{}", name), name.span());
+    let docs = crate::idl::extract_doc_lines(&input.attrs);
+    let mut idl_type_def = serde_json::Map::new();
+    idl_type_def.insert("name".into(), Value::String(pod_name.to_string()));
+    if !docs.is_empty() {
+        idl_type_def.insert(
+            "docs".into(),
+            Value::Array(docs.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    idl_type_def.insert(
+        "type".into(),
+        json!({
+            "kind": "type",
+            "alias": "u8",
+        }),
+    );
+    let idl_type_def = syn::LitStr::new(&Value::Object(idl_type_def).to_string(), pod_name.span());
 
     // Per-variant associated constants keep the original variant name
     // (PascalCase), so swapping a field type from `Enum` to `PodEnum` is a
@@ -222,14 +240,22 @@ pub fn expand(item: TokenStream) -> TokenStream {
             }
         }
 
-        // `#[repr(transparent)] struct Pod{Enum}(pub u8)` — at the byte
-        // level the wrapper is a plain `u8`, so it gets the same no-op
-        // `IdlAccountType` treatment as `PodU64` / `PodBool`. Without
-        // this impl, using the wrapper inside a `#[derive(Accounts)]`
-        // field trips the trait bound on the generated `__register_idl_deps`
-        // walk under `--features idl-build`.
+        // `#[repr(transparent)] struct Pod{Enum}(pub u8)` — the wire shape is
+        // just a byte, but it still needs a type def so downstream
+        // `declare_program!` consumers can resolve `Pod{Enum}` references.
         #[cfg(feature = "idl-build")]
-        impl anchor_lang_v2::IdlAccountType for #pod_name {}
+        impl anchor_lang_v2::IdlAccountType for #pod_name {
+            const __IDL_TYPE_DEF: Option<&'static str> = Some(#idl_type_def);
+
+            fn __register_idl_deps(
+                _accounts: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
+                types: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
+            ) {
+                if let Some(t) = <Self as anchor_lang_v2::IdlAccountType>::__IDL_TYPE_DEF {
+                    types.push(t);
+                }
+            }
+        }
     };
 
     TokenStream::from(expanded)

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -192,17 +192,29 @@ impl<T: IdlAccountType, const N: usize> IdlAccountType for [T; N] {
 }
 
 // `PodVec<T, MAX>` — the zero-copy bounded-capacity analog of `Vec<T>`.
-// Forward `__register_idl_deps` so a `#[account]` zero-copy type holding
-// a `PodVec<Inner, 16>` still pulls `Inner` into the IDL's `types[]`.
+// It contributes a generic type definition so downstream `declare_program!`
+// consumers can reconstruct the length prefix plus fixed-capacity backing
+// array, then recurses into the element type.
 #[doc(hidden)]
 impl<T, const MAX: usize> IdlAccountType for crate::pod::PodVec<T, MAX>
 where
     T: bytemuck::Pod + IdlAccountType,
 {
+    const __IDL_TYPE_DEF: Option<&'static str> = Some(
+        "{\"name\":\"PodVec\",\"generics\":[{\"kind\":\"type\",\"name\":\"T\"},\
+         {\"kind\":\"const\",\"name\":\"MAX\",\"type\":\"usize\"}],\
+         \"serialization\":\"bytemuck\",\"repr\":{\"kind\":\"c\"},\
+         \"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"len\",\"type\":\"u16\"},\
+         {\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]}}",
+    );
+
     fn __register_idl_deps(
         accounts: &mut alloc::vec::Vec<&'static str>,
         types: &mut alloc::vec::Vec<&'static str>,
     ) {
+        if let Some(t) = <Self as IdlAccountType>::__IDL_TYPE_DEF {
+            types.push(t);
+        }
         T::__register_idl_deps(accounts, types);
     }
 }

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -120,20 +120,46 @@ impl_idl_account_type_noop!(
     pinocchio::address::Address,
 );
 
-// Pod integer wrappers — treated the same as their native counterparts for
-// IDL purposes (they map to `"u64"`, `"i32"`, etc. via `rust_type_to_idl`'s
-// string-based dispatch). The blanket impl here keeps the trait resolvable
-// when users reference them from nested structs.
-impl_idl_account_type_noop!(
-    crate::pod::PodBool,
-    crate::pod::PodU16,
-    crate::pod::PodU32,
-    crate::pod::PodU64,
-    crate::pod::PodU128,
-    crate::pod::PodI16,
-    crate::pod::PodI32,
-    crate::pod::PodI64,
-    crate::pod::PodI128,
+// Pod scalar wrappers still lower like their native counterparts when they
+// appear directly in a field type, but generic bytemuck helpers like `PodVec`
+// can reference them by name. Register them as alias defs so those named
+// references resolve in the final IDL.
+macro_rules! impl_idl_account_type_pod_alias {
+    ($(($t:path, $name:literal, $alias:literal)),* $(,)?) => {
+        $(
+            #[doc(hidden)]
+            impl IdlAccountType for $t {
+                const __IDL_TYPE_DEF: Option<&'static str> = Some(concat!(
+                    "{\"name\":\"",
+                    $name,
+                    "\",\"type\":{\"kind\":\"type\",\"alias\":\"",
+                    $alias,
+                    "\"}}"
+                ));
+
+                fn __register_idl_deps(
+                    _accounts: &mut alloc::vec::Vec<&'static str>,
+                    types: &mut alloc::vec::Vec<&'static str>,
+                ) {
+                    if let Some(t) = <Self as IdlAccountType>::__IDL_TYPE_DEF {
+                        types.push(t);
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_idl_account_type_pod_alias!(
+    (crate::pod::PodBool, "PodBool", "bool"),
+    (crate::pod::PodU16, "PodU16", "u16"),
+    (crate::pod::PodU32, "PodU32", "u32"),
+    (crate::pod::PodU64, "PodU64", "u64"),
+    (crate::pod::PodU128, "PodU128", "u128"),
+    (crate::pod::PodI16, "PodI16", "i16"),
+    (crate::pod::PodI32, "PodI32", "i32"),
+    (crate::pod::PodI64, "PodI64", "i64"),
+    (crate::pod::PodI128, "PodI128", "i128"),
 );
 
 #[doc(hidden)]
@@ -215,7 +241,59 @@ where
         if let Some(t) = <Self as IdlAccountType>::__IDL_TYPE_DEF {
             types.push(t);
         }
+        crate::pod::PodU16::__register_idl_deps(accounts, types);
         T::__register_idl_deps(accounts, types);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IdlAccountType;
+
+    #[test]
+    fn pod_vec_registers_length_wrapper_for_native_elements() {
+        let mut accounts = alloc::vec::Vec::new();
+        let mut types = alloc::vec::Vec::new();
+
+        <crate::pod::PodVec<u8, 4> as IdlAccountType>::__register_idl_deps(
+            &mut accounts,
+            &mut types,
+        );
+
+        assert!(
+            types.iter().any(|ty| ty.contains("\"name\":\"PodVec\"")),
+            "PodVec should register its own type definition: {types:?}"
+        );
+        assert!(
+            types
+                .iter()
+                .any(|ty| ty.contains("\"name\":\"PodU16\"") && ty.contains("\"alias\":\"u16\"")),
+            "PodVec should register its PodU16 length wrapper: {types:?}"
+        );
+    }
+
+    #[test]
+    fn pod_vec_registers_defined_element_wrappers() {
+        let mut accounts = alloc::vec::Vec::new();
+        let mut types = alloc::vec::Vec::new();
+
+        <crate::pod::PodVec<crate::pod::PodU64, 4> as IdlAccountType>::__register_idl_deps(
+            &mut accounts,
+            &mut types,
+        );
+
+        assert!(
+            types
+                .iter()
+                .any(|ty| ty.contains("\"name\":\"PodU16\"") && ty.contains("\"alias\":\"u16\"")),
+            "PodVec should keep its PodU16 length helper defined: {types:?}"
+        );
+        assert!(
+            types
+                .iter()
+                .any(|ty| ty.contains("\"name\":\"PodU64\"") && ty.contains("\"alias\":\"u64\"")),
+            "PodVec should register named pod element wrappers: {types:?}"
+        );
     }
 }
 

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -204,7 +204,7 @@ where
         "{\"name\":\"PodVec\",\"generics\":[{\"kind\":\"type\",\"name\":\"T\"},\
          {\"kind\":\"const\",\"name\":\"MAX\",\"type\":\"usize\"}],\
          \"serialization\":\"bytemuck\",\"repr\":{\"kind\":\"c\"},\
-         \"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"len\",\"type\":\"u16\"},\
+         \"type\":{\"kind\":\"struct\",\"fields\":[{\"name\":\"len\",\"type\":{\"defined\":{\"name\":\"PodU16\"}}},\
          {\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]}}",
     );
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -363,6 +363,31 @@ mod shim {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn idl_generation_rejects_lossy_packed_repr_modifiers() {
+    compile_fail_case(
+        "event_bytemuck_packed_two",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[event(bytemuck)]
+#[repr(C, packed(2))]
+pub struct Bad {
+    pub tag: u16,
+    pub wide: u64,
+}
+"#,
+        &[
+            "Anchor IDL only supports `#[repr(..., packed)]` or `#[repr(..., packed(1))]`",
+            "lossy IDL layout",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn malformed_discriminator_attribute_has_targeted_message() {
     compile_fail_case(
         "bad_discriminator",

--- a/tests-v2/programs/declare-program/types/idls/weird_types.json
+++ b/tests-v2/programs/declare-program/types/idls/weird_types.json
@@ -455,7 +455,11 @@
         "fields": [
           {
             "name": "len",
-            "type": "u16"
+            "type": {
+              "defined": {
+                "name": "PodU16"
+              }
+            }
           },
           {
             "name": "data",

--- a/tests-v2/programs/declare-program/types/idls/weird_types.json
+++ b/tests-v2/programs/declare-program/types/idls/weird_types.json
@@ -425,6 +425,107 @@
           }
         ]
       }
+    },
+    {
+      "name": "PodMode",
+      "type": {
+        "kind": "type",
+        "alias": "u8"
+      }
+    },
+    {
+      "name": "PodVec",
+      "generics": [
+        {
+          "kind": "type",
+          "name": "T"
+        },
+        {
+          "kind": "const",
+          "name": "MAX",
+          "type": "usize"
+        }
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "len",
+            "type": "u16"
+          },
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                {
+                  "generic": "T"
+                },
+                {
+                  "generic": "MAX"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodWrapperOnly",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mode",
+            "type": {
+              "defined": {
+                "name": "PodMode"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodVecOnly",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "items",
+            "type": {
+              "defined": {
+                "name": "PodVec",
+                "generics": [
+                  {
+                    "kind": "type",
+                    "type": {
+                      "defined": {
+                        "name": "PodU64"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "const",
+                    "value": "4"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -115,6 +115,18 @@ pub struct Counter {
 #[derive(IdlType)]
 pub struct PairTupleIdl(pub u64, pub bool);
 
+#[account]
+#[repr(C)]
+pub struct PodWrapperOnly {
+    pub mode: PodMode,
+}
+
+#[account]
+#[repr(C)]
+pub struct PodVecOnly {
+    pub items: PodVec<PodU64, 4>,
+}
+
 // ---- Handlers -------------------------------------------------------------
 
 #[program]
@@ -304,5 +316,51 @@ mod idl_tests {
         assert!(type_def.contains("\"name\":\"PairTupleIdl\""));
         assert!(type_def.contains("\"kind\":\"struct\""));
         assert!(type_def.contains("\"fields\":[\"u64\",\"bool\"]"));
+    }
+
+    #[test]
+    fn pod_wrapper_registers_alias_type_definition() {
+        let type_def =
+            <PodMode as IdlAccountType>::__IDL_TYPE_DEF.expect("PodMode should emit an IDL type");
+        assert!(type_def.contains("\"name\":\"PodMode\""));
+        assert!(type_def.contains("\"alias\":\"u8\""));
+
+        let mut accounts = Vec::new();
+        let mut types = Vec::new();
+        <PodWrapperOnly as IdlAccountType>::__register_idl_deps(&mut accounts, &mut types);
+        let wrapper_account = types
+            .iter()
+            .find(|entry| entry.contains("\"name\":\"PodWrapperOnly\""))
+            .expect("PodWrapperOnly should emit its IDL type");
+        assert!(wrapper_account.contains("\"defined\":{\"name\":\"PodMode\"}"));
+        assert!(types.iter().any(|entry| entry.contains("\"name\":\"PodMode\"")));
+    }
+
+    #[test]
+    fn pod_vec_registers_generic_layout_and_account_fields_use_generics() {
+        let mut accounts = Vec::new();
+        let mut types = Vec::new();
+        <PodVecOnly as IdlAccountType>::__register_idl_deps(&mut accounts, &mut types);
+
+        let pod_vec_account = types
+            .iter()
+            .find(|entry| entry.contains("\"name\":\"PodVecOnly\""))
+            .expect("PodVecOnly should emit its IDL type");
+        assert!(pod_vec_account.contains("\"defined\":{"));
+        assert!(pod_vec_account.contains("\"name\":\"PodVec\""));
+        assert!(pod_vec_account.contains("\"kind\":\"type\",\"type\":{\"defined\":{\"name\":\"PodU64\"}}"));
+        assert!(pod_vec_account.contains("\"kind\":\"const\",\"value\":\"4\""));
+
+        let pod_vec_type = types
+            .iter()
+            .find(|entry| {
+                entry.contains("\"name\":\"PodVec\"")
+                    && entry.contains("\"kind\":\"const\",\"name\":\"MAX\",\"type\":\"usize\"")
+            })
+            .expect("PodVec generic layout should be registered");
+        assert!(pod_vec_type.contains("\"generics\":[{\"kind\":\"type\",\"name\":\"T\"},{\"kind\":\"const\",\"name\":\"MAX\",\"type\":\"usize\"}]"));
+        assert!(pod_vec_type.contains("\"serialization\":\"bytemuck\""));
+        assert!(pod_vec_type.contains("\"repr\":{\"kind\":\"c\"}"));
+        assert!(pod_vec_type.contains("\"fields\":[{\"name\":\"len\",\"type\":\"u16\"},{\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]"));
     }
 }

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -375,7 +375,7 @@ mod idl_tests {
         assert!(pod_vec_type.contains("\"generics\":[{\"kind\":\"type\",\"name\":\"T\"},{\"kind\":\"const\",\"name\":\"MAX\",\"type\":\"usize\"}]"));
         assert!(pod_vec_type.contains("\"serialization\":\"bytemuck\""));
         assert!(pod_vec_type.contains("\"repr\":{\"kind\":\"c\"}"));
-        assert!(pod_vec_type.contains("\"fields\":[{\"name\":\"len\",\"type\":\"u16\"},{\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]"));
+        assert!(pod_vec_type.contains("\"fields\":[{\"name\":\"len\",\"type\":{\"defined\":{\"name\":\"PodU16\"}}},{\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]"));
     }
 
     #[test]

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -128,14 +128,14 @@ pub struct PodVecOnly {
 }
 
 #[account]
-#[repr(C, packed)]
+#[repr(C, packed(1))]
 pub struct PackedProducer {
     pub tag: u8,
     pub wide: u64,
 }
 
 #[event(bytemuck)]
-#[repr(C, packed)]
+#[repr(C, packed(1))]
 pub struct PackedSnapshot {
     pub tag: u8,
     pub wide: u64,

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -127,6 +127,20 @@ pub struct PodVecOnly {
     pub items: PodVec<PodU64, 4>,
 }
 
+#[account]
+#[repr(C, packed)]
+pub struct PackedProducer {
+    pub tag: u8,
+    pub wide: u64,
+}
+
+#[event(bytemuck)]
+#[repr(C, packed)]
+pub struct PackedSnapshot {
+    pub tag: u8,
+    pub wide: u64,
+}
+
 // ---- Handlers -------------------------------------------------------------
 
 #[program]
@@ -362,5 +376,23 @@ mod idl_tests {
         assert!(pod_vec_type.contains("\"serialization\":\"bytemuck\""));
         assert!(pod_vec_type.contains("\"repr\":{\"kind\":\"c\"}"));
         assert!(pod_vec_type.contains("\"fields\":[{\"name\":\"len\",\"type\":\"u16\"},{\"name\":\"data\",\"type\":{\"array\":[{\"generic\":\"T\"},{\"generic\":\"MAX\"}]}}]"));
+    }
+
+    #[test]
+    fn packed_bytemuck_idl_preserves_packed_repr() {
+        let type_def =
+            <PackedProducer as IdlAccountType>::__IDL_TYPE_DEF.expect("PackedProducer should emit an IDL type");
+        assert!(type_def.contains("\"name\":\"PackedProducer\""));
+        assert!(type_def.contains("\"serialization\":\"bytemuck\""));
+        assert!(type_def.contains("\"repr\":{\"kind\":\"c\",\"packed\":true}"));
+    }
+
+    #[test]
+    fn packed_bytemuck_event_idl_preserves_packed_repr() {
+        let type_def =
+            <PackedSnapshot as IdlAccountType>::__IDL_TYPE_DEF.expect("PackedSnapshot should emit an IDL type");
+        assert!(type_def.contains("\"name\":\"PackedSnapshot\""));
+        assert!(type_def.contains("\"serialization\":\"bytemuck\""));
+        assert!(type_def.contains("\"repr\":{\"kind\":\"c\",\"packed\":true}"));
     }
 }

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -380,8 +380,8 @@ mod idl_tests {
 
     #[test]
     fn packed_bytemuck_idl_preserves_packed_repr() {
-        let type_def =
-            <PackedProducer as IdlAccountType>::__IDL_TYPE_DEF.expect("PackedProducer should emit an IDL type");
+        let type_def = <PackedProducer as IdlAccountType>::__idl_type_def()
+            .expect("PackedProducer should emit an IDL type");
         assert!(type_def.contains("\"name\":\"PackedProducer\""));
         assert!(type_def.contains("\"serialization\":\"bytemuck\""));
         assert!(type_def.contains("\"repr\":{\"kind\":\"c\",\"packed\":true}"));
@@ -389,8 +389,8 @@ mod idl_tests {
 
     #[test]
     fn packed_bytemuck_event_idl_preserves_packed_repr() {
-        let type_def =
-            <PackedSnapshot as IdlAccountType>::__IDL_TYPE_DEF.expect("PackedSnapshot should emit an IDL type");
+        let type_def = <PackedSnapshot as IdlAccountType>::__idl_type_def()
+            .expect("PackedSnapshot should emit an IDL type");
         assert!(type_def.contains("\"name\":\"PackedSnapshot\""));
         assert!(type_def.contains("\"serialization\":\"bytemuck\""));
         assert!(type_def.contains("\"repr\":{\"kind\":\"c\",\"packed\":true}"));

--- a/tests-v2/src/declare-program/types.rs
+++ b/tests-v2/src/declare-program/types.rs
@@ -31,6 +31,10 @@ fn declared_weird_types_compile_and_serialize() {
     assert_idl_type::<weird_types::PackedBytemuck>();
     assert_idl_type::<weird_types::TransparentBytemuck>();
     assert_idl_type::<weird_types::AlignedBytemuck>();
+    assert_idl_type::<weird_types::PodMode>();
+    assert_idl_type::<weird_types::PodVec<anchor_lang_v2::pod::PodU64, 4>>();
+    assert_idl_type::<weird_types::PodWrapperOnly>();
+    assert_idl_type::<weird_types::PodVecOnly>();
 
     assert!(<weird_types::UnitMarker as IdlAccountType>::__IDL_TYPE_DEF
         .expect("unit struct should retain its IDL type definition")
@@ -88,6 +92,12 @@ fn declared_weird_type_docs_and_repr_metadata_compile() {
     assert_eq!(core::mem::size_of::<weird_types::TransparentBytemuck>(), 8);
     assert_eq!(core::mem::align_of::<weird_types::AlignedBytemuck>(), 16);
     assert_eq!(core::mem::size_of::<weird_types::AlignedBytemuck>(), 16);
+    assert_eq!(core::mem::size_of::<weird_types::PodWrapperOnly>(), 1);
+    assert_eq!(
+        core::mem::size_of::<weird_types::PodVec<anchor_lang_v2::pod::PodU64, 4>>(),
+        34
+    );
+    assert_eq!(core::mem::size_of::<weird_types::PodVecOnly>(), 34);
 
     let packed = weird_types::PackedBytemuck { wide: 7, tag: 9 };
     assert_eq!(anchor_lang_v2::bytemuck::bytes_of(&packed).len(), 9);

--- a/tests-v2/src/declare-program/types.rs
+++ b/tests-v2/src/declare-program/types.rs
@@ -97,7 +97,12 @@ fn declared_weird_type_docs_and_repr_metadata_compile() {
         core::mem::size_of::<weird_types::PodVec<anchor_lang_v2::pod::PodU64, 4>>(),
         34
     );
+    assert_eq!(
+        core::mem::align_of::<weird_types::PodVec<anchor_lang_v2::pod::PodU64, 4>>(),
+        1
+    );
     assert_eq!(core::mem::size_of::<weird_types::PodVecOnly>(), 34);
+    assert_eq!(core::mem::align_of::<weird_types::PodVecOnly>(), 1);
 
     let packed = weird_types::PackedBytemuck { wide: 7, tag: 9 };
     assert_eq!(anchor_lang_v2::bytemuck::bytes_of(&packed).len(), 9);


### PR DESCRIPTION
## Finding

Generated IDL did not model `PodVec`, pod wrappers, or packed bytemuck layouts accurately, breaking downstream `declare_program!` consumers.

## Fix

Emit their actual layouts and preserve packed representations so producer and consumer agree on wire structure. Generated-IDL and consumer regressions verify compatibility.