### PR TITLE
fix(ts): reject invalid hex strings

### DIFF
--- a/ts/packages/anchor/src/utils/bytes/hex.ts
+++ b/ts/packages/anchor/src/utils/bytes/hex.ts
@@ -11,6 +11,9 @@ export function decode(data: string): Buffer {
   if (data.indexOf("0x") === 0) {
     data = data.substr(2);
   }
+  if (/[^0-9a-fA-F]/.test(data)) {
+    throw new Error("Invalid hex string");
+  }
   if (data.length % 2 === 1) {
     data = "0" + data;
   }

--- a/ts/packages/anchor/tests/bytes.spec.ts
+++ b/ts/packages/anchor/tests/bytes.spec.ts
@@ -1,0 +1,11 @@
+import { decode } from "../src/utils/bytes/hex";
+
+describe("hex bytes", () => {
+  it.each(["gg", "0x1g"])("rejects invalid hex input %s", (input) => {
+    expect(() => decode(input)).toThrow("Invalid hex string");
+  });
+
+  it("continues to left-pad odd-length input", () => {
+    expect(decode("abc")).toEqual(Buffer.from([0x0a, 0xbc]));
+  });
+});


### PR DESCRIPTION
## Summary

The hexadecimal byte decoder previously passed every two-character chunk to `parseInt` without validating the input first.

This allowed malformed values to be silently decoded. For example, `gg` produced a zero byte because `Buffer.from` coerced `NaN` to `0`, while `1g` was partially parsed as `1`.

This change rejects non-hexadecimal characters after removing the optional `0x` prefix. Existing behavior for valid input, including left-padding odd-length strings, is preserved.

Regression tests cover:

- invalid unprefixed hexadecimal input
- invalid prefixed input that `parseInt` would partially accept
- valid odd-length input


## Branch Target

This is a non-breaking bug fix targeting `master`.
