### PR TITLE
fix(avm): validate platform-tools version before path construction

### DIFF
--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -28,7 +28,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         fs,
-        path::{Path, PathBuf},
+        path::{Component, Path, PathBuf},
         process::{Command, Stdio},
         sync::LazyLock,
     },
@@ -505,6 +505,32 @@ pub fn platform_tools_version_path(version: &str) -> PathBuf {
     get_platform_tools_dir_path().join(version)
 }
 
+fn normalize_platform_tools_version(version: &str) -> Result<String> {
+    let path = Path::new(version);
+    let mut components = path.components();
+    let is_normal_component =
+        matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none();
+    let version_without_prefix = version.strip_prefix('v').unwrap_or(version);
+    let valid_format = version_without_prefix
+        .split_once('.')
+        .is_some_and(|(major, minor)| {
+            !major.is_empty()
+                && !minor.is_empty()
+                && major.bytes().all(|b| b.is_ascii_digit())
+                && minor.bytes().all(|b| b.is_ascii_digit())
+        });
+
+    if path.is_absolute() || version.contains(['/', '\\']) || !is_normal_component || !valid_format
+    {
+        bail!(
+            "Invalid platform-tools version `{version}`; expected `v<major>.<minor>` or \
+             `<major>.<minor>`"
+        );
+    }
+
+    Ok(format!("v{version_without_prefix}"))
+}
+
 /// List installed platform-tools versions, lexicographically ordered.
 pub fn read_installed_platform_tools() -> Result<Vec<String>> {
     let dir = get_platform_tools_dir_path();
@@ -575,11 +601,7 @@ pub fn download_url(version: &str) -> String {
 /// and atomically renamed on success so a failed install never leaves a
 /// half-populated directory at the canonical path.
 pub fn install_platform_tools(version: &str, force: bool) -> Result<()> {
-    let version = if version.starts_with('v') {
-        version.to_string()
-    } else {
-        format!("v{version}")
-    };
+    let version = normalize_platform_tools_version(version)?;
     let target = platform_tools_version_path(&version);
     if !force && looks_installed(&target) {
         println!(
@@ -648,11 +670,7 @@ fn replace_install_dir(staging: &Path, target: &Path) -> Result<()> {
 
 /// Remove an installed platform-tools version.
 pub fn uninstall_platform_tools(version: &str) -> Result<()> {
-    let version = if version.starts_with('v') {
-        version.to_string()
-    } else {
-        format!("v{version}")
-    };
+    let version = normalize_platform_tools_version(version)?;
     let target = platform_tools_version_path(&version);
     if !target.exists() {
         bail!(
@@ -971,6 +989,27 @@ mod tests {
         let url = download_url("v1.54");
         assert!(url.starts_with("https://github.com/anza-xyz/platform-tools/releases/download/"));
         assert!(url.ends_with(host_asset_name()));
+    }
+
+    #[test]
+    fn platform_tools_versions_are_validated_and_normalized() {
+        assert_eq!(normalize_platform_tools_version("v1.54").unwrap(), "v1.54");
+        assert_eq!(normalize_platform_tools_version("1.54").unwrap(), "v1.54");
+
+        for version in [
+            "v1.54/../../../victim",
+            r"v1.54\..\victim",
+            "/v1.54",
+            ".",
+            "..",
+            "v1",
+            "v1.54.0",
+        ] {
+            assert!(
+                normalize_platform_tools_version(version).is_err(),
+                "{version} should be rejected"
+            );
+        }
     }
 
     // ── looks_installed ─────────────────────────────────────────────────────

--- a/avm/tests/resolution_flow.rs
+++ b/avm/tests/resolution_flow.rs
@@ -386,6 +386,34 @@ fn avm_subcommands_resolve_solana_and_platform_tools_from_project() {
     );
 }
 
+#[test]
+fn platform_tools_uninstall_rejects_path_traversal() {
+    let fixture = Fixture::new();
+    let project = fixture.project("platform-tools-path-traversal");
+    fs::create_dir_all(fixture.avm_home.join("platform-tools/v1.54")).unwrap();
+
+    let victim = fixture._temp.path().join("victim");
+    let marker = victim.join("marker");
+    fs::create_dir_all(&victim).unwrap();
+    fs::write(&marker, "keep").unwrap();
+
+    let output = fixture.run_avm(
+        &project,
+        ["platform-tools", "uninstall", "v1.54/../../../victim"],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Invalid platform-tools version"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        marker.exists(),
+        "uninstall must not delete outside AVM_HOME"
+    );
+}
+
 fn create_tar_gz(archive: &Path, source_dir: &Path, entry: &str) {
     let output = Command::new("tar")
         .arg("-czf")


### PR DESCRIPTION
Fixes: #4805 

Implemented the AVM platform-tools validation fix.

  - Added shared version normalization accepting only v<major>.<minor> or <major>.<minor>.
  - Rejects absolute paths, separators, traversal, non-normal components, and malformed versions.
  - Applied validation before filesystem/network operations in install and uninstall.
  - Added unit validation tests and a CLI regression proving v1.54/../../../victim cannot delete outside $AVM_HOME/platform-
    tools.

