### PR TITLE
fix(lang-v2): honor wincode enum tags in idl and init space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9336,6 +9336,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "token-interface-test",
+ "wincode 0.5.4",
 ]
 
 [[package]]

--- a/cli/src/codama.rs
+++ b/cli/src/codama.rs
@@ -20,6 +20,7 @@ use {
         path::{Path, PathBuf},
         process::{Command, Stdio},
     },
+    syn::{Expr, ExprLit, Lit},
 };
 
 /// The `@codama/nodes` package version we target. The Codama IDL is versioned
@@ -732,10 +733,11 @@ fn type_node_from_anchor(ty: &JsonValue, generics: &Generics) -> Result<JsonValu
             .iter()
             .map(|v| enum_variant_from_anchor(v, generics))
             .collect::<Result<_>>()?;
+        let size = enum_tag_size_from_anchor(obj)?;
         return Ok(json!({
             "kind": "enumTypeNode",
             "variants": variant_nodes,
-            "size": number_node("u8"),
+            "size": size,
         }));
     }
 
@@ -822,37 +824,105 @@ fn enum_variant_from_anchor(variant: &JsonValue, generics: &Generics) -> Result<
         .ok_or_else(|| anyhow!("Enum variant must be an object: {variant}"))?;
     let name = obj.get("name").and_then(JsonValue::as_str).unwrap_or("");
     let fields = obj.get("fields").and_then(JsonValue::as_array);
+    let discriminator = enum_variant_discriminator_from_anchor(obj)?;
     match fields {
-        None => Ok(json!({
-            "kind": "enumEmptyVariantTypeNode",
-            "name": camel_case(name),
-        })),
-        Some(fs) if fs.is_empty() => Ok(json!({
-            "kind": "enumEmptyVariantTypeNode",
-            "name": camel_case(name),
-        })),
+        None => Ok(enum_variant_node(
+            "enumEmptyVariantTypeNode",
+            name,
+            discriminator,
+            None,
+        )),
+        Some(fs) if fs.is_empty() => Ok(enum_variant_node(
+            "enumEmptyVariantTypeNode",
+            name,
+            discriminator,
+            None,
+        )),
         Some(fs) if is_struct_field_array(fs) => {
             let nodes: Vec<JsonValue> = fs
                 .iter()
                 .map(|f| struct_field_from_anchor(f, generics))
                 .collect::<Result<_>>()?;
-            Ok(json!({
-                "kind": "enumStructVariantTypeNode",
-                "name": camel_case(name),
-                "struct": { "kind": "structTypeNode", "fields": nodes },
-            }))
+            Ok(enum_variant_node(
+                "enumStructVariantTypeNode",
+                name,
+                discriminator,
+                Some((
+                    "struct",
+                    json!({ "kind": "structTypeNode", "fields": nodes }),
+                )),
+            ))
         }
         Some(fs) => {
             let items: Vec<JsonValue> = fs
                 .iter()
                 .map(|f| type_node_from_anchor(f, generics))
                 .collect::<Result<_>>()?;
-            Ok(json!({
-                "kind": "enumTupleVariantTypeNode",
-                "name": camel_case(name),
-                "tuple": { "kind": "tupleTypeNode", "items": items },
-            }))
+            Ok(enum_variant_node(
+                "enumTupleVariantTypeNode",
+                name,
+                discriminator,
+                Some(("tuple", json!({ "kind": "tupleTypeNode", "items": items }))),
+            ))
         }
+    }
+}
+
+fn enum_variant_node(
+    kind: &str,
+    name: &str,
+    discriminator: Option<u32>,
+    payload: Option<(&str, JsonValue)>,
+) -> JsonValue {
+    let mut node = Map::new();
+    node.insert("kind".into(), JsonValue::String(kind.into()));
+    node.insert("name".into(), JsonValue::String(camel_case(name)));
+    if let Some(discriminator) = discriminator {
+        node.insert("discriminator".into(), json!(discriminator));
+    }
+    if let Some((key, value)) = payload {
+        node.insert(key.into(), value);
+    }
+    JsonValue::Object(node)
+}
+
+fn enum_tag_size_from_anchor(obj: &Map<String, JsonValue>) -> Result<JsonValue> {
+    match obj.get("tagEncoding").and_then(JsonValue::as_str) {
+        None => Ok(number_node("u8")),
+        Some(format) if NUMBER_LEAVES.contains(&format) => Ok(number_node(format)),
+        Some(format) => bail!("Unsupported enum `tagEncoding` for Codama: `{format}`"),
+    }
+}
+
+fn enum_variant_discriminator_from_anchor(obj: &Map<String, JsonValue>) -> Result<Option<u32>> {
+    let Some(tag) = obj.get("tag") else {
+        return Ok(None);
+    };
+    match tag {
+        JsonValue::Number(number) => number
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| anyhow!("Enum variant `tag` must fit in u32: {number}"))
+            .map(Some),
+        JsonValue::String(tag) => parse_variant_tag_str(tag).map(Some),
+        other => bail!("Enum variant `tag` must be a string or number, got {other}"),
+    }
+}
+
+fn parse_variant_tag_str(tag: &str) -> Result<u32> {
+    if let Ok(value) = tag.parse::<u32>() {
+        return Ok(value);
+    }
+
+    let expr = syn::parse_str::<Expr>(tag)
+        .with_context(|| format!("Enum variant `tag` is not valid Rust: `{tag}`"))?;
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(int), ..
+        }) => int
+            .base10_parse::<u32>()
+            .with_context(|| format!("Enum variant `tag` must be a u32 literal: `{tag}`")),
+        _ => bail!("Enum variant `tag` must be a numeric literal for Codama: `{tag}`"),
     }
 }
 
