### PR TITLE
feat(avm): Verify GH attestation when installing binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "portpicker",
  "ratatui",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rustc-demangle",
  "semver",
  "serde",
@@ -684,12 +684,38 @@ dependencies = [
  "clap 4.6.1",
  "clap_complete",
  "dirs",
- "reqwest",
+ "reqwest 0.13.4",
  "semver",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
+ "sigstore-verify",
  "tempfile",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1179,6 +1205,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmpv2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39"
+dependencies = [
+ "crmf",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "cms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1410,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crmf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92"
+dependencies = [
+ "cms",
+ "der",
+ "spki",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1550,12 +1621,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1571,6 +1676,17 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1728,6 +1844,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "eager"
@@ -1963,6 +2085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2126,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2294,6 +2428,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "histogram"
@@ -2674,6 +2814,48 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -3351,6 +3533,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3618,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portpicker"
@@ -3547,6 +3757,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3854,6 +4065,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reqwest-middleware"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,7 +4113,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.1",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -3897,7 +4148,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3977,6 +4228,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4040,9 +4292,10 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4074,6 +4327,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -4216,6 +4475,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4392,6 +4662,164 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "sigstore-bundle"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5948e95f63e900fa92936ecf72c7f2251f83d27560a35a4aae560cc745f8b687"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-crypto"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f27364b37bec104a904f10a675c8cdf05d5e48a980569368f0cd0c119b2652"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "const-oid 0.9.6",
+ "der",
+ "digest 0.10.7",
+ "pem 3.0.6",
+ "rand_core 0.9.5",
+ "sha2 0.10.9",
+ "signature",
+ "sigstore-types",
+ "spki",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-merkle"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee85fd9fb550efd7c8a59447cb0ef4eb02f1258f3ffa80c88d38427c3930af3"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-rekor"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b97c5a866f849a9445ae657bef0caa2db053a82827e6dae3a2b3de9c15a6a1a"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "sigstore-trust-root"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389b54d1b8ace20ba86fdf90e5e655495f65f1abbc7d5d0eb7494defa9ad32f0"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "jiff",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-tsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58fe92d4d8cf4b7215b927b70bc1245b6e0d70d801febdfe0cd265ad97ebf8b"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "cmpv2",
+ "cms",
+ "const-oid 0.9.6",
+ "der",
+ "hex",
+ "jiff",
+ "rand 0.9.4",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+ "x509-tsp",
+]
+
+[[package]]
+name = "sigstore-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236474c535a3157839926a0ae18f9c0c22b151e49634da6e5b18ad7cac8a3b69"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "pem 3.0.6",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-verify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558f71aad0e1c5925d29ae2024f55f0f8898a7ad450c93668f99086624c421e0"
+dependencies = [
+ "base64 0.22.1",
+ "cms",
+ "const-oid 0.9.6",
+ "hex",
+ "jiff",
+ "pem 3.0.6",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tracing",
+ "x509-cert",
 ]
 
 [[package]]
@@ -5168,7 +5596,7 @@ dependencies = [
  "crossbeam-channel",
  "gethostname",
  "log",
- "reqwest",
+ "reqwest 0.12.28",
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",
@@ -5609,7 +6037,7 @@ dependencies = [
  "futures",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "semver",
  "serde",
@@ -5644,7 +6072,7 @@ checksum = "8a81a57ed54176e3aa4bca8e894f9326638a3f6870f79b078d8b3fadda8a4c9b"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -5929,7 +6357,7 @@ dependencies = [
  "log",
  "nix",
  "num_cpus",
- "pem",
+ "pem 1.1.1",
  "percentage",
  "rand 0.8.6",
  "rustls",
@@ -6895,6 +7323,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7134,7 +7583,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7297,6 +7758,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -8021,6 +8488,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8036,6 +8517,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
+]
+
+[[package]]
+name = "x509-tsp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1"
+dependencies = [
+ "cmpv2",
+ "cms",
+ "der",
 ]
 
 [[package]]

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -20,14 +20,21 @@ chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
-reqwest = { workspace = true, default-features = false, features = [
+
+# FIXME: `sigstore-verify` uses reqwest 0.13 whereas the workspace uses 0.12
+# to match the Solana crates. Use 0.13 here to avoid bundling two copies
+# in avm. Unify them once the workspace dependency is updated.
+reqwest = { version = "0.13.4", default-features = false, features = [
   "blocking",
   "json",
-  "rustls-tls",
+  "query",
+  "rustls",
 ] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0"
 sha2 = "0.10.9"
+sigstore-verify = { version = "0.11.0", default-features = false }
 toml = "0.7.6"
 
 [dev-dependencies]

--- a/avm/src/attestation.rs
+++ b/avm/src/attestation.rs
@@ -1,0 +1,238 @@
+use {
+    crate::HTTP_CLIENT,
+    anyhow::{bail, Context, Result},
+    reqwest::{header::USER_AGENT, StatusCode},
+    semver::Version,
+    serde::Deserialize,
+    serde_json::Value,
+    sha2::{Digest, Sha256},
+    sigstore_verify::{
+        trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT},
+        types::{Bundle, Sha256Hash, SignatureContent, Statement},
+        VerificationPolicy, Verifier,
+    },
+    std::{fs::File, io::Read, path::Path},
+};
+
+const GITHUB_REPOSITORY: &str = "otter-sec/anchor";
+const GITHUB_ACTIONS_ISSUER: &str = "https://token.actions.githubusercontent.com";
+const SLSA_PROVENANCE_V1: &str = "https://slsa.dev/provenance/v1";
+const RELEASE_WORKFLOW: &str = ".github/workflows/build-cli.yaml";
+const NIGHTLY_WORKFLOW: &str = ".github/workflows/nightly-attested-binaries.yaml";
+
+#[derive(Deserialize)]
+struct AttestationsResponse {
+    attestations: Vec<GitHubAttestation>,
+}
+
+#[derive(Deserialize)]
+struct GitHubAttestation {
+    bundle: Value,
+}
+
+pub(crate) fn verify_release(path: &Path, version: &Version) -> Result<()> {
+    verify(path, &release_identity(version))
+}
+
+pub(crate) fn verify_nightly(path: &Path) -> Result<()> {
+    verify(path, &nightly_identity())
+}
+
+fn release_identity(version: &Version) -> String {
+    workflow_identity(RELEASE_WORKFLOW, &format!("refs/tags/v{version}"))
+}
+
+fn nightly_identity() -> String {
+    workflow_identity(NIGHTLY_WORKFLOW, "refs/heads/master")
+}
+
+fn workflow_identity(workflow: &str, git_ref: &str) -> String {
+    format!("https://github.com/{GITHUB_REPOSITORY}/{workflow}@{git_ref}")
+}
+
+fn verify(path: &Path, expected_identity: &str) -> Result<()> {
+    let digest = sha256_file(path)?;
+    let attestations = fetch_attestations(digest).with_context(|| {
+        format!(
+            "Fetching build provenance attestations for `{}`",
+            path.display()
+        )
+    })?;
+    verify_attestations(&attestations, digest, expected_identity)
+}
+
+fn fetch_attestations(digest: Sha256Hash) -> Result<Vec<GitHubAttestation>> {
+    let url = format!(
+        "https://api.github.com/repos/{GITHUB_REPOSITORY}/attestations/sha256:{}",
+        digest.to_hex()
+    );
+    let response = HTTP_CLIENT
+        .get(&url)
+        .header(USER_AGENT, "avm https://github.com/otter-sec/anchor")
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .query(&[("predicate_type", SLSA_PROVENANCE_V1)])
+        .send()
+        .with_context(|| format!("Fetching attestations from {url}"))?;
+
+    if response.status() == StatusCode::NOT_FOUND {
+        bail!(
+            "No build provenance attestation found for digest `sha256:{}`",
+            digest.to_hex()
+        );
+    }
+    if !response.status().is_success() {
+        bail!(
+            "Failed to fetch build provenance attestations for digest `sha256:{}` (status {})",
+            digest.to_hex(),
+            response.status()
+        );
+    }
+
+    let response = response
+        .json::<AttestationsResponse>()
+        .context("Parsing GitHub attestation response")?;
+    Ok(response.attestations)
+}
+
+fn verify_attestations(
+    attestations: &[GitHubAttestation],
+    digest: Sha256Hash,
+    expected_identity: &str,
+) -> Result<()> {
+    if attestations.is_empty() {
+        bail!(
+            "No build provenance attestation found for digest `sha256:{}`",
+            digest.to_hex()
+        );
+    }
+
+    let trusted_root = TrustedRoot::from_json(SIGSTORE_PRODUCTION_TRUSTED_ROOT)
+        .context("Loading Sigstore production trust root")?;
+    let verifier = Verifier::new(&trusted_root);
+    let policy = VerificationPolicy::default()
+        .require_identity(expected_identity)
+        .require_issuer(GITHUB_ACTIONS_ISSUER);
+    let mut verification_errors = Vec::new();
+
+    for attestation in attestations {
+        let result = (|| -> Result<()> {
+            let json = serde_json::to_string(&attestation.bundle)
+                .context("Serializing Sigstore bundle")?;
+            let bundle = Bundle::from_json(&json).context("Parsing Sigstore bundle")?;
+            require_slsa_provenance(&bundle)?;
+            verifier
+                .verify(digest, &bundle, &policy)
+                .context("Verifying Sigstore bundle")?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(err) => verification_errors.push(err),
+        }
+    }
+
+    let detail = verification_errors
+        .first()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "unknown verification failure".to_string());
+    bail!(
+        "No valid build provenance attestation from `{expected_identity}` for digest `sha256:{}`: \
+         {detail}",
+        digest.to_hex()
+    )
+}
+
+fn require_slsa_provenance(bundle: &Bundle) -> Result<()> {
+    let SignatureContent::DsseEnvelope(envelope) = &bundle.content else {
+        bail!("Build provenance attestation is not a DSSE envelope");
+    };
+    if envelope.payload_type != "application/vnd.in-toto+json" {
+        bail!(
+            "Build provenance attestation has unexpected payload type `{}`",
+            envelope.payload_type
+        );
+    }
+
+    let statement = serde_json::from_slice::<Statement>(&envelope.decode_payload())
+        .context("Parsing in-toto attestation statement")?;
+    if statement.predicate_type != SLSA_PROVENANCE_V1 {
+        bail!(
+            "Build provenance attestation has unexpected predicate type `{}`",
+            statement.predicate_type
+        );
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<Sha256Hash> {
+    let mut file = File::open(path)
+        .with_context(|| format!("Opening `{}` for attestation verification", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("Reading `{}`", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(Sha256Hash::from_bytes(hasher.finalize().into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_identity_is_scoped_to_tagged_build_workflow() {
+        assert_eq!(
+            release_identity(&Version::new(1, 2, 3)),
+            "https://github.com/otter-sec/anchor/.github/workflows/build-cli.yaml@refs/tags/v1.2.3"
+        );
+    }
+
+    #[test]
+    fn nightly_identity_is_scoped_to_master_workflow() {
+        assert_eq!(
+            nightly_identity(),
+            "https://github.com/otter-sec/anchor/.github/workflows/nightly-attested-binaries.yaml@refs/heads/master"
+        );
+    }
+
+    #[test]
+    fn sha256_file_hashes_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact");
+        std::fs::write(&path, b"anchor").unwrap();
+
+        assert_eq!(
+            sha256_file(&path).unwrap().to_hex(),
+            "79bfb0e2ba76b9d447606ddbcc494834f05a4c11deb052e74b49ea307a3c5bcd"
+        );
+    }
+
+    #[test]
+    fn fetches_and_verifies_attested_nightly_digest_and_rejects_mismatches() {
+        let digest = Sha256Hash::from_hex(
+            "7f0f0ad9dcce712f1db299255f374689d3fb30ac6381f8cbbc538361fac52001",
+        )
+        .unwrap();
+        let attestations = fetch_attestations(digest).unwrap();
+
+        verify_attestations(&attestations, digest, &nightly_identity()).unwrap();
+
+        let wrong_digest = Sha256Hash::from_bytes([0; 32]);
+        assert!(verify_attestations(&attestations, wrong_digest, &nightly_identity()).is_err());
+        assert!(verify_attestations(
+            &attestations,
+            digest,
+            &release_identity(&Version::new(1, 1, 2))
+        )
+        .is_err());
+    }
+}

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -1,3 +1,4 @@
+mod attestation;
 pub mod platform_tools;
 pub mod resolve;
 pub mod solana;
@@ -502,11 +503,10 @@ pub fn install_version(
         } else {
             ""
         };
-        let res = DOWNLOAD_CLIENT
-            .get(format!(
-                "https://github.com/otter-sec/anchor/releases/download/v{version}/anchor-{version}-{target}{ext}"
-            ))
-            .send()?;
+        let url = format!(
+            "https://github.com/otter-sec/anchor/releases/download/v{version}/anchor-{version}-{target}{ext}"
+        );
+        let res = DOWNLOAD_CLIENT.get(&url).send()?;
         match res.status() {
             StatusCode::NOT_FOUND => bail!(
                 "No prebuilt binary found for version `{version}` (HTTP 404). Try `avm install \
@@ -519,15 +519,32 @@ pub fn install_version(
             _ => (),
         }
 
-        let bin_path = version_binary_path(&version);
-        fs::write(&bin_path, res.bytes()?)?;
+        let staging_dir = get_tmp_install_dir_path();
+        fs::create_dir_all(&staging_dir)
+            .with_context(|| format!("Creating {}", staging_dir.display()))?;
+        let staging_path =
+            staging_dir.join(format!(".anchor-{version}-download-{}", std::process::id()));
+        if staging_path.exists() {
+            fs::remove_file(&staging_path)
+                .with_context(|| format!("Removing stale {}", staging_path.display()))?;
+        }
 
-        // Set file to executable on UNIX
-        #[cfg(unix)]
-        fs::set_permissions(
-            bin_path,
-            <fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o775),
-        )?;
+        let result = (|| -> Result<()> {
+            fs::write(&staging_path, res.bytes()?).with_context(|| {
+                format!("Writing downloaded binary to {}", staging_path.display())
+            })?;
+            attestation::verify_release(&staging_path, &version).with_context(|| {
+                format!(
+                    "Downloaded Anchor {version} binary from `{url}` failed build provenance \
+                     verification. Refusing to install it; use `avm install {version} \
+                     --from-source` to build from source instead."
+                )
+            })?;
+            install_binary_atomic(&staging_path, &version_binary_path(&version))
+        })();
+
+        let _ = fs::remove_file(&staging_path);
+        result?;
     }
 
     let is_at_least_0_32 = version >= Version::new(0, 32, 0);
@@ -1087,6 +1104,12 @@ fn download_nightly_artifact(artifact: &NightlyArtifact, dest: &Path) -> Result<
         );
     }
     fs::write(dest, bytes.as_ref()).with_context(|| format!("Writing {}", dest.display()))?;
+    attestation::verify_nightly(dest).with_context(|| {
+        format!(
+            "Downloaded nightly artifact `{url}` failed build provenance verification. Refusing \
+             to install it."
+        )
+    })?;
     Ok(())
 }
 

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -260,7 +260,7 @@ pub fn use_version(opt_version: Option<Version>) -> Result<()> {
             .expect("Expected input")?;
         match input.as_str() {
             "y" | "yes" => {
-                return install_version(InstallTarget::Version(version), false, false, false)
+                return install_version(InstallTarget::Version(version), false, false, false, false)
             }
             _ => return Err(anyhow!("Installation rejected.")),
         };
@@ -279,10 +279,23 @@ pub enum InstallTarget {
     Path(PathBuf),
 }
 
+fn warn_attestation_skipped() {
+    eprintln!(
+        "WARNING: Skipping build provenance attestation verification. Installing unauthenticated \
+         binaries is potentially dangerous."
+    );
+}
+
 /// Update to the latest version
-pub fn update(include_pre_release: bool) -> Result<()> {
+pub fn update(include_pre_release: bool, skip_attestation: bool) -> Result<()> {
     let latest_version = get_latest_version(include_pre_release)?;
-    install_version(InstallTarget::Version(latest_version), false, false, false)
+    install_version(
+        InstallTarget::Version(latest_version),
+        false,
+        false,
+        false,
+        skip_attestation,
+    )
 }
 
 /// The commit sha provided can be shortened,
@@ -374,6 +387,7 @@ pub fn install_version(
     force: bool,
     from_source: bool,
     with_solana_verify: bool,
+    skip_attestation: bool,
 ) -> Result<()> {
     let (version, from_source) = match &install_target {
         InstallTarget::Version(version) => (version.to_owned(), from_source),
@@ -533,13 +547,17 @@ pub fn install_version(
             fs::write(&staging_path, res.bytes()?).with_context(|| {
                 format!("Writing downloaded binary to {}", staging_path.display())
             })?;
-            attestation::verify_release(&staging_path, &version).with_context(|| {
-                format!(
-                    "Downloaded Anchor {version} binary from `{url}` failed build provenance \
-                     verification. Refusing to install it; use `avm install {version} \
-                     --from-source` to build from source instead."
-                )
-            })?;
+            if skip_attestation {
+                warn_attestation_skipped();
+            } else {
+                attestation::verify_release(&staging_path, &version).with_context(|| {
+                    format!(
+                        "Downloaded Anchor {version} binary from `{url}` failed build provenance \
+                         verification. Refusing to install it; use `avm install {version} \
+                         --from-source` to build from source instead."
+                    )
+                })?;
+            }
             install_binary_atomic(&staging_path, &version_binary_path(&version))
         })();
 
@@ -849,13 +867,13 @@ pub fn nightly_anchor_binary_path() -> PathBuf {
     })
 }
 
-pub fn enable_nightly() -> Result<()> {
+pub fn enable_nightly(skip_attestation: bool) -> Result<()> {
     ensure_paths();
     if !nightly_enabled() {
         backup_stable_avm()?;
     }
 
-    let version = ensure_nightly_installed()?;
+    let version = ensure_nightly_installed(skip_attestation)?;
     point_anchor_stub_to(&stable_avm_backup_path())
         .context("Pointing anchor stub at nightly proxy")?;
     fs::write(nightly_enabled_file_path(), b"enabled\n").context("Writing Anchor nightly state")?;
@@ -880,7 +898,7 @@ pub fn ensure_nightly_active() -> Result<Option<String>> {
     if !nightly_enabled() {
         return Ok(None);
     }
-    ensure_nightly_installed().map(Some)
+    ensure_nightly_installed(false).map(Some)
 }
 
 fn nightly_enabled() -> bool {
@@ -951,7 +969,7 @@ fn nightly_binaries_exist() -> bool {
     nightly_anchor_binary_path().is_file() && nightly_avm_binary_path().is_file()
 }
 
-fn ensure_nightly_installed() -> Result<String> {
+fn ensure_nightly_installed(skip_attestation: bool) -> Result<String> {
     ensure_paths();
 
     let now = Utc::now().timestamp();
@@ -973,7 +991,7 @@ fn ensure_nightly_installed() -> Result<String> {
 
     match fetch_nightly_manifest() {
         Ok(manifest) => {
-            if let Err(err) = install_nightly_manifest(&manifest) {
+            if let Err(err) = install_nightly_manifest(&manifest, skip_attestation) {
                 write_nightly_cache_error();
                 if nightly_binaries_exist() {
                     let version = cached_nightly_version().unwrap_or_else(|| "cached".to_string());
@@ -1026,7 +1044,7 @@ fn fetch_nightly_manifest() -> Result<NightlyManifest> {
         .context("Parsing Anchor nightly manifest")
 }
 
-fn install_nightly_manifest(manifest: &NightlyManifest) -> Result<()> {
+fn install_nightly_manifest(manifest: &NightlyManifest, skip_attestation: bool) -> Result<()> {
     let target = rustc_host_target()?;
     let anchor = nightly_artifact(manifest, "anchor", &target)?;
     let avm = nightly_artifact(manifest, "avm", &target)?;
@@ -1035,8 +1053,11 @@ fn install_nightly_manifest(manifest: &NightlyManifest) -> Result<()> {
         cached_version.as_deref() != Some(manifest.version.as_str()) || !nightly_binaries_exist();
 
     if needs_download {
-        install_nightly_artifact(&anchor, &nightly_anchor_binary_path())?;
-        install_nightly_artifact(&avm, &nightly_avm_binary_path())?;
+        if skip_attestation {
+            warn_attestation_skipped();
+        }
+        install_nightly_artifact(&anchor, &nightly_anchor_binary_path(), skip_attestation)?;
+        install_nightly_artifact(&avm, &nightly_avm_binary_path(), skip_attestation)?;
     }
     Ok(())
 }
@@ -1059,7 +1080,11 @@ fn nightly_artifact(
         })
 }
 
-fn install_nightly_artifact(artifact: &NightlyArtifact, destination: &Path) -> Result<()> {
+fn install_nightly_artifact(
+    artifact: &NightlyArtifact,
+    destination: &Path,
+    skip_attestation: bool,
+) -> Result<()> {
     let staging = get_tmp_install_dir_path().join(format!(
         "nightly-{}-{}",
         artifact.tool,
@@ -1073,7 +1098,7 @@ fn install_nightly_artifact(artifact: &NightlyArtifact, destination: &Path) -> R
 
     let result = (|| -> Result<()> {
         let archive_path = staging.join(&artifact.file);
-        download_nightly_artifact(artifact, &archive_path)?;
+        download_nightly_artifact(artifact, &archive_path, skip_attestation)?;
         extract_tar_gz(&archive_path, &staging)?;
         let extracted = extracted_nightly_binary(&staging, &artifact.tool)?;
         install_binary_atomic(&extracted, destination)?;
@@ -1084,7 +1109,11 @@ fn install_nightly_artifact(artifact: &NightlyArtifact, destination: &Path) -> R
     result
 }
 
-fn download_nightly_artifact(artifact: &NightlyArtifact, dest: &Path) -> Result<()> {
+fn download_nightly_artifact(
+    artifact: &NightlyArtifact,
+    dest: &Path,
+    skip_attestation: bool,
+) -> Result<()> {
     let url = nightly_artifact_url(artifact);
     let response = DOWNLOAD_CLIENT
         .get(&url)
@@ -1104,12 +1133,14 @@ fn download_nightly_artifact(artifact: &NightlyArtifact, dest: &Path) -> Result<
         );
     }
     fs::write(dest, bytes.as_ref()).with_context(|| format!("Writing {}", dest.display()))?;
-    attestation::verify_nightly(dest).with_context(|| {
-        format!(
-            "Downloaded nightly artifact `{url}` failed build provenance verification. Refusing \
-             to install it."
-        )
-    })?;
+    if !skip_attestation {
+        attestation::verify_nightly(dest).with_context(|| {
+            format!(
+                "Downloaded nightly artifact `{url}` failed build provenance verification. \
+                 Refusing to install it."
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -15,7 +15,7 @@ use {
         fmt::Write as FmtWrite,
         fs,
         io::{BufRead, Write},
-        path::{Path, PathBuf},
+        path::{Component, Path, PathBuf},
         process::{Command, Stdio},
         sync::LazyLock,
     },
@@ -1085,6 +1085,7 @@ fn install_nightly_artifact(
     destination: &Path,
     skip_attestation: bool,
 ) -> Result<()> {
+    let archive_name = nightly_archive_name(&artifact.file)?;
     let staging = get_tmp_install_dir_path().join(format!(
         "nightly-{}-{}",
         artifact.tool,
@@ -1097,7 +1098,7 @@ fn install_nightly_artifact(
     fs::create_dir_all(&staging).with_context(|| format!("Creating {}", staging.display()))?;
 
     let result = (|| -> Result<()> {
-        let archive_path = staging.join(&artifact.file);
+        let archive_path = staging.join(archive_name);
         download_nightly_artifact(artifact, &archive_path, skip_attestation)?;
         extract_tar_gz(&archive_path, &staging)?;
         let extracted = extracted_nightly_binary(&staging, &artifact.tool)?;
@@ -1107,6 +1108,15 @@ fn install_nightly_artifact(
 
     let _ = fs::remove_dir_all(&staging);
     result
+}
+
+fn nightly_archive_name(file: &str) -> Result<&Path> {
+    let path = Path::new(file);
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(path),
+        _ => bail!("Invalid nightly artifact filename `{file}`"),
+    }
 }
 
 fn download_nightly_artifact(
@@ -1563,6 +1573,25 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("does not include `anchor` for target `x86_64-unknown-linux-gnu`"));
+    }
+
+    #[test]
+    fn test_nightly_archive_name_rejects_path_traversal() {
+        assert_eq!(
+            nightly_archive_name("anchor.tar.gz").unwrap(),
+            Path::new("anchor.tar.gz")
+        );
+
+        for file in [
+            "../outside.tar.gz",
+            "nested/archive.tar.gz",
+            "/tmp/outside.tar.gz",
+            ".",
+            "..",
+            "",
+        ] {
+            assert!(nightly_archive_name(file).is_err(), "accepted `{file}`");
+        }
     }
 
     #[test]

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -40,6 +40,10 @@ pub enum Commands {
         /// Build from source code rather than downloading prebuilt binaries
         from_source: bool,
         #[clap(long)]
+        /// Skip build provenance attestation verification. This is potentially dangerous because
+        /// downloaded binaries will not be authenticated
+        skip_attestation: bool,
+        #[clap(long)]
         /// Install `solana-verify` as well
         verify: bool,
     },
@@ -59,6 +63,10 @@ pub enum Commands {
         #[clap(long)]
         /// Include pre-release versions when selecting the latest
         pre_release: bool,
+        #[clap(long)]
+        /// Skip build provenance attestation verification. This is potentially dangerous because
+        /// downloaded binaries will not be authenticated
+        skip_attestation: bool,
     },
     #[clap(about = "Update avm itself to the latest version via cargo install")]
     SelfUpdate {
@@ -74,6 +82,10 @@ pub enum Commands {
         #[clap(long)]
         /// Disable the nightly channel and restore normal version resolution
         disable: bool,
+        #[clap(long, conflicts_with = "disable")]
+        /// Skip build provenance attestation verification. This is potentially dangerous because
+        /// downloaded binaries will not be authenticated
+        skip_attestation: bool,
     },
     #[clap(about = "Generate shell completions for AVM")]
     Completions {
@@ -200,6 +212,7 @@ pub fn entry(opts: Cli) -> Result<()> {
             path,
             force,
             from_source,
+            skip_attestation,
             verify,
         } => {
             let install_target = if let Some(path) = path {
@@ -207,7 +220,7 @@ pub fn entry(opts: Cli) -> Result<()> {
             } else {
                 parse_install_target(&version_or_commit.unwrap())?
             };
-            avm::install_version(install_target, force, from_source, verify)
+            avm::install_version(install_target, force, from_source, verify, skip_attestation)
         }
         Commands::Uninstall { version } => {
             let v = Version::parse(&version)
@@ -215,16 +228,22 @@ pub fn entry(opts: Cli) -> Result<()> {
             avm::uninstall_version(&v)
         }
         Commands::List { pre_release } => avm::list_versions(pre_release),
-        Commands::Update { pre_release } => avm::update(pre_release),
+        Commands::Update {
+            pre_release,
+            skip_attestation,
+        } => avm::update(pre_release, skip_attestation),
         Commands::SelfUpdate {
             pre_release,
             bleeding_edge,
         } => avm::self_update(pre_release, bleeding_edge),
-        Commands::Nightly { disable } => {
+        Commands::Nightly {
+            disable,
+            skip_attestation,
+        } => {
             if disable {
                 avm::disable_nightly()
             } else {
-                avm::enable_nightly()
+                avm::enable_nightly(skip_attestation)
             }
         }
         Commands::Completions { shell } => {
@@ -411,7 +430,13 @@ fn ensure_resolved_binary(resolution: &Resolution) -> Result<PathBuf> {
         _ => anyhow::bail!("Installation declined."),
     }
 
-    avm::install_version(InstallTarget::Version(version.clone()), false, false, false)?;
+    avm::install_version(
+        InstallTarget::Version(version.clone()),
+        false,
+        false,
+        false,
+        false,
+    )?;
 
     if !binary_path.exists() {
         anyhow::bail!(
@@ -557,5 +582,50 @@ mod tests {
     #[test]
     fn test_resolve_use_version_invalid() {
         assert!(resolve_use_version(Some("not-a-version".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_parse_skip_attestation_for_binary_install_commands() {
+        let install =
+            Cli::try_parse_from(["avm", "install", "1.1.2", "--skip-attestation"]).unwrap();
+        assert!(matches!(
+            install.command,
+            Commands::Install {
+                skip_attestation: true,
+                ..
+            }
+        ));
+
+        let update = Cli::try_parse_from(["avm", "update", "--skip-attestation"]).unwrap();
+        assert!(matches!(
+            update.command,
+            Commands::Update {
+                skip_attestation: true,
+                ..
+            }
+        ));
+
+        let nightly = Cli::try_parse_from(["avm", "nightly", "--skip-attestation"]).unwrap();
+        assert!(matches!(
+            nightly.command,
+            Commands::Nightly {
+                skip_attestation: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_skip_attestation_help_warns_that_it_is_dangerous() {
+        for subcommand in ["install", "update", "nightly"] {
+            let mut command = Cli::command();
+            let help = command
+                .find_subcommand_mut(subcommand)
+                .unwrap()
+                .render_long_help()
+                .to_string();
+            assert!(help.contains("--skip-attestation"));
+            assert!(help.contains("potentially dangerous"));
+        }
     }
 }


### PR DESCRIPTION
Closes #4769

We generate nightly and on-release attestations, so consume them from AVM before installing.
This also adds a `--skip-attestation` flag, with appropriate warnings about the danger here.