### PR TITLE
Fix/v2 constraint init rhs validation (extension)

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -891,7 +891,6 @@ fn validate_init_constraint_refs(
 
     Ok(())
 }
-
 fn field_offset_expr(
     field_offsets: &[(String, TokenStream2)],
     ident: &Ident,
@@ -1053,7 +1052,6 @@ fn wrap_init_body_with_constraints(
         .map(|nc| {
             let ns = syn::Ident::new(&nc.namespace, proc_macro2::Span::call_site());
             let key = syn::Ident::new(&nc.key, proc_macro2::Span::call_site());
-            let value = &nc.value;
             let expected = if expr_as_known_field_ident(value, field_names).is_some() {
                 quote! { AsRef::as_ref(&#value) }
             } else {

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -845,6 +845,7 @@ fn emit_constraint_expected_binding(
 fn validate_init_constraint_refs(
     field_name: &Ident,
     attrs: &AccountAttrs,
+    field_names: &[String],
     field_summaries: &[FieldSummary],
 ) -> syn::Result<()> {
     if !(attrs.is_init || attrs.is_init_if_needed) {
@@ -857,6 +858,22 @@ fn validate_init_constraint_refs(
         .expect("current field should exist in summaries");
 
     for nc in &attrs.namespaced {
+        if !nc.is_update
+            && matches!(
+                builtin_init_param_value_kind(&nc.namespace, &nc.raw_key),
+                Some(BuiltinInitParamValueKind::AccountView)
+            )
+            && expr_as_known_field_ident(&nc.value, field_names).is_none()
+        {
+            return Err(syn::Error::new(
+                nc.value.span(),
+                format!(
+                    "`{}::{}` init constraint requires a sibling account field reference",
+                    nc.namespace, nc.raw_key
+                ),
+            ));
+        }
+
         let Some(root) = expr_root_ident(&nc.value) else {
             continue;
         };
@@ -2144,7 +2161,7 @@ pub fn parse_field(
 ) -> syn::Result<AccountField> {
     let field_name = field.ident.as_ref().expect("named field");
     let field_ty = &field.ty;
-    validate_init_constraint_refs(field_name, attrs, field_summaries)?;
+    validate_init_constraint_refs(field_name, attrs, field_names, field_summaries)?;
     if attrs.close.is_some() && !attrs.is_mut {
         return Err(syn::Error::new(
             field_name.span(),

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1366,6 +1366,8 @@ fn require_summary_field<'a>(
 }
 
 pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
+    let field_names: Vec<String> = fields.iter().map(|field| field.name.to_string()).collect();
+
     for target in fields {
         let attrs = &target.attrs;
         let required = extract_option_inner(&target.ty).is_none();
@@ -1420,10 +1422,16 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 } else {
                     for constraint in token_program_constraints {
                         let token_program =
-                            expr_as_field_ident(&constraint.value).ok_or_else(|| {
+                            expr_as_known_field_ident(&constraint.value, &field_names)
+                                .ok_or_else(|| {
                                 syn::Error::new(
                                     constraint.value.span(),
-                                    "SPL token program constraints must reference an account field",
+                                    format!(
+                                        "SPL init constraint `{}::{}` needs an AccountView, not \
+                                         a pubkey. Use a sibling account field of your Accounts \
+                                         struct instead of a const or field access",
+                                        constraint.namespace, constraint.raw_key
+                                    ),
                                 )
                             })?;
                         require_summary_field(
@@ -1441,11 +1449,15 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
                 constraint.raw_key == "mint"
                     && matches!(constraint.namespace.as_str(), "token" | "associated_token")
             }) {
-                let mint = expr_as_field_ident(&constraint.value).ok_or_else(|| {
+                let mint = expr_as_known_field_ident(&constraint.value, &field_names).ok_or_else(|| {
                     syn::Error::new(
                         constraint.value.span(),
-                        "the mint constraint must reference an account field for token \
-                         initialization",
+                        format!(
+                            "SPL init constraint `{}::{}` needs an AccountView, not a pubkey. \
+                             Use a sibling account field of your Accounts struct instead of a \
+                             const or field access",
+                            constraint.namespace, constraint.raw_key
+                        ),
                     )
                 })?;
                 require_summary_field(fields, &mint, target, "token mint", false)?;

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1052,6 +1052,7 @@ fn wrap_init_body_with_constraints(
         .map(|nc| {
             let ns = syn::Ident::new(&nc.namespace, proc_macro2::Span::call_site());
             let key = syn::Ident::new(&nc.key, proc_macro2::Span::call_site());
+            let value = &nc.value;
             let expected = if expr_as_known_field_ident(value, field_names).is_some() {
                 quote! { AsRef::as_ref(&#value) }
             } else {

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -868,7 +868,7 @@ fn validate_init_constraint_refs(
             return Err(syn::Error::new(
                 nc.value.span(),
                 format!(
-                    "`{}::{}` init constraint requires a sibling account field reference",
+                    "SPL init constraint `{}::{}` needs an AccountView, not a pubkey. Use a sibling account field of your Accounts struct instead of a const or field access",
                     nc.namespace, nc.raw_key
                 ),
             ));

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -313,22 +313,6 @@ fn unchecked_account_load_mut_accepts_writable() {
     assert_eq!(ua.address().to_bytes(), [0xAB; 32]);
 }
 
-#[test]
-fn unchecked_account_close_constraint_fails_at_runtime() {
-    let data_buf = AccountBuffer::<128>::new();
-    data_buf.init([0xAB; 32], [0x99; 32], 0, false, true, false);
-
-    let receiver_buf = AccountBuffer::<128>::new();
-    receiver_buf.init([0xCD; 32], [0x99; 32], 0, false, true, false);
-
-    let views = [unsafe { data_buf.view() }, unsafe { receiver_buf.view() }];
-    let (mut accounts, _, _) =
-        CloseUnchecked::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
-            .unwrap();
-
-    let err = expect_err(accounts.exit_accounts(&[]));
-    assert_eq!(err, ProgramError::InvalidArgument);
-}
 // -- Program<T> ---------------------------------------------------------
 
 #[test]

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -313,6 +313,22 @@ fn unchecked_account_load_mut_accepts_writable() {
     assert_eq!(ua.address().to_bytes(), [0xAB; 32]);
 }
 
+#[test]
+fn unchecked_account_close_constraint_fails_at_runtime() {
+    let data_buf = AccountBuffer::<128>::new();
+    data_buf.init([0xAB; 32], [0x99; 32], 0, false, true, false);
+
+    let receiver_buf = AccountBuffer::<128>::new();
+    receiver_buf.init([0xCD; 32], [0x99; 32], 0, false, true, false);
+
+    let views = [unsafe { data_buf.view() }, unsafe { receiver_buf.view() }];
+    let (mut accounts, _, _) =
+        CloseUnchecked::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
+            .unwrap();
+
+    let err = expect_err(accounts.exit_accounts(&[]));
+    assert_eq!(err, ProgramError::InvalidArgument);
+}
 // -- Program<T> ---------------------------------------------------------
 
 #[test]

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -709,6 +709,168 @@ pub struct Good {
 }
 
 #[test]
+fn namespaced_constraints_accept_instruction_args_in_exit_hooks() {
+    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("spl-v2");
+
+    CompileCase::new(
+        "namespaced_constraint_instruction_arg_exit",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::{self, Mint},
+    token::Token,
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[account]
+pub struct AuthorityData {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+#[instruction(decimals: u8)]
+pub struct Good {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Account<AuthorityData>,
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = decimals,
+        mint::authority = authority,
+    )]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_pass();
+}
+
+#[test]
+fn namespaced_constraints_accept_sibling_field_paths_in_exit_and_update_hooks() {
+    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("spl-v2");
+
+    CompileCase::new(
+        "namespaced_constraint_sibling_field_paths",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::mint::{self, Mint};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[account]
+pub struct Config {
+    pub authority: Address,
+    pub decimals: u8,
+}
+
+#[derive(Accounts)]
+pub struct Good {
+    pub config: Account<Config>,
+    #[account(
+        mut,
+        mint::authority = config.authority,
+        mint::decimals = config.decimals,
+        update(mint::authority = config.authority, mint::decimals = config.decimals),
+    )]
+    pub mint: Account<Mint>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_pass();
+}
+
+#[test]
+fn namespaced_constraints_reject_self_refs_during_init() {
+    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("spl-v2");
+
+    CompileCase::new(
+        "namespaced_constraint_init_self_ref",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::token::{Token, TokenAccount};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, token::authority = token_account)]
+    pub token_account: Account<TokenAccount>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&[
+        "cannot reference `token_account` while that account is still being initialized",
+    ]);
+}
+
+#[test]
+fn namespaced_constraints_reject_later_init_refs() {
+    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("spl-v2");
+
+    CompileCase::new(
+        "namespaced_constraint_later_init_ref",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::{Token, TokenAccount},
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<TokenAccount>,
+    #[account(init, payer = payer, mint::decimals = 6, mint::authority = payer)]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&["cannot reference later init field `mint` before it is initialized"]);
+}
+
+#[test]
 fn associated_token_rejects_unknown_constraint_key() {
     CompileCase::new(
         "associated_token_unknown_constraint_key",

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -661,6 +661,54 @@ pub struct Bad {
 }
 
 #[test]
+fn namespaced_constraints_accept_qualified_constants_as_values() {
+    CompileCase::new(
+        "namespaced_constraint_qualified_constant",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Default, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Counter {
+    pub value: u64,
+}
+
+impl Owner for Counter {
+    const OWNER: Address = Address::from_str_const("11111111111111111111111111111111");
+}
+
+impl Discriminator for Counter {
+    const DISCRIMINATOR: &'static [u8] = &[1, 2, 3, 4, 5, 6, 7, 8];
+}
+
+pub mod counter_ns {
+    use super::*;
+
+    pub struct MinValueConstraint;
+
+    impl AccountConstraint<BorshAccount<Counter>> for MinValueConstraint {
+        type Value = u64;
+
+        fn check(_: &BorshAccount<Counter>, _: &u64) -> anchor_lang_v2::Result<()> {
+            Ok(())
+        }
+    }
+}
+
+mod limits {
+    pub const MIN: u64 = 7;
+}
+
+#[derive(Accounts)]
+pub struct Good {
+    #[account(counter_ns::min_value = limits::MIN)]
+    pub counter: BorshAccount<Counter>,
+}
+"#,
+    )
+    .expect_pass();
+}
+
+#[test]
 fn associated_token_rejects_unknown_constraint_key() {
     CompileCase::new(
         "associated_token_unknown_constraint_key",

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -661,216 +661,6 @@ pub struct Bad {
 }
 
 #[test]
-fn namespaced_constraints_accept_qualified_constants_as_values() {
-    CompileCase::new(
-        "namespaced_constraint_qualified_constant",
-        r#"
-use anchor_lang_v2::prelude::*;
-
-#[derive(Default, wincode::SchemaRead, wincode::SchemaWrite)]
-pub struct Counter {
-    pub value: u64,
-}
-
-impl Owner for Counter {
-    const OWNER: Address = Address::from_str_const("11111111111111111111111111111111");
-}
-
-impl Discriminator for Counter {
-    const DISCRIMINATOR: &'static [u8] = &[1, 2, 3, 4, 5, 6, 7, 8];
-}
-
-pub mod counter_ns {
-    use super::*;
-
-    pub struct MinValueConstraint;
-
-    impl AccountConstraint<BorshAccount<Counter>> for MinValueConstraint {
-        type Value = u64;
-
-        fn check(_: &BorshAccount<Counter>, _: &u64) -> anchor_lang_v2::Result<()> {
-            Ok(())
-        }
-    }
-}
-
-mod limits {
-    pub const MIN: u64 = 7;
-}
-
-#[derive(Accounts)]
-pub struct Good {
-    #[account(counter_ns::min_value = limits::MIN)]
-    pub counter: BorshAccount<Counter>,
-}
-"#,
-    )
-    .expect_pass();
-}
-
-#[test]
-fn namespaced_constraints_accept_instruction_args_in_exit_hooks() {
-    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("spl-v2");
-
-    CompileCase::new(
-        "namespaced_constraint_instruction_arg_exit",
-        r#"
-use anchor_lang_v2::prelude::*;
-use anchor_spl_v2::{
-    mint::{self, Mint},
-    token::Token,
-};
-
-declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
-
-#[account]
-pub struct AuthorityData {
-    pub value: u64,
-}
-
-#[derive(Accounts)]
-#[instruction(decimals: u8)]
-pub struct Good {
-    #[account(mut)]
-    pub payer: Signer,
-    pub authority: Account<AuthorityData>,
-    #[account(
-        init,
-        payer = payer,
-        mint::decimals = decimals,
-        mint::authority = authority,
-    )]
-    pub mint: Account<Mint>,
-    pub token_program: Program<Token>,
-    pub system_program: Program<System>,
-}
-"#,
-    )
-    .dep(format!(
-        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
-        spl.display()
-    ))
-    .expect_pass();
-}
-
-#[test]
-fn namespaced_constraints_accept_sibling_field_paths_in_exit_and_update_hooks() {
-    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("spl-v2");
-
-    CompileCase::new(
-        "namespaced_constraint_sibling_field_paths",
-        r#"
-use anchor_lang_v2::prelude::*;
-use anchor_spl_v2::mint::{self, Mint};
-
-declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
-
-#[account]
-pub struct Config {
-    pub authority: Address,
-    pub decimals: u8,
-}
-
-#[derive(Accounts)]
-pub struct Good {
-    pub config: Account<Config>,
-    #[account(
-        mut,
-        mint::authority = config.authority,
-        mint::decimals = config.decimals,
-        update(mint::authority = config.authority, mint::decimals = config.decimals),
-    )]
-    pub mint: Account<Mint>,
-}
-"#,
-    )
-    .dep(format!(
-        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
-        spl.display()
-    ))
-    .expect_pass();
-}
-
-#[test]
-fn namespaced_constraints_reject_self_refs_during_init() {
-    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("spl-v2");
-
-    CompileCase::new(
-        "namespaced_constraint_init_self_ref",
-        r#"
-use anchor_lang_v2::prelude::*;
-use anchor_spl_v2::token::{Token, TokenAccount};
-
-declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
-
-#[derive(Accounts)]
-pub struct Bad {
-    #[account(mut)]
-    pub payer: Signer,
-    #[account(init, payer = payer, token::authority = token_account)]
-    pub token_account: Account<TokenAccount>,
-    pub token_program: Program<Token>,
-    pub system_program: Program<System>,
-}
-"#,
-    )
-    .dep(format!(
-        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
-        spl.display()
-    ))
-    .expect_fail(&[
-        "cannot reference `token_account` while that account is still being initialized",
-    ]);
-}
-
-#[test]
-fn namespaced_constraints_reject_later_init_refs() {
-    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("spl-v2");
-
-    CompileCase::new(
-        "namespaced_constraint_later_init_ref",
-        r#"
-use anchor_lang_v2::prelude::*;
-use anchor_spl_v2::{
-    mint::Mint,
-    token::{Token, TokenAccount},
-};
-
-declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
-
-#[derive(Accounts)]
-pub struct Bad {
-    #[account(mut)]
-    pub payer: Signer,
-    #[account(init, payer = payer, token::mint = mint, token::authority = payer)]
-    pub token_account: Account<TokenAccount>,
-    #[account(init, payer = payer, mint::decimals = 6, mint::authority = payer)]
-    pub mint: Account<Mint>,
-    pub token_program: Program<Token>,
-    pub system_program: Program<System>,
-}
-"#,
-    )
-    .dep(format!(
-        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
-        spl.display()
-    ))
-    .expect_fail(&["cannot reference later init field `mint` before it is initialized"]);
-}
-
-#[test]
 fn namespaced_constraints_reject_non_account_rhs_for_init_params() {
     let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -905,7 +695,9 @@ pub struct Bad {
         "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
         spl.display()
     ))
-    .expect_fail(&["`mint::authority` init constraint requires a sibling account field reference"]);
+    .expect_fail(&[
+        "SPL init constraint `mint::authority` needs an AccountView, not a pubkey",
+    ]);
 
     CompileCase::new(
         "namespaced_constraint_init_const_freeze_authority_rejected",
@@ -942,7 +734,7 @@ pub struct Bad {
         spl.display()
     ))
     .expect_fail(&[
-        "`mint::freeze_authority` init constraint requires a sibling account field reference",
+        "SPL init constraint `mint::freeze_authority` needs an AccountView, not a pubkey",
     ]);
 
     CompileCase::new(
@@ -980,7 +772,7 @@ pub struct Bad {
         spl.display()
     ))
     .expect_fail(&[
-        "`mint::token_program` init constraint requires a sibling account field reference",
+        "SPL init constraint `mint::token_program` needs an AccountView, not a pubkey",
     ]);
 
     CompileCase::new(
@@ -1008,7 +800,9 @@ pub struct Bad {
         "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
         spl.display()
     ))
-    .expect_fail(&["`token::mint` init constraint requires a sibling account field reference"]);
+    .expect_fail(&[
+        "SPL init constraint `token::mint` needs an AccountView, not a pubkey",
+    ]);
 
     CompileCase::new(
         "namespaced_constraint_init_const_token_authority_rejected",
@@ -1039,7 +833,9 @@ pub struct Bad {
         "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
         spl.display()
     ))
-    .expect_fail(&["`token::authority` init constraint requires a sibling account field reference"]);
+    .expect_fail(&[
+        "SPL init constraint `token::authority` needs an AccountView, not a pubkey",
+    ]);
 
     CompileCase::new(
         "namespaced_constraint_init_const_token_token_program_rejected",
@@ -1077,7 +873,7 @@ pub struct Bad {
         spl.display()
     ))
     .expect_fail(&[
-        "`token::token_program` init constraint requires a sibling account field reference",
+        "SPL init constraint `token::token_program` needs an AccountView, not a pubkey",
     ]);
 
     CompileCase::new(
@@ -1112,7 +908,9 @@ pub struct Bad {
         "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
         spl.display()
     ))
-    .expect_fail(&["`mint::authority` init constraint requires a sibling account field reference"]);
+    .expect_fail(&[
+        "SPL init constraint `mint::authority` needs an AccountView, not a pubkey",
+    ]);
 }
 
 #[test]

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -871,6 +871,78 @@ pub struct Bad {
 }
 
 #[test]
+fn namespaced_constraints_reject_non_account_rhs_for_init_params() {
+    let spl = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("spl-v2");
+
+    CompileCase::new(
+        "namespaced_constraint_init_const_authority_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::Token,
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const AUTH: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, mint::decimals = 6, mint::authority = AUTH)]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&["`mint::authority` init constraint requires a sibling account field reference"]);
+
+    CompileCase::new(
+        "namespaced_constraint_init_nested_field_authority_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::Token,
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[account]
+pub struct Config {
+    pub authority: Address,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub config: Account<Config>,
+    #[account(init, payer = payer, mint::decimals = 6, mint::authority = config.authority)]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&["`mint::authority` init constraint requires a sibling account field reference"]);
+}
+
+#[test]
 fn associated_token_rejects_unknown_constraint_key() {
     CompileCase::new(
         "associated_token_unknown_constraint_key",

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -908,6 +908,179 @@ pub struct Bad {
     .expect_fail(&["`mint::authority` init constraint requires a sibling account field reference"]);
 
     CompileCase::new(
+        "namespaced_constraint_init_const_freeze_authority_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::Token,
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const AUTH: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 6,
+        mint::authority = payer,
+        mint::freeze_authority = AUTH
+    )]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&[
+        "`mint::freeze_authority` init constraint requires a sibling account field reference",
+    ]);
+
+    CompileCase::new(
+        "namespaced_constraint_init_const_mint_token_program_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::Token,
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const TOKEN_PROGRAM_ID: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 6,
+        mint::authority = payer,
+        mint::token_program = TOKEN_PROGRAM_ID
+    )]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&[
+        "`mint::token_program` init constraint requires a sibling account field reference",
+    ]);
+
+    CompileCase::new(
+        "namespaced_constraint_init_const_token_mint_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::token::{Token, TokenAccount};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const MINT: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, token::mint = MINT, token::authority = payer)]
+    pub token_account: Account<TokenAccount>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&["`token::mint` init constraint requires a sibling account field reference"]);
+
+    CompileCase::new(
+        "namespaced_constraint_init_const_token_authority_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::{Token, TokenAccount},
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const AUTH: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: Account<Mint>,
+    #[account(init, payer = payer, token::mint = mint, token::authority = AUTH)]
+    pub token_account: Account<TokenAccount>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&["`token::authority` init constraint requires a sibling account field reference"]);
+
+    CompileCase::new(
+        "namespaced_constraint_init_const_token_token_program_rejected",
+        r#"
+use anchor_lang_v2::prelude::*;
+use anchor_spl_v2::{
+    mint::Mint,
+    token::{Token, TokenAccount},
+};
+
+declare_id!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+const TOKEN_PROGRAM_ID: Address = anchor_lang_v2::address!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint: Account<Mint>,
+    #[account(
+        init,
+        payer = payer,
+        token::mint = mint,
+        token::authority = payer,
+        token::token_program = TOKEN_PROGRAM_ID
+    )]
+    pub token_account: Account<TokenAccount>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+}
+"#,
+    )
+    .dep(format!(
+        "anchor-spl-v2 = {{ path = \"{}\", features = [\"guardrails\"] }}",
+        spl.display()
+    ))
+    .expect_fail(&[
+        "`token::token_program` init constraint requires a sibling account field reference",
+    ]);
+
+    CompileCase::new(
         "namespaced_constraint_init_nested_field_authority_rejected",
         r#"
 use anchor_lang_v2::prelude::*;


### PR DESCRIPTION
Rejects non-account RHS values for built-in SPL init constraints in lang-v2, requiring sibling account fields instead of const pubkeys or nested field access, with focused compile-fail coverage for namespaced init diagnostics.