### PR TITLE
fix(lang-v2): preserve instruction prefix coercion

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4507,18 +4507,12 @@ fn process_handler(
                     fn __coerce(self, __ix_data: &'ix [u8]) -> anchor_lang_v2::Result<#tuple_ty>;
                 }
 
-                impl<'ix> __AnchorIxArgCoerce<'ix> for () {
+                impl<'ix, __AnchorIxArgs> __AnchorIxArgCoerce<'ix> for __AnchorIxArgs {
                     #[inline(always)]
                     fn __coerce(self, __ix_data: &'ix [u8]) -> anchor_lang_v2::Result<#tuple_ty> {
+                        let _ = self;
                         #deser_args
                         Ok((#(#extra_arg_names,)*))
-                    }
-                }
-
-                impl<'ix> __AnchorIxArgCoerce<'ix> for #tuple_ty {
-                    #[inline(always)]
-                    fn __coerce(self, _ix_data: &'ix [u8]) -> anchor_lang_v2::Result<#tuple_ty> {
-                        Ok(self)
                     }
                 }
 
@@ -6248,8 +6242,8 @@ mod tests {
             "expected fallback coercion trait in wrapper: {wrapper}"
         );
         assert!(
-            wrapper.contains("impl < 'ix > __AnchorIxArgCoerce < 'ix > for ()"),
-            "expected missing-#[instruction] fallback impl in wrapper: {wrapper}"
+            wrapper.contains("impl < 'ix , __AnchorIxArgs > __AnchorIxArgCoerce < 'ix > for __AnchorIxArgs"),
+            "expected generic instruction-arg coercion impl in wrapper: {wrapper}"
         );
     }
 

--- a/lang-v2/tests/single_deser.rs
+++ b/lang-v2/tests/single_deser.rs
@@ -2,6 +2,20 @@
 
 use anchor_lang_v2::{prelude::*, TryAccounts};
 
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod prefix_only_instruction_args {
+    use super::*;
+
+    pub fn ix(ctx: &mut Context<PrefixOnly>, amount: u64, step: i32) -> Result<()> {
+        let _ = ctx;
+        let _ = amount;
+        let _ = step;
+        Ok(())
+    }
+}
+
 #[derive(Accounts)]
 pub struct NoArgs {
     pub account: UncheckedAccount,
@@ -10,6 +24,12 @@ pub struct NoArgs {
 #[derive(Accounts)]
 #[instruction(amount: u64, step: i32)]
 pub struct WithArgs {
+    pub account: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+#[instruction(amount: u64)]
+pub struct PrefixOnly {
     pub account: UncheckedAccount,
 }
 
@@ -26,7 +46,18 @@ fn _instruction_args_are_tuple<'a>(args: <WithArgs as TryAccounts>::IxArgs<'a>) 
     args
 }
 
+fn _instruction_args_keep_declared_prefix<'a>(
+    args: <PrefixOnly as TryAccounts>::IxArgs<'a>,
+) -> (u64,) {
+    args
+}
+
 #[test]
 fn instruction_args_map_to_tuple() {
     let _: fn(_) -> _ = _instruction_args_are_tuple;
+}
+
+#[test]
+fn instruction_attr_keeps_prefix_tuple() {
+    let _: fn(_) -> _ = _instruction_args_keep_declared_prefix;
 }

--- a/tests-v2/tests/instruction_prefix.rs
+++ b/tests-v2/tests/instruction_prefix.rs
@@ -1,0 +1,111 @@
+use std::{fs, path::PathBuf, process::Command};
+
+fn compile_pass_case(name: &str, source: &str) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir.join("target/compile-cases").join(name);
+    let src_dir = crate_dir.join("src");
+    let anchor_lang_v2 = manifest_dir
+        .parent()
+        .expect("tests-v2 should live under the workspace root")
+        .join("lang-v2");
+
+    if crate_dir.exists() {
+        fs::remove_dir_all(&crate_dir).unwrap();
+    }
+    fs::create_dir_all(&src_dir).unwrap();
+
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+wincode = {{ version = "0.5", features = ["derive"] }}
+
+[workspace]
+"#,
+            anchor_lang_v2.display()
+        ),
+    )
+    .unwrap();
+    fs::write(src_dir.join("lib.rs"), source).unwrap();
+
+    let output = Command::new("cargo")
+        .args(["check", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo check for {name}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "{name} failed to compile\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn instruction_attr_keeps_declared_prefix_tuple() {
+    compile_pass_case(
+        "tests_v2_instruction_prefix",
+        r#"
+#![allow(dead_code)]
+
+use anchor_lang_v2::{prelude::*, TryAccounts};
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod prefix_only_instruction_args {
+    use super::*;
+
+    pub fn ix(ctx: &mut Context<PrefixOnly>, amount: u64, step: i32) -> Result<()> {
+        let _ = ctx;
+        let _ = amount;
+        let _ = step;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct NoArgs {
+    pub account: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+#[instruction(amount: u64, step: i32)]
+pub struct WithArgs {
+    pub account: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+#[instruction(amount: u64)]
+pub struct PrefixOnly {
+    pub account: UncheckedAccount,
+}
+
+fn _no_args_maps_to_unit() {
+    let _: <NoArgs as TryAccounts>::IxArgs<'static> = ();
+}
+
+fn _instruction_args_are_tuple<'a>(args: <WithArgs as TryAccounts>::IxArgs<'a>) -> (u64, i32) {
+    args
+}
+
+fn _instruction_args_keep_declared_prefix<'a>(
+    args: <PrefixOnly as TryAccounts>::IxArgs<'a>,
+) -> (u64,) {
+    args
+}
+"#,
+    );
+}


### PR DESCRIPTION
Finding
`#[instruction(...)]` only accepted no arguments or the full handler tuple, so documented prefix-only argument usage failed to compile in `lang-v2`.

Fix
This PR restores prefix tuple coercion for partial `#[instruction(...)]` usage without requiring the complete handler signature. Added regression tests for prefix and full argument coercions.