### PR TITLE
Fix/v2 declare program tuple fields

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -3558,35 +3558,52 @@ fn gen_declare_program_type_fields(
     public: bool,
 ) -> syn::Result<DeclareTypeFields> {
     let visibility = public.then(|| quote! { pub });
-    if fields.iter().all(serde_json::Value::is_object) {
-        let mut field_tokens = Vec::new();
-        let mut field_tys = Vec::new();
-        for field in fields {
-            let field_name = json_str(field, "name", span)?;
-            let field_ident = Ident::new(&to_snake_case(field_name), span);
-            let ty_value = field.get("type").ok_or_else(|| {
-                syn::Error::new(span, format!("field `{field_name}` is missing type"))
-            })?;
-            let ty = declare_idl_type_to_tokens(ty_value, span)?;
-            field_tokens.push(quote! { #visibility #field_ident: #ty, });
-            field_tys.push(ty);
+    let field_shape = serde_json::from_value::<anchor_lang_idl::types::IdlDefinedFields>(
+        serde_json::Value::Array(fields.to_vec()),
+    )
+    .map_err(|err| syn::Error::new(span, format!("invalid IDL field list: {err}")))?;
+
+    match field_shape {
+        anchor_lang_idl::types::IdlDefinedFields::Named(fields) => {
+            let mut field_tokens = Vec::new();
+            let mut field_tys = Vec::new();
+            for field in fields {
+                let field_name = &field.name;
+                let ty_value = serde_json::to_value(&field.ty).map_err(|err| {
+                    syn::Error::new(
+                        span,
+                        format!("failed to normalize IDL field `{field_name}` type: {err}"),
+                    )
+                })?;
+                let ty = declare_idl_type_to_tokens(&ty_value, span)?;
+                let field_ident = Ident::new(&to_snake_case(field_name), span);
+                field_tokens.push(quote! { #visibility #field_ident: #ty, });
+                field_tys.push(ty);
+            }
+            Ok(DeclareTypeFields::Named {
+                fields: field_tokens,
+                tys: field_tys,
+            })
         }
-        Ok(DeclareTypeFields::Named {
-            fields: field_tokens,
-            tys: field_tys,
-        })
-    } else {
-        let mut field_tokens = Vec::new();
-        let mut field_tys = Vec::new();
-        for field in fields {
-            let ty = declare_idl_type_to_tokens(field, span)?;
-            field_tokens.push(quote! { #visibility #ty });
-            field_tys.push(ty);
+        anchor_lang_idl::types::IdlDefinedFields::Tuple(fields) => {
+            let mut field_tokens = Vec::new();
+            let mut field_tys = Vec::new();
+            for field in fields {
+                let ty_value = serde_json::to_value(&field).map_err(|err| {
+                    syn::Error::new(
+                        span,
+                        format!("failed to normalize tuple field type for declare_program!: {err}"),
+                    )
+                })?;
+                let ty = declare_idl_type_to_tokens(&ty_value, span)?;
+                field_tokens.push(quote! { #visibility #ty });
+                field_tys.push(ty);
+            }
+            Ok(DeclareTypeFields::Tuple {
+                fields: field_tokens,
+                tys: field_tys,
+            })
         }
-        Ok(DeclareTypeFields::Tuple {
-            fields: field_tokens,
-            tys: field_tys,
-        })
     }
 }
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -760,6 +760,42 @@ pub fn use_declared_types(
 }
 
 #[test]
+fn declare_program_mixed_object_field_shapes_fail_cleanly() {
+    CompileCase::new(
+        "declare_program_mixed_object_field_shapes",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_program!(bad);
+"#,
+    )
+    .file(
+        "idls/bad.json",
+        r#"{
+  "address": "11111111111111111111111111111111",
+  "metadata": { "name": "bad", "version": "0.1.0", "spec": "0.1.0" },
+  "instructions": [],
+  "types": [
+    {
+      "name": "MixedFields",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bytes",
+            "type": { "vec": "u8" }
+          },
+          { "option": "bool" }
+        ]
+      }
+    }
+  ]
+}"#,
+    )
+    .expect_fail(&["failed to parse IDL", "IdlDefinedFields"]);
+}
+
+#[test]
 fn declare_program_non_returning_cpi_has_no_return_wrapper() {
     CompileCase::new(
         "declare_program_non_return_wrapper",

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -697,6 +697,69 @@ pub fn use_return<'a>(program: &'a Address, data: CpiHandle<'a>) {
 }
 
 #[test]
+fn declare_program_object_tuple_fields_compile() {
+    CompileCase::new(
+        "declare_program_object_tuple_fields",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_program!(bad);
+
+pub fn use_declared_types(
+    value: bad::ObjectTuple,
+    variant: bad::ObjectEnum,
+) -> anchor_lang_v2::__alloc::vec::Vec<u8> {
+    let bad::ObjectTuple(bytes, maybe) = value;
+    let _ = maybe;
+    match variant {
+        bad::ObjectEnum::Wrapped(inner, flag) => {
+            let _ = flag;
+            inner
+        }
+    }
+    .clone()
+}
+"#,
+    )
+    .file(
+        "idls/bad.json",
+        r#"{
+  "address": "11111111111111111111111111111111",
+  "metadata": { "name": "bad", "version": "0.1.0", "spec": "0.1.0" },
+  "instructions": [],
+  "types": [
+    {
+      "name": "ObjectTuple",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "vec": "u8" },
+          { "option": "bool" }
+        ]
+      }
+    },
+    {
+      "name": "ObjectEnum",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Wrapped",
+            "fields": [
+              { "vec": "u8" },
+              { "option": "bool" }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}"#,
+    )
+    .expect_pass();
+}
+
+#[test]
 fn declare_program_non_returning_cpi_has_no_return_wrapper() {
     CompileCase::new(
         "declare_program_non_return_wrapper",


### PR DESCRIPTION
Finding
`declare_program!` inferred tuple versus named fields from JSON value shapes, so object-valued tuple elements were misread as named fields and failed codegen.

Fix
This PR distinguishes tuple and named fields from the IDL field shape itself rather than each JSON value. Added regression tests for tuple and named object fields.