### PR TITLE
Fix/v2 qualified accounts paths

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -595,18 +595,10 @@ fn with_ix_lifetime(ty: &Type, ix: &syn::Lifetime) -> Type {
 
 fn nested_client_accounts_type(ty: &Type) -> Option<TokenStream2> {
     let inner = parse::extract_nested_inner_type(ty)?;
-    let Type::Path(inner_path) = inner else {
-        return None;
-    };
-    let inner_ident = &inner_path.path.segments.last()?.ident;
-    let module_ident = Ident::new(
-        &format!(
-            "__client_accounts_{}",
-            inner_ident.to_string().to_lowercase()
-        ),
-        inner_ident.span(),
-    );
-    Some(quote! { super::#module_ident::#inner_ident })
+    let inner_path = QualifiedTypePath::from_type(inner)?;
+    let inner_ident = &inner_path.leaf_ident;
+    let module_path = inner_path.helper_module_path("__client_accounts_", 1, inner_ident.span());
+    Some(quote! { #module_path::#inner_ident })
 }
 
 fn idl_field_ty(field: &parse::AccountField) -> Option<&Type> {
@@ -1617,15 +1609,13 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                     let inner_ty = parse::extract_nested_inner_type(&f.ty).expect(
                         "is_nested_type was true but extract_nested_inner_type returned None",
                     );
-                    let inner_name = parse::field_ty_str(inner_ty);
-                    let inner_ident = syn::Ident::new(&inner_name, n.span());
-                    let inner_mod = syn::Ident::new(
-                        &format!("__cpi_accounts_{}", inner_name.to_lowercase()),
-                        n.span(),
-                    );
+                    let inner_path = QualifiedTypePath::from_type(inner_ty)
+                        .expect("Nested<T> inner type must be a path");
+                    let inner_ident = &inner_path.leaf_ident;
+                    let inner_mod = inner_path.helper_module_path("__cpi_accounts_", 1, n.span());
                     quote! {
                         #[nested]
-                        pub #n: super::#inner_mod::#inner_ident<'a>
+                        pub #n: #inner_mod::#inner_ident<'a>
                     }
                 } else if f.is_optional && f.idl_writable {
                     let signer_expr = cpi_meta_signer_expr(f);
@@ -3862,6 +3852,70 @@ impl HandlerCodegen {
     }
 }
 
+#[derive(Clone)]
+struct QualifiedTypePath {
+    path: syn::Path,
+    leaf_ident: Ident,
+}
+
+impl QualifiedTypePath {
+    fn from_type(ty: &Type) -> Option<Self> {
+        let Type::Path(type_path) = ty else {
+            return None;
+        };
+        Self::from_path(&type_path.path)
+    }
+
+    fn from_path(path: &syn::Path) -> Option<Self> {
+        let leaf_ident = path.segments.last()?.ident.clone();
+        Some(Self {
+            path: path.clone(),
+            leaf_ident,
+        })
+    }
+
+    fn helper_module_path(
+        &self,
+        prefix: &str,
+        relative_depth: usize,
+        span: proc_macro2::Span,
+    ) -> TokenStream2 {
+        let helper_ident = Ident::new(
+            &format!("{prefix}{}", self.leaf_ident.to_string().to_lowercase()),
+            span,
+        );
+
+        let mut prefix_segments: Vec<_> = self.path.segments.iter().cloned().collect();
+        prefix_segments.pop();
+
+        let is_absolute = self.path.leading_colon.is_some()
+            || prefix_segments
+                .first()
+                .map(|seg| seg.ident == "crate")
+                .unwrap_or(false);
+
+        if prefix_segments
+            .first()
+            .map(|seg| seg.ident == "self")
+            .unwrap_or(false)
+        {
+            prefix_segments.remove(0);
+        }
+
+        let super_prefix: Vec<_> = if is_absolute {
+            Vec::new()
+        } else {
+            (0..relative_depth).map(|_| quote! { super :: }).collect()
+        };
+
+        quote! {
+            #(#super_prefix)*
+            #(#prefix_segments ::)*
+            #helper_ident
+        }
+    }
+}
+
 fn is_unit_type(ty: &Type) -> bool {
     matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
 }
@@ -3995,10 +4049,12 @@ fn process_handler(
             )
         }
     };
-    let accounts_type = match extract_context_accounts_ident(first_arg) {
+    let accounts_type = match extract_context_accounts_path(first_arg) {
         Ok(accounts_type) => accounts_type,
         Err(err) => return HandlerCodegen::error(handler, err),
     };
+    let accounts_path = &accounts_type.path;
+    let accounts_ident = &accounts_type.leaf_ident;
 
     let extra_args: Vec<(&Ident, &Type)> = args_iter
         .filter_map(|arg| {
@@ -4036,7 +4092,7 @@ fn process_handler(
                 #[inline(always)]
                 fn __anchor_assert_no_ix_args(_: ()) {}
 
-                match anchor_lang_v2::run_handler::<#accounts_type, #return_ty>(
+                match anchor_lang_v2::run_handler::<#accounts_path, #return_ty>(
                     __program_id,
                     __cursor,
                     __ix_data,
@@ -4088,7 +4144,7 @@ fn process_handler(
                     }
                 }
 
-                match anchor_lang_v2::run_handler::<#accounts_type, #return_ty>(
+                match anchor_lang_v2::run_handler::<#accounts_path, #return_ty>(
                     __program_id,
                     __cursor,
                     __ix_data,
@@ -4152,30 +4208,19 @@ fn process_handler(
     };
 
     // Client accounts re-export.
-    let client_mod = syn::Ident::new(
-        &format!(
-            "__client_accounts_{}",
-            accounts_type.to_string().to_lowercase()
-        ),
-        fn_name.span(),
-    );
-    let resolved_type = syn::Ident::new(&format!("{accounts_type}Resolved"), accounts_type.span());
+    let client_mod = accounts_type.helper_module_path("__client_accounts_", 1, fn_name.span());
+    let resolved_type =
+        syn::Ident::new(&format!("{accounts_ident}Resolved"), accounts_ident.span());
     let accounts_reexport = quote! {
-        pub use super::#client_mod::#accounts_type;
-        pub use super::#client_mod::#resolved_type;
+        pub use #client_mod::#accounts_ident;
+        pub use #client_mod::#resolved_type;
     };
 
     // CPI accounts re-export — `__cpi_accounts_<lowercase>` is emitted by
     // `#[derive(Accounts)]` at the same scope as the program's outputs.
-    let cpi_mod = syn::Ident::new(
-        &format!(
-            "__cpi_accounts_{}",
-            accounts_type.to_string().to_lowercase()
-        ),
-        fn_name.span(),
-    );
+    let cpi_mod = accounts_type.helper_module_path("__cpi_accounts_", 2, fn_name.span());
     let cpi_accounts_reexport = quote! {
-        pub use super::super::#cpi_mod::#accounts_type;
+        pub use #cpi_mod::#accounts_ident;
     };
 
     // CPI wrapper function — mirrors the handler's argument list (sans
@@ -4204,7 +4249,7 @@ fn process_handler(
         };
         quote! {
             pub fn #fn_name #lt_decl(
-                __ctx: anchor_lang_v2::CpiContext<'a, accounts::#accounts_type<'a>>,
+                __ctx: anchor_lang_v2::CpiContext<'a, accounts::#accounts_ident<'a>>,
                 #(#extra_arg_names: #extra_arg_types,)*
             ) #ret_ty {
                 let __ix = super::instruction::#ix_struct_name #ix_lt_use_local {
@@ -4238,13 +4283,13 @@ fn process_handler(
         accounts_reexport,
         cpi_wrapper,
         cpi_accounts_reexport,
-        accounts_type_name: accounts_type.to_string(),
+        accounts_type_name: quote! { #accounts_path }.to_string(),
         idl_name: fn_name_str,
         idl_disc: idl::disc_json(&disc_bytes_for_idl),
         idl_args: idl::build_args_json(&extra_args),
         idl_returns_json,
         idl_docs_json,
-        idl_accounts_type: quote! { #accounts_type },
+        idl_accounts_type: quote! { #accounts_path },
         arg_types: extra_args.iter().map(|(_, t)| (*t).clone()).collect(),
         return_type,
     }
@@ -5686,7 +5731,7 @@ fn parse_discrim_attr(handler: &syn::ItemFn) -> syn::Result<Option<DiscrimAttr>>
     Ok(None)
 }
 
-fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
+fn extract_context_accounts_path(arg: &FnArg) -> syn::Result<QualifiedTypePath> {
     let ty = match arg {
         FnArg::Typed(pt) => &*pt.ty,
         _ => {
@@ -5787,7 +5832,12 @@ fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
         ));
     }
 
-    Ok(accounts_segment.ident.clone())
+    QualifiedTypePath::from_path(&accounts_path.path).ok_or_else(|| {
+        syn::Error::new(
+            accounts_path.span(),
+            "Context generic must be an accounts struct type, for example `Context<Buy>`",
+        )
+    })
 }
 
 /// Converts `snake_case` to `CamelCase` (e.g. `execute_transfer` → `ExecuteTransfer`).
@@ -5861,6 +5911,40 @@ mod tests {
         assert!(
             wrapper.contains("impl < 'ix > __AnchorIxArgCoerce < 'ix > for ()"),
             "expected missing-#[instruction] fallback impl in wrapper: {wrapper}"
+        );
+    }
+
+    #[test]
+    fn extract_context_accounts_path_preserves_qualified_segments() {
+        let arg: FnArg = syn::parse_quote! {
+            ctx: &mut Context<shared::Inner>
+        };
+
+        let accounts_path =
+            extract_context_accounts_path(&arg).expect("qualified context path should parse");
+        let full_path = &accounts_path.path;
+
+        assert_eq!(quote!(#full_path).to_string(), "shared :: Inner");
+        assert_eq!(accounts_path.leaf_ident.to_string(), "Inner");
+    }
+
+    #[test]
+    fn qualified_type_helper_module_path_tracks_original_scope() {
+        let ty: Type = syn::parse_quote!(crate::shared::Inner);
+        let qualified =
+            QualifiedTypePath::from_type(&ty).expect("qualified nested path should parse");
+        let client_path =
+            qualified.helper_module_path("__client_accounts_", 1, proc_macro2::Span::call_site());
+        let cpi_path =
+            qualified.helper_module_path("__cpi_accounts_", 2, proc_macro2::Span::call_site());
+
+        assert_eq!(
+            quote!(#client_path::Inner).to_string(),
+            "crate :: shared :: __client_accounts_inner :: Inner"
+        );
+        assert_eq!(
+            quote!(#cpi_path::Inner).to_string(),
+            "crate :: shared :: __cpi_accounts_inner :: Inner"
         );
     }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -45,6 +45,46 @@ wincode = {{ version = "0.5", features = ["derive"] }}
     }
 }
 
+fn compile_pass_case(name: &str, source: &str) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir.join("target/macro-diagnostics").join(name);
+    let src_dir = crate_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+wincode = {{ version = "0.5", features = ["derive"] }}
+
+[workspace]
+"#,
+            manifest_dir.display()
+        ),
+    )
+    .unwrap();
+    fs::write(src_dir.join("lib.rs"), source).unwrap();
+
+    let output = Command::new("cargo")
+        .args(["check", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo check for {name}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "{name} failed to compile\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 #[cfg_attr(
     miri,
@@ -234,6 +274,58 @@ fn check() {
 }
 "#,
         &["SlotHashes", "SysvarId"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn qualified_accounts_paths_compile() {
+    compile_pass_case(
+        "qualified_accounts_paths",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub mod shared {
+    use super::*;
+
+    #[derive(Accounts)]
+    pub struct Inner {
+        pub signer: Signer,
+    }
+
+    #[derive(Accounts)]
+    pub struct Outer {
+        pub inner: Nested<crate::shared2::Leaf>,
+    }
+}
+
+pub mod shared2 {
+    use super::*;
+
+    #[derive(Accounts)]
+    pub struct Leaf {
+        pub signer: Signer,
+    }
+}
+
+#[program]
+pub mod qualified_paths {
+    use super::*;
+
+    pub fn use_qualified_ctx(_ctx: &mut Context<shared::Inner>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn use_nested(_ctx: &mut Context<shared::Outer>) -> Result<()> {
+        Ok(())
+    }
+}
+"#,
     );
 }
 


### PR DESCRIPTION
## Finding

Qualified `Context<T>` and `Nested<T>` paths were reduced to their final segment, causing generated code to reference the wrong type.

## Fix

Preserve complete type paths while retaining leaf names only for generated helper modules. Compilation regressions cover qualified `Context` and `Nested`.