### PR TITLE
ci: update Agave and Surfpool versions

### DIFF
--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -16,8 +16,8 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: false
-      solana_version: 3.1.10
+      solana_version: 4.1.2
       node_version: 22.22.3
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching
-      surfpool_cli_version: 1.2.0
+      surfpool_cli_version: 1.5.0

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -43,11 +43,11 @@ jobs:
 
       - uses: ./.github/actions/setup-solana/
         env:
-          SOLANA_VERSION: "3.1.10"
+          SOLANA_VERSION: "4.1.2"
 
       - uses: ./.github/actions/setup-surfpool/
         env:
-          SURFPOOL_CLI_VERSION: "1.2.0"
+          SURFPOOL_CLI_VERSION: "1.5.0"
 
       - name: Install cargo-release
         run: cargo install cargo-release --version 1.1.1 --locked

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -279,7 +279,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SOLANA_CLI=v3.1.10
+            SOLANA_CLI=v4.1.2
             ANCHOR_CLI=${{ github.ref_name }}
           provenance: mode=max
           sbom: true

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -15,9 +15,9 @@ permissions:
   contents: read
 
 env:
-  SOLANA_VERSION: "3.1.10"
+  SOLANA_VERSION: "4.1.2"
   NODE_VERSION: "20"
-  SURFPOOL_CLI_VERSION: "1.2.0"
+  SURFPOOL_CLI_VERSION: "1.5.0"
 
 jobs:
   # Build CLI once to share across test jobs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,8 +22,8 @@ jobs:
     uses: ./.github/workflows/reusable-tests.yaml
     with:
       cache: true
-      solana_version: 3.1.10
+      solana_version: 4.1.2
       node_version: 22.22.3
       cargo_profile: debug
       anchor_binary_name: anchor-binary
-      surfpool_cli_version: 1.2.0
+      surfpool_cli_version: 1.5.0

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -103,7 +103,7 @@ pub enum SolanaCommand {
     /// Install and activate a Solana CLI version. With no argument, installs
     /// the project-resolved version.
     Install {
-        /// Solana CLI version, e.g. `3.1.10`.
+        /// Solana CLI version, e.g. `4.1.2`.
         version: Option<String>,
         /// Run the installer even if the requested version is already active.
         #[clap(long)]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 # Anchor version.
 ANCHOR_CLI=v1.1.2
 # Solana toolchain.
-SOLANA_CLI=v3.1.10
+SOLANA_CLI=v4.1.2
 # Build version should match the Anchor cli version.
 VERSIONED_IMG_NAME=quay.io/ottersec/anchor:$(ANCHOR_CLI)
 

--- a/docs-v2/src/content/docs/v1/get-started/installation.mdx
+++ b/docs-v2/src/content/docs/v1/get-started/installation.mdx
@@ -37,9 +37,9 @@ After installation, you should see output similar to the following:
 ```console
 Installed Versions:
 Rust: rustc 1.95.0 (59807616e 2026-04-14)
-Solana CLI: solana-cli 3.1.14 (src:ca2c682f; feat:534737035, client:Agave)
+Solana CLI: solana-cli 4.1.2 (src:182084b8; feat:c763ae0a, client:Agave)
 Anchor CLI: anchor-cli 0.32.1
-Surfpool CLI: surfpool 1.2.0
+Surfpool CLI: surfpool 1.5.0
 Node.js: v24.12.0
 Yarn: 1.22.22
 

--- a/docs-v2/src/content/docs/v1/reference/anchor-toml.mdx
+++ b/docs-v2/src/content/docs/v1/reference/anchor-toml.mdx
@@ -297,7 +297,7 @@ Overrides toolchain versions for the workspace, similar to [`rust-toolchain.toml
 ```toml
 [toolchain]
 anchor_version = "1.0.1"    # `anchor-cli` version to use (requires `avm`)
-solana_version = "3.1.10"   # Solana version to use (applies to all Solana tools)
+solana_version = "4.1.2"    # Solana version to use (applies to all Solana tools)
 package_manager = "yarn"    # JS package manager to use
 ```
 

--- a/docs-v2/src/content/docs/v2/reference/anchor-toml.mdx
+++ b/docs-v2/src/content/docs/v2/reference/anchor-toml.mdx
@@ -128,7 +128,7 @@ Toolchain settings choose versions and JavaScript package tooling:
 ```toml showLineNumbers=false
 [toolchain]
 anchor_version = "1.0.1"
-solana_version = "3.1.10"
+solana_version = "4.1.2"
 package_manager = "pnpm"
 ```
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -29,7 +29,7 @@ After installation, you should see output similar to the following:
 ```
 Installed Versions:
 Rust: rustc 1.85.0 (4d91de4e4 2025-02-17)
-Solana CLI: solana-cli 3.1.10 (src:7bc9c805; feat:1620780344, client:Agave)
+Solana CLI: solana-cli 4.1.2 (src:182084b8; feat:c763ae0a, client:Agave)
 Anchor CLI: anchor-cli 1.1.2
 Node.js: v23.9.0
 Yarn: 1.22.1

--- a/docs/content/docs/references/anchor-toml.mdx
+++ b/docs/content/docs/references/anchor-toml.mdx
@@ -394,7 +394,7 @@ Override toolchain data in the workspace similar to
 ```toml
 [toolchain]
 anchor_version = "1.1.2"    # `anchor-cli` version to use(requires `avm`)
-solana_version = "3.1.10"   # Solana version requirement to use(applies to all Solana tools)
+solana_version = "4.1.2"    # Solana version requirement to use(applies to all Solana tools)
 package_manager = "yarn"     # JS package manager to use
 ```
 

--- a/docs/content/docs/references/avm.mdx
+++ b/docs/content/docs/references/avm.mdx
@@ -126,7 +126,7 @@ it to Anchor's recommended Solana version.
 
 Project Solana versions are parsed as semver requirements. AVM chooses the
 newest hosted Solana CLI installer that satisfies the requirement; use an exact
-comparator such as `=3.1.10` to require one specific hosted version.
+comparator such as `=4.1.2` to require one specific hosted version.
 
 When `anchor` is invoked through the AVM stub, AVM also ensures the resolved
 Solana CLI version is active before spawning the selected `anchor-cli` binary.

--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 active_version=$(solana -V | awk '{print $2}')
-if [ "$active_version" != "3.1.10" ]; then
-  agave-install init 3.1.10
+if [ "$active_version" != "4.1.2" ]; then
+  agave-install init 4.1.2
 fi
 
 git submodule update --init --recursive --depth 1


### PR DESCRIPTION
Some recent CI failures seem to be caused by out-of-date validators. Surfpool occasionally fails to materialise accounts in time for the `validator-clone` test, and https://github.com/solana-program/program-metadata/pull/84 broke our cloned deployment of the metadata program. Update both to latest