### PR TITLE
Fix/v2 missing payer diagnostics

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -56,6 +56,8 @@ pub struct AccountAttrs {
     pub is_zeroed: bool,
     pub is_executable: bool,
     pub is_dup: bool,
+    pub init_span: Option<proc_macro2::Span>,
+    pub init_if_needed_span: Option<proc_macro2::Span>,
     /// None = no bump attr, Some(None) = `bump` without value, Some(Some(expr)) = `bump = expr`
     pub bump: Option<Option<Expr>>,
     pub payer: Option<Ident>,
@@ -79,6 +81,7 @@ pub struct AccountAttrs {
     /// they are emitted as checks in the order written.
     pub raw_constraints: Vec<(Expr, Option<Expr>)>,
     pub realloc: Option<Expr>,
+    pub realloc_span: Option<proc_macro2::Span>,
     pub realloc_payer: Option<Ident>,
     pub realloc_zero: bool,
     /// Namespaced constraints: token::mint, mint::authority, etc.
@@ -110,6 +113,8 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         is_zeroed: false,
         is_executable: false,
         is_dup: false,
+        init_span: None,
+        init_if_needed_span: None,
         bump: None,
         payer: None,
         space: None,
@@ -123,6 +128,7 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         close: None,
         raw_constraints: Vec::new(),
         realloc: None,
+        realloc_span: None,
         realloc_payer: None,
         realloc_zero: false,
         namespaced: Vec::new(),
@@ -140,10 +146,12 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     "init" => {
                         result.is_init = true;
                         result.is_mut = true;
+                        result.init_span = Some(ident.span());
                     }
                     "init_if_needed" => {
                         result.is_init_if_needed = true;
                         result.is_mut = true;
+                        result.init_if_needed_span = Some(ident.span());
                     }
                     "zeroed" => {
                         result.is_zeroed = true;
@@ -261,6 +269,7 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
                     "realloc" => {
                         input.parse::<Token![=]>()?;
                         result.realloc = Some(input.parse()?);
+                        result.realloc_span = Some(ident.span());
                         result.is_mut = true;
                     }
                     "realloc_payer" => {
@@ -393,6 +402,31 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
             "`seeds::program` requires `seeds`",
         ));
     }
+
+    if result.payer.is_none() {
+        if let Some(init_span) = result.init_span {
+            return Err(syn::Error::new(
+                init_span,
+                "`init` requires `payer = <target>`",
+            ));
+        }
+        if let Some(init_if_needed_span) = result.init_if_needed_span {
+            return Err(syn::Error::new(
+                init_if_needed_span,
+                "`init_if_needed` requires `payer = <target>`",
+            ));
+        }
+    }
+
+    if result.realloc.is_some() && result.realloc_payer.is_none() {
+        return Err(syn::Error::new(
+            result
+                .realloc_span
+                .unwrap_or_else(proc_macro2::Span::call_site),
+            "`realloc` requires `realloc_payer = <target>`",
+        ));
+    }
+-
 
     Ok(result)
 }
