### PR TITLE
fix: keep BORSH_CONFIG alignment checks enabled

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -83,6 +83,10 @@ name = "borsh_exit_semantics"
 required-features = ["testing"]
 
 [[test]]
+name = "borsh_borrow_alignment"
+required-features = ["testing"]
+
+[[test]]
 name = "serialized_account_custom_codec"
 required-features = ["testing"]
 

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -107,15 +107,13 @@ pub use wincode;
 ///
 /// Programs that don't use these types are unaffected.
 ///
-/// # `ZERO_COPY_ALIGN_CHECK = false`
+/// # Borrowed zero-copy caveat
 ///
-/// Borsh's u32 length prefix puts payload data 4 bytes off natural alignment,
-/// so handler args like `amounts: &[u64]` would otherwise fail wincode's
-/// runtime alignment guard. The guard exists to prevent Rust-level UB on
-/// hosts where misaligned wide loads are undefined; SBPF's `ldxdw` has no
-/// alignment-specialized variants and the Solana program ecosystem already
-/// reads u64 from arbitrary `&[u8]` offsets, so disabling the check on SBPF
-/// is safe.
+/// Borsh's u32 length prefix means borrowed wide slices like `&[u64]` start
+/// four bytes into the buffer and therefore fail wincode's zero-copy
+/// alignment guard. `BORSH_CONFIG` keeps that guard enabled so safe
+/// deserialization cannot form a misaligned Rust reference; use owned
+/// arguments (`Vec<u64>`) or align-1 borrowed data (`&[u8]`, `&str`) instead.
 pub const BORSH_CONFIG: BorshConfig = wincode::config::Configuration::new();
 
 /// Solana allows at most 16 seeds when deriving a PDA.
@@ -126,7 +124,7 @@ pub const MAX_PAYER_SEEDS_WITH_BUMP: usize = MAX_PAYER_SEEDS + 1;
 /// Concrete type of [`BORSH_CONFIG`]. Spelled out so downstream callers can
 /// name it in trait bounds (e.g. `T: wincode::SchemaRead<'de, BorshConfig>`).
 pub type BorshConfig = wincode::config::Configuration<
-    false,
+    true,
     { wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT },
     wincode::len::FixIntLen<u32>,
     wincode::int_encoding::LittleEndian,

--- a/lang-v2/tests/borsh_borrow_alignment.rs
+++ b/lang-v2/tests/borsh_borrow_alignment.rs
@@ -1,0 +1,22 @@
+use anchor_lang_v2::{wincode, BORSH_CONFIG};
+
+#[test]
+fn borsh_config_rejects_misaligned_borrowed_wide_slices() {
+    let values = [11_u64, 22, 33];
+    let encoded = wincode::config::serialize(&values[..], BORSH_CONFIG).unwrap();
+
+    let err = wincode::config::deserialize::<&[u64], _>(&encoded, BORSH_CONFIG).unwrap_err();
+    assert!(
+        err.to_string().contains("unaligned"),
+        "expected an unaligned-reference error, got: {err}"
+    );
+}
+
+#[test]
+fn borsh_config_still_deserializes_owned_wide_vectors() {
+    let values = vec![11_u64, 22, 33];
+    let encoded = wincode::config::serialize(&values, BORSH_CONFIG).unwrap();
+
+    let decoded: Vec<u64> = wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
+    assert_eq!(decoded, values);
+}

--- a/tests-v2/tests/borsh_borrow_alignment.rs
+++ b/tests-v2/tests/borsh_borrow_alignment.rs
@@ -1,0 +1,31 @@
+use anchor_lang_v2::{wincode, BORSH_CONFIG};
+
+#[test]
+fn borsh_config_rejects_misaligned_borrowed_u64_slices() {
+    let values = [11_u64, 22, 33];
+    let encoded = wincode::config::serialize(&values[..], BORSH_CONFIG).unwrap();
+
+    let err = wincode::config::deserialize::<&[u64], _>(&encoded, BORSH_CONFIG).unwrap_err();
+    assert!(
+        err.to_string().contains("unaligned"),
+        "expected an unaligned-reference error, got: {err}"
+    );
+}
+
+#[test]
+fn borsh_config_still_deserializes_owned_u64_vectors() {
+    let values = vec![11_u64, 22, 33];
+    let encoded = wincode::config::serialize(&values, BORSH_CONFIG).unwrap();
+
+    let decoded: Vec<u64> = wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
+    assert_eq!(decoded, values);
+}
+
+#[test]
+fn borsh_config_still_deserializes_align_one_borrowed_bytes() {
+    let values: &[u8] = b"anchor borrow checks";
+    let encoded = wincode::config::serialize(values, BORSH_CONFIG).unwrap();
+
+    let decoded: &[u8] = wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
+    assert_eq!(decoded, values);
+}

--- a/tests-v2/tests/borsh_borrow_alignment.rs
+++ b/tests-v2/tests/borsh_borrow_alignment.rs
@@ -1,27 +1,6 @@
 use anchor_lang_v2::{wincode, BORSH_CONFIG};
 
 #[test]
-fn borsh_config_rejects_misaligned_borrowed_u64_slices() {
-    let values = [11_u64, 22, 33];
-    let encoded = wincode::config::serialize(&values[..], BORSH_CONFIG).unwrap();
-
-    let err = wincode::config::deserialize::<&[u64], _>(&encoded, BORSH_CONFIG).unwrap_err();
-    assert!(
-        err.to_string().contains("unaligned"),
-        "expected an unaligned-reference error, got: {err}"
-    );
-}
-
-#[test]
-fn borsh_config_still_deserializes_owned_u64_vectors() {
-    let values = vec![11_u64, 22, 33];
-    let encoded = wincode::config::serialize(&values, BORSH_CONFIG).unwrap();
-
-    let decoded: Vec<u64> = wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
-    assert_eq!(decoded, values);
-}
-
-#[test]
 fn borsh_config_still_deserializes_align_one_borrowed_bytes() {
     let values: &[u8] = b"anchor borrow checks";
     let encoded = wincode::config::serialize(values, BORSH_CONFIG).unwrap();


### PR DESCRIPTION
Finding
`BORSH_CONFIG` disabled alignment validation for borrowed decodes, so values like `&[u64]` could be constructed from unaligned Borsh payload offsets.

Fix
This PR keeps borrowed-value alignment validation enabled and rejects unsafe unaligned decodes instead of constructing invalid references. Added regression tests for aligned and unaligned borrowed decodes.