### PR TITLE
Fix/v2 bare context diagnostics

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -5686,6 +5686,25 @@ fn parse_discrim_attr(handler: &syn::ItemFn) -> syn::Result<Option<DiscrimAttr>>
     Ok(None)
 }
 
+fn missing_context_accounts_type_error(span: proc_macro2::Span) -> syn::Error {
+    syn::Error::new(
+        span,
+        "missing accounts type: expected `Context<YourAccountsStruct>`",
+    )
+}
+
+fn bare_context_segment<'a>(ty: &'a Type) -> Option<&'a syn::PathSegment> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident == "Context" && matches!(segment.arguments, syn::PathArguments::None) {
+        Some(segment)
+    } else {
+        None
+    }
+}
+
 fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
     let ty = match arg {
         FnArg::Typed(pt) => &*pt.ty,
@@ -5698,6 +5717,9 @@ fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
     };
 
     let Type::Reference(reference) = ty else {
+        if let Some(context_segment) = bare_context_segment(ty) {
+            return Err(missing_context_accounts_type_error(context_segment.span()));
+        }
         if let Type::Path(context_path) = ty {
             if let Some(context_segment) = context_path.path.segments.last() {
                 if context_segment.ident == "Context" {
@@ -5724,6 +5746,9 @@ fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
             "first parameter must be `ctx: &mut Context<T>`",
         ));
     };
+    if let Some(context_segment) = bare_context_segment(reference.elem.as_ref()) {
+        return Err(missing_context_accounts_type_error(context_segment.span()));
+    }
     if reference.mutability.is_none() {
         return Err(syn::Error::new(
             reference.span(),
@@ -5751,10 +5776,7 @@ fn extract_context_accounts_ident(arg: &FnArg) -> syn::Result<Ident> {
     }
 
     let syn::PathArguments::AngleBracketed(args) = &context_segment.arguments else {
-        return Err(syn::Error::new(
-            context_segment.span(),
-            "missing accounts type: expected `Context<YourAccountsStruct>`",
-        ));
+        return Err(missing_context_accounts_type_error(context_segment.span()));
     };
     if args.args.len() != 1 {
         return Err(syn::Error::new(
@@ -5861,6 +5883,34 @@ mod tests {
         assert!(
             wrapper.contains("impl < 'ix > __AnchorIxArgCoerce < 'ix > for ()"),
             "expected missing-#[instruction] fallback impl in wrapper: {wrapper}"
+        );
+    }
+
+    #[test]
+    fn bare_context_by_value_reports_missing_accounts_type_first() {
+        let arg: FnArg = syn::parse_quote! {
+            ctx: Context
+        };
+
+        let err = extract_context_accounts_ident(&arg).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "missing accounts type: expected `Context<YourAccountsStruct>`"
+        );
+    }
+
+    #[test]
+    fn bare_context_by_ref_reports_missing_accounts_type_first() {
+        let arg: FnArg = syn::parse_quote! {
+            ctx: &Context
+        };
+
+        let err = extract_context_accounts_ident(&arg).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "missing accounts type: expected `Context<YourAccountsStruct>`"
         );
     }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1,6 +1,15 @@
 use std::{fs, path::PathBuf, process::Command};
 
 fn compile_fail_case(name: &str, source: &str, snippets: &[&str]) {
+    compile_fail_case_with_forbidden(name, source, snippets, &[]);
+}
+
+fn compile_fail_case_with_forbidden(
+    name: &str,
+    source: &str,
+    snippets: &[&str],
+    forbidden_snippets: &[&str],
+) {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let crate_dir = manifest_dir.join("target/macro-diagnostics").join(name);
     let src_dir = crate_dir.join("src");
@@ -41,6 +50,12 @@ wincode = {{ version = "0.5", features = ["derive"] }}
         assert!(
             stderr.contains(snippet),
             "{name} stderr did not contain {snippet:?}\n\nstderr:\n{stderr}"
+        );
+    }
+    for forbidden in forbidden_snippets {
+        assert!(
+            !stderr.contains(forbidden),
+            "{name} stderr unexpectedly contained {forbidden:?}\n\nstderr:\n{stderr}"
         );
     }
 }
@@ -177,6 +192,53 @@ pub mod bad_discriminator {
 pub struct Noop {}
 "#,
         &["`#[discrim = ...]` value must be an integer literal or byte array literal"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn bare_context_reports_missing_accounts_type_before_mutability() {
+    compile_fail_case_with_forbidden(
+        "bare_context_by_value",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod bare_context_by_value {
+    use super::*;
+
+    pub fn ix(_ctx: Context) -> Result<()> {
+        Ok(())
+    }
+}
+"#,
+        &["missing accounts type: expected `Context<YourAccountsStruct>`"],
+        &["handler context must be passed by mutable reference"],
+    );
+
+    compile_fail_case_with_forbidden(
+        "bare_context_by_ref",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod bare_context_by_ref {
+    use super::*;
+
+    pub fn ix(_ctx: &Context) -> Result<()> {
+        Ok(())
+    }
+}
+"#,
+        &["missing accounts type: expected `Context<YourAccountsStruct>`"],
+        &["handler context must be mutable"],
     );
 }
 


### PR DESCRIPTION
## Finding

Bare `Context` handlers reported a mutability error before explaining that the required Accounts type argument was missing.

## Fix

Diagnose the missing Accounts type before performing handler mutability validation. Macro diagnostics cover bare `Context` and `&Context` handlers.