### PR TITLE
Fix/v2 slab tail guards

### DIFF
--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -233,6 +233,10 @@ where
                 H::DATA_OFFSET % core::mem::align_of::<H>() == 0,
                 "Slab header DATA_OFFSET is not aligned for the header type",
             );
+            assert!(
+                !Self::HAS_TAIL || core::mem::align_of::<T>() <= 8,
+                "Slab tail alignment exceeds Solana's 8-byte account data alignment",
+            );
         };
     }
 
@@ -429,18 +433,30 @@ where
 
     /// Read the `len` field without requiring `LEN_OFFSET` alignment —
     /// `from_le_bytes` operates on a copy, so misaligned layouts are fine.
+    ///
+    /// Returns `None` when an external shrink has shortened the live account
+    /// data below the `len` field itself.
     #[inline(always)]
-    fn read_len(&self) -> u32 {
+    fn read_len(&self) -> Option<u32> {
+        if self.view.data_len() < Self::LEN_OFFSET + 4 {
+            return None;
+        }
         let bytes = self.guard_bytes();
         let mut buf = [0u8; 4];
         buf.copy_from_slice(&bytes[Self::LEN_OFFSET..Self::LEN_OFFSET + 4]);
-        u32::from_le_bytes(buf)
+        Some(u32::from_le_bytes(buf))
     }
 
     /// Write the `len` field. Same alignment-free pattern as `read_len`.
+    ///
+    /// If an external shrink has removed the field entirely, this becomes a
+    /// no-op after still validating the mutable-borrow contract.
     #[inline(always)]
     fn write_len(&mut self, new_len: u32) {
         let bytes = self.guard_bytes_mut();
+        if bytes.len() < Self::LEN_OFFSET + 4 {
+            return;
+        }
         bytes[Self::LEN_OFFSET..Self::LEN_OFFSET + 4].copy_from_slice(&new_len.to_le_bytes());
     }
 
@@ -470,9 +486,12 @@ where
     }
 
     /// Current number of items in the tail region.
+    ///
+    /// Returns 0 if an external shrink has shortened the live account data
+    /// below the `len` field.
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.read_len() as usize
+        self.read_len().unwrap_or(0) as usize
     }
 
     /// How many items the account's tail region can currently hold.