@@ -1231,7 +1265,19 @@ fn emit_init_body(
     field_summaries: &[FieldSummary],
     is_optional: bool,
 ) -> syn::Result<TokenStream2> {
-    let payer = attrs.payer.as_ref().expect("init requires payer");
+    let payer = attrs.payer.as_ref().ok_or_else(|| {
+        syn::Error::new(
+            attrs
+                .init_span
+                .or(attrs.init_if_needed_span)
+                .unwrap_or_else(|| field_name.span()),
+            if attrs.is_init {
+                "`init` requires `payer = <target>`"
+            } else {
+                "`init_if_needed` requires `payer = <target>`"
+            },
+        )
+    })?;
     let space = init_space_expr(field_ty, attrs);
     let owner = match attrs.owner.as_ref() {
         Some(expr) => quote! { #expr },
@@ -2287,10 +2333,12 @@ pub fn parse_field(
 
     // realloc
     if let Some(ref new_space) = attrs.realloc {
-        let realloc_payer = attrs
-            .realloc_payer
-            .as_ref()
-            .expect("realloc requires realloc_payer");
+        let realloc_payer = attrs.realloc_payer.as_ref().ok_or_else(|| {
+            syn::Error::new(
+                attrs.realloc_span.unwrap_or_else(|| field_name.span()),
+                "`realloc` requires `realloc_payer = <target>`",
+            )
+        })?;
         let zero_fill = attrs.realloc_zero;
         let realloc_target = if is_optional {
             quote! { #field_name }
@@ -2626,6 +2674,54 @@ mod tests {
         let parsed = parse_account_attrs(&attrs).expect("init_if_needed + bump=<expr>");
         assert!(parsed.is_init_if_needed);
         assert!(matches!(parsed.bump, Some(Some(_))));
+    }
+
+    #[test]
+    fn init_without_payer_is_rejected() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(init, space = 8)]
+        )];
+        let err = match parse_account_attrs(&attrs) {
+            Ok(_) => panic!("init without payer must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("`init` requires `payer = <target>`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn init_if_needed_without_payer_is_rejected() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(init_if_needed, space = 8)]
+        )];
+        let err = match parse_account_attrs(&attrs) {
+            Ok(_) => panic!("init_if_needed without payer must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("`init_if_needed` requires `payer = <target>`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn realloc_without_realloc_payer_is_rejected() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(mut, realloc = 16, realloc_zero = false)]
+        )];
+        let err = match parse_account_attrs(&attrs) {
+            Ok(_) => panic!("realloc without realloc_payer must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("`realloc` requires `realloc_payer = <target>`"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -426,7 +426,6 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
             "`realloc` requires `realloc_payer = <target>`",
         ));
     }
--
 
     Ok(result)
 }

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -47,6 +47,15 @@ live = []
 }
 
 fn compile_fail_case(name: &str, source: &str, snippets: &[&str]) {
+    compile_fail_case_with_forbidden(name, source, snippets, &[]);
+}
+
+fn compile_fail_case_with_forbidden(
+    name: &str,
+    source: &str,
+    snippets: &[&str],
+    forbidden_snippets: &[&str],
+) {
     let output = cargo_case(name, source, "check", &[]);
 
     assert!(
@@ -58,6 +67,12 @@ fn compile_fail_case(name: &str, source: &str, snippets: &[&str]) {
         assert!(
             stderr.contains(snippet),
             "{name} stderr did not contain {snippet:?}\n\nstderr:\n{stderr}"
+        );
+    }
+    for forbidden in forbidden_snippets {
+        assert!(
+            !stderr.contains(forbidden),
+            "{name} stderr unexpectedly contained {forbidden:?}\n\nstderr:\n{stderr}"
         );
     }
 }
@@ -607,6 +622,61 @@ pub struct Bad {
 }
 "#,
         &["the payer specified for an init constraint must be mutable"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn missing_init_and_realloc_payers_are_diagnosed() {
+    compile_fail_case_with_forbidden(
+        "missing_init_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct MissingInitPayer {
+    #[account(init, space = 8 + core::mem::size_of::<Data>())]
+    pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`init` requires `payer = <target>`"],
+        &["proc-macro derive panicked"],
+    );
+
+    compile_fail_case_with_forbidden(
+        "missing_realloc_payer",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct MissingReallocPayer {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, realloc = 16, realloc_zero = false)]
+    pub data: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["`realloc` requires `realloc_payer = <target>`"],
+        &["proc-macro derive panicked"],
     );
 }
 


### PR DESCRIPTION
## Finding

Missing `payer` or `realloc_payer` attributes reached `expect(...)`, causing procedural macro panics instead of useful compiler errors.

## Fix

Validate required payer attributes during Accounts parsing and emit targeted diagnostics before code generation. Regressions cover missing init and realloc payers.