### PR TITLE
Fix/v2 event authority const

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4916,32 +4916,6 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
     });
     let event_authority_check = event_authority_dispatch_check(precomputed_event_authority);
 
-    let disc_parse = if use_byte_disc {
-        quote! {
-            const __MIN_IX_DATA_LEN: usize = #disc_size + #min_args_size_expr;
-            if __ix_data_len < __MIN_IX_DATA_LEN {
-                return anchor_lang_v2::Error::from(
-                    anchor_lang_v2::ErrorCode::InstructionFallbackNotFound,
-                ).into();
-            }
-            let __disc: u8 = *__ix_data_ptr;
-            let __ix_data: &[u8] =
-                ::core::slice::from_raw_parts(__ix_data_ptr.add(1), __ix_data_len - 1);
-        }
-    } else {
-        quote! {
-            if __ix_data_len < 8 {
-                return anchor_lang_v2::Error::from(
-                    anchor_lang_v2::ErrorCode::InstructionFallbackNotFound,
-                ).into();
-            }
-            let __disc: u64 = u64::from_le_bytes(
-                *(__ix_data_ptr as *const [u8; 8])
-            );
-            let __ix_data: &[u8] =
-                ::core::slice::from_raw_parts(__ix_data_ptr.add(8), __ix_data_len - 8);
-        }
-    };
     let event_cpi_dispatch = quote! {
         // Reserve the full event-CPI tag before user dispatch. A custom
         // 1-byte discriminator can overlap the first tag byte, but it
@@ -6426,6 +6400,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn event_authority_dispatch_uses_precomputed_const_when_available() {
         let generated = event_authority_dispatch_check(Some([7; 32])).to_string();
 

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -6425,4 +6425,35 @@ mod tests {
             "expected targeted prefix diagnostic: {generated}"
         );
     }
+
+    fn event_authority_dispatch_uses_precomputed_const_when_available() {
+        let generated = event_authority_dispatch_check(Some([7; 32])).to_string();
+
+        assert!(
+            generated.contains("const __EXPECTED_EVENT_AUTHORITY"),
+            "expected precomputed const path: {generated}"
+        );
+        assert!(
+            generated.contains("Address :: new_from_array"),
+            "expected embedded address bytes: {generated}"
+        );
+        assert!(
+            !generated.contains("find_program_address"),
+            "precomputed path should not call find_program_address: {generated}"
+        );
+    }
+
+    #[test]
+    fn event_authority_dispatch_falls_back_to_runtime_find() {
+        let generated = event_authority_dispatch_check(None).to_string();
+
+        assert!(
+            generated.contains("find_program_address"),
+            "fallback path should still derive the event authority at runtime: {generated}"
+        );
+        assert!(
+            !generated.contains("const __EXPECTED_EVENT_AUTHORITY"),
+            "fallback path should not emit the precomputed constant: {generated}"
+        );
+    }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2404,6 +2404,40 @@ struct ProgramConfig {
     program_id: Expr,
 }
 
+fn event_authority_dispatch_check(precomputed_event_authority: Option<[u8; 32]>) -> TokenStream2 {
+    if let Some(address) = precomputed_event_authority {
+        let address_bytes = address.iter().map(|byte| quote! { #byte });
+        quote! {
+            const __EXPECTED_EVENT_AUTHORITY: anchor_lang_v2::Address =
+                anchor_lang_v2::Address::new_from_array([#(#address_bytes),*]);
+            if !anchor_lang_v2::address_eq(
+                __event_authority.address(),
+                &__EXPECTED_EVENT_AUTHORITY,
+            ) {
+                return anchor_lang_v2::Error::from(
+                    anchor_lang_v2::ErrorCode::ConstraintSeeds,
+                ).into();
+            }
+        }
+    } else {
+        quote! {
+            let (__expected_event_authority, _) =
+                anchor_lang_v2::find_program_address(
+                    &[b"__event_authority"],
+                    __program_id,
+                );
+            if !anchor_lang_v2::address_eq(
+                __event_authority.address(),
+                &__expected_event_authority,
+            ) {
+                return anchor_lang_v2::Error::from(
+                    anchor_lang_v2::ErrorCode::ConstraintSeeds,
+                ).into();
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 struct DiscrimAttr {
     bytes: Vec<u8>,
@@ -4877,6 +4911,37 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
         })
         .collect();
 
+    let precomputed_event_authority = crate::pda::discover_program_id().and_then(|program_id| {
+        crate::pda::precompute_pda(&[b"__event_authority"], &program_id).map(|(_, address)| address)
+    });
+    let event_authority_check = event_authority_dispatch_check(precomputed_event_authority);
+
+    let disc_parse = if use_byte_disc {
+        quote! {
+            const __MIN_IX_DATA_LEN: usize = #disc_size + #min_args_size_expr;
+            if __ix_data_len < __MIN_IX_DATA_LEN {
+                return anchor_lang_v2::Error::from(
+                    anchor_lang_v2::ErrorCode::InstructionFallbackNotFound,
+                ).into();
+            }
+            let __disc: u8 = *__ix_data_ptr;
+            let __ix_data: &[u8] =
+                ::core::slice::from_raw_parts(__ix_data_ptr.add(1), __ix_data_len - 1);
+        }
+    } else {
+        quote! {
+            if __ix_data_len < 8 {
+                return anchor_lang_v2::Error::from(
+                    anchor_lang_v2::ErrorCode::InstructionFallbackNotFound,
+                ).into();
+            }
+            let __disc: u64 = u64::from_le_bytes(
+                *(__ix_data_ptr as *const [u8; 8])
+            );
+            let __ix_data: &[u8] =
+                ::core::slice::from_raw_parts(__ix_data_ptr.add(8), __ix_data_len - 8);
+        }
+    };
     let event_cpi_dispatch = quote! {
         // Reserve the full event-CPI tag before user dispatch. A custom
         // 1-byte discriminator can overlap the first tag byte, but it
@@ -4898,19 +4963,7 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                         anchor_lang_v2::ErrorCode::ConstraintSigner,
                     ).into();
                 }
-                let (__expected_event_authority, _) =
-                    anchor_lang_v2::find_program_address(
-                        &[b"__event_authority"],
-                        __program_id,
-                    );
-                if !anchor_lang_v2::address_eq(
-                    __event_authority.address(),
-                    &__expected_event_authority,
-                ) {
-                    return anchor_lang_v2::Error::from(
-                        anchor_lang_v2::ErrorCode::ConstraintSeeds,
-                    ).into();
-                }
+                #event_authority_check
                 return 0;
             }
         }

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1,4 +1,5 @@
 use {
+    crate::pda::{discover_program_id, precompute_pda, seeds_as_byte_literals},
     proc_macro2::TokenStream as TokenStream2,
     quote::{quote, quote_spanned},
     syn::{
@@ -989,12 +990,10 @@ fn emit_seeds_check(
     };
     // Try to precompute the bump and PDA at expansion time.
     if using_our_program_id {
-        if let Some(literal_seeds) = crate::pda::seeds_as_byte_literals(seeds) {
-            if let Some(program_id) = crate::pda::discover_program_id() {
+        if let Some(literal_seeds) = seeds_as_byte_literals(seeds) {
+            if let Some(program_id) = discover_program_id() {
                 let seed_slices: Vec<&[u8]> = literal_seeds.iter().map(|s| s.as_slice()).collect();
-                if let Some((bump, pda_bytes)) =
-                    crate::pda::precompute_pda(&seed_slices, &program_id)
-                {
+                if let Some((bump, pda_bytes)) = precompute_pda(&seed_slices, &program_id) {
                     // Field-scoped const names keep multiple fields'
                     // bumps + PDAs from colliding, even when two
                     // constraints share an outer scope.


### PR DESCRIPTION
## Finding
`event_cpi_dispatch` recomputed the canonical `__event_authority` PDA at runtime even when the program ID was known during macro expansion. That spent compute units deriving a fixed address on every dispatch.

## Fix
This PR precomputes the canonical event authority address during macro expansion when possible and emits a constant address check in the dispatcher, falling back to runtime derivation only when needed. It also adds codegen regression tests covering the emitted constant check and the remaining runtime fallback path.
