### PR TITLE
Fix/v2 pda explicit bump

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1020,7 +1020,7 @@ fn emit_payer_signer_seeds_binding(
                     return Err(anchor_lang_v2::ErrorCode::ConstraintSeeds.into());
                 }
                 let __payer_bump: u8 = #bump_expr;
-                anchor_lang_v2::verify_program_address(
+                anchor_lang_v2::create_and_verify_program_address(
                     &[#(#seed_refs),* , &[__payer_bump]],
                     __program_id,
                     __payer.address(),
@@ -1062,7 +1062,7 @@ fn emit_payer_signer_seeds_binding(
             let __payer_seed_count = __payer_seed_ref.len();
             __payer_seed_buf[..__payer_seed_count].copy_from_slice(__payer_seed_ref);
             __payer_seed_buf[__payer_seed_count] = &__payer_bump_bytes;
-            anchor_lang_v2::verify_program_address(
+            anchor_lang_v2::create_and_verify_program_address(
                 &__payer_seed_buf[..__payer_seed_count + 1],
                 __program_id,
                 __payer.address(),
@@ -1769,7 +1769,7 @@ pub fn parse_field(
                         {
                             #(#seed_bindings)*
                             let __bump_val: u8 = #bump_expr;
-                            anchor_lang_v2::verify_program_address(
+                            anchor_lang_v2::create_and_verify_program_address(
                                 &[#(#seed_refs),* , &[__bump_val]],
                                 #pda_program,
                                 #field_name.account().address(),
@@ -1822,7 +1822,7 @@ pub fn parse_field(
                             let __n = __seed_ref.len();
                             __seed_buf[..__n].copy_from_slice(__seed_ref);
                             __seed_buf[__n] = &__bump_bytes;
-                            anchor_lang_v2::verify_program_address(
+                            anchor_lang_v2::create_and_verify_program_address(
                                 &__seed_buf[..__n + 1],
                                 #pda_program,
                                 #field_name.account().address(),

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2395,6 +2395,68 @@ mod tests {
     }
 
     #[test]
+    fn explicit_bump_constraints_use_strict_pda_verifier() {
+        use syn::parse::Parser;
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(seeds = [b"vault"], bump = user_bump)]
+                pub vault: Account<Vault>
+            })
+            .unwrap();
+        let parsed = parse_field(
+            &field,
+            &["vault".into()],
+            &[],
+            quote::quote!(0usize),
+            &[],
+            &[],
+        )
+        .unwrap();
+        let joined = parsed
+            .constraints
+            .iter()
+            .map(|t| t.to_string())
+            .collect::<String>();
+        assert!(
+            joined.contains("create_and_verify_program_address"),
+            "explicit bump checks must use the strict PDA verifier, got: {joined}"
+        );
+        assert!(
+            !joined.contains("anchor_lang_v2 :: verify_program_address"),
+            "explicit bump checks must not use the hash-only verifier, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn explicit_payer_bumps_use_strict_pda_verifier() {
+        let payer = syn::Ident::new("payer", proc_macro2::Span::call_site());
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(seeds = [b"payer"], bump = payer_bump)]
+        )];
+        let field_summaries = vec![FieldSummary {
+            name: payer.clone(),
+            ty: syn::parse_quote!(SystemAccount),
+            attrs: parse_account_attrs(&attrs).unwrap(),
+        }];
+        let binding = emit_payer_signer_seeds_binding(
+            &payer,
+            &["payer".into()],
+            &field_summaries,
+        )
+        .unwrap()
+        .to_string();
+        assert!(
+            binding.contains("create_and_verify_program_address"),
+            "explicit payer bumps must use the strict PDA verifier, got: {binding}"
+        );
+        assert!(
+            !binding.contains("anchor_lang_v2 :: verify_program_address"),
+            "explicit payer bumps must not use the hash-only verifier, got: {binding}"
+        );
+    }
+
+    #[test]
     fn init_with_explicit_bump_is_rejected() {
         // Mirrors Anchor v1: `init` requires the canonical bump (off-curve
         // guarantee), so caller-supplied bumps must be rejected at parse

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -221,6 +221,13 @@ pub fn find_and_verify_program_address(
 /// Uses `sol_sha256` + `sol_curve_validate_point` directly instead of
 /// `sol_create_program_address`. The seeds slice should already be
 /// runtime-valid and include the bump byte.
+///
+/// # Warning
+///
+/// This helper does not search for or canonicalize the bump. If the bump is
+/// caller-controlled, use [`find_program_address`] or
+/// [`create_and_verify_program_address`] so the runtime re-checks the full
+/// PDA shape before you trust the result.
 #[inline(always)]
 pub fn create_program_address(
     seeds: &[&[u8]],
@@ -246,6 +253,13 @@ pub fn create_program_address(
 /// which also performs host-side seed and curve validation. For untrusted bumps
 /// use `find_and_verify_program_address`. Seeds should already include the bump
 /// byte.
+///
+/// # Warning
+///
+/// This helper is only safe when the bump embedded in `seeds` is already
+/// trusted. For caller-controlled bumps, use
+/// [`create_and_verify_program_address`] so the full PDA validation path runs
+/// before accepting `expected`.
 #[inline(always)]
 pub fn verify_program_address(
     seeds: &[&[u8]],
@@ -633,6 +647,30 @@ pub fn realloc_account(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod pda_tests {
+    use super::*;
+
+    #[test]
+    fn strict_verifier_rejects_on_curve_expected_for_explicit_bump() {
+        let program_id = Address::new_from_array([7; 32]);
+        let base_seed = b"vault";
+        let (derived, bump) = find_program_address(&[base_seed.as_ref()], &program_id);
+        let bump_bytes = [bump];
+        let seeds = [base_seed.as_ref(), bump_bytes.as_ref()];
+
+        let on_curve_expected = (0u8..=u8::MAX)
+            .map(|byte| Address::new_from_array([byte; 32]))
+            .find(|address| address.is_on_curve() && !pinocchio::address::address_eq(address, &derived))
+            .expect("must find a deterministic on-curve address");
+
+        assert_eq!(
+            create_and_verify_program_address(&seeds, &program_id, &on_curve_expected),
+            Err(ProgramError::InvalidSeeds)
+        );
+    }
 }
 
 #[cfg(all(test, feature = "const-rent"))]

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -653,18 +653,43 @@ pub fn realloc_account(
 mod pda_tests {
     use super::*;
 
-    #[test]
-    fn strict_verifier_rejects_on_curve_expected_for_explicit_bump() {
-        let program_id = Address::new_from_array([7; 32]);
-        let base_seed = b"vault";
-        let (derived, bump) = find_program_address(&[base_seed.as_ref()], &program_id);
-        let bump_bytes = [bump];
-        let seeds = [base_seed.as_ref(), bump_bytes.as_ref()];
+    fn unchecked_pda_address_for_seed_byte(
+        seed_byte: u8,
+        bump: u8,
+        program_id: &Address,
+    ) -> Address {
+        let mut preimage = [0u8; 1 + 1 + 32 + 21];
+        preimage[0] = seed_byte;
+        preimage[1] = bump;
+        preimage[2..34].copy_from_slice(program_id.as_ref());
+        preimage[34..].copy_from_slice(b"ProgramDerivedAddress");
+        Address::new_from_array(crate::hash::sha256(&preimage))
+    }
 
-        let on_curve_expected = (0u8..=u8::MAX)
-            .map(|byte| Address::new_from_array([byte; 32]))
-            .find(|address| address.is_on_curve() && !pinocchio::address::address_eq(address, &derived))
-            .expect("must find a deterministic on-curve address");
+    #[test]
+    fn strict_verifier_rejects_on_curve_hash_for_explicit_bump() {
+        let program_id = Address::new_from_array([7; 32]);
+        let (seed_byte, bump, on_curve_expected) = (0u8..=u8::MAX)
+            .find_map(|seed_byte| {
+                (0u8..=u8::MAX).find_map(|bump| {
+                    let candidate = unchecked_pda_address_for_seed_byte(seed_byte, bump, &program_id);
+                    candidate.is_on_curve().then_some((seed_byte, bump, candidate))
+                })
+            })
+            .expect("must find a deterministic on-curve raw PDA hash");
+        let seed = [seed_byte];
+        let bump_bytes = [bump];
+        let seeds = [seed.as_ref(), bump_bytes.as_ref()];
+
+        // This is the real caller-controlled explicit-bump danger: the raw
+        // hash matches `expected`, but the result is on-curve and therefore
+        // not a valid PDA. The strict verifier must reject before the address
+        // comparison can succeed.
+        assert!(on_curve_expected.is_on_curve());
+        assert_eq!(
+            create_program_address(&seeds, &program_id),
+            Err(ProgramError::InvalidSeeds)
+        );
 
         assert_eq!(
             create_and_verify_program_address(&seeds, &program_id, &on_curve_expected),

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -274,6 +274,26 @@ pub fn verify_program_address(
     }
 }
 
+/// Strictly verify that `expected` matches the PDA derived from `seeds`.
+///
+/// Unlike [`verify_program_address`], this re-runs the full
+/// [`create_program_address`] validation path so the derived address must be
+/// off-curve and the seed tuple must satisfy the runtime's PDA shape rules.
+/// Use this when the bump byte is caller-controlled.
+#[inline(always)]
+pub fn create_and_verify_program_address(
+    seeds: &[&[u8]],
+    program_id: &Address,
+    expected: &Address,
+) -> Result<(), ProgramError> {
+    let computed = create_program_address(seeds, program_id)?;
+    if pinocchio::address::address_eq(&computed, expected) {
+        Ok(())
+    } else {
+        Err(ProgramError::InvalidSeeds)
+    }
+}
+
 /// Like [`find_and_verify_program_address`] but skips `sol_curve_validate_point`.
 ///
 /// Safe when the account was signed for (`MIN_DATA_LEN > 0` or `init`):

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -178,7 +178,8 @@ pub use {
     context::{Bumps, Context, MutMask},
     context_cpi::{unchecked_invoke_signed_fixed, CpiContext},
     cpi::{
-        create_account, create_account_signed, create_program_address,
+        create_account, create_account_signed, create_and_verify_program_address,
+        create_program_address,
         find_and_verify_program_address, find_and_verify_program_address_skip_curve,
         find_program_address, verify_program_address,
     },


### PR DESCRIPTION
## Finding
`lang-v2` validated explicit PDA bumps by only checking the derived address. That skipped the stricter PDA creation check Anchor v1 enforced for explicit bump verification.

## Fix
This PR switches explicit bump validation to the stricter PDA creation path, so supplied bumps must satisfy the same PDA rules as v1 instead of only matching the final address. It also adds regression coverage for explicit bump checks on both fixed seed arrays and opaque seed expressions.
