### PR TITLE
Fix/v2 declare program idl deps

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2342,11 +2342,11 @@ fn parse_program_config_tokens(attr: TokenStream2) -> syn::Result<ProgramConfig>
 }
 
 fn impl_declare_program(name: &Ident) -> syn::Result<TokenStream2> {
-    let idl = read_declare_program_idl(name)?;
-    gen_declared_program(name, &idl)
+    let (idl, idl_path) = read_declare_program_idl(name)?;
+    gen_declared_program(name, &idl, &idl_path)
 }
 
-fn read_declare_program_idl(name: &Ident) -> syn::Result<serde_json::Value> {
+fn read_declare_program_idl(name: &Ident) -> syn::Result<(serde_json::Value, std::path::PathBuf)> {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").map_err(|err| {
         syn::Error::new(
             name.span(),
@@ -2368,30 +2368,46 @@ fn read_declare_program_idl(name: &Ident) -> syn::Result<serde_json::Value> {
             format!("failed to read IDL `{}`: {err}", idl_path.display()),
         )
     })?;
+    let tracked_idl_path = idl_path.canonicalize().map_err(|err| {
+        syn::Error::new(
+            name.span(),
+            format!(
+                "failed to canonicalize IDL path `{}` for dependency tracking: {err}",
+                idl_path.display()
+            ),
+        )
+    })?;
     let idl = anchor_lang_idl::convert::convert_idl(&idl).map_err(|err| {
         syn::Error::new(
             name.span(),
             format!("failed to parse IDL `{}`: {err}", idl_path.display()),
         )
     })?;
-    serde_json::to_value(idl).map_err(|err| {
-        syn::Error::new(
-            name.span(),
-            format!(
-                "failed to normalize IDL `{}` after parsing: {err}",
-                idl_path.display()
-            ),
-        )
-    })
+    serde_json::to_value(idl)
+        .map(|idl| (idl, tracked_idl_path))
+        .map_err(|err| {
+            syn::Error::new(
+                name.span(),
+                format!(
+                    "failed to normalize IDL `{}` after parsing: {err}",
+                    idl_path.display()
+                ),
+            )
+        })
 }
 
-fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<TokenStream2> {
+fn gen_declared_program(
+    name: &Ident,
+    idl: &serde_json::Value,
+    idl_path: &std::path::Path,
+) -> syn::Result<TokenStream2> {
     let address = idl
         .get("address")
         .or_else(|| idl.pointer("/metadata/address"))
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| syn::Error::new(name.span(), "IDL is missing program address"))?;
     let address_lit = syn::LitStr::new(address, name.span());
+    let idl_path_lit = syn::LitStr::new(&idl_path.display().to_string(), name.span());
     let instructions = idl
         .get("instructions")
         .and_then(serde_json::Value::as_array)
@@ -2488,6 +2504,9 @@ fn gen_declared_program(name: &Ident, idl: &serde_json::Value) -> syn::Result<To
     Ok(quote! {
         pub mod #name {
             use super::*;
+
+            #[allow(dead_code)]
+            const __ANCHOR_DECLARE_PROGRAM_IDL_BYTES: &[u8] = include_bytes!(#idl_path_lit);
 
             pub const ID: anchor_lang_v2::Address =
                 anchor_lang_v2::address!(#address_lit);

--- a/tests-v2/tests/declare_program_idl_deps.rs
+++ b/tests-v2/tests/declare_program_idl_deps.rs
@@ -1,0 +1,118 @@
+use std::{fs, path::PathBuf, process::Command};
+
+fn write_idl(path: &std::path::Path, constant_name: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"{{
+  "address": "11111111111111111111111111111111",
+  "metadata": {{ "name": "bad", "version": "0.1.0", "spec": "0.1.0" }},
+  "instructions": [],
+  "constants": [
+    {{
+      "name": "{constant_name}",
+      "type": "u64",
+      "value": "1"
+    }}
+  ]
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+fn run_cargo_check(crate_dir: &std::path::Path, target_dir: &std::path::Path) -> std::process::Output {
+    Command::new("cargo")
+        .args(["check", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", target_dir)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo check for {}: {err}", crate_dir.display()))
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and rewrites temporary workspaces; covered by normal cargo test"
+)]
+fn declare_program_tracks_idl_file_dependencies() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir
+        .join("target/compile-cases")
+        .join("declare_program_idl_dependency_tracking");
+    let src_dir = crate_dir.join("src");
+    let idl_dir = crate_dir.join("idls");
+    let target_dir = crate_dir.join("target");
+    let anchor_lang_v2 = manifest_dir
+        .parent()
+        .expect("tests-v2 should live under the workspace root")
+        .join("lang-v2");
+
+    if crate_dir.exists() {
+        fs::remove_dir_all(&crate_dir).unwrap();
+    }
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&idl_dir).unwrap();
+
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "declare_program_idl_dependency_tracking"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+wincode = {{ version = "0.5", features = ["derive"] }}
+
+[workspace]
+"#,
+            anchor_lang_v2.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_program!(bad);
+
+pub fn read_old_const() -> u64 {
+    bad::constants::OLD_CONST
+}
+"#,
+    )
+    .unwrap();
+
+    let idl_path = idl_dir.join("bad.json");
+    write_idl(&idl_path, "OLD_CONST");
+
+    let first = run_cargo_check(&crate_dir, &target_dir);
+    assert!(
+        first.status.success(),
+        "initial build should succeed\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr),
+    );
+
+    write_idl(&idl_path, "NEW_CONST");
+
+    let second = run_cargo_check(&crate_dir, &target_dir);
+    assert!(
+        !second.status.success(),
+        "editing only the imported IDL should invalidate declare_program! output"
+    );
+
+    let rendered = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr),
+    );
+    assert!(
+        rendered.contains("OLD_CONST"),
+        "rebuild output should mention the stale constant reference\n\n{rendered}"
+    );
+}

