### PR TITLE
chore: Fix new Clippy warnings

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1264,8 +1264,8 @@ fn canonicalize_filepath_from_origin(
             format!(
                 "Error reading (possibly relative) path: {}. If relative, this is the path that \
                  was used as the current path: {}",
-                &file_path.as_ref().display(),
-                &origin.as_ref().display()
+                file_path.as_ref().display(),
+                origin.as_ref().display()
             )
         })?
         .display()
@@ -1825,7 +1825,7 @@ impl Program {
         let program_kp = Keypair::new();
         let mut file = File::create(&path)
             .with_context(|| format!("Error creating file with path: {}", path.display()))?;
-        file.write_all(format!("{:?}", &program_kp.to_bytes()).as_bytes())?;
+        file.write_all(format!("{:?}", program_kp.to_bytes()).as_bytes())?;
         Ok(WithPath::new(file, path))
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5618,7 +5618,7 @@ fn stream_solana_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<Lo
                     Err(e) => {
                         eprintln!(
                             "Warning: Failed to subscribe to logs for genesis program {}: {}",
-                            &entry.address, e
+                            entry.address, e
                         );
                         continue;
                     }

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1514,10 +1514,10 @@ impl TestTemplate {
                 fs::create_dir_all("tests")?;
 
                 if js {
-                    let mut test = File::create(format!("tests/{}.js", &project_name))?;
+                    let mut test = File::create(format!("tests/{}.js", project_name))?;
                     test.write_all(mocha(project_name, anchor_version).as_bytes())?;
                 } else {
-                    let mut mocha = File::create(format!("tests/{}.ts", &project_name))?;
+                    let mut mocha = File::create(format!("tests/{}.ts", project_name))?;
                     mocha.write_all(ts_mocha(project_name, anchor_version).as_bytes())?;
                 }
             }
@@ -1526,10 +1526,10 @@ impl TestTemplate {
                 fs::create_dir_all("tests")?;
 
                 if js {
-                    let mut test = File::create(format!("tests/{}.test.js", &project_name))?;
+                    let mut test = File::create(format!("tests/{}.test.js", project_name))?;
                     test.write_all(js_jest(project_name, anchor_version).as_bytes())?;
                 } else {
-                    let mut test = File::create(format!("tests/{}.test.ts", &project_name))?;
+                    let mut test = File::create(format!("tests/{}.test.ts", project_name))?;
                     test.write_all(ts_jest(project_name, anchor_version).as_bytes())?;
                 }
             }
@@ -1565,7 +1565,7 @@ impl TestTemplate {
             }
             Self::Mollusk => {
                 // Build the test suite.
-                let tests_path_str = format!("programs/{}/tests", &project_name);
+                let tests_path_str = format!("programs/{}/tests", project_name);
                 let tests_path = Path::new(&tests_path_str);
                 fs::create_dir_all(tests_path)?;
 
@@ -1579,7 +1579,7 @@ impl TestTemplate {
             }
 
             Self::Litesvm => {
-                let tests_path_str = format!("programs/{}/tests", &project_name);
+                let tests_path_str = format!("programs/{}/tests", project_name);
                 let tests_path = Path::new(&tests_path_str);
                 fs::create_dir_all(tests_path)?;
                 let mut files = Vec::new();

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -14,7 +14,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .iter()
         .map(|ix| {
             #[allow(clippy::unwrap_used, reason = "computed from valid Rust identifier as module path")]
-            let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
+            let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", ix.anchor_ident).parse().unwrap();
             let cpi_method = {
                 let name = &ix.raw_method.sig.ident;
                 let name_str = name.to_string();


### PR DESCRIPTION
A new version of Clippy has hit CI, so fix the new warnings that have come up.