### PR TITLE
Fix/v2 idl supported pda seeds

### DIFF
--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -905,16 +905,28 @@ fn docs_value(docs: &[String]) -> Value {
 // Seed classification (Part E — `pda: {...}` emission)
 // ---------------------------------------------------------------------------
 
-/// Classified seed expression. Only explicitly recognized shapes carry
-/// structured IDL metadata; unsupported regular seed expressions are emitted
-/// as opaque `{"kind":"expr"}` placeholders. Program seed expressions can use
-/// the runtime variant because `seeds::program` must evaluate to address bytes.
+/// Classified seed expression. Only supported IDL seed shapes survive to the
+/// final JSON: statically-known shapes stay `Static`, constant-only runtime
+/// expressions become `Runtime`, and runtime-only unsupported expressions are
+/// filtered out as `Unsupported`.
 #[derive(Clone)]
 pub enum SeedJson {
     /// Pre-serialized JSON object — known at macro time.
     Static(String),
     /// Token expression evaluating to `alloc::string::String` at IDL-build
     /// time.
+    Runtime(TokenStream2),
+    /// Expression depends on runtime-only values and cannot be represented in
+    /// the current IDL seed spec.
+    Unsupported,
+}
+
+#[derive(Clone)]
+pub enum SeedListJson {
+    /// Per-seed JSON objects already split into the spec's supported variants.
+    Listed(Vec<SeedJson>),
+    /// Token expression evaluating to a full JSON seed array string (including
+    /// the surrounding `[...]`) at IDL-build time.
     Runtime(TokenStream2),
 }
 
@@ -926,6 +938,9 @@ impl SeedJson {
                 anchor_lang_v2::__alloc::string::String::from(#s)
             },
             SeedJson::Runtime(ts) => ts,
+            SeedJson::Unsupported => unreachable!(
+                "unsupported seed must be filtered out before IDL emission"
+            ),
         }
     }
 }
