### PR TITLE
Fix/v2 init space wincode

### DIFF
--- a/lang-v2/derive/src/init_space.rs
+++ b/lang-v2/derive/src/init_space.rs
@@ -11,8 +11,9 @@ use {
     quote::{quote, quote_spanned, ToTokens},
     std::collections::VecDeque,
     syn::{
-        parse::ParseStream, parse_macro_input, punctuated::Punctuated, token::Comma, Attribute,
-        DeriveInput, Expr, Field, Fields, GenericArgument, PathArguments, Type, TypeArray,
+        parse::ParseStream, parse_macro_input, punctuated::Punctuated, spanned::Spanned,
+        token::Comma, Attribute, DeriveInput, Expr, Field, Fields, GenericArgument, PathArguments,
+        Type, TypeArray,
     },
 };
 
@@ -22,10 +23,7 @@ pub fn expand(item: TokenStream) -> TokenStream {
     let name = input.ident;
 
     let process_struct_fields = |fields: Punctuated<Field, Comma>| {
-        let recurse = fields.into_iter().map(|f| {
-            let mut max_len_args = get_max_len_args(&f.attrs);
-            len_from_type(f.ty, &mut max_len_args)
-        });
+        let recurse = fields.into_iter().map(field_len_tokens);
 
         quote! {
             #[automatically_derived]
@@ -48,10 +46,7 @@ pub fn expand(item: TokenStream) -> TokenStream {
         },
         syn::Data::Enum(enm) => {
             let variants = enm.variants.into_iter().map(|v| {
-                let len = v.fields.into_iter().map(|f| {
-                    let mut max_len_args = get_max_len_args(&f.attrs);
-                    len_from_type(f.ty, &mut max_len_args)
-                });
+                let len = v.fields.into_iter().map(field_len_tokens);
 
                 quote! {
                     0 #(+ #len)*
@@ -79,6 +74,65 @@ pub fn expand(item: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
+}
+
+fn field_len_tokens(field: Field) -> TokenStream2 {
+    if let Some(err) = unsupported_wincode_attr_error(&field.attrs) {
+        return err.to_compile_error();
+    }
+
+    let mut max_len_args = get_max_len_args(&field.attrs);
+    len_from_type(field.ty, &mut max_len_args)
+}
+
+fn unsupported_wincode_attr_error(attributes: &[Attribute]) -> Option<syn::Error> {
+    for attr in attributes {
+        if !attr.path().is_ident("wincode") {
+            continue;
+        }
+
+        let mut unsupported = None;
+        let parse = attr.parse_nested_meta(|meta| {
+            let span = meta.path.span();
+            if meta.path.is_ident("skip") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some(("skip", span));
+            } else if meta.path.is_ident("with") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some(("with", span));
+            }
+            Ok(())
+        });
+
+        if let Err(err) = parse {
+            return Some(err);
+        }
+
+        if let Some((kind, span)) = unsupported {
+            let message = match kind {
+                "skip" => {
+                    "#[derive(InitSpace)] does not support `#[wincode(skip)]` fields because \
+                     wincode field overrides change the serialized layout; remove the override \
+                     or compute the account size manually"
+                }
+                "with" => {
+                    "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` fields \
+                     because custom wincode codecs can change the serialized layout; remove the \
+                     override or compute the account size manually"
+                }
+                _ => unreachable!(),
+            };
+            return Some(syn::Error::new(span, message));
+        }
+    }
+
+    None
 }
 
 fn gen_max<T: Iterator<Item = TokenStream2>>(mut iter: T) -> TokenStream2 {

--- a/lang-v2/derive/src/init_space.rs
+++ b/lang-v2/derive/src/init_space.rs
@@ -11,9 +11,8 @@ use {
     quote::{quote, quote_spanned, ToTokens},
     std::collections::VecDeque,
     syn::{
-        parse::ParseStream, parse_macro_input, punctuated::Punctuated, spanned::Spanned,
-        token::Comma, Attribute, DeriveInput, Expr, Field, Fields, GenericArgument, PathArguments,
-        Type, TypeArray,
+        parse::ParseStream, parse_macro_input, punctuated::Punctuated, token::Comma, Attribute,
+        DeriveInput, Expr, Field, Fields, GenericArgument, PathArguments, Type, TypeArray,
     },
 };
 
@@ -77,62 +76,31 @@ pub fn expand(item: TokenStream) -> TokenStream {
 }
 
 fn field_len_tokens(field: Field) -> TokenStream2 {
-    if let Some(err) = unsupported_wincode_attr_error(&field.attrs) {
-        return err.to_compile_error();
+    match crate::find_unsupported_wincode_attr(&field.attrs) {
+        Ok(Some((crate::UnsupportedWincodeAttrKind::Skip, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(skip)]` fields because \
+                 wincode field overrides change the serialized layout; remove the override or \
+                 compute the account size manually",
+            )
+            .to_compile_error();
+        }
+        Ok(Some((crate::UnsupportedWincodeAttrKind::With, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` fields because \
+                 custom wincode codecs can change the serialized layout; remove the override or \
+                 compute the account size manually",
+            )
+            .to_compile_error();
+        }
+        Ok(None) => {}
+        Err(err) => return err.to_compile_error(),
     }
 
     let mut max_len_args = get_max_len_args(&field.attrs);
     len_from_type(field.ty, &mut max_len_args)
-}
-
-fn unsupported_wincode_attr_error(attributes: &[Attribute]) -> Option<syn::Error> {
-    for attr in attributes {
-        if !attr.path().is_ident("wincode") {
-            continue;
-        }
-
-        let mut unsupported = None;
-        let parse = attr.parse_nested_meta(|meta| {
-            let span = meta.path.span();
-            if meta.path.is_ident("skip") {
-                if meta.input.peek(syn::Token![=]) {
-                    let value = meta.value()?;
-                    let _ = value.parse::<Expr>()?;
-                }
-                unsupported = Some(("skip", span));
-            } else if meta.path.is_ident("with") {
-                if meta.input.peek(syn::Token![=]) {
-                    let value = meta.value()?;
-                    let _ = value.parse::<Expr>()?;
-                }
-                unsupported = Some(("with", span));
-            }
-            Ok(())
-        });
-
-        if let Err(err) = parse {
-            return Some(err);
-        }
-
-        if let Some((kind, span)) = unsupported {
-            let message = match kind {
-                "skip" => {
-                    "#[derive(InitSpace)] does not support `#[wincode(skip)]` fields because \
-                     wincode field overrides change the serialized layout; remove the override \
-                     or compute the account size manually"
-                }
-                "with" => {
-                    "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` fields \
-                     because custom wincode codecs can change the serialized layout; remove the \
-                     override or compute the account size manually"
-                }
-                _ => unreachable!(),
-            };
-            return Some(syn::Error::new(span, message));
-        }
-    }
-
-    None
 }
 
 fn gen_max<T: Iterator<Item = TokenStream2>>(mut iter: T) -> TokenStream2 {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -84,6 +84,17 @@ pub(crate) fn find_unsupported_wincode_attr(
                 if meta.input.peek(syn::Token![=]) {
                     let value = meta.value()?;
                     let _ = value.parse::<Expr>()?;
+                } else if meta.input.peek(syn::token::Paren) {
+                    meta.parse_nested_meta(|nested| {
+                        if nested.path.is_ident("default") {
+                            return Ok(());
+                        }
+                        if nested.path.is_ident("default_val") {
+                            let value = nested.value()?;
+                            let _ = value.parse::<Expr>()?;
+                        }
+                        Ok(())
+                    })?;
                 }
                 unsupported = Some((UnsupportedWincodeAttrKind::Skip, span));
             } else if meta.path.is_ident("with") {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1833,6 +1833,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
     let disc_literals: Vec<_> = disc_bytes.iter().map(|b| quote! { #b }).collect();
 
     let struct_docs = idl::extract_doc_lines(attrs);
+    if is_borsh {
+        if let Err(err) = reject_wincode_idl_overrides_in_fields("`#[account(borsh)]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     // `#[account]` has two modes: default zero-copy (Pod + repr(C)) and opt-in
     // borsh (`#[account(borsh)]`). The borsh mode is implemented on top of
     // wincode + `BORSH_CONFIG`, which produces byte-identical output to a
@@ -2102,6 +2107,11 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     // `"bytemuck"` tag here would lie in the IDL for non-Pod types.
     let (idl_type_strings, field_tys) = match &input.data {
         Data::Struct(data) => {
+            if let Err(err) =
+                reject_wincode_idl_overrides_in_fields("`#[derive(IdlType)]`", &data.fields)
+            {
+                return err.to_compile_error().into();
+            }
             let strings = match &data.fields {
                 Fields::Named(named) => idl::build_type_strings(
                     &name_str,
@@ -2135,6 +2145,11 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             (strings, field_tys)
         }
         Data::Enum(data) => {
+            if let Err(err) =
+                reject_wincode_idl_overrides_in_variants("`#[derive(IdlType)]`", &data.variants)
+            {
+                return err.to_compile_error().into();
+            }
             let strings = idl::build_enum_type_strings(
                 &name_str,
                 &empty_disc,
@@ -3866,6 +3881,74 @@ fn is_unit_type(ty: &Type) -> bool {
     matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
 }
 
+fn reject_wincode_idl_overrides_in_fields(surface: &str, fields: &syn::Fields) -> syn::Result<()> {
+    for field in fields.iter() {
+        if let Some(err) = unsupported_wincode_idl_attr_error(surface, &field.attrs) {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+fn reject_wincode_idl_overrides_in_variants(
+    surface: &str,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+) -> syn::Result<()> {
+    for variant in variants {
+        reject_wincode_idl_overrides_in_fields(surface, &variant.fields)?;
+    }
+    Ok(())
+}
+
+fn unsupported_wincode_idl_attr_error(
+    surface: &str,
+    attrs: &[syn::Attribute],
+) -> Option<syn::Error> {
+    for attr in attrs {
+        if !attr.path().is_ident("wincode") {
+            continue;
+        }
+
+        let mut unsupported = None;
+        let parse = attr.parse_nested_meta(|meta| {
+            let span = meta.path.span();
+            if meta.path.is_ident("skip") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some(("skip", span));
+            } else if meta.path.is_ident("with") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some(("with", span));
+            }
+            Ok(())
+        });
+
+        if let Err(err) = parse {
+            return Some(err);
+        }
+
+        if let Some((kind, span)) = unsupported {
+            let message = match kind {
+                "skip" => format!(
+                    "{surface} does not support `#[wincode(skip)]` fields because generated IDL would not match the serialized wire layout; remove the override or exclude this type from generated IDL"
+                ),
+                "with" => format!(
+                    "{surface} does not support `#[wincode(with = ...)]` fields because custom wincode codecs can change the serialized wire layout; remove the override or exclude this type from generated IDL"
+                ),
+                _ => unreachable!(),
+            };
+            return Some(syn::Error::new(span, message));
+        }
+    }
+
+    None
+}
+
 fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Type>> {
     let syn::ReturnType::Type(_, ty) = output else {
         return Ok(None);
@@ -4955,6 +5038,11 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
         EventMode::Bytemuck => idl::TypeKind::BytemuckRepr,
     };
     let struct_docs = idl::extract_doc_lines(attrs);
+    if matches!(mode, EventMode::Wincode) {
+        if let Err(err) = reject_wincode_idl_overrides_in_fields("`#[event]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     let event_type_strings = if let Fields::Named(named) = fields {
         idl::build_type_strings(&name_str, disc_bytes, &struct_docs, &named.named, type_kind)
     } else {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -5536,6 +5536,9 @@ pub fn constant(_attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// Variable-size fields (`String`, `Vec<T>`) require a `#[max_len(N)]` helper
 /// attribute to specify the reserved capacity.
+/// Fields using `#[wincode(skip)]` or `#[wincode(with = ...)]` are rejected:
+/// those overrides change the wire layout, so the derive cannot infer a safe
+/// `INIT_SPACE` constant.
 ///
 /// # Example
 ///

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -11,7 +11,7 @@ mod pod_wrapper;
 
 use {
     proc_macro::TokenStream,
-    proc_macro2::TokenStream as TokenStream2,
+    proc_macro2::{Span, TokenStream as TokenStream2},
     quote::quote,
     syn::{
         parse::Parser, parse_macro_input, spanned::Spanned, Data, DeriveInput, Expr, Fields, FnArg,
@@ -61,6 +61,49 @@ struct SignerExpr {
 struct AccountMetaAttrs {
     skip: bool,
     duplicate_readonly: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum UnsupportedWincodeAttrKind {
+    Skip,
+    With,
+}
+
+pub(crate) fn find_unsupported_wincode_attr(
+    attrs: &[syn::Attribute],
+) -> syn::Result<Option<(UnsupportedWincodeAttrKind, Span)>> {
+    for attr in attrs {
+        if !attr.path().is_ident("wincode") {
+            continue;
+        }
+
+        let mut unsupported = None;
+        let parse = attr.parse_nested_meta(|meta| {
+            let span = meta.path.span();
+            if meta.path.is_ident("skip") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some((UnsupportedWincodeAttrKind::Skip, span));
+            } else if meta.path.is_ident("with") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some((UnsupportedWincodeAttrKind::With, span));
+            }
+            Ok(())
+        });
+
+        parse?;
+
+        if unsupported.is_some() {
+            return Ok(unsupported);
+        }
+    }
+
+    Ok(None)
 }
 
 fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
@@ -3904,49 +3947,22 @@ fn unsupported_wincode_idl_attr_error(
     surface: &str,
     attrs: &[syn::Attribute],
 ) -> Option<syn::Error> {
-    for attr in attrs {
-        if !attr.path().is_ident("wincode") {
-            continue;
-        }
-
-        let mut unsupported = None;
-        let parse = attr.parse_nested_meta(|meta| {
-            let span = meta.path.span();
-            if meta.path.is_ident("skip") {
-                if meta.input.peek(syn::Token![=]) {
-                    let value = meta.value()?;
-                    let _ = value.parse::<Expr>()?;
-                }
-                unsupported = Some(("skip", span));
-            } else if meta.path.is_ident("with") {
-                if meta.input.peek(syn::Token![=]) {
-                    let value = meta.value()?;
-                    let _ = value.parse::<Expr>()?;
-                }
-                unsupported = Some(("with", span));
-            }
-            Ok(())
-        });
-
-        if let Err(err) = parse {
-            return Some(err);
-        }
-
-        if let Some((kind, span)) = unsupported {
-            let message = match kind {
-                "skip" => format!(
-                    "{surface} does not support `#[wincode(skip)]` fields because generated IDL would not match the serialized wire layout; remove the override or exclude this type from generated IDL"
-                ),
-                "with" => format!(
-                    "{surface} does not support `#[wincode(with = ...)]` fields because custom wincode codecs can change the serialized wire layout; remove the override or exclude this type from generated IDL"
-                ),
-                _ => unreachable!(),
-            };
-            return Some(syn::Error::new(span, message));
-        }
+    match find_unsupported_wincode_attr(attrs) {
+        Ok(Some((UnsupportedWincodeAttrKind::Skip, span))) => Some(syn::Error::new(
+            span,
+            format!(
+                "{surface} does not support `#[wincode(skip)]` fields because generated IDL would not match the serialized wire layout; remove the override or exclude this type from generated IDL"
+            ),
+        )),
+        Ok(Some((UnsupportedWincodeAttrKind::With, span))) => Some(syn::Error::new(
+            span,
+            format!(
+                "{surface} does not support `#[wincode(with = ...)]` fields because custom wincode codecs can change the serialized wire layout; remove the override or exclude this type from generated IDL"
+            ),
+        )),
+        Ok(None) => None,
+        Err(err) => Some(err),
     }
-
-    None
 }
 
 fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Type>> {

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -201,6 +201,72 @@ mod shim {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn idl_generation_rejects_wincode_field_overrides() {
+    compile_fail_case(
+        "idl_type_wincode_skip",
+        r#"
+use anchor_lang_v2::IdlType;
+
+#[derive(IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Bad {
+    #[wincode(skip)]
+    pub skipped: u64,
+    pub kept: u8,
+}
+"#,
+        &[
+            "`#[derive(IdlType)]` does not support `#[wincode(skip)]` fields",
+            "generated IDL would not match the serialized wire layout",
+        ],
+    );
+
+    compile_fail_case(
+        "account_borsh_wincode_skip",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account(borsh)]
+pub struct Bad {
+    #[wincode(skip)]
+    pub skipped: u64,
+    pub kept: u8,
+}
+"#,
+        &[
+            "`#[account(borsh)]` does not support `#[wincode(skip)]` fields",
+            "generated IDL would not match the serialized wire layout",
+        ],
+    );
+
+    compile_fail_case(
+        "event_wincode_with",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[event]
+pub struct Bad {
+    #[wincode(with = "shim::ByteCodec")]
+    pub packed: u64,
+}
+
+mod shim {
+    pub struct ByteCodec;
+}
+"#,
+        &[
+            "`#[event]` does not support `#[wincode(with = ...)]` fields",
+            "custom wincode codecs can change the serialized wire layout",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn malformed_discriminator_attribute_has_targeted_message() {
     compile_fail_case(
         "bad_discriminator",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -155,6 +155,52 @@ pub struct Bad<'a> {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn init_space_rejects_wincode_field_overrides() {
+    compile_fail_case(
+        "init_space_wincode_skip",
+        r#"
+use anchor_lang_v2::InitSpace;
+
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Bad {
+    #[wincode(skip)]
+    pub skipped: u64,
+    pub kept: u8,
+}
+"#,
+        &[
+            "#[derive(InitSpace)] does not support `#[wincode(skip)]` fields",
+            "serialized layout",
+        ],
+    );
+
+    compile_fail_case(
+        "init_space_wincode_with",
+        r#"
+use anchor_lang_v2::InitSpace;
+
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Bad {
+    #[wincode(with = "shim::ByteCodec")]
+    pub packed: u64,
+}
+
+mod shim {
+    pub struct ByteCodec;
+}
+"#,
+        &[
+            "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` fields",
+            "custom wincode codecs can change the serialized layout",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn malformed_discriminator_attribute_has_targeted_message() {
     compile_fail_case(
         "bad_discriminator",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -175,6 +175,24 @@ pub struct Bad {
     );
 
     compile_fail_case(
+        "init_space_wincode_skip_default_val",
+        r#"
+use anchor_lang_v2::InitSpace;
+
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Bad {
+    #[wincode(skip(default_val = 9))]
+    pub skipped: u64,
+    pub kept: u8,
+}
+"#,
+        &[
+            "#[derive(InitSpace)] does not support `#[wincode(skip)]` fields",
+            "serialized layout",
+        ],
+    );
+
+    compile_fail_case(
         "init_space_wincode_with",
         r#"
 use anchor_lang_v2::InitSpace;


### PR DESCRIPTION
## Finding

`InitSpace` and generated IDL ignored `#[wincode(skip)]` and `#[wincode(with)]`, allowing declared layouts to disagree with wire encoding.

## Fix

Reject unsupported field-level wincode overrides consistently instead of calculating misleading sizes or schemas. Compile-fail regressions cover each unsupported override.