@@ -514,6 +533,9 @@ where
     #[inline]
     pub fn as_slice(&self) -> &[T] {
         let len = self.effective_len();
+        if self.view.data_len() < Self::ITEMS_OFFSET {
+            return &[];
+        }
         let bytes = self.guard_bytes();
         // `ITEMS_OFFSET` is const-computed to be `align_of::<T>()`-aligned,
         // and Pod requires `size_of` is a multiple of `align_of`, so every
@@ -528,6 +550,9 @@ where
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         let len = self.effective_len();
+        if self.view.data_len() < Self::ITEMS_OFFSET {
+            return &mut [];
+        }
         let bytes = self.guard_bytes_mut();
         let items_bytes =
             &mut bytes[Self::ITEMS_OFFSET..Self::ITEMS_OFFSET + len * core::mem::size_of::<T>()];

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -181,7 +181,6 @@ fn load_mut_rejects_data_len_below_items_offset() {
 #[test]
 fn load_rejects_len_greater_than_capacity_via_from_ref_validate_tail() {
     let buf = setup_ledger(/*capacity*/ 1, /*len*/ 2);
-    let mut buf = buf;
 
     let view = unsafe { buf.view() };
     let result = CounterLedger::load(view);
@@ -190,7 +189,7 @@ fn load_rejects_len_greater_than_capacity_via_from_ref_validate_tail() {
 
 #[test]
 fn load_mut_rejects_len_greater_than_capacity_via_validate_tail() {
-    let mut buf = setup_ledger(/*capacity*/ 1, /*len*/ 2);
+    let buf = setup_ledger(/*capacity*/ 1, /*len*/ 2);
 
     let view = unsafe { buf.view() };
     let result = unsafe { CounterLedger::load_mut(view) };
@@ -214,6 +213,46 @@ fn capacity_returns_zero_when_data_len_below_items_offset() {
 
     // Post-fix: capacity() guards against underflow and returns 0.
     assert_eq!(slab.capacity(), 0);
+}
+
+#[test]
+fn len_and_slices_degrade_to_empty_when_len_field_is_missing() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab.capacity(), 4);
+
+    // External resize removes the tail `len` field itself while the slab is
+    // still retained.
+    buf.set_data_len((LEN_OFFSET + 3) as u64); // < LEN_OFFSET + 4
+
+    assert_eq!(slab.capacity(), 0);
+    assert_eq!(slab.len(), 0);
+    assert!(slab.as_slice().is_empty());
+    assert!(slab.as_mut_slice().is_empty());
+}
+
+#[test]
+fn tail_mutations_noop_or_error_when_len_field_is_missing() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+
+    // External resize removes the tail `len` field itself while the slab is
+    // still retained.
+    buf.set_data_len((LEN_OFFSET + 3) as u64); // < LEN_OFFSET + 4
+
+    assert_eq!(slab.pop(), None);
+    slab.truncate(2);
+    slab.clear();
+    assert_eq!(
+        slab.try_push([0x55; 8]).unwrap_err(),
+        ProgramError::AccountDataTooSmall
+    );
+    assert_eq!(slab.len(), 0);
 }
 
 // -- Regression: as_slice clamps len to capacity after external shrink
@@ -306,7 +345,7 @@ fn swap_remove_panics_when_index_geq_effective_len() {
                 struct."
 )]
 fn clear_panics_when_tail_mutation_uses_guard_bytes_mut_on_read_only_slab() {
-    let mut buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
+    let buf = setup_ledger(/*capacity*/ 2, /*len*/ 1);
 
     let view = unsafe { buf.view() };
     let mut slab = CounterLedger::load(view).unwrap();
@@ -364,7 +403,7 @@ fn slab_resize_to_capacity_clamps_len() {
 
 #[test]
 fn min_lamports_matches_rent_helper_for_current_space() {
-    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
     let view = unsafe { buf.view() };
     let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
@@ -378,12 +417,12 @@ fn min_lamports_matches_rent_helper_for_current_space() {
 
 #[test]
 fn refund_moves_excess_lamports_to_recipient() {
-    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required + 500);
 
-    let mut recipient = AccountBuffer::<128>::new();
+    let recipient = AccountBuffer::<128>::new();
     recipient.init([0xBB; 32], PROGRAM_ID, 0, false, true, false);
     recipient.set_lamports(25);
 
@@ -399,12 +438,12 @@ fn refund_moves_excess_lamports_to_recipient() {
 
 #[test]
 fn refund_is_noop_when_account_is_at_rent_floor() {
-    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required);
 
-    let mut recipient = AccountBuffer::<128>::new();
+    let recipient = AccountBuffer::<128>::new();
     recipient.init([0xBB; 32], PROGRAM_ID, 0, false, true, false);
     recipient.set_lamports(25);
 
@@ -420,12 +459,12 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 
 #[test]
 fn top_up_is_noop_when_account_already_has_enough_lamports() {
-    let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
 
     let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
     buf.set_lamports(required + 123);
 
-    let mut payer = AccountBuffer::<128>::new();
+    let payer = AccountBuffer::<128>::new();
     payer.init([0xCC; 32], PROGRAM_ID, 0, true, true, false);
     payer.set_lamports(999);
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1184,6 +1184,54 @@ pub unsafe fn load_bad(view: AccountView) {
 }
 
 #[test]
+fn slab_overaligned_tail_does_not_compile() {
+    CompileCase::new(
+        "slab_overaligned_tail",
+        r#"
+use anchor_lang_v2::{
+    accounts::{Slab, SlabSchema},
+    prelude::*,
+    AccountView,
+};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GoodHeader {
+    value: u64,
+}
+
+unsafe impl anchor_lang_v2::bytemuck::Zeroable for GoodHeader {}
+unsafe impl anchor_lang_v2::bytemuck::Pod for GoodHeader {}
+
+impl SlabSchema for GoodHeader {
+    const DATA_OFFSET: usize = 0;
+    const MIN_DATA_LEN: usize = 8;
+
+    fn validate(
+        _view: &AccountView,
+        _data: &[u8],
+    ) -> core::result::Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy)]
+pub struct OveralignedTail([u8; 16]);
+
+unsafe impl anchor_lang_v2::bytemuck::Zeroable for OveralignedTail {}
+unsafe impl anchor_lang_v2::bytemuck::Pod for OveralignedTail {}
+
+pub unsafe fn load_bad(view: AccountView) {
+    let _ = <Slab<GoodHeader, OveralignedTail> as AnchorAccount>::load_mut(view);
+}
+"#,
+    )
+    .build()
+    .expect_fail(&["Slab tail alignment exceeds Solana's 8-byte account data alignment"]);
+}
+
+#[test]
 fn realloc_on_unchecked_account_does_not_compile() {
     CompileCase::new(
         "realloc_on_unchecked_account",


### PR DESCRIPTION
## Finding

Slab accepted over-aligned tail types and could panic when a retained account was shrunk below its tail-length metadata.

## Fix

Reject tail alignment above eight bytes and safely handle missing tail metadata after account shrinkage. Runtime and compile-fail regressions cover both cases.