@@ -1617,22 +1687,26 @@ mod tests {
                 "name": "E",
                 "type": {
                     "kind": "enum",
+                    "tagEncoding": "u32",
                     "variants": [
-                        { "name": "Empty" },
-                        { "name": "Tup", "fields": ["u8", "u16"] },
-                        { "name": "Stru", "fields": [{ "name": "x", "type": "bool" }] }
+                        { "name": "Empty", "tag": "5" },
+                        { "name": "Tup", "tag": "8", "fields": ["u8", "u16"] },
+                        { "name": "Stru", "tag": "13", "fields": [{ "name": "x", "type": "bool" }] }
                     ]
                 }
             }]
         });
         let root = convert_str(&serde_json::to_string(&idl).unwrap());
-        let variants = root["program"]["definedTypes"][0]["type"]["variants"]
-            .as_array()
-            .unwrap();
+        let enum_node = &root["program"]["definedTypes"][0]["type"];
+        assert_eq!(enum_node["size"]["format"], "u32");
+        let variants = enum_node["variants"].as_array().unwrap();
         assert_eq!(variants[0]["kind"], "enumEmptyVariantTypeNode");
+        assert_eq!(variants[0]["discriminator"], 5);
         assert_eq!(variants[1]["kind"], "enumTupleVariantTypeNode");
+        assert_eq!(variants[1]["discriminator"], 8);
         assert_eq!(variants[1]["tuple"]["items"][0]["format"], "u8");
         assert_eq!(variants[2]["kind"], "enumStructVariantTypeNode");
+        assert_eq!(variants[2]["discriminator"], 13);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3363,7 +3363,7 @@ fn deserialize_idl_defined_type_to_json(
                 }
             }
         }