@@ -947,12 +962,41 @@ impl SeedJson {
 ///   with `nonce` in `ix_arg_names`
 ///   → `{"kind":"arg","path":"nonce"}`
 ///
-/// Anything else (a constant ref like `MY_PREFIX`, a const-fn call like
-/// `<Marker as Id>::id()`, wrapped account/arg field access, etc.) is opaque:
-/// `{"kind":"expr"}`. Runtime constraints still evaluate the original Rust
-/// expression; this only avoids over-promising IDL/client metadata.
+/// Constant-only expressions that aren't structurally recognized are evaluated
+/// at IDL-build time into `{"kind":"const","value":[...]}`. Expressions that
+/// depend on runtime account/arg values remain `Unsupported` and should cause
+/// PDA metadata omission rather than invalid IDL output.
 pub fn classify_seed(expr: &Expr, field_names: &[String], ix_arg_names: &[String]) -> SeedJson {
-    classify_seed_inner(expr, field_names, ix_arg_names)
+    if let Some(seed) = classify_seed_inner(expr, field_names, ix_arg_names) {
+        seed
+    } else if expr_references_runtime_seed_inputs(expr, field_names, ix_arg_names) {
+        SeedJson::Unsupported
+    } else {
+        runtime_seed(expr)
+    }
+}
+
+pub fn classify_seed_list(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> Option<SeedListJson> {
+    match expr {
+        Expr::Array(arr) => {
+            let seeds: Vec<_> = arr
+                .elems
+                .iter()
+                .map(|seed| classify_seed(seed, field_names, ix_arg_names))
+                .collect();
+            seeds
+                .iter()
+                .all(|seed| !matches!(seed, SeedJson::Unsupported))
+                .then_some(SeedListJson::Listed(seeds))
+        }
+        _ => (!expr_references_runtime_seed_inputs(expr, field_names, ix_arg_names)).then_some(
+            SeedListJson::Runtime(runtime_seeds(expr)),
+        ),
+    }
 }
 
 /// Classify `seeds::program = <expr>` into an IDL seed. Unlike arbitrary PDA
@@ -962,21 +1006,11 @@ pub fn classify_program_seed(
     expr: &Expr,
     field_names: &[String],
     ix_arg_names: &[String],
-) -> SeedJson {
-    let seed = classify_seed_inner(expr, field_names, ix_arg_names);
+) -> Option<SeedJson> {
+    let seed = classify_seed(expr, field_names, ix_arg_names);
     match seed {
-        SeedJson::Static(ref s) if s == r#"{"kind":"expr"}"# => {
-            if expr_contains_macro(expr)
-                || expr_references_local_binding(expr, field_names, ix_arg_names)
-            {
-                seed
-            } else {
-                SeedJson::Runtime(quote! {
-                    anchor_lang_v2::idl_build::__idl_const_seed_json(#expr)
-                })
-            }
-        }
-        _ => seed,
+        SeedJson::Unsupported => None,
+        other => Some(other),
     }
 }
 
@@ -1045,7 +1079,23 @@ fn static_seed(value: Value) -> SeedJson {
     SeedJson::Static(value.to_string())
 }
 
-fn classify_seed_inner(expr: &Expr, field_names: &[String], ix_arg_names: &[String]) -> SeedJson {
+fn runtime_seed(expr: &Expr) -> SeedJson {
+    SeedJson::Runtime(quote! {
+        anchor_lang_v2::idl_build::__idl_const_seed_json(#expr)
+    })
+}
+
+fn runtime_seeds(expr: &Expr) -> TokenStream2 {
+    quote! {
+        anchor_lang_v2::idl_build::__idl_const_seeds_json(#expr)
+    }
+}
+
+fn classify_seed_inner(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> Option<SeedJson> {
     // Peel `&<inner>` wrappers — they're common in seed expressions and
     // always transparent to classification.
     let mut cur = expr;
@@ -1055,9 +1105,9 @@ fn classify_seed_inner(expr: &Expr, field_names: &[String], ix_arg_names: &[Stri
 
     if let Expr::Lit(lit) = cur {
         match &lit.lit {
-            Lit::ByteStr(bs) => return static_seed(const_seed_value(&bs.value())),
-            Lit::Str(s) => return static_seed(const_seed_value(s.value().as_bytes())),
-            Lit::Byte(b) => return static_seed(const_seed_value(&[b.value()])),
+            Lit::ByteStr(bs) => return Some(static_seed(const_seed_value(&bs.value()))),
+            Lit::Str(s) => return Some(static_seed(const_seed_value(s.value().as_bytes()))),
+            Lit::Byte(b) => return Some(static_seed(const_seed_value(&[b.value()]))),
             _ => {}
         }
     }
@@ -1079,27 +1129,27 @@ fn classify_seed_inner(expr: &Expr, field_names: &[String], ix_arg_names: &[Stri
             break;
         }
         if let Some(b) = bytes {
-            return static_seed(const_seed_value(&b));
+            return Some(static_seed(const_seed_value(&b)));
         }
     }
 
     if let Some(root) = account_seed_root_ident(cur) {
         if field_names.contains(&root) {
-            return static_seed(account_seed_value(&root));
+            return Some(static_seed(account_seed_value(&root)));
         }
     }
 
     if let Some(root) = arg_seed_root_ident(cur) {
         if ix_arg_names.contains(&root) {
-            return static_seed(arg_seed_value(&root));
+            return Some(static_seed(arg_seed_value(&root)));
         }
     }
 
     if let Some(s) = string_as_bytes(cur) {
-        return static_seed(const_seed_value(s.value().as_bytes()));
+        return Some(static_seed(const_seed_value(s.value().as_bytes())));
     }
 
-    static_seed(json!({ "kind": "expr" }))
+    None
 }
 
 /// Return the bare root ident for simple, client-derivable seed expressions.
@@ -1139,6 +1189,44 @@ fn method_receiver<'a>(expr: &'a Expr, method: &str) -> Option<&'a Expr> {
         return None;
     };
     (mc.method == method && mc.args.is_empty()).then_some(&*mc.receiver)
+}
+
+fn expr_references_runtime_seed_inputs(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> bool {
+    struct RuntimeSeedInputVisitor<'a> {
+        names: Vec<&'a str>,
+        found: bool,
+    }
+
+    impl<'ast> Visit<'ast> for RuntimeSeedInputVisitor<'_> {
+        fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+            if self.found {
+                return;
+            }
+            if let Some(ident) = node.path.get_ident() {
+                let ident = ident.to_string();
+                if self.names.iter().any(|name| *name == ident) {
+                    self.found = true;
+                    return;
+                }
+            }
+            syn::visit::visit_expr_path(self, node);
+        }
+    }
+
+    let mut visitor = RuntimeSeedInputVisitor {
+        names: field_names
+            .iter()
+            .chain(ix_arg_names.iter())
+            .map(String::as_str)
+            .collect(),
+        found: false,
+    };
+    visitor.visit_expr(expr);
+    visitor.found
 }
 
 fn account_seed_root_ident(expr: &Expr) -> Option<String> {
@@ -1200,19 +1288,32 @@ fn arg_seed_value(path: &str) -> Value {
 /// Static seeds become string-literal pushes. The whole expression assembles a
 /// single `String` via `push_str`, avoiding intermediate `Vec` /
 /// `serde_json::Value` round-trips.
-pub fn pda_object_emission(seeds: &[SeedJson], program: Option<&SeedJson>) -> TokenStream2 {
-    let seed_pushes: Vec<TokenStream2> = seeds
-        .iter()
-        .enumerate()
-        .map(|(i, s)| {
-            let expr = s.clone().into_string_expr();
-            let comma = if i == 0 { "" } else { "," };
+pub fn pda_object_emission(seeds: &SeedListJson, program: Option<&SeedJson>) -> TokenStream2 {
+    let seeds_expr = match seeds {
+        SeedListJson::Listed(seeds) => {
+            let seed_pushes: Vec<TokenStream2> = seeds
+                .iter()
+                .enumerate()
+                .map(|(i, s)| {
+                    let expr = s.clone().into_string_expr();
+                    let comma = if i == 0 { "" } else { "," };
+                    quote! {
+                        __seeds.push_str(#comma);
+                        __seeds.push_str(&{ #expr });
+                    }
+                })
+                .collect();
             quote! {
-                __pda.push_str(#comma);
-                __pda.push_str(&{ #expr });
+                {
+                    let mut __seeds = anchor_lang_v2::__alloc::string::String::from("[");
+                    #(#seed_pushes)*
+                    __seeds.push(']');
+                    __seeds
+                }
             }
-        })
-        .collect();
+        }
+        SeedListJson::Runtime(ts) => quote! { { #ts } },
+    };
     let program_part = match program {
         None => quote! {},
         Some(p) => {
@@ -1225,9 +1326,8 @@ pub fn pda_object_emission(seeds: &[SeedJson], program: Option<&SeedJson>) -> To
     };
     quote! {
         {
-            let mut __pda = anchor_lang_v2::__alloc::string::String::from("{\"seeds\":[");
-            #(#seed_pushes)*
-            __pda.push(']');
+            let mut __pda = anchor_lang_v2::__alloc::string::String::from("{\"seeds\":");
+            __pda.push_str(&{ #seeds_expr });
             #program_part
             __pda.push('}');
             __pda

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -98,7 +98,7 @@ struct AssociatedTokenInit {
 /// mirrors the optional `seeds::program = expr` override.
 #[derive(Clone)]
 pub struct IdlPdaMeta {
-    pub seeds: Vec<crate::idl::SeedJson>,
+    pub seeds: crate::idl::SeedListJson,
     pub program: Option<crate::idl::SeedJson>,
 }
 
@@ -1821,26 +1821,17 @@ pub fn parse_field(
         None => (None, None, None),
     };
     let idl_docs = crate::idl::extract_doc_lines(&field.attrs);
-    let idl_pda = attrs.seeds.as_ref().map(|seeds_expr| {
-        let seed_entries: Vec<crate::idl::SeedJson> = if let Expr::Array(arr) = seeds_expr {
-            arr.elems
-                .iter()
-                .map(|s| crate::idl::classify_seed(s, field_names, ix_arg_names))
-                .collect()
-        } else {
-            // Non-array seed expr — surface as the placeholder `{"kind":"expr"}`
-            // shape. Static because it doesn't depend on the user's expr value.
-            vec![crate::idl::SeedJson::Static(
-                r#"{"kind":"expr"}"#.to_string(),
-            )]
+    let idl_pda = attrs.seeds.as_ref().and_then(|seeds_expr| {
+        let seeds = crate::idl::classify_seed_list(seeds_expr, field_names, ix_arg_names)?;
+        let program = match attrs.seeds_program.as_ref() {
+            Some(program_expr) => Some(crate::idl::classify_program_seed(
+                program_expr,
+                field_names,
+                ix_arg_names,
+            )?),
+            None => None,
         };
-        IdlPdaMeta {
-            seeds: seed_entries,
-            program: attrs
-                .seeds_program
-                .as_ref()
-                .map(|p| crate::idl::classify_program_seed(p, field_names, ix_arg_names)),
-        }
+        Some(IdlPdaMeta { seeds, program })
     });
     let idl_field_ty: Option<syn::Type> = {
         let base_ty = option_inner.unwrap_or(field_ty);

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -226,3 +226,21 @@ pub fn __idl_const_seed_json(value: impl AsRef<[u8]>) -> alloc::string::String {
     s.push_str("]}");
     s
 }
+
+pub fn __idl_const_seeds_json<I, B>(values: I) -> alloc::string::String
+where
+    I: IntoIterator<Item = B>,
+    B: AsRef<[u8]>,
+{
+    let mut s = alloc::string::String::from("[");
+    let mut first = true;
+    for value in values {
+        if !first {
+            s.push(',');
+        }
+        first = false;
+        s.push_str(&__idl_const_seed_json(value));
+    }
+    s.push(']');
+    s
+}

--- a/tests-v2/Cargo.toml
+++ b/tests-v2/Cargo.toml
@@ -48,7 +48,7 @@ ix-macro = { path = "programs/ix-macro" }
 min-ix-data-len = { path = "programs/min-ix-data-len" }
 optional-accounts = { path = "programs/optional-accounts" }
 program-interface = { path = "programs/program-interface", features = ["cpi"] }
-seeds = { path = "programs/seeds" }
+seeds = { path = "programs/seeds", features = ["idl-build"] }
 space-annotation = { path = "programs/space-annotation" }
 spl-test = { path = "programs/spl", features = ["cpi"] }
 spl-ata-test = { path = "programs/spl-ata", features = ["cpi"] }

--- a/tests-v2/tests/idl_metadata.rs
+++ b/tests-v2/tests/idl_metadata.rs
@@ -59,11 +59,38 @@ fn fn_seed_expression_emits_const_seed_bytes() {
 }
 
 #[test]
+fn mixed_supported_seeds_preserve_const_and_account_metadata() {
+    let items = parse_accounts(&seeds::CheckMixed::__idl_accounts());
+    let account = single_account(&items, 1);
+    let pda = account.pda.as_ref().expect("mixed seed account should include pda");
+
+    assert_eq!(pda.seeds.len(), 2);
+    match &pda.seeds[0] {
+        IdlSeed::Const(seed) => assert_eq!(seed.value, b"user"),
+        other => panic!("expected leading const seed metadata, got {other:?}"),
+    }
+    match &pda.seeds[1] {
+        IdlSeed::Account(seed) => assert_eq!(seed.path, "payer"),
+        other => panic!("expected trailing account seed metadata, got {other:?}"),
+    }
+}
+
+#[test]
 fn unsupported_runtime_seed_omits_pda_metadata() {
     let items = parse_accounts(&seeds::InitDirectAccountFieldSeed::__idl_accounts());
     let account = single_account(&items, 2);
     assert!(
         account.pda.is_none(),
         "runtime-only account-data seed should omit unsupported pda metadata"
+    );
+}
+
+#[test]
+fn wrapped_runtime_arg_seed_omits_pda_metadata() {
+    let items = parse_accounts(&seeds::InitWrappedArgSeed::__idl_accounts());
+    let account = single_account(&items, 1);
+    assert!(
+        account.pda.is_none(),
+        "wrapped runtime arg seed should omit unsupported pda metadata"
     );
 }

--- a/tests-v2/tests/idl_metadata.rs
+++ b/tests-v2/tests/idl_metadata.rs
@@ -31,3 +31,39 @@ fn marker_id_program_seed_emits_marker_address_bytes() {
         other => panic!("expected const program seed, got {other:?}"),
     }
 }
+
+#[test]
+fn const_seed_expression_emits_const_seed_bytes() {
+    let items = parse_accounts(&seeds::CheckConstSeeds::__idl_accounts());
+    let account = single_account(&items, 1);
+    let pda = account.pda.as_ref().expect("const seed account should include pda");
+
+    assert_eq!(pda.seeds.len(), 1);
+    match &pda.seeds[0] {
+        IdlSeed::Const(seed) => assert_eq!(seed.value, b"data"),
+        other => panic!("expected const seed metadata, got {other:?}"),
+    }
+}
+
+#[test]
+fn fn_seed_expression_emits_const_seed_bytes() {
+    let items = parse_accounts(&seeds::CheckFnSeeds::__idl_accounts());
+    let account = single_account(&items, 1);
+    let pda = account.pda.as_ref().expect("function seed account should include pda");
+
+    assert_eq!(pda.seeds.len(), 1);
+    match &pda.seeds[0] {
+        IdlSeed::Const(seed) => assert_eq!(seed.value, b"data"),
+        other => panic!("expected const seed metadata, got {other:?}"),
+    }
+}
+
+#[test]
+fn unsupported_runtime_seed_omits_pda_metadata() {
+    let items = parse_accounts(&seeds::InitDirectAccountFieldSeed::__idl_accounts());
+    let account = single_account(&items, 2);
+    assert!(
+        account.pda.is_none(),
+        "runtime-only account-data seed should omit unsupported pda metadata"
+    );
+}


### PR DESCRIPTION
Finding
IDL seed lowering emitted unsupported `{"kind":"expr"}` variants, so valid constant-path seeds and runtime-only expressions could produce invalid PDA seed IDL.

Fix
This PR lowers constant-only expressions to supported const seeds and omits unsupported runtime-only seed shapes from emitted IDL. Added regression tests for constant and omitted unsupported seeds.