### PR TITLE
fix(lang-v2/tests-v2): reject padded bytemuck event layouts

### DIFF
--- a/lang-v2/README.md
+++ b/lang-v2/README.md
@@ -82,7 +82,7 @@ Here are some examples of optimizations present in Anchor v2.
 - **PDA bumps precomputed at macro time.** If your seeds are all literals, the derive runs the PDA search during compilation and bakes the canonical bump in as a `const`. This lets us skip the runtime PDA search entirely.
 - **Skip the on-curve check for program-owned PDAs.** If the program already owns the account, it had to be created via signed CPI — which did the curve check at the time. Verification can just hash-and-compare. Saves ~1,000 CU per verify.
 - **Wincode events by default.** Much cheaper than borsh on SBF, and still handles `Vec` / `String` / `Option` / enums. 3–10× cheaper than borsh.
-- **`#[event(bytemuck)]` for fixed-size events.** The struct's `repr(C)` Pod layout already matches the wire format, so emitting is just disc + one memcpy of the body. No per-field encoding.
+- **`#[event(bytemuck)]` for fixed-size events.** The struct's `repr(C)` Pod layout already matches the wire format, so emitting is just disc + one memcpy of the body. No per-field encoding, with compile-time rejection of padded layouts.
 - **Alignment-1 Pod wrappers** (`PodU64`, `PodI128`, `PodBool`, ...). Integers stored as `[u8; N]` so the whole `#[account]` struct casts directly from the account's raw bytes. Zero deserialization.
 - **`PodVec<T, MAX>`**: fixed-capacity vec with a `u16` length, stored inline in the account. Variable-length data without heap allocation.
 - **Typed `CpiHandle` lets us use pinocchio's unchecked CPI.** The unchecked path would be UB under stale-borrow aliasing, but the Rust borrow checker rules that out at compile time — so `CpiContext::invoke()` takes it. Turns UB into a compile error and drops one runtime check per CPI.

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -5521,15 +5521,13 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // `Pod` trait propagates through nested types).
                 #(#field_pod_asserts)*
 
-                // `repr(C)` padding is target-dependent: on SBF `u128` is
-                // align-8, so a `{Address (align 1), u64, u128}` struct has
-                // no padding; on x86_64 hosts `u128` is align-16, inserting
-                // a phantom 8-byte gap before the `u128`. Gating on the
-                // Solana target means `cargo check` accepts the struct
-                // based on BPF layout (the only layout that actually
-                // ships) and `cargo build-sbf` still enforces the no-
-                // padding invariant.
-                #[cfg(target_os = "solana")]
+                // `repr(C)` padding is target-dependent: a layout that is
+                // tightly packed on SBF can still gain a host-only padding
+                // hole (for example, before a `u128`). The bytemuck event
+                // surface is also available to host-side consumers, so the
+                // no-padding assertion must run everywhere we emit the
+                // `Pod` impl; otherwise the host type could drift from the
+                // bytes the program logs on-chain.
                 const _: () = {
                     let mut __size = 0usize;
                     #(#field_size_steps)*
@@ -5555,29 +5553,23 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
                 //       uninit-byte types (`bool`, enums, `Option`), and
                 //       any user struct that itself isn't `Pod`.
                 //   (3) No interior padding bytes        — enforced by the
-                //       `size_of::<Self>() == Σ size_of::<Field>()` assert
-                //       under `cfg(target_os = "solana")`. Padding bytes
-                //       are `MaybeUninit`, which would be read by
+                //       `size_of::<Self>() == Σ size_of::<Field>()` assert.
+                //       Padding bytes are `MaybeUninit`, which would be read by
                 //       `bytemuck::bytes_of` / `bytemuck::from_bytes` and
                 //       constitute UB — the assert precludes the case.
                 //   (4) `Copy` + `'static`               — `Copy` is
                 //       derived above; `'static` is required by
                 //       `assert_pod::<T: 'static>` transitively.
                 //
-                // The cfg-gated padding assert deliberately only evaluates
-                // on the Solana target. `repr(C)` padding is target-
-                // dependent: on SBF `u128` is align-8, so `{Address (align
-                // 1), u64, u128}` is perfectly packed; on x86_64 hosts
-                // `u128` is align-16, so that same layout has a phantom
-                // 8-byte gap during `cargo check`. This is not a soundness
-                // hole — the event bytes only get memcpy'd into
-                // `sol_log_data` on the actual deployment target, where
-                // the assert does run.
+                // The padding assert deliberately runs on every target.
+                // `#[event(bytemuck)]` also emits `Pod` on every target, so
+                // letting host-only padding through would make off-chain
+                // `bytemuck::from_bytes` consumers accept a shape that does
+                // not match the bytes emitted by the deployed program.
                 //
-                // Not using `#[derive(Pod)]` because bytemuck's own
-                // padding check is unconditional (not target-gated) and
-                // would reject `u128`-carrying events on host compile even
-                // though their on-chain layout is sound.
+                // Not using `#[derive(Pod)]` so we can keep the targeted
+                // field diagnostics above instead of falling straight into
+                // bytemuck's generic trait errors.
                 unsafe impl anchor_lang_v2::bytemuck::Pod for #name {}
                 unsafe impl anchor_lang_v2::bytemuck::Zeroable for #name {}
 

--- a/lang-v2/src/event.rs
+++ b/lang-v2/src/event.rs
@@ -14,9 +14,9 @@ pub const EVENT_IX_TAG_LE: &[u8] = &EVENT_IX_TAG.to_le_bytes();
 ///   `Vec`/`String`/`Option`/enums and is materially cheaper than borsh on
 ///   SBF (3–10× fewer CUs).
 /// - opt-in (`#[event(bytemuck)]`) — zero-copy `copy_nonoverlapping` of a
-///   `repr(C)` struct with a compile-time padding assertion. Cheapest on
-///   fixed-size shapes, but the struct must contain only fixed-size,
-///   non-fat-pointer fields.
+///   `repr(C)` struct with a compile-time no-padding assertion on every
+///   target. Cheapest on fixed-size shapes, but the struct must contain
+///   only fixed-size, non-fat-pointer fields.
 pub trait Event: Discriminator {
     /// Serialize the event: discriminator bytes followed by event data.
     fn data(&self) -> Vec<u8>;

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -534,6 +534,43 @@ fn declare_program_account_group_variants_do_not_collide_with_existing_types() {
 }
 
 #[test]
+fn event_bytemuck_rejects_host_padding_layouts() {
+    CompileCase::new(
+        "event_bytemuck_rejects_host_padding_layouts",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[event(bytemuck)]
+pub struct BadLayout {
+    pub authority: Address,
+    pub count: u64,
+    pub amount: u128,
+}
+"#,
+    )
+    .expect_fail(&["struct has `repr(C)` alignment padding"]);
+}
+
+#[test]
+fn event_bytemuck_accepts_explicit_padding() {
+    CompileCase::new(
+        "event_bytemuck_accepts_explicit_padding",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[event(bytemuck)]
+pub struct GoodLayout {
+    pub authority: Address,
+    pub count: u64,
+    pub _pad: [u8; 8],
+    pub amount: u128,
+}
+"#,
+    )
+    .expect_pass();
+}
+
+#[test]
 fn declare_program_missing_accounts_array_fails_clearly() {
     declare_program_compile_fail_case(
         "declare_program_missing_accounts_array",


### PR DESCRIPTION
## Finding

Bytemuck event padding was checked only on Solana targets, although the generated `Pod` implementation also existed on host targets.

## Fix

Enforce the no-padding assertion on every target and document explicit padding or wincode as alternatives. Host compile-fail coverage checks padded events.