-        IdlTypeDefTy::Enum { variants } => {
+        IdlTypeDefTy::Enum { variants, .. } => {
             let repr = <u8 as AnchorDeserialize>::deserialize(data)?;
 
             let variant = variants

--- a/idl/spec/src/lib.rs
+++ b/idl/spec/src/lib.rs
@@ -236,6 +236,8 @@ pub enum IdlTypeDefTy {
         fields: Option<IdlDefinedFields>,
     },
     Enum {
+        #[serde(default, rename = "tagEncoding", skip_serializing_if = "is_default")]
+        tag_encoding: Option<String>,
         variants: Vec<IdlEnumVariant>,
     },
     Type {
@@ -248,6 +250,8 @@ pub struct IdlEnumVariant {
     pub name: String,
     #[serde(skip_serializing_if = "is_default")]
     pub fields: Option<IdlDefinedFields>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub tag: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/idl/src/convert.rs
+++ b/idl/src/convert.rs
@@ -201,9 +201,17 @@ mod legacy {
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     #[serde(rename_all = "lowercase", tag = "kind")]
     pub enum IdlTypeDefinitionTy {
-        Struct { fields: Vec<IdlField> },
-        Enum { variants: Vec<IdlEnumVariant> },
-        Alias { value: IdlType },
+        Struct {
+            fields: Vec<IdlField>,
+        },
+        Enum {
+            #[serde(default, rename = "tagEncoding")]
+            tag_encoding: Option<String>,
+            variants: Vec<IdlEnumVariant>,
+        },
+        Alias {
+            value: IdlType,
+        },
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -211,6 +219,8 @@ mod legacy {
         pub name: String,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pub fields: Option<EnumFields>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub tag: Option<String>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -443,7 +453,11 @@ mod legacy {
                         ))
                     },
                 },
-                IdlTypeDefinitionTy::Enum { variants } => Self::Enum {
+                IdlTypeDefinitionTy::Enum {
+                    variants,
+                    tag_encoding,
+                } => Self::Enum {
+                    tag_encoding,
                     variants: variants
                         .into_iter()
                         .map(|variant| t::IdlEnumVariant {
@@ -456,6 +470,7 @@ mod legacy {
                                     tys.into_iter().map(Into::into).collect(),
                                 ),
                             }),
+                            tag: variant.tag,
                         })
                         .collect(),
                 },

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -573,17 +573,22 @@ pub fn build_enum_type_strings(
     name: &str,
     disc: &[u8],
     docs: &[String],
+    enum_attrs: &[syn::Attribute],
     variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
     kind: TypeKind,
     generics: &Generics,
-) -> IdlTypeStrings {
+) -> syn::Result<IdlTypeStrings> {
     let mut lowerer = TypeLowerer::with_generics(generics);
     let mut type_def_obj = build_type_def_header(name, docs, kind, generics);
+    let tag_encoding = crate::wincode_attrs::enum_tag_encoding_string(enum_attrs)?;
     let variant_values: Vec<Value> = variants
         .iter()
         .map(|v| {
             let mut obj = serde_json::Map::new();
             obj.insert("name".into(), Value::String(v.ident.to_string()));
+            if let Some(tag) = crate::wincode_attrs::variant_tag_string(&v.attrs)? {
+                obj.insert("tag".into(), Value::String(tag));
+            }
             match &v.fields {
                 syn::Fields::Unit => {}
                 syn::Fields::Named(named) => {
@@ -603,32 +608,57 @@ pub fn build_enum_type_strings(
                     obj.insert("fields".into(), Value::Array(tys));
                 }
             }
-            Value::Object(obj)
+            Ok(Value::Object(obj))
         })
-        .collect();
-    type_def_obj.insert(
-        "type".into(),
-        json!({ "kind": "enum", "variants": variant_values }),
-    );
-    IdlTypeStrings {
+        .collect::<syn::Result<_>>()?;
+    let mut type_obj = serde_json::Map::new();
+    type_obj.insert("kind".into(), Value::String("enum".into()));
+    if let Some(tag_encoding) = tag_encoding {
+        type_obj.insert("tagEncoding".into(), Value::String(tag_encoding));
+    }
+    type_obj.insert("variants".into(), Value::Array(variant_values));
+    type_def_obj.insert("type".into(), Value::Object(type_obj));
+    Ok(IdlTypeStrings {
         account_entry: build_account_entry(name, disc),
         type_def: lowerer.finish(Value::Object(type_def_obj)),
-    }
+    })
 }
 
 pub fn build_enum_type_def_emission(
     name: &str,
     docs: &[String],
+    enum_attrs: &[syn::Attribute],
     variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
     kind: TypeKind,
     generics: &Generics,
-) -> TokenStream2 {
-    let (header, suffix) = type_def_header_parts(name, docs, kind, generics, "enum");
+) -> syn::Result<TokenStream2> {
+    const VARIANT_MARKER: &str = "__anchor_private_variants__";
+    let mut type_def_obj = build_type_def_header(name, docs, kind, generics);
+    let mut type_obj = serde_json::Map::new();
+    type_obj.insert("kind".into(), Value::String("enum".into()));
+    if let Some(tag_encoding) = crate::wincode_attrs::enum_tag_encoding_string(enum_attrs)? {
+        type_obj.insert("tagEncoding".into(), Value::String(tag_encoding));
+    }
+    type_obj.insert(
+        "variants".into(),
+        Value::Array(vec![Value::String(VARIANT_MARKER.to_owned())]),
+    );
+    type_def_obj.insert("type".into(), Value::Object(type_obj));
+
+    let header = Value::Object(type_def_obj).to_string();
+    let marker = Value::String(VARIANT_MARKER.to_owned()).to_string();
+    let (header, suffix) = header
+        .split_once(&marker)
+        .expect("enum type definition should contain the variant marker");
     let variant_pushes: Vec<_> = variants
         .iter()
         .map(|variant| variant_push_stmt(variant, generics))
-        .collect();
-    build_joined_type_def_emission(header, suffix, &variant_pushes)
+        .collect::<syn::Result<_>>()?;
+    Ok(build_joined_type_def_emission(
+        header.to_owned(),
+        suffix.to_owned(),
+        &variant_pushes,
+    ))
 }
 
 /// Compose the program-level `accounts[]` entry. Returns `None` when the
@@ -729,13 +759,13 @@ fn field_push_stmt(field: &syn::Field, generics: &Generics) -> TokenStream2 {
     }
 }
 
-fn variant_push_stmt(variant: &syn::Variant, generics: &Generics) -> TokenStream2 {
-    let variant_json = variant_emission(variant, generics);
+fn variant_push_stmt(variant: &syn::Variant, generics: &Generics) -> syn::Result<TokenStream2> {
+    let variant_json = variant_emission(variant, generics)?;
     let cfg_attrs = crate::cfg_attrs(&variant.attrs);
-    quote! {
+    Ok(quote! {
         #(#cfg_attrs)*
         __entries.push(#variant_json);
-    }
+    })
 }
 
 fn named_field_emission(field: &syn::Field, generics: &Generics) -> TokenStream2 {
@@ -750,16 +780,24 @@ fn unnamed_field_emission(field: &syn::Field, generics: &Generics) -> TokenStrea
     lowerer.finish(value)
 }
 
-fn variant_emission(variant: &syn::Variant, generics: &Generics) -> TokenStream2 {
-    let name = variant.ident.to_string();
+fn variant_emission(variant: &syn::Variant, generics: &Generics) -> syn::Result<TokenStream2> {
+    let mut header_obj = serde_json::Map::new();
+    header_obj.insert("name".into(), Value::String(variant.ident.to_string()));
+    if let Some(tag) = crate::wincode_attrs::variant_tag_string(&variant.attrs)? {
+        header_obj.insert("tag".into(), Value::String(tag));
+    }
     match &variant.fields {
         syn::Fields::Unit => {
-            let variant_json = json!({ "name": name }).to_string();
-            quote! { #variant_json }
+            let variant_json = Value::Object(header_obj).to_string();
+            Ok(quote! { #variant_json })
         }
         syn::Fields::Named(named) => {
             const FIELD_MARKER: &str = "__anchor_private_variant_fields__";
-            let header = json!({ "name": name, "fields": [FIELD_MARKER] }).to_string();
+            header_obj.insert(
+                "fields".into(),
+                Value::Array(vec![Value::String(FIELD_MARKER.to_owned())]),
+            );
+            let header = Value::Object(header_obj).to_string();
             let marker = Value::String(FIELD_MARKER.to_owned()).to_string();
             let (header, suffix) = header
                 .split_once(&marker)
@@ -769,11 +807,19 @@ fn variant_emission(variant: &syn::Variant, generics: &Generics) -> TokenStream2
                 .iter()
                 .map(|field| field_push_stmt(field, generics))
                 .collect();
-            build_joined_entry_emission(header.to_owned(), &field_pushes, suffix.to_owned())
+            Ok(build_joined_entry_emission(
+                header.to_owned(),
+                &field_pushes,
+                suffix.to_owned(),
+            ))
         }
         syn::Fields::Unnamed(unnamed) => {
             const FIELD_MARKER: &str = "__anchor_private_variant_fields__";
-            let header = json!({ "name": name, "fields": [FIELD_MARKER] }).to_string();
+            header_obj.insert(
+                "fields".into(),
+                Value::Array(vec![Value::String(FIELD_MARKER.to_owned())]),
+            );
+            let header = Value::Object(header_obj).to_string();
             let marker = Value::String(FIELD_MARKER.to_owned()).to_string();
             let (header, suffix) = header
                 .split_once(&marker)
@@ -790,7 +836,11 @@ fn variant_emission(variant: &syn::Variant, generics: &Generics) -> TokenStream2
                     }
                 })
                 .collect();
-            build_joined_entry_emission(header.to_owned(), &field_pushes, suffix.to_owned())
+            Ok(build_joined_entry_emission(
+                header.to_owned(),
+                &field_pushes,
+                suffix.to_owned(),
+            ))
         }
     }
 }

--- a/lang-v2/derive/src/init_space.rs
+++ b/lang-v2/derive/src/init_space.rs
@@ -20,6 +20,11 @@ pub fn expand(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let name = input.ident;
+    let enum_tag_len = match enum_tag_len_tokens(&input.attrs) {
+        Ok(Some(tag_len)) => tag_len,
+        Ok(None) => quote!(1),
+        Err(err) => return err.to_compile_error().into(),
+    };
 
     let process_struct_fields = |fields: Punctuated<Field, Comma>| {
         let recurse = fields.into_iter().map(field_len_tokens);
@@ -57,7 +62,7 @@ pub fn expand(item: TokenStream) -> TokenStream {
             quote! {
                 #[automatically_derived]
                 impl anchor_lang_v2::Space for #name {
-                    const INIT_SPACE: usize = 1 + #max;
+                    const INIT_SPACE: usize = #enum_tag_len + #max;
                 }
             }
         }
@@ -101,6 +106,44 @@ fn field_len_tokens(field: Field) -> TokenStream2 {
 
     let mut max_len_args = get_max_len_args(&field.attrs);
     len_from_type(field.ty, &mut max_len_args)
+}
+
+fn enum_tag_len_tokens(attrs: &[Attribute]) -> syn::Result<Option<TokenStream2>> {
+    let Some(tag_encoding) = crate::wincode_attrs::enum_tag_encoding_type(attrs)? else {
+        return Ok(None);
+    };
+
+    let Type::Path(tag_path) = &tag_encoding else {
+        return Err(syn::Error::new_spanned(
+            &tag_encoding,
+            "#[derive(InitSpace)] only supports primitive integer `#[wincode(tag_encoding = ...)]` \
+             overrides; compute the enum size manually for custom tag encodings",
+        ));
+    };
+
+    let Some(segment) = tag_path.path.segments.last() else {
+        return Err(syn::Error::new_spanned(
+            &tag_encoding,
+            "invalid `#[wincode(tag_encoding = ...)]` type",
+        ));
+    };
+
+    let len = match segment.ident.to_string().as_str() {
+        "i8" | "u8" => quote!(1),
+        "i16" | "u16" => quote!(2),
+        "i32" | "u32" => quote!(4),
+        "i64" | "u64" => quote!(8),
+        "i128" | "u128" => quote!(16),
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &tag_encoding,
+                "#[derive(InitSpace)] only supports primitive integer `#[wincode(tag_encoding = ...)]` \
+                 overrides; compute the enum size manually for custom tag encodings",
+            ))
+        }
+    };
+
+    Ok(Some(len))
 }
 
 fn gen_max<T: Iterator<Item = TokenStream2>>(mut iter: T) -> TokenStream2 {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -8,6 +8,7 @@ mod init_space;
 mod parse;
 mod pda;
 mod pod_wrapper;
+mod wincode_attrs;
 
 use {
     proc_macro::TokenStream,
@@ -2246,25 +2247,18 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_derive(IdlType)]
+#[proc_macro_derive(IdlType, attributes(wincode))]
 pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let name_str = name.to_string();
 
     let docs = idl::extract_doc_lines(&input.attrs);
-    // `IdlType` items have no discriminator — they're just plain type
-    // definitions referenced from other structs. `build_*_type_json` still
-    // expect a discriminator for shape uniformity with `#[account]` /
-    // `#[event]`; we pass an empty slice and strip the discriminator field
-    // downstream when splitting accounts vs types entries. The spec's
-    // `IdlTypeDef` doesn't carry `discriminator`, so the program-level
-    // assembly already elides it when reconstructing types entries.
-    // Default to `Borsh` serialization (no `serialization` / `repr` fields).
-    // `IdlType` is layout-agnostic — users opt into Pod separately via
-    // their own `bytemuck::Pod` derive if they need zero-copy. Forcing a
-    // `"bytemuck"` tag here would lie in the IDL for non-Pod types.
-    let empty_disc: [u8; 0] = [];
+    // `IdlType` items are plain type definitions that only contribute to the
+    // program-level `types[]` array. Default to `Borsh` serialization (no
+    // `serialization` / `repr` fields). `IdlType` is layout-agnostic — users
+    // opt into Pod separately via their own `bytemuck::Pod` derive if they
+    // need zero-copy.
     let (idl_type_def, field_dep_walkers, idl_validation_tokens) = match &input.data {
         Data::Struct(data) => (
             idl::build_struct_type_def_emission(
@@ -2277,17 +2271,24 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             cfg_field_dep_walkers(&data.fields),
             wincode_idl_override_tokens_for_fields("`#[derive(IdlType)]`", &data.fields),
         ),
-        Data::Enum(data) => (
-            idl::build_enum_type_def_emission(
+        Data::Enum(data) => {
+            let idl_type_def = match idl::build_enum_type_def_emission(
                 &name_str,
                 &docs,
+                &input.attrs,
                 &data.variants,
                 idl::TypeKind::Borsh,
                 &input.generics,
-            ),
-            cfg_variant_dep_walkers(&data.variants),
-            wincode_idl_override_tokens_for_variants("`#[derive(IdlType)]`", &data.variants),
-        ),
+            ) {
+                Ok(idl_type_def) => idl_type_def,
+                Err(err) => return err.to_compile_error().into(),
+            };
+            (
+                idl_type_def,
+                cfg_variant_dep_walkers(&data.variants),
+                wincode_idl_override_tokens_for_variants("`#[derive(IdlType)]`", &data.variants),
+            )
+        }
         Data::Union(_) => {
             return syn::Error::new(
                 name.span(),
@@ -2297,7 +2298,6 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             .into();
         }
     };
-    let _ = empty_disc;
 
     // Thread any generic / lifetime params from the input type through
     // the impl so `#[derive(IdlType)] struct Foo<'a>` lowers to
@@ -3231,6 +3231,20 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         format!("declare_program! does not support bytemuck enum type `{name}`"),
                     ));
                 }
+                let tag_encoding_attr = type_obj
+                    .get("tagEncoding")
+                    .or_else(|| type_obj.get("tag_encoding"))
+                    .map(|tag_encoding| match tag_encoding {
+                        serde_json::Value::String(tag_encoding) => {
+                            let tag_encoding = syn::LitStr::new(tag_encoding, ident.span());
+                            Ok(quote! { #[wincode(tag_encoding = #tag_encoding)] })
+                        }
+                        other => Err(syn::Error::new(
+                            ident.span(),
+                            format!("enum type `{name}` has non-string `tagEncoding`: {other}"),
+                        )),
+                    })
+                    .transpose()?;
                 let variants = type_obj
                     .get("variants")
                     .and_then(serde_json::Value::as_array)
@@ -3245,8 +3259,41 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                 for variant in variants {
                     let variant_name = json_str(variant, "name", ident.span())?;
                     let variant_ident = Ident::new(variant_name, ident.span());
+                    let tag_attr = variant
+                        .get("tag")
+                        .map(|tag| match tag {
+                            serde_json::Value::String(tag) => {
+                                let tag = tag.parse::<TokenStream2>().map_err(|err| {
+                                    syn::Error::new(
+                                        ident.span(),
+                                        format!(
+                                            "variant `{variant_name}` has invalid `tag` tokens `{tag}`: {err}"
+                                        ),
+                                    )
+                                })?;
+                                Ok(quote! { #[wincode(tag = #tag)] })
+                            }
+                            serde_json::Value::Number(tag) => {
+                                let tag = tag.to_string().parse::<TokenStream2>().map_err(|err| {
+                                    syn::Error::new(
+                                        ident.span(),
+                                        format!(
+                                            "variant `{variant_name}` has invalid numeric `tag`: {err}"
+                                        ),
+                                    )
+                                })?;
+                                Ok(quote! { #[wincode(tag = #tag)] })
+                            }
+                            other => Err(syn::Error::new(
+                                ident.span(),
+                                format!(
+                                    "variant `{variant_name}` has unsupported `tag` value `{other}`"
+                                ),
+                            )),
+                        })
+                        .transpose()?;
                     let Some(fields) = variant.get("fields") else {
-                        variant_tokens.push(quote! { #variant_ident, });
+                        variant_tokens.push(quote! { #tag_attr #variant_ident, });
                         continue;
                     };
                     let fields = fields.as_array().ok_or_else(|| {
@@ -3259,13 +3306,14 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     idl_field_tys.extend(fields.tys().iter().cloned());
                     match fields {
                         DeclareTypeFields::Named { fields, .. } => {
-                            variant_tokens.push(quote! { #variant_ident { #(#fields)* }, });
+                            variant_tokens
+                                .push(quote! { #tag_attr #variant_ident { #(#fields)* }, });
                         }
                         DeclareTypeFields::Tuple { fields, .. } => {
-                            variant_tokens.push(quote! { #variant_ident(#(#fields),*), });
+                            variant_tokens.push(quote! { #tag_attr #variant_ident(#(#fields),*), });
                         }
                         DeclareTypeFields::Unit => {
-                            variant_tokens.push(quote! { #variant_ident, });
+                            variant_tokens.push(quote! { #tag_attr #variant_ident, });
                         }
                     }
                 }
@@ -3281,6 +3329,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     #(#docs)*
                     #repr
                     #[derive(Clone, anchor_lang_v2::wincode::SchemaRead, anchor_lang_v2::wincode::SchemaWrite)]
+                    #tag_encoding_attr
                     pub enum #ident #impl_generics {
                         #(#variant_tokens)*
                     }
@@ -5982,7 +6031,7 @@ pub fn constant(_attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     pub name: String,
 /// }
 /// ```
-#[proc_macro_derive(InitSpace, attributes(max_len))]
+#[proc_macro_derive(InitSpace, attributes(max_len, wincode))]
 pub fn derive_init_space(item: TokenStream) -> TokenStream {
     init_space::expand(item)
 }

--- a/lang-v2/derive/src/wincode_attrs.rs
+++ b/lang-v2/derive/src/wincode_attrs.rs
@@ -1,0 +1,78 @@
+use {
+    quote::ToTokens,
+    syn::{Attribute, Expr, LitStr, Token, Type},
+};
+
+pub(crate) fn enum_tag_encoding_string(attrs: &[Attribute]) -> syn::Result<Option<String>> {
+    parse_enum_tag_encoding(attrs).map(|tag_encoding| tag_encoding.map(|lit| lit.value()))
+}
+
+pub(crate) fn enum_tag_encoding_type(attrs: &[Attribute]) -> syn::Result<Option<Type>> {
+    parse_enum_tag_encoding(attrs)?
+        .map(|lit| lit.parse::<Type>())
+        .transpose()
+}
+
+pub(crate) fn variant_tag_string(attrs: &[Attribute]) -> syn::Result<Option<String>> {
+    parse_variant_tag(attrs).map(|tag| tag.map(|expr| expr.to_token_stream().to_string()))
+}
+
+fn parse_enum_tag_encoding(attrs: &[Attribute]) -> syn::Result<Option<LitStr>> {
+    let mut tag_encoding = None;
+    for attr in attrs {
+        if !attr.path().is_ident("wincode") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("tag_encoding") {
+                if tag_encoding.is_some() {
+                    return Err(meta.error("duplicate `tag_encoding`"));
+                }
+                tag_encoding = Some(meta.value()?.parse()?);
+            } else {
+                consume_meta_input(&meta)?;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(tag_encoding)
+}
+
+fn parse_variant_tag(attrs: &[Attribute]) -> syn::Result<Option<Expr>> {
+    let mut tag = None;
+    for attr in attrs {
+        if !attr.path().is_ident("wincode") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("tag") {
+                if tag.is_some() {
+                    return Err(meta.error("duplicate `tag`"));
+                }
+                tag = Some(meta.value()?.parse()?);
+            } else {
+                consume_meta_input(&meta)?;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(tag)
+}
+
+fn consume_meta_input(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<()> {
+    if meta.input.peek(Token![=]) {
+        let value = meta.value()?;
+        let _ = value.parse::<Expr>()?;
+    } else if meta.input.peek(syn::token::Paren) {
+        meta.parse_nested_meta(|nested| {
+            consume_meta_input(&nested)?;
+            Ok(())
+        })?;
+    }
+
+    Ok(())
+}

--- a/lang-v2/tests/init_space.rs
+++ b/lang-v2/tests/init_space.rs
@@ -140,6 +140,19 @@ fn enum_picks_largest_variant_plus_discriminator() {
     assert_eq!(Variant::INIT_SPACE, 1 + 16);
 }
 
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[wincode(tag_encoding = "u32")]
+enum WideTagVariant {
+    A,
+    B(u64),
+    C { _x: u16 },
+}
+
+#[test]
+fn enum_honors_wincode_tag_encoding_size() {
+    assert_eq!(WideTagVariant::INIT_SPACE, 4 + 8);
+}
+
 #[derive(InitSpace)]
 struct Unit;
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -105,6 +105,68 @@ fn cargo_test_pass_case(name: &str, source: &str, features: &[&str]) {
     );
 }
 
+fn cargo_test_pass_case_with_files(
+    name: &str,
+    source: &str,
+    features: &[&str],
+    extra_files: &[(&str, &str)],
+) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir.join("target/macro-diagnostics").join(name);
+    let src_dir = crate_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+wincode = {{ version = "0.5", features = ["derive"] }}
+
+[features]
+idl-build = []
+
+[workspace]
+"#,
+            manifest_dir.display()
+        ),
+    )
+    .unwrap();
+    fs::write(src_dir.join("lib.rs"), source).unwrap();
+
+    for (path, contents) in extra_files {
+        let file_path = crate_dir.join(path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(file_path, contents).unwrap();
+    }
+
+    let mut command = Command::new("cargo");
+    command
+        .args(["test", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"));
+    if !features.is_empty() {
+        command.arg("--features").arg(features.join(","));
+    }
+
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo test for {name}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "{name} tests failed\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 #[cfg_attr(
     miri,
@@ -279,6 +341,45 @@ mod shim {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn idl_enum_preserves_wincode_tag_metadata() {
+    cargo_test_pass_case_with_files(
+        "idl_enum_wincode_tags",
+        r#"
+use anchor_lang_v2::{IdlAccountType, IdlType};
+
+#[derive(Clone, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+#[wincode(tag_encoding = "u32")]
+pub enum Tagged {
+    #[wincode(tag = 5)]
+    A,
+    #[wincode(tag = 8)]
+    B(u64),
+}
+
+#[cfg(all(test, feature = "idl-build"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emitted_idl_keeps_wincode_tag_metadata() {
+        let idl = <Tagged as IdlAccountType>::__IDL_TYPE_DEF.unwrap();
+        assert!(idl.contains("\"tagEncoding\":\"u32\""));
+        assert!(idl.contains("\"name\":\"A\""));
+        assert!(idl.contains("\"tag\":\"5\""));
+        assert!(idl.contains("\"tag\":\"8\""));
+    }
+}
+"#,
+        &["idl-build"],
+        &[],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn idl_generation_rejects_wincode_field_overrides() {
     compile_fail_case(
         "idl_type_wincode_skip",
@@ -337,6 +438,74 @@ mod shim {
             "`#[event]` does not support `#[wincode(with = ...)]` fields",
             "custom wincode codecs can change the serialized wire layout",
         ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn declare_program_honors_wincode_enum_tag_metadata() {
+    cargo_test_pass_case_with_files(
+        "declare_program_wincode_enum_tags",
+        r#"
+use anchor_lang_v2::declare_program;
+
+declare_program!(tagged_program);
+
+#[cfg(test)]
+mod tests {
+    use super::tagged_program::types::Tagged;
+
+    #[test]
+    fn declared_enum_roundtrips_with_custom_tags() {
+        let a_bytes = anchor_lang_v2::wincode::config::serialize(
+            &Tagged::A,
+            anchor_lang_v2::BORSH_CONFIG,
+        )
+        .unwrap();
+        assert_eq!(a_bytes, 5u32.to_le_bytes());
+
+        let b_bytes = anchor_lang_v2::wincode::config::serialize(
+            &Tagged::B(9),
+            anchor_lang_v2::BORSH_CONFIG,
+        )
+        .unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&8u32.to_le_bytes());
+        expected.extend_from_slice(&9u64.to_le_bytes());
+        assert_eq!(b_bytes, expected);
+    }
+}
+"#,
+        &[],
+        &[(
+            "idls/tagged_program.json",
+            r#"{
+  "address": "11111111111111111111111111111111",
+  "metadata": {
+    "name": "tagged_program",
+    "version": "0.1.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [],
+  "accounts": [],
+  "types": [
+    {
+      "name": "Tagged",
+      "type": {
+        "kind": "enum",
+        "tagEncoding": "u32",
+        "variants": [
+          { "name": "A", "tag": "5" },
+          { "name": "B", "tag": "8", "fields": ["u64"] }
+        ]
+      }
+    }
+  ]
+}"#,
+        )],
     );
 }
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn emitted_idl_keeps_wincode_tag_metadata() {
-        let idl = <Tagged as IdlAccountType>::__IDL_TYPE_DEF.unwrap();
+        let idl = <Tagged as IdlAccountType>::__idl_type_def().unwrap();
         assert!(idl.contains("\"tagEncoding\":\"u32\""));
         assert!(idl.contains("\"name\":\"A\""));
         assert!(idl.contains("\"tag\":\"5\""));

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -227,7 +227,7 @@ pub fn convert_idl_type_def_to_ts(
                 #ty
             }
         }
-        IdlTypeDefTy::Enum { variants } => {
+        IdlTypeDefTy::Enum { variants, .. } => {
             let variants = variants.iter().map(|variant| {
                 let variant_name = format_ident!("{}", variant.name);
                 handle_defined_fields(
@@ -278,7 +278,7 @@ fn can_derive_copy(ty_def: &IdlTypeDef, ty_defs: &[IdlTypeDef]) -> bool {
         IdlTypeDefTy::Struct { fields } => {
             can_derive_common(fields.as_ref(), ty_defs, can_derive_copy_ty)
         }
-        IdlTypeDefTy::Enum { variants } => variants
+        IdlTypeDefTy::Enum { variants, .. } => variants
             .iter()
             .all(|variant| can_derive_common(variant.fields.as_ref(), ty_defs, can_derive_copy_ty)),
         IdlTypeDefTy::Type { alias } => can_derive_copy_ty(alias, ty_defs),

--- a/tests-v2/Cargo.toml
+++ b/tests-v2/Cargo.toml
@@ -84,3 +84,4 @@ serde_json = "1"
 spl-token-2022-interface = "2.1"
 spl-token-group-interface = "0.7"
 spl-token-metadata-interface = "0.8"
+wincode = { version = "0.5", features = ["derive"] }

--- a/tests-v2/tests/idl_convert.rs
+++ b/tests-v2/tests/idl_convert.rs
@@ -210,7 +210,7 @@ fn legacy_idl_conversion_preserves_surface_and_generates_discriminators() {
         .iter()
         .find(|ty| ty.name == "Choice")
         .expect("legacy type should convert");
-    let IdlTypeDefTy::Enum { variants } = &choice.ty else {
+    let IdlTypeDefTy::Enum { variants, .. } = &choice.ty else {
         panic!("legacy enum should remain an enum");
     };
     assert_eq!(variants[1].name, "Tuple");

--- a/tests-v2/tests/wincode_enum_tags.rs
+++ b/tests-v2/tests/wincode_enum_tags.rs
@@ -1,0 +1,189 @@
+use std::{fs, path::PathBuf, process::Command};
+
+use anchor_lang_v2::{wincode, InitSpace, Space};
+
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[wincode(tag_encoding = "u32")]
+enum WideTagVariant {
+    A,
+    B(u64),
+    C { _x: u16 },
+}
+
+#[test]
+fn init_space_honors_wincode_tag_encoding() {
+    assert_eq!(WideTagVariant::INIT_SPACE, 4 + 8);
+}
+
+fn cargo_test_case(name: &str, source: &str, features: &[&str], extra_files: &[(&str, &str)]) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir.join("target/compile-cases").join(name);
+    let src_dir = crate_dir.join("src");
+    let anchor_lang_v2 = manifest_dir
+        .parent()
+        .expect("tests-v2 should live under the workspace root")
+        .join("lang-v2");
+
+    if crate_dir.exists() {
+        fs::remove_dir_all(&crate_dir).unwrap();
+    }
+    fs::create_dir_all(&src_dir).unwrap();
+
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+wincode = {{ version = "0.5", features = ["derive"] }}
+
+[features]
+idl-build = []
+
+[workspace]
+"#,
+            anchor_lang_v2.display()
+        ),
+    )
+    .unwrap();
+    fs::write(src_dir.join("lib.rs"), source).unwrap();
+
+    for (relative_path, contents) in extra_files {
+        let path = crate_dir.join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    let mut command = Command::new("cargo");
+    command.args(["test", "--offline", "--manifest-path"]);
+    command.arg(crate_dir.join("Cargo.toml"));
+    if !features.is_empty() {
+        command.arg("--features");
+        command.arg(features.join(","));
+    }
+
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo test for {name}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "{name} tests failed\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn emitted_idl_keeps_wincode_tag_metadata() {
+    cargo_test_case(
+        "tests_v2_idl_enum_wincode_tags",
+        r#"
+use anchor_lang_v2::{IdlAccountType, IdlType};
+
+#[derive(Clone, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+#[wincode(tag_encoding = "u32")]
+pub enum Tagged {
+    #[wincode(tag = 5)]
+    A,
+    #[wincode(tag = 8)]
+    B(u64),
+}
+
+#[cfg(all(test, feature = "idl-build"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emitted_idl_keeps_wincode_tag_metadata() {
+        let idl = <Tagged as IdlAccountType>::__IDL_TYPE_DEF.unwrap();
+        assert!(idl.contains("\"tagEncoding\":\"u32\""));
+        assert!(idl.contains("\"name\":\"A\""));
+        assert!(idl.contains("\"tag\":\"5\""));
+        assert!(idl.contains("\"tag\":\"8\""));
+    }
+}
+"#,
+        &["idl-build"],
+        &[],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn declare_program_round_trips_wincode_enum_tags() {
+    cargo_test_case(
+        "tests_v2_declare_program_wincode_tags",
+        r#"
+use anchor_lang_v2::declare_program;
+
+declare_program!(tagged_program);
+
+#[cfg(test)]
+mod tests {
+    use super::tagged_program::types::Tagged;
+
+    #[test]
+    fn declared_enum_roundtrips_with_custom_tags() {
+        let a_bytes = anchor_lang_v2::wincode::config::serialize(
+            &Tagged::A,
+            anchor_lang_v2::BORSH_CONFIG,
+        )
+        .unwrap();
+        assert_eq!(a_bytes, 5u32.to_le_bytes());
+
+        let b_bytes = anchor_lang_v2::wincode::config::serialize(
+            &Tagged::B(9),
+            anchor_lang_v2::BORSH_CONFIG,
+        )
+        .unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&8u32.to_le_bytes());
+        expected.extend_from_slice(&9u64.to_le_bytes());
+        assert_eq!(b_bytes, expected);
+    }
+}
+"#,
+        &[],
+        &[(
+            "idls/tagged_program.json",
+            r#"{
+  "address": "11111111111111111111111111111111",
+  "metadata": {
+    "name": "tagged_program",
+    "version": "0.1.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [],
+  "accounts": [],
+  "types": [
+    {
+      "name": "Tagged",
+      "type": {
+        "kind": "enum",
+        "tagEncoding": "u32",
+        "variants": [
+          { "name": "A", "tag": "5" },
+          { "name": "B", "tag": "8", "fields": ["u64"] }
+        ]
+      }
+    }
+  ]
+}"#,
+        )],
+    );
+}

--- a/tests-v2/tests/wincode_enum_tags.rs
+++ b/tests-v2/tests/wincode_enum_tags.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn emitted_idl_keeps_wincode_tag_metadata() {
-        let idl = <Tagged as IdlAccountType>::__IDL_TYPE_DEF.unwrap();
+        let idl = <Tagged as IdlAccountType>::__idl_type_def().unwrap();
         assert!(idl.contains("\"tagEncoding\":\"u32\""));
         assert!(idl.contains("\"name\":\"A\""));
         assert!(idl.contains("\"tag\":\"5\""));


### PR DESCRIPTION
Finding
`InitSpace` and enum IDL generation assumed one-byte enum tags, dropping custom `wincode` tag encodings and per-variant tag values.

Fix
This PR honors `wincode(tag_encoding = ...)` and variant `#[wincode(tag = ...)]` metadata in sizing and generated enum IDL. Added regression tests for custom tag encodings and tags.