--- a/tests-v2/tests/declare_program_idl_deps.rs
+++ b/tests-v2/tests/declare_program_idl_deps.rs
@@ -21,7 +21,28 @@ fn write_idl(path: &std::path::Path, constant_name: &str) {
     .unwrap();
 }
 
-fn run_cargo_check(crate_dir: &std::path::Path, target_dir: &std::path::Path) -> std::process::Output {
+fn write_source(path: &std::path::Path, constant_name: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"
+use anchor_lang_v2::prelude::*;
+
+declare_program!(bad);
+
+pub fn read_declared_const() -> u64 {{
+    bad::constants::{constant_name}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn run_cargo_check(
+    crate_dir: &std::path::Path,
+    target_dir: &std::path::Path,
+) -> std::process::Output {
     Command::new("cargo")
         .args(["check", "--offline", "--manifest-path"])
         .arg(crate_dir.join("Cargo.toml"))
@@ -30,16 +51,9 @@ fn run_cargo_check(crate_dir: &std::path::Path, target_dir: &std::path::Path) ->
         .unwrap_or_else(|err| panic!("failed to run cargo check for {}: {err}", crate_dir.display()))
 }
 
-#[test]
-#[cfg_attr(
-    miri,
-    ignore = "spawns cargo and rewrites temporary workspaces; covered by normal cargo test"
-)]
-fn declare_program_tracks_idl_file_dependencies() {
+fn setup_case(case_name: &str, constant_name: &str) -> (PathBuf, PathBuf, PathBuf) {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let crate_dir = manifest_dir
-        .join("target/compile-cases")
-        .join("declare_program_idl_dependency_tracking");
+    let crate_dir = manifest_dir.join("target/compile-cases").join(case_name);
     let src_dir = crate_dir.join("src");
     let idl_dir = crate_dir.join("idls");
     let target_dir = crate_dir.join("target");
@@ -58,7 +72,7 @@ fn declare_program_tracks_idl_file_dependencies() {
         crate_dir.join("Cargo.toml"),
         format!(
             r#"[package]
-name = "declare_program_idl_dependency_tracking"
+name = "{case_name}"
 version = "0.1.0"
 edition = "2021"
 publish = false
@@ -73,22 +87,47 @@ wincode = {{ version = "0.5", features = ["derive"] }}
         ),
     )
     .unwrap();
-    fs::write(
-        src_dir.join("lib.rs"),
-        r#"
-use anchor_lang_v2::prelude::*;
-
-declare_program!(bad);
-
-pub fn read_old_const() -> u64 {
-    bad::constants::OLD_CONST
-}
-"#,
-    )
-    .unwrap();
+    write_source(&src_dir.join("lib.rs"), constant_name);
 
     let idl_path = idl_dir.join("bad.json");
-    write_idl(&idl_path, "OLD_CONST");
+    write_idl(&idl_path, constant_name);
+    (crate_dir, idl_path, target_dir)
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and rewrites temporary workspaces; covered by normal cargo test"
+)]
+fn declare_program_rechecks_cleanly_when_idl_is_unchanged() {
+    let (crate_dir, _idl_path, target_dir) =
+        setup_case("declare_program_idl_dependency_stable_recheck", "OLD_CONST");
+
+    let first = run_cargo_check(&crate_dir, &target_dir);
+    assert!(
+        first.status.success(),
+        "initial build should succeed\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr),
+    );
+
+    let second = run_cargo_check(&crate_dir, &target_dir);
+    assert!(
+        second.status.success(),
+        "rechecking without IDL changes should stay green\n\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr),
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and rewrites temporary workspaces; covered by normal cargo test"
+)]
+fn declare_program_tracks_idl_file_dependencies() {
+    let (crate_dir, idl_path, target_dir) =
+        setup_case("declare_program_idl_dependency_tracking", "OLD_CONST");
 
     let first = run_cargo_check(&crate_dir, &target_dir);
     assert!(


### PR DESCRIPTION
Finding
`declare_program!` read imported IDL files from disk without tracking them as compiler dependencies, so incremental builds could reuse stale generated code.

Fix
This PR uses `include_bytes!` to track imported IDL files as compiler dependencies and invalidate stale incremental builds after JSON-only changes. Added regression tests for changed and unchanged IDL rebuilds.