### PR TITLE
Resolve and install project toolchains in AVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,6 @@ name = "avm"
 version = "1.1.2"
 dependencies = [
  "anyhow",
- "cargo_metadata",
  "cargo_toml",
  "cfg-if",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "clap 4.6.1",
  "clap_complete",
  "dirs",
+ "fs2",
  "reqwest 0.13.4",
  "semver",
  "serde",
@@ -2125,6 +2126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.26"
 dirs = "4.0.0"
+fs2 = "0.4.3"
 
 # FIXME: `sigstore-verify` uses reqwest 0.13 whereas the workspace uses 0.12
 # to match the Solana crates. Use 0.13 here to avoid bundling two copies

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.32"
-cargo_metadata = "0.23.1"
 cargo_toml.workspace = true
 cfg-if = "1.0.0"
 chrono = "0.4"

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -35,7 +35,5 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.9"
 sigstore-verify = { version = "0.11.0", default-features = false }
-toml = "0.7.6"
-
-[dev-dependencies]
 tempfile = "3.3.0"
+toml = "0.7.6"

--- a/avm/idl-nightly-map.toml
+++ b/avm/idl-nightly-map.toml
@@ -1,0 +1,21 @@
+# Rust nightly compatibility for proc-macro2's semver-exempt API.
+#
+# Anchor's IDL build enables `procmacro2_semver_exempt`, whose API tracks Rust
+# nightly rather than proc-macro2's normal semver contract. AVM reads the
+# project's locked proc-macro2 version and chooses the entry with the largest
+# `proc_macro2` floor that is <= that version.
+#
+# `fallback` is used when the project has no Cargo.lock or does not lock
+# proc-macro2. Keep it compatible with the newest proc-macro2 release.
+
+fallback = "nightly-2026-06-10"
+
+[[entries]]
+proc_macro2 = "1.0.0"
+nightly = "nightly-2025-04-15"
+
+# proc-macro2 1.0.95 updated its semver-exempt API for the proc_macro changes
+# in nightly-2025-04-16.
+[[entries]]
+proc_macro2 = "1.0.95"
+nightly = "nightly-2026-06-10"

--- a/avm/platform-tools-map.toml
+++ b/avm/platform-tools-map.toml
@@ -16,6 +16,10 @@
 # release. Source of truth: `src/version` in anza-xyz/rust on the
 # `solana-tools-<platform_tools>` branch.
 #
+# `cargo_lock_v4` records whether the bundled Cargo rejects lockfile v4
+# (`unsupported`), accepts it only with `-Znext-lockfile-bump` (`opt-in`), or
+# accepts it without an unstable opt-in (`native`).
+#
 # `fallback` is used when the project does not pin a Solana version at all.
 # Keep it equal to the platform-tools version of the newest entry below.
 
@@ -25,63 +29,76 @@ fallback = "v1.54"
 solana = "1.17.25"
 platform_tools = "v1.37"
 rustc = "1.68.0"
+cargo_lock_v4 = "unsupported"
 
 [[entries]]
 solana = "1.18.0"
 platform_tools = "v1.39"
 rustc = "1.72.0"
+cargo_lock_v4 = "opt-in"
 
 [[entries]]
 solana = "1.18.8"
 platform_tools = "v1.41"
 rustc = "1.75.0"
+cargo_lock_v4 = "opt-in"
 
 [[entries]]
 solana = "2.0.5"
 platform_tools = "v1.42"
 rustc = "1.75.0"
+cargo_lock_v4 = "opt-in"
 
 [[entries]]
 solana = "2.1.0"
 platform_tools = "v1.43"
 rustc = "1.79.0"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "2.2.1"
 platform_tools = "v1.44"
 rustc = "1.79.0"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "2.2.3"
 platform_tools = "v1.45"
 rustc = "1.79.0"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "2.2.8"
 platform_tools = "v1.46"
 rustc = "1.79.0"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "2.2.11"
 platform_tools = "v1.47"
 rustc = "1.84.1"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "2.2.15"
 platform_tools = "v1.48"
 rustc = "1.84.1"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "3.0.0"
 platform_tools = "v1.51"
 rustc = "1.84.1"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "3.1.1"
 platform_tools = "v1.52"
 rustc = "1.89.0"
+cargo_lock_v4 = "native"
 
 [[entries]]
 solana = "4.0.0"
 platform_tools = "v1.54"
 rustc = "1.89.0"
+cargo_lock_v4 = "native"

--- a/avm/platform-tools-map.toml
+++ b/avm/platform-tools-map.toml
@@ -3,7 +3,7 @@
 # Source of truth: `DEFAULT_PLATFORM_TOOLS_VERSION` (or its predecessor, the
 # `platform_tools_version = String::from("vX.Y")` literal) in cargo-build-sbf:
 #
-#   1.18.x : solana-labs/solana, sdk/cargo-build-sbf/src/main.rs
+#   1.17.x – 1.18.x : solana-labs/solana, sdk/cargo-build-sbf/src/main.rs
 #   2.0.x – 2.3.x : anza-xyz/agave, sdk/cargo-build-sbf/src/main.rs
 #                   (then platform-tools-sdk/cargo-build-sbf/src/main.rs from 2.2)
 #   3.0.x+ : anza-xyz/agave, platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -20,6 +20,11 @@
 # Keep it equal to the platform-tools version of the newest entry below.
 
 fallback = "v1.54"
+
+[[entries]]
+solana = "1.17.25"
+platform_tools = "v1.37"
+rustc = "1.68.0"
 
 [[entries]]
 solana = "1.18.0"

--- a/avm/src/idl_nightly.rs
+++ b/avm/src/idl_nightly.rs
@@ -1,0 +1,350 @@
+//! Rust nightly resolution for Anchor IDL builds.
+//!
+//! Anchor enables proc-macro2's semver-exempt API while compiling IDLs. That
+//! API follows Rust nightly and can change independently of proc-macro2's
+//! stable API, so the compatible nightly is resolved from the proc-macro2
+//! version in the project's Cargo.lock using `../idl-nightly-map.toml`.
+//! Projects without a usable lockfile receive the map's current fallback.
+
+use {
+    anyhow::{anyhow, bail, Context, Result},
+    semver::Version,
+    serde::Deserialize,
+    std::{
+        collections::BTreeMap,
+        fs,
+        path::{Path, PathBuf},
+        sync::LazyLock,
+    },
+};
+
+const IDL_NIGHTLY_MAP_TOML: &str = include_str!("../idl-nightly-map.toml");
+
+#[derive(Debug, Deserialize)]
+struct IdlNightlyMap {
+    fallback: String,
+    entries: Vec<MapEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MapEntry {
+    proc_macro2: String,
+    nightly: String,
+}
+
+#[derive(Debug)]
+struct ParsedMap {
+    fallback: String,
+    entries: Vec<ParsedMapEntry>,
+}
+
+#[derive(Debug)]
+struct ParsedMapEntry {
+    proc_macro2: Version,
+    nightly: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoLock {
+    #[serde(default)]
+    package: Vec<LockedPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LockedPackage {
+    name: String,
+    version: String,
+}
+
+static MAP: LazyLock<ParsedMap> = LazyLock::new(|| {
+    let raw: IdlNightlyMap =
+        toml::from_str(IDL_NIGHTLY_MAP_TOML).expect("Built-in IDL nightly map must parse");
+    assert_valid_nightly(&raw.fallback);
+
+    let mut entries = raw
+        .entries
+        .into_iter()
+        .map(|entry| {
+            let proc_macro2 = Version::parse(&entry.proc_macro2).unwrap_or_else(|err| {
+                panic!(
+                    "Invalid proc-macro2 version `{}` in IDL nightly map: {err}",
+                    entry.proc_macro2
+                )
+            });
+            assert_valid_nightly(&entry.nightly);
+            ParsedMapEntry {
+                proc_macro2,
+                nightly: entry.nightly,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let was_sorted = entries
+        .windows(2)
+        .all(|window| window[0].proc_macro2 < window[1].proc_macro2);
+    assert!(
+        was_sorted,
+        "idl-nightly-map.toml entries must be sorted by proc-macro2 version"
+    );
+    let _ = was_sorted;
+    entries.sort_by(|a, b| a.proc_macro2.cmp(&b.proc_macro2));
+
+    ParsedMap {
+        fallback: raw.fallback,
+        entries,
+    }
+});
+
+fn assert_valid_nightly(toolchain: &str) {
+    let date = toolchain.strip_prefix("nightly-").unwrap_or_else(|| {
+        panic!("Invalid IDL nightly `{toolchain}`: expected nightly-YYYY-MM-DD")
+    });
+    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .unwrap_or_else(|err| panic!("Invalid IDL nightly `{toolchain}`: {err}"));
+}
+
+#[derive(Debug, Clone)]
+pub struct IdlNightlyResolution {
+    pub version: String,
+    pub source: IdlNightlySource,
+}
+
+#[derive(Debug, Clone)]
+pub enum IdlNightlySource {
+    CargoLock {
+        path: PathBuf,
+        proc_macro2_versions: Vec<Version>,
+    },
+    Fallback,
+}
+
+impl IdlNightlySource {
+    pub fn describe(&self) -> String {
+        match self {
+            Self::CargoLock {
+                path,
+                proc_macro2_versions,
+            } => format!(
+                "proc-macro2 {} in {}",
+                proc_macro2_versions
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                path.display()
+            ),
+            Self::Fallback => "IDL nightly fallback".to_string(),
+        }
+    }
+}
+
+/// Resolve the Rust nightly for IDL generation from the nearest Cargo.lock.
+pub fn resolve_idl_nightly(start: &Path) -> Result<IdlNightlyResolution> {
+    let Some(lockfile) = find_ancestor_file(start, "Cargo.lock") else {
+        return Ok(fallback_resolution());
+    };
+    let versions = locked_proc_macro2_versions(&lockfile)?;
+    if versions.is_empty() {
+        return Ok(fallback_resolution());
+    }
+
+    let mut resolved = BTreeMap::<String, Vec<Version>>::new();
+    for version in &versions {
+        let nightly = lookup_nightly(version).ok_or_else(|| {
+            anyhow!(
+                "No IDL nightly mapping exists for proc-macro2 {version} from {}",
+                lockfile.display()
+            )
+        })?;
+        resolved.entry(nightly).or_default().push(version.clone());
+    }
+
+    if resolved.len() != 1 {
+        let details = resolved
+            .iter()
+            .map(|(nightly, versions)| {
+                format!(
+                    "{nightly} for proc-macro2 {}",
+                    versions
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        bail!(
+            "No single IDL nightly supports every proc-macro2 version in {}: {details}",
+            lockfile.display()
+        );
+    }
+
+    let version = resolved.into_keys().next().unwrap();
+    Ok(IdlNightlyResolution {
+        version,
+        source: IdlNightlySource::CargoLock {
+            path: lockfile,
+            proc_macro2_versions: versions,
+        },
+    })
+}
+
+fn fallback_resolution() -> IdlNightlyResolution {
+    IdlNightlyResolution {
+        version: MAP.fallback.clone(),
+        source: IdlNightlySource::Fallback,
+    }
+}
+
+fn lookup_nightly(proc_macro2: &Version) -> Option<String> {
+    MAP.entries
+        .iter()
+        .rposition(|entry| entry.proc_macro2 <= *proc_macro2)
+        .map(|idx| MAP.entries[idx].nightly.clone())
+}
+
+fn locked_proc_macro2_versions(lockfile: &Path) -> Result<Vec<Version>> {
+    let text = fs::read_to_string(lockfile)
+        .with_context(|| format!("Reading Cargo lockfile {}", lockfile.display()))?;
+    let lock: CargoLock = toml::from_str(&text)
+        .with_context(|| format!("Parsing Cargo lockfile {}", lockfile.display()))?;
+    let mut versions = lock
+        .package
+        .into_iter()
+        .filter(|package| package.name == "proc-macro2")
+        .map(|package| {
+            Version::parse(&package.version).with_context(|| {
+                format!(
+                    "Parsing proc-macro2 version `{}` in {}",
+                    package.version,
+                    lockfile.display()
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    versions.sort();
+    versions.dedup();
+    Ok(versions)
+}
+
+fn find_ancestor_file(start: &Path, name: &str) -> Option<PathBuf> {
+    let mut dir = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start.to_path_buf()
+    };
+    loop {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// Validate the embedded map without initializing its global cache.
+pub fn validate_embedded_map() -> Result<()> {
+    let raw: IdlNightlyMap =
+        toml::from_str(IDL_NIGHTLY_MAP_TOML).context("Parsing embedded IDL nightly map")?;
+    if raw.entries.is_empty() {
+        bail!("idl-nightly-map.toml must have at least one entry");
+    }
+    validate_nightly(&raw.fallback)?;
+
+    let entries = raw
+        .entries
+        .iter()
+        .map(|entry| {
+            validate_nightly(&entry.nightly)?;
+            Version::parse(&entry.proc_macro2).with_context(|| {
+                format!(
+                    "Invalid proc-macro2 version `{}` in IDL nightly map",
+                    entry.proc_macro2
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if !entries.windows(2).all(|window| window[0] < window[1]) {
+        bail!("idl-nightly-map.toml entries must be sorted by proc-macro2 version");
+    }
+    Ok(())
+}
+
+fn validate_nightly(toolchain: &str) -> Result<()> {
+    let date = toolchain
+        .strip_prefix("nightly-")
+        .ok_or_else(|| anyhow!("Invalid IDL nightly `{toolchain}`: expected nightly-YYYY-MM-DD"))?;
+    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .with_context(|| format!("Invalid IDL nightly `{toolchain}`"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::fs, tempfile::TempDir};
+
+    fn v(version: &str) -> Version {
+        Version::parse(version).unwrap()
+    }
+
+    fn write_lock(dir: &Path, versions: &[&str]) {
+        let packages = versions
+            .iter()
+            .map(|version| {
+                format!("[[package]]\nname = \"proc-macro2\"\nversion = \"{version}\"\n")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(dir.join("Cargo.lock"), format!("version = 4\n\n{packages}"))
+            .expect("write lockfile");
+    }
+
+    #[test]
+    fn embedded_map_parses_and_is_sorted() {
+        validate_embedded_map().unwrap();
+        assert!(MAP
+            .entries
+            .windows(2)
+            .all(|window| window[0].proc_macro2 < window[1].proc_macro2));
+    }
+
+    #[test]
+    fn lookup_uses_proc_macro2_release_boundary() {
+        assert_eq!(lookup_nightly(&v("1.0.94")).unwrap(), "nightly-2025-04-15");
+        assert_eq!(lookup_nightly(&v("1.0.95")).unwrap(), "nightly-2026-06-10");
+        assert_eq!(lookup_nightly(&v("1.0.107")).unwrap(), "nightly-2026-06-10");
+    }
+
+    #[test]
+    fn resolves_from_locked_proc_macro2() {
+        let dir = TempDir::new().unwrap();
+        write_lock(dir.path(), &["1.0.86"]);
+        let resolution = resolve_idl_nightly(dir.path()).unwrap();
+        assert_eq!(resolution.version, "nightly-2025-04-15");
+        assert!(matches!(
+            resolution.source,
+            IdlNightlySource::CargoLock { .. }
+        ));
+    }
+
+    #[test]
+    fn falls_back_without_locked_proc_macro2() {
+        let dir = TempDir::new().unwrap();
+        let resolution = resolve_idl_nightly(dir.path()).unwrap();
+        assert_eq!(resolution.version, "nightly-2026-06-10");
+        assert!(matches!(resolution.source, IdlNightlySource::Fallback));
+    }
+
+    #[test]
+    fn mixed_incompatible_proc_macro2_versions_error() {
+        let dir = TempDir::new().unwrap();
+        write_lock(dir.path(), &["1.0.94", "1.0.95"]);
+        let error = resolve_idl_nightly(dir.path()).unwrap_err().to_string();
+        assert!(error.contains("No single IDL nightly"), "{error}");
+        assert!(error.contains("nightly-2025-04-15"), "{error}");
+        assert!(error.contains("nightly-2026-06-10"), "{error}");
+    }
+}

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -1,4 +1,5 @@
 mod attestation;
+pub mod idl_nightly;
 pub mod platform_tools;
 pub mod resolve;
 pub mod solana;

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -4,11 +4,16 @@ use {
     clap::{CommandFactory, Parser, Subcommand},
     semver::Version,
     std::{
-        ffi::OsStr,
+        env,
+        ffi::{OsStr, OsString},
+        fs,
         io::IsTerminal,
         path::{Path, PathBuf},
+        process::Command,
     },
 };
+
+const REAL_CARGO_ENV: &str = "AVM_REAL_CARGO";
 
 #[derive(Parser)]
 #[clap(name = "avm", about = "Anchor version manager", version)]
@@ -355,17 +360,26 @@ fn anchor_proxy() -> Result<()> {
     spawn_anchor(binary_path, args)
 }
 
+/// Spawn the resolved Anchor CLI with a temporary Cargo proxy first on `PATH`.
+///
+/// The proxy lives until the child exits and receives the absolute path to the
+/// real Cargo executable through [`REAL_CARGO_ENV`], avoiding recursive proxy
+/// invocation when it delegates the command.
 fn spawn_anchor(binary_path: PathBuf, args: Vec<String>) -> Result<()> {
-    let exit = std::process::Command::new(binary_path)
+    let cargo_proxy = CargoProxy::new()?;
+    let path = env::join_paths(
+        [
+            cargo_proxy.dir.path().to_path_buf(),
+            avm::get_bin_dir_path(),
+        ]
+        .into_iter()
+        .chain(env::split_paths(&env::var_os("PATH").unwrap_or_default())),
+    )?;
+
+    let exit = Command::new(binary_path)
         .args(args)
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                avm::get_bin_dir_path().to_string_lossy(),
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        )
+        .env("PATH", path)
+        .env(REAL_CARGO_ENV, &cargo_proxy.real_cargo)
         // Signal to the spawned anchor-cli that AVM has already resolved the
         // toolchain version, so it must not re-exec via `[toolchain] anchor_version`.
         .env("AVM_ACTIVE", "1")
@@ -376,6 +390,117 @@ fn spawn_anchor(binary_path: PathBuf, args: Vec<String>) -> Result<()> {
 
     if !exit.status.success() {
         std::process::exit(exit.status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+/// Owns the temporary `cargo` entry point and the Cargo executable it delegates to.
+///
+/// The entry point is the current AVM executable under Cargo's filename, making
+/// AVM a multi-call binary without installing another executable permanently.
+struct CargoProxy {
+    dir: tempfile::TempDir,
+    real_cargo: PathBuf,
+}
+
+impl CargoProxy {
+    fn new() -> Result<Self> {
+        let current_exe = env::current_exe().context("resolving AVM executable")?;
+        let real_cargo = find_real_cargo(&current_exe)?;
+        let dir = tempfile::tempdir().context("creating temporary Cargo proxy directory")?;
+        let proxy = dir
+            .path()
+            .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&current_exe, &proxy)
+            .context("creating temporary Cargo proxy")?;
+        #[cfg(windows)]
+        fs::copy(&current_exe, &proxy).context("creating temporary Cargo proxy")?;
+
+        Ok(Self { dir, real_cargo })
+    }
+}
+
+/// Find Cargo on the original `PATH`, skipping entries that resolve back to AVM.
+fn find_real_cargo(current_exe: &Path) -> Result<PathBuf> {
+    let cargo_name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+    let current_exe = fs::canonicalize(current_exe).context("canonicalizing AVM executable")?;
+
+    env::split_paths(&env::var_os("PATH").unwrap_or_default())
+        .map(|dir| dir.join(cargo_name))
+        .find(|candidate| {
+            candidate.is_file()
+                && fs::canonicalize(candidate)
+                    .map(|candidate| candidate != current_exe)
+                    .unwrap_or(false)
+        })
+        .ok_or_else(|| anyhow!("Could not find `cargo` on PATH"))
+}
+
+/// Handle an AVM invocation whose executable name is `cargo`.
+///
+/// Only an unversioned `+nightly` selector is pinned. Every other invocation,
+/// including `cargo build-sbf` and explicitly dated toolchains, is forwarded
+/// unchanged to the real Cargo executable.
+fn cargo_proxy() -> Result<()> {
+    let real_cargo =
+        env::var_os(REAL_CARGO_ENV).ok_or_else(|| anyhow!("{REAL_CARGO_ENV} is not set"))?;
+    let mut args = env::args_os().skip(1).collect::<Vec<_>>();
+
+    if args
+        .first()
+        .is_some_and(|toolchain| toolchain == "+nightly")
+    {
+        let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let resolution = avm::idl_nightly::resolve_idl_nightly(&cwd)?;
+        pin_idl_nightly(&mut args, &resolution.version);
+        ensure_idl_nightly_installed(&resolution.version)?;
+    }
+
+    let status = Command::new(real_cargo)
+        .args(args)
+        .status()
+        .context("running Cargo through AVM proxy")?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+/// Rewrite `+nightly` to the pinned IDL nightly and report whether it changed.
+fn pin_idl_nightly(args: &mut [OsString], idl_nightly: &str) -> bool {
+    let Some(toolchain) = args.first_mut() else {
+        return false;
+    };
+    if toolchain != "+nightly" {
+        return false;
+    }
+
+    *toolchain = format!("+{idl_nightly}").into();
+    true
+}
+
+fn ensure_idl_nightly_installed(idl_nightly: &str) -> Result<()> {
+    let output = Command::new("rustup")
+        .args(["toolchain", "list"])
+        .output()
+        .context("listing installed Rust toolchains")?;
+    let installed = String::from_utf8(output.stdout)?
+        .lines()
+        .any(|line| line.starts_with(idl_nightly));
+    if installed {
+        return Ok(());
+    }
+
+    let status = Command::new("rustup")
+        .args(["toolchain", "install", idl_nightly, "--profile", "minimal"])
+        .status()
+        .context("installing pinned IDL Rust toolchain")?;
+    if !status.success() {
+        anyhow::bail!("Failed to install Rust toolchain {idl_nightly}");
     }
 
     Ok(())
@@ -448,7 +573,7 @@ fn ensure_resolved_binary(resolution: &Resolution) -> Result<PathBuf> {
 }
 
 fn main() -> Result<()> {
-    // If the binary is named `anchor` then run the proxy.
+    // If the binary is named `anchor` or `cargo` then run the relevant proxy.
     if let Some(stem) = std::env::args()
         .next()
         .as_ref()
@@ -456,6 +581,9 @@ fn main() -> Result<()> {
     {
         if stem == "anchor" {
             return anchor_proxy();
+        }
+        if stem == "cargo" {
+            return cargo_proxy();
         }
     }
 
@@ -469,6 +597,21 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use {super::*, avm::InstallTarget};
+
+    #[test]
+    fn pins_only_unversioned_nightly_cargo_invocations() {
+        let mut nightly = vec![OsString::from("+nightly"), OsString::from("test")];
+        assert!(pin_idl_nightly(&mut nightly, "nightly-2025-04-15"));
+        assert_eq!(nightly[0], "+nightly-2025-04-15");
+
+        let mut build_sbf = vec![OsString::from("build-sbf")];
+        assert!(!pin_idl_nightly(&mut build_sbf, "nightly-2025-04-15"));
+        assert_eq!(build_sbf[0], "build-sbf");
+
+        let mut dated = vec![OsString::from("+nightly-2026-07-01")];
+        assert!(!pin_idl_nightly(&mut dated, "nightly-2025-04-15"));
+        assert_eq!(dated[0], "+nightly-2026-07-01");
+    }
 
     // --- is_pre_release ---
 

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -15,6 +15,7 @@ use {
 };
 
 const REAL_CARGO_ENV: &str = "AVM_REAL_CARGO";
+const CARGO_NEXT_LOCKFILE_BUMP_ENV: &str = "CARGO_UNSTABLE_NEXT_LOCKFILE_BUMP";
 
 #[derive(Parser)]
 #[clap(name = "avm", about = "Anchor version manager", version)]
@@ -344,7 +345,7 @@ fn anchor_proxy() -> Result<()> {
     let args = std::env::args().skip(1).collect::<Vec<String>>();
 
     if avm::ensure_nightly_active()?.is_some() {
-        return spawn_anchor(avm::nightly_anchor_binary_path(), args);
+        return spawn_anchor(avm::nightly_anchor_binary_path(), args, false);
     }
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
@@ -357,11 +358,17 @@ fn anchor_proxy() -> Result<()> {
 
     let binary_path = ensure_resolved_binary(&resolution)?;
     prepend_solana_bin_to_path()?;
-    let _platform_tools_guard = ensure_resolved_solana(&cwd, &resolution)?
+    let platform_tools_guard = ensure_resolved_solana(&cwd, &resolution)?
         .map(|solana| ensure_resolved_platform_tools(&cwd, &solana))
         .transpose()?;
 
-    spawn_anchor(binary_path, args)
+    spawn_anchor(
+        binary_path,
+        args,
+        platform_tools_guard
+            .as_ref()
+            .is_some_and(|guard| guard.enable_next_lockfile_bump),
+    )
 }
 
 /// Spawn the resolved Anchor CLI with a temporary Cargo proxy first on `PATH`.
@@ -369,7 +376,11 @@ fn anchor_proxy() -> Result<()> {
 /// The proxy lives until the child exits and receives the absolute path to the
 /// real Cargo executable through [`REAL_CARGO_ENV`], avoiding recursive proxy
 /// invocation when it delegates the command.
-fn spawn_anchor(binary_path: PathBuf, args: Vec<String>) -> Result<()> {
+fn spawn_anchor(
+    binary_path: PathBuf,
+    args: Vec<String>,
+    enable_next_lockfile_bump: bool,
+) -> Result<()> {
     let cargo_proxy = CargoProxy::new()?;
     let path = env::join_paths(
         [
@@ -380,14 +391,20 @@ fn spawn_anchor(binary_path: PathBuf, args: Vec<String>) -> Result<()> {
         .chain(env::split_paths(&env::var_os("PATH").unwrap_or_default())),
     )?;
 
-    let exit = Command::new(binary_path)
+    let mut command = Command::new(binary_path);
+    command
         .args(args)
         .env("PATH", path)
         .env(REAL_CARGO_ENV, &cargo_proxy.real_cargo)
         // Signal to the spawned anchor-cli that AVM has already resolved the
         // toolchain version, so it must not re-exec via `[toolchain] anchor_version`.
         .env("AVM_ACTIVE", "1")
-        .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
+        .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback");
+    if enable_next_lockfile_bump {
+        command.env(CARGO_NEXT_LOCKFILE_BUMP_ENV, "true");
+    }
+
+    let exit = command
         .spawn()?
         .wait_with_output()
         .expect("Failed to run anchor-cli");
@@ -546,6 +563,7 @@ fn ensure_resolved_solana(
 /// aliases for the duration of the Anchor invocation.
 struct PlatformToolsGuard {
     _lock: fs::File,
+    enable_next_lockfile_bump: bool,
 }
 
 /// Ensure the platform-tools requested by the project are installed in
@@ -603,7 +621,13 @@ fn ensure_resolved_platform_tools(
     let toolchain_name = platform_tools_toolchain_name(solana, &resolution);
     ensure_rustup_toolchain_link(&toolchain_name, &platform_tools_path.join("rust"))?;
 
-    Ok(PlatformToolsGuard { _lock: lock })
+    let enable_next_lockfile_bump =
+        avm::platform_tools::cargo_lock_v4_requires_opt_in(cwd, &resolution)?;
+
+    Ok(PlatformToolsGuard {
+        _lock: lock,
+        enable_next_lockfile_bump,
+    })
 }
 
 fn acquire_platform_tools_lock() -> Result<fs::File> {

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -2,6 +2,7 @@ use {
     anyhow::{anyhow, Context, Error, Result},
     avm::{InstallTarget, Resolution},
     clap::{CommandFactory, Parser, Subcommand},
+    fs2::FileExt,
     semver::Version,
     std::{
         env,
@@ -355,7 +356,10 @@ fn anchor_proxy() -> Result<()> {
     })?;
 
     let binary_path = ensure_resolved_binary(&resolution)?;
-    ensure_resolved_solana(&cwd, &resolution)?;
+    prepend_solana_bin_to_path()?;
+    let _platform_tools_guard = ensure_resolved_solana(&cwd, &resolution)?
+        .map(|solana| ensure_resolved_platform_tools(&cwd, &solana))
+        .transpose()?;
 
     spawn_anchor(binary_path, args)
 }
@@ -506,12 +510,26 @@ fn ensure_idl_nightly_installed(idl_nightly: &str) -> Result<()> {
     Ok(())
 }
 
+/// Make freshly installed Solana executables visible to AVM and the Anchor
+/// process without relying on shell-profile changes.
+fn prepend_solana_bin_to_path() -> Result<()> {
+    let path = env::join_paths(
+        std::iter::once(avm::solana::active_release_bin_path()?)
+            .chain(env::split_paths(&env::var_os("PATH").unwrap_or_default())),
+    )?;
+    env::set_var("PATH", path);
+    Ok(())
+}
+
 /// Ensure the Solana CLI requested by the same project context is active
 /// before spawning the resolved Anchor binary.
-fn ensure_resolved_solana(cwd: &Path, resolution: &Resolution) -> Result<()> {
+fn ensure_resolved_solana(
+    cwd: &Path,
+    resolution: &Resolution,
+) -> Result<Option<avm::SolanaCliResolution>> {
     let Some(solana) = avm::solana::resolve_solana_cli_for_anchor_resolution(cwd, resolution)?
     else {
-        return Ok(());
+        return Ok(None);
     };
 
     avm::solana::ensure_solana_cli(&solana.version).with_context(|| {
@@ -520,7 +538,171 @@ fn ensure_resolved_solana(cwd: &Path, resolution: &Resolution) -> Result<()> {
             solana.version,
             solana.source.describe()
         )
-    })
+    })?;
+    Ok(Some(solana))
+}
+
+/// Holds the cross-process lock protecting Rustup's mutable Solana toolchain
+/// aliases for the duration of the Anchor invocation.
+struct PlatformToolsGuard {
+    _lock: fs::File,
+}
+
+/// Ensure the platform-tools requested by the project are installed in
+/// `cargo-build-sbf`'s shared cache and linked under the Rustup name expected by
+/// the active Solana generation.
+fn ensure_resolved_platform_tools(
+    cwd: &Path,
+    solana: &avm::SolanaCliResolution,
+) -> Result<PlatformToolsGuard> {
+    let lock = acquire_platform_tools_lock()?;
+    let resolution = avm::platform_tools::resolve_platform_tools_for_solana_cli(cwd, solana)?;
+    let platform_tools_path =
+        avm::platform_tools::solana_cache_platform_tools_path(&resolution.version)?;
+
+    if !avm::platform_tools::platform_tools_are_installed_at(&platform_tools_path) {
+        if cargo_build_sbf_supports_install_only()? {
+            let status = Command::new("cargo")
+                .args([
+                    "build-sbf",
+                    "--install-only",
+                    "--tools-version",
+                    &resolution.version,
+                ])
+                .status()
+                .with_context(|| {
+                    format!(
+                        "installing platform-tools {} resolved from {}",
+                        resolution.version,
+                        resolution.source.describe()
+                    )
+                })?;
+            if !status.success() {
+                anyhow::bail!(
+                    "Failed to install platform-tools {} resolved from {}",
+                    resolution.version,
+                    resolution.source.describe()
+                );
+            }
+        } else {
+            avm::platform_tools::install_platform_tools_in_solana_cache(
+                &resolution.version,
+                false,
+            )?;
+        }
+    }
+
+    if !avm::platform_tools::platform_tools_are_installed_at(&platform_tools_path) {
+        anyhow::bail!(
+            "platform-tools {} installation did not create a Rust sysroot at {}",
+            resolution.version,
+            platform_tools_path.display()
+        );
+    }
+
+    let toolchain_name = platform_tools_toolchain_name(solana, &resolution);
+    ensure_rustup_toolchain_link(&toolchain_name, &platform_tools_path.join("rust"))?;
+
+    Ok(PlatformToolsGuard { _lock: lock })
+}
+
+fn acquire_platform_tools_lock() -> Result<fs::File> {
+    fs::create_dir_all(&*avm::AVM_HOME)
+        .with_context(|| format!("creating {}", avm::AVM_HOME.display()))?;
+    let lock_path = avm::AVM_HOME.join(".platform-tools.lock");
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("opening {}", lock_path.display()))?;
+    FileExt::lock_exclusive(&lock).with_context(|| format!("locking {}", lock_path.display()))?;
+    Ok(lock)
+}
+
+fn cargo_build_sbf_supports_install_only() -> Result<bool> {
+    let output = match Command::new("cargo-build-sbf").arg("--help").output() {
+        Ok(output) => output,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err).context("checking cargo-build-sbf capabilities"),
+    };
+    if !output.status.success() {
+        return Ok(false);
+    }
+
+    Ok(
+        String::from_utf8_lossy(&output.stdout).contains("--install-only")
+            || String::from_utf8_lossy(&output.stderr).contains("--install-only"),
+    )
+}
+
+fn platform_tools_toolchain_name(
+    solana: &avm::SolanaCliResolution,
+    platform_tools: &avm::PlatformToolsResolution,
+) -> String {
+    if solana.version.major < 3 {
+        "solana".to_string()
+    } else {
+        format!(
+            "{}-sbpf-solana-{}",
+            platform_tools.rustc, platform_tools.version
+        )
+    }
+}
+
+fn ensure_rustup_toolchain_link(name: &str, rust_path: &Path) -> Result<()> {
+    let output = Command::new("rustup")
+        .args(["toolchain", "list", "-v"])
+        .output()
+        .context("listing linked Rust toolchains")?;
+    if !output.status.success() {
+        anyhow::bail!("Failed to list linked Rust toolchains");
+    }
+
+    let installed_path = String::from_utf8(output.stdout)?.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        (fields.next() == Some(name))
+            .then(|| line.split_whitespace().last().map(PathBuf::from))
+            .flatten()
+    });
+
+    if installed_path
+        .as_deref()
+        .is_some_and(|installed| paths_refer_to_same_directory(installed, rust_path))
+    {
+        return Ok(());
+    }
+
+    if installed_path.is_some() {
+        let status = Command::new("rustup")
+            .args(["toolchain", "uninstall", name])
+            .status()
+            .with_context(|| format!("unlinking Rust toolchain {name}"))?;
+        if !status.success() {
+            anyhow::bail!("Failed to unlink Rust toolchain {name}");
+        }
+    }
+
+    let status = Command::new("rustup")
+        .arg("toolchain")
+        .arg("link")
+        .arg(name)
+        .arg(rust_path)
+        .status()
+        .with_context(|| format!("linking Rust toolchain {name}"))?;
+    if !status.success() {
+        anyhow::bail!("Failed to link Rust toolchain {name}");
+    }
+
+    Ok(())
+}
+
+fn paths_refer_to_same_directory(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 /// Ensure the binary for `resolution.version` exists on disk, prompting the user

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -6,10 +6,9 @@
 //! ascending Solana version, so resolution is a linear floor lookup: pick the
 //! entry with the largest `solana` key that is `<= requested`. Project Solana
 //! requirements are resolved against the hosted Solana CLI candidate set, and
-//! AVM picks the newest compatible candidate whose platform-tools rustc can
-//! compile the locked dependency graph. When the project pins no Solana version
-//! at all, fall back to the map's `fallback` field (kept equal to the newest
-//! entry's `platform_tools`).
+//! AVM picks the newest compatible candidate. When the project pins no Solana
+//! version at all, fall back to the map's `fallback` field (kept equal to the
+//! newest entry's `platform_tools`).
 //!
 //! Installation: download the matching tarball from `anza-xyz/platform-tools`
 //! GitHub releases and extract into `$AVM_HOME/platform-tools/<version>/`.
@@ -26,11 +25,9 @@ use {
         AVM_HOME, DOWNLOAD_CLIENT,
     },
     anyhow::{anyhow, bail, Context, Result},
-    cargo_metadata::{DependencyKind, Metadata, MetadataCommand, PackageId, TargetKind},
     semver::Version,
     serde::Deserialize,
     std::{
-        collections::{HashMap, HashSet},
         fs,
         path::{Path, PathBuf},
         process::{Command, Stdio},
@@ -171,21 +168,18 @@ pub struct PlatformToolsResolution {
 /// Walks the same project-detection logic as [`resolve_solana_version`], then
 /// performs a floor lookup in the embedded map.
 pub fn resolve_platform_tools(start: &Path) -> Result<PlatformToolsResolution> {
-    let required_rust = required_rust_version_from_metadata(start)?;
     match resolve_solana_version(start)? {
-        Some(solana_res) => resolve_for_project_solana(&solana_res, required_rust.as_ref()),
-        None => resolve_fallback(required_rust.as_ref()),
+        Some(solana_res) => resolve_for_project_solana(&solana_res),
+        None => Ok(resolve_fallback()),
     }
 }
 
 /// Resolve platform-tools for the exact Solana CLI selected by the Anchor
-/// proxy, while checking that its bundled Rust compiler can build the locked
-/// dependency graph.
+/// proxy.
 pub fn resolve_platform_tools_for_solana_cli(
-    start: &Path,
+    _start: &Path,
     solana_res: &SolanaCliResolution,
 ) -> Result<PlatformToolsResolution> {
-    let required_rust = required_rust_version_from_metadata(start)?;
     let resolution = match &solana_res.source {
         SolanaCliResolutionSource::Project(source) => {
             resolve_for_solana_version(&solana_res.version, source.clone())
@@ -216,23 +210,6 @@ pub fn resolve_platform_tools_for_solana_cli(
         }
     };
 
-    if let Some(required) = required_rust {
-        if resolution.rustc < required.rustc {
-            bail!(
-                "Solana {} resolved from {} maps to platform-tools {} with rustc {}, but {} {} \
-                 requires rustc {}. Pin a newer `[toolchain] solana_version`, update Cargo.lock, \
-                 or pin a dependency version compatible with the Solana toolchain.",
-                solana_res.version,
-                solana_res.source.describe(),
-                resolution.version,
-                resolution.rustc,
-                required.package,
-                required.package_version,
-                required.rustc,
-            );
-        }
-    }
-
     Ok(resolution)
 }
 
@@ -241,19 +218,8 @@ fn resolve_for_solana(solana_res: &SolanaResolution) -> PlatformToolsResolution 
     resolve_for_solana_version(&solana_res.version, solana_res.source.clone())
 }
 
-fn resolve_for_project_solana(
-    solana_res: &SolanaResolution,
-    required_rust: Option<&RequiredRustVersion>,
-) -> Result<PlatformToolsResolution> {
+fn resolve_for_project_solana(solana_res: &SolanaResolution) -> Result<PlatformToolsResolution> {
     let candidates = solana_candidates(solana_res)?;
-    resolve_for_solana_candidates(solana_res, &candidates, required_rust)
-}
-
-fn resolve_for_solana_candidates(
-    solana_res: &SolanaResolution,
-    candidates: &[Version],
-    required_rust: Option<&RequiredRustVersion>,
-) -> Result<PlatformToolsResolution> {
     let Some(newest) = candidates.last() else {
         bail!(
             "No Solana versions available for {}",
@@ -261,64 +227,22 @@ fn resolve_for_solana_candidates(
         );
     };
 
-    for solana in candidates.iter().rev() {
-        let resolution = resolve_for_solana_version(solana, solana_res.source.clone());
-        if required_rust
-            .map(|required| resolution.rustc >= required.rustc)
-            .unwrap_or(true)
-        {
-            return Ok(resolution);
-        }
-    }
-
-    let newest_resolution = resolve_for_solana_version(newest, solana_res.source.clone());
-    let required =
-        required_rust.expect("candidate loop only fails when a rustc requirement exists");
-    let req = solana_res
-        .version_req
-        .as_deref()
-        .map(|req| format!("Solana requirement `{req}`"))
-        .unwrap_or_else(|| format!("Solana {}", solana_res.version));
-    bail!(
-        "No hosted Solana CLI satisfying {req} provides platform-tools with rustc >= {}. The \
-         newest compatible Solana candidate is {newest}, which maps to platform-tools {} with \
-         rustc {}, but {} {} requires rustc {}. Relax `[toolchain] solana_version`, update \
-         Cargo.lock, or pin a dependency version compatible with the Solana toolchain.",
-        required.rustc,
-        newest_resolution.version,
-        newest_resolution.rustc,
-        required.package,
-        required.package_version,
-        required.rustc,
-    );
+    Ok(resolve_for_solana_version(
+        newest,
+        solana_res.source.clone(),
+    ))
 }
 
-fn resolve_fallback(
-    required_rust: Option<&RequiredRustVersion>,
-) -> Result<PlatformToolsResolution> {
+fn resolve_fallback() -> PlatformToolsResolution {
     let entry = MAP
         .entries
         .last()
         .expect("platform-tools map must have at least one entry");
-    if let Some(required) = required_rust {
-        if entry.rustc < required.rustc {
-            bail!(
-                "The fallback platform-tools {} bundles rustc {}, but {} {} requires rustc {}. \
-                 Pin a Solana version whose platform-tools release has a newer rustc, update \
-                 Cargo.lock, or pin a compatible dependency version.",
-                entry.platform_tools,
-                entry.rustc,
-                required.package,
-                required.package_version,
-                required.rustc,
-            );
-        }
-    }
-    Ok(PlatformToolsResolution {
+    PlatformToolsResolution {
         version: entry.platform_tools.clone(),
         rustc: entry.rustc.clone(),
         source: PlatformToolsSource::Fallback,
-    })
+    }
 }
 
 fn solana_candidates(solana_res: &SolanaResolution) -> Result<Vec<Version>> {
@@ -385,188 +309,6 @@ pub fn lookup_for_solana_version(solana: &Version) -> Result<String> {
 /// want to surface it to the user (e.g. `avm platform-tools resolve`).
 pub fn fallback_version() -> &'static str {
     &MAP.fallback
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RequiredRustVersion {
-    package: String,
-    package_version: Version,
-    rustc: Version,
-}
-
-fn required_rust_version_from_metadata(start: &Path) -> Result<Option<RequiredRustVersion>> {
-    let mut max = None::<RequiredRustVersion>;
-    for manifest_path in candidate_metadata_manifests(start) {
-        let Some(metadata) = locked_metadata(&manifest_path)? else {
-            continue;
-        };
-        if let Some(required) = max_required_rust_version(&metadata) {
-            if max
-                .as_ref()
-                .map(|current| required.rustc > current.rustc)
-                .unwrap_or(true)
-            {
-                max = Some(required);
-            }
-        }
-    }
-    Ok(max)
-}
-
-fn locked_metadata(manifest_path: &Path) -> Result<Option<Metadata>> {
-    match MetadataCommand::new()
-        .manifest_path(manifest_path)
-        .other_options(vec!["--locked".to_string()])
-        .exec()
-    {
-        Ok(metadata) => Ok(Some(metadata)),
-        Err(cargo_metadata::Error::CargoMetadata { stderr })
-            if find_ancestor_file(
-                manifest_path.parent().unwrap_or_else(|| Path::new(".")),
-                "Cargo.lock",
-            )
-            .is_none()
-                && stderr.contains("lock file") =>
-        {
-            Ok(None)
-        }
-        Err(cargo_metadata::Error::CargoMetadata { stderr })
-            if is_detached_workspace_metadata_error(&stderr) =>
-        {
-            Ok(None)
-        }
-        Err(err) => Err(err).with_context(|| {
-            format!(
-                "Reading Cargo metadata from {} for dependency rust-version requirements",
-                manifest_path.display()
-            )
-        }),
-    }
-}
-
-fn is_detached_workspace_metadata_error(stderr: &str) -> bool {
-    stderr.contains("current package believes it's in a workspace when it's not")
-        || stderr.contains("failed to find a workspace root")
-}
-
-fn candidate_metadata_manifests(start: &Path) -> Vec<PathBuf> {
-    if let Some(anchor_toml) = find_ancestor_file(start, "Anchor.toml") {
-        let workspace_root = anchor_toml.parent().unwrap_or_else(|| Path::new("."));
-        let mut out = Vec::<PathBuf>::new();
-        let programs_dir = workspace_root.join("programs");
-        if let Ok(entries) = fs::read_dir(&programs_dir) {
-            for entry in entries.flatten() {
-                let candidate = entry.path().join("Cargo.toml");
-                if candidate.is_file() {
-                    out.push(candidate);
-                }
-            }
-        }
-        let root_cargo = workspace_root.join("Cargo.toml");
-        if root_cargo.is_file() {
-            out.push(root_cargo);
-        }
-        out.sort();
-        out.dedup();
-        return out;
-    }
-
-    find_ancestor_file(start, "Cargo.toml")
-        .into_iter()
-        .collect()
-}
-
-fn max_required_rust_version(metadata: &Metadata) -> Option<RequiredRustVersion> {
-    let resolve = metadata.resolve.as_ref()?;
-    let packages = metadata
-        .packages
-        .iter()
-        .map(|package| (&package.id, package))
-        .collect::<HashMap<_, _>>();
-
-    let workspace_members = metadata
-        .workspace_members
-        .iter()
-        .cloned()
-        .collect::<HashSet<_>>();
-    let mut roots = metadata
-        .packages
-        .iter()
-        .filter(|package| workspace_members.contains(&package.id))
-        .filter(|package| {
-            package
-                .targets
-                .iter()
-                .any(|target| target.kind.iter().any(|kind| kind == &TargetKind::CDyLib))
-        })
-        .map(|package| package.id.clone())
-        .collect::<Vec<_>>();
-    if roots.is_empty() {
-        roots = metadata.workspace_members.clone();
-    }
-
-    let nodes = resolve
-        .nodes
-        .iter()
-        .map(|node| (&node.id, node))
-        .collect::<HashMap<_, _>>();
-    let mut stack = roots;
-    let mut visited = HashSet::<PackageId>::new();
-    let mut max = None::<RequiredRustVersion>;
-
-    while let Some(id) = stack.pop() {
-        if !visited.insert(id.clone()) {
-            continue;
-        }
-
-        if let Some(package) = packages.get(&id) {
-            if let Some(rustc) = package.rust_version.clone() {
-                let candidate = RequiredRustVersion {
-                    package: package.name.to_string(),
-                    package_version: package.version.clone(),
-                    rustc,
-                };
-                if max
-                    .as_ref()
-                    .map(|current| candidate.rustc > current.rustc)
-                    .unwrap_or(true)
-                {
-                    max = Some(candidate);
-                }
-            }
-        }
-
-        let Some(node) = nodes.get(&id) else {
-            continue;
-        };
-        for dep in &node.deps {
-            if dep_builds_with_program_toolchain(dep) {
-                stack.push(dep.pkg.clone());
-            }
-        }
-    }
-
-    max
-}
-
-fn dep_builds_with_program_toolchain(dep: &cargo_metadata::NodeDep) -> bool {
-    dep.dep_kinds.is_empty()
-        || dep
-            .dep_kinds
-            .iter()
-            .any(|kind| matches!(kind.kind, DependencyKind::Normal | DependencyKind::Build))
-}
-
-fn find_ancestor_file(start: &Path, name: &str) -> Option<PathBuf> {
-    let mut cur = Some(start);
-    while let Some(dir) = cur {
-        let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        cur = dir.parent();
-    }
-    None
 }
 
 // ── Install / storage ────────────────────────────────────────────────────────
@@ -852,12 +594,7 @@ pub fn validate_embedded_map() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::resolve::SolanaResolutionSource,
-        std::{fs, path::PathBuf},
-        tempfile::TempDir,
-    };
+    use {super::*, crate::resolve::SolanaResolutionSource, std::path::PathBuf};
 
     fn v(s: &str) -> Version {
         Version::parse(s).unwrap()
@@ -877,21 +614,6 @@ mod tests {
             source: SolanaResolutionSource::AnchorToml(PathBuf::from("Anchor.toml")),
             version_req: Some(req.to_string()),
         }
-    }
-
-    fn required_rust(package: &str, package_version: &str, rustc: &str) -> RequiredRustVersion {
-        RequiredRustVersion {
-            package: package.to_string(),
-            package_version: v(package_version),
-            rustc: v(rustc),
-        }
-    }
-
-    fn write(path: &Path, contents: &str) {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap();
-        }
-        fs::write(path, contents).unwrap();
     }
 
     // ── Embedded map ─────────────────────────────────────────────────────────
@@ -960,15 +682,9 @@ mod tests {
         assert!(lookup_for_solana_version(&v("0.1.0")).is_err());
     }
 
-    // ── Rust-version aware resolution ───────────────────────────────────────
-
     #[test]
-    fn semver_solana_req_moves_forward_for_dependency_rust_version() {
-        let res = resolve_for_project_solana(
-            &fake_solana_req("2.2.1", "2.2.1"),
-            Some(&required_rust("indexmap", "2.12.1", "1.82.0")),
-        )
-        .unwrap();
+    fn semver_solana_req_uses_newest_hosted_candidate() {
+        let res = resolve_for_project_solana(&fake_solana_req("2.2.1", "2.2.1")).unwrap();
 
         assert_eq!(res.version, "v1.48");
         assert_eq!(res.rustc, v("1.84.1"));
@@ -979,52 +695,15 @@ mod tests {
     }
 
     #[test]
-    fn semver_solana_req_uses_newest_hosted_candidate_without_rust_requirement() {
-        let res = resolve_for_project_solana(&fake_solana_req("2.2.1", "2.2.1"), None).unwrap();
+    fn exact_solana_req_uses_pinned_candidate() {
+        let res = resolve_for_project_solana(&fake_solana_req("=2.2.1", "2.2.1")).unwrap();
 
-        assert_eq!(res.version, "v1.48");
-        assert_eq!(res.rustc, v("1.84.1"));
+        assert_eq!(res.version, "v1.44");
+        assert_eq!(res.rustc, v("1.79.0"));
         assert!(matches!(
             res.source,
-            PlatformToolsSource::Mapped { solana, .. } if solana == v("2.3.13")
+            PlatformToolsSource::Mapped { solana, .. } if solana == v("2.2.1")
         ));
-    }
-
-    #[test]
-    fn exact_solana_req_errors_when_platform_tools_rustc_is_too_old() {
-        let err = resolve_for_project_solana(
-            &fake_solana_req("=2.2.1", "2.2.1"),
-            Some(&required_rust("indexmap", "2.12.1", "1.82.0")),
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-
-        assert!(msg.contains("Solana requirement `=2.2.1`"));
-        assert!(msg.contains("platform-tools v1.44 with rustc 1.79.0"));
-        assert!(msg.contains("indexmap 2.12.1 requires rustc 1.82.0"));
-    }
-
-    #[test]
-    fn metadata_skips_excluded_workspace_manifest() {
-        let dir = TempDir::new().unwrap();
-        write(
-            &dir.path().join("Cargo.toml"),
-            "[workspace]\nmembers = [\"programs/main\"]\nexclude = \
-             [\"programs/excluded\"]\n[workspace.dependencies]\nserde = \"1\"\n",
-        );
-        write(
-            &dir.path().join("programs/main/Cargo.toml"),
-            "[package]\nname = \"main\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        );
-        write(
-            &dir.path().join("programs/excluded/Cargo.toml"),
-            "[package]\nname = \"excluded\"\nversion = \"0.1.0\"\nedition = \
-             \"2021\"\n[dependencies]\nserde = { workspace = true }\n",
-        );
-
-        let metadata = locked_metadata(&dir.path().join("programs/excluded/Cargo.toml")).unwrap();
-
-        assert!(metadata.is_none());
     }
 
     // ── Specific known transitions ──────────────────────────────────────────

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -17,8 +17,12 @@
 //! `platform-tools-{linux|osx|windows}-{x86_64|aarch64}.tar.bz2`.
 use {
     crate::{
-        resolve::{resolve_solana_version, SolanaResolution, SolanaResolutionSource},
-        solana::installable_solana_cli_versions_for_req,
+        resolve::{
+            resolve_solana_version, ResolutionSource, SolanaResolution, SolanaResolutionSource,
+        },
+        solana::{
+            installable_solana_cli_versions_for_req, SolanaCliResolution, SolanaCliResolutionSource,
+        },
         AVM_HOME, DOWNLOAD_CLIENT,
     },
     anyhow::{anyhow, bail, Context, Result},
@@ -115,6 +119,12 @@ pub enum PlatformToolsSource {
         solana: Version,
         solana_source: SolanaResolutionSource,
     },
+    /// Mapped from a Solana version selected through the Anchor release map.
+    AnchorMap {
+        solana: Version,
+        anchor: Version,
+        anchor_source: ResolutionSource,
+    },
     /// Project did not pin Solana → use the map's hardcoded fallback.
     Fallback,
 }
@@ -132,6 +142,14 @@ impl PlatformToolsSource {
             } => format!(
                 "solana {solana} predates map; using earliest entry ({})",
                 solana_source.describe()
+            ),
+            Self::AnchorMap {
+                solana,
+                anchor,
+                anchor_source,
+            } => format!(
+                "solana {solana} recommended for anchor {anchor} ({})",
+                anchor_source.describe()
             ),
             Self::Fallback => "fallback (no Solana version pinned)".to_string(),
         }
@@ -158,6 +176,64 @@ pub fn resolve_platform_tools(start: &Path) -> Result<PlatformToolsResolution> {
         Some(solana_res) => resolve_for_project_solana(&solana_res, required_rust.as_ref()),
         None => resolve_fallback(required_rust.as_ref()),
     }
+}
+
+/// Resolve platform-tools for the exact Solana CLI selected by the Anchor
+/// proxy, while checking that its bundled Rust compiler can build the locked
+/// dependency graph.
+pub fn resolve_platform_tools_for_solana_cli(
+    start: &Path,
+    solana_res: &SolanaCliResolution,
+) -> Result<PlatformToolsResolution> {
+    let required_rust = required_rust_version_from_metadata(start)?;
+    let resolution = match &solana_res.source {
+        SolanaCliResolutionSource::Project(source) => {
+            resolve_for_solana_version(&solana_res.version, source.clone())
+        }
+        SolanaCliResolutionSource::AnchorMap {
+            anchor,
+            anchor_source,
+        } => {
+            let entry = MAP
+                .entries
+                .iter()
+                .rev()
+                .find(|entry| entry.solana <= solana_res.version)
+                .unwrap_or_else(|| {
+                    MAP.entries
+                        .first()
+                        .expect("platform-tools map must have at least one entry")
+                });
+            PlatformToolsResolution {
+                version: entry.platform_tools.clone(),
+                rustc: entry.rustc.clone(),
+                source: PlatformToolsSource::AnchorMap {
+                    solana: solana_res.version.clone(),
+                    anchor: anchor.clone(),
+                    anchor_source: anchor_source.clone(),
+                },
+            }
+        }
+    };
+
+    if let Some(required) = required_rust {
+        if resolution.rustc < required.rustc {
+            bail!(
+                "Solana {} resolved from {} maps to platform-tools {} with rustc {}, but {} {} \
+                 requires rustc {}. Pin a newer `[toolchain] solana_version`, update Cargo.lock, \
+                 or pin a dependency version compatible with the Solana toolchain.",
+                solana_res.version,
+                solana_res.source.describe(),
+                resolution.version,
+                resolution.rustc,
+                required.package,
+                required.package_version,
+                required.rustc,
+            );
+        }
+    }
+
+    Ok(resolution)
 }
 
 #[cfg(test)]
@@ -575,13 +651,49 @@ pub fn download_url(version: &str) -> String {
 /// and atomically renamed on success so a failed install never leaves a
 /// half-populated directory at the canonical path.
 pub fn install_platform_tools(version: &str, force: bool) -> Result<()> {
+    let target = platform_tools_version_path(version);
+    install_platform_tools_at(version, &target, force)
+}
+
+/// Path used by every generation of `cargo-build-sbf` for a cached
+/// platform-tools release.
+pub fn solana_cache_platform_tools_path(version: &str) -> Result<PathBuf> {
     let version = if version.starts_with('v') {
         version.to_string()
     } else {
         format!("v{version}")
     };
-    let target = platform_tools_version_path(&version);
-    if !force && looks_installed(&target) {
+
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow!("Could not find home directory"))?
+        .join(".cache")
+        .join("solana")
+        .join(version)
+        .join("platform-tools"))
+}
+
+/// Install a platform-tools release directly into the cache consumed by
+/// `cargo-build-sbf`.
+///
+/// This is the compatibility path for Solana releases whose bundled
+/// `cargo-build-sbf` predates `--install-only`.
+pub fn install_platform_tools_in_solana_cache(version: &str, force: bool) -> Result<()> {
+    let target = solana_cache_platform_tools_path(version)?;
+    install_platform_tools_at(version, &target, force)
+}
+
+/// Return whether `target` contains an extracted platform-tools Rust sysroot.
+pub fn platform_tools_are_installed_at(target: &Path) -> bool {
+    looks_installed(target)
+}
+
+fn install_platform_tools_at(version: &str, target: &Path, force: bool) -> Result<()> {
+    let version = if version.starts_with('v') {
+        version.to_string()
+    } else {
+        format!("v{version}")
+    };
+    if !force && looks_installed(target) {
         println!(
             "platform-tools {version} is already installed at {}",
             target.display()
@@ -592,7 +704,11 @@ pub fn install_platform_tools(version: &str, force: bool) -> Result<()> {
     fs::create_dir_all(parent).with_context(|| format!("Creating {}", parent.display()))?;
 
     // Stage download + extract in a sibling directory.
-    let staging = parent.join(format!("{version}.partial"));
+    let target_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("Invalid platform-tools target path: {}", target.display()))?;
+    let staging = parent.join(format!("{target_name}.partial"));
     if staging.exists() {
         fs::remove_dir_all(&staging)
             .with_context(|| format!("Cleaning up stale {}", staging.display()))?;
@@ -625,7 +741,7 @@ pub fn install_platform_tools(version: &str, force: bool) -> Result<()> {
 
     match result {
         Ok(()) => {
-            replace_install_dir(&staging, &target)?;
+            replace_install_dir(&staging, target)?;
             println!("Installed platform-tools {version} to {}", target.display());
             Ok(())
         }

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -919,6 +919,11 @@ mod tests {
     }
 
     #[test]
+    fn known_transition_1_17_25_to_v1_37() {
+        assert_eq!(lookup_for_solana_version(&v("1.17.25")).unwrap(), "v1.37");
+    }
+
+    #[test]
     fn known_transition_1_18_8_to_v1_41() {
         assert_eq!(lookup_for_solana_version(&v("1.18.8")).unwrap(), "v1.41");
     }

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -17,7 +17,8 @@
 use {
     crate::{
         resolve::{
-            resolve_solana_version, ResolutionSource, SolanaResolution, SolanaResolutionSource,
+            find_ancestor_file, resolve_solana_version, ResolutionSource, SolanaResolution,
+            SolanaResolutionSource,
         },
         solana::{
             installable_solana_cli_versions_for_req, SolanaCliResolution, SolanaCliResolutionSource,
@@ -48,6 +49,20 @@ struct MapEntry {
     solana: String,
     platform_tools: String,
     rustc: String,
+    cargo_lock_v4: CargoLockV4Support,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CargoLockV4Support {
+    Unsupported,
+    OptIn,
+    Native,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoLockHeader {
+    version: Option<u32>,
 }
 
 /// Parsed and validated form of the static map.
@@ -63,6 +78,7 @@ struct PlatformToolsMapEntry {
     solana: Version,
     platform_tools: String,
     rustc: Version,
+    cargo_lock_v4: CargoLockV4Support,
 }
 
 static MAP: LazyLock<ParsedMap> = LazyLock::new(|| {
@@ -82,6 +98,7 @@ static MAP: LazyLock<ParsedMap> = LazyLock::new(|| {
                 solana,
                 platform_tools: e.platform_tools,
                 rustc,
+                cargo_lock_v4: e.cargo_lock_v4,
             }
         })
         .collect();
@@ -160,6 +177,8 @@ pub struct PlatformToolsResolution {
     pub version: String,
     /// Rust compiler bundled in this platform-tools release.
     pub rustc: Version,
+    /// Whether the bundled Cargo can consume a version 4 Cargo.lock.
+    pub cargo_lock_v4: CargoLockV4Support,
     pub source: PlatformToolsSource,
 }
 
@@ -201,6 +220,7 @@ pub fn resolve_platform_tools_for_solana_cli(
             PlatformToolsResolution {
                 version: entry.platform_tools.clone(),
                 rustc: entry.rustc.clone(),
+                cargo_lock_v4: entry.cargo_lock_v4,
                 source: PlatformToolsSource::AnchorMap {
                     solana: solana_res.version.clone(),
                     anchor: anchor.clone(),
@@ -241,6 +261,7 @@ fn resolve_fallback() -> PlatformToolsResolution {
     PlatformToolsResolution {
         version: entry.platform_tools.clone(),
         rustc: entry.rustc.clone(),
+        cargo_lock_v4: entry.cargo_lock_v4,
         source: PlatformToolsSource::Fallback,
     }
 }
@@ -264,6 +285,7 @@ fn resolve_for_solana_version(
         Some(idx) => PlatformToolsResolution {
             version: entries[idx].platform_tools.clone(),
             rustc: entries[idx].rustc.clone(),
+            cargo_lock_v4: entries[idx].cargo_lock_v4,
             source: PlatformToolsSource::Mapped {
                 solana: solana.clone(),
                 solana_source,
@@ -279,12 +301,42 @@ fn resolve_for_solana_version(
             PlatformToolsResolution {
                 version: earliest.platform_tools.clone(),
                 rustc: earliest.rustc.clone(),
+                cargo_lock_v4: earliest.cargo_lock_v4,
                 source: PlatformToolsSource::BelowMap {
                     solana: solana.clone(),
                     solana_source,
                 },
             }
         }
+    }
+}
+
+/// Validate lockfile-v4 compatibility and return whether Cargo needs its
+/// unstable opt-in.
+pub fn cargo_lock_v4_requires_opt_in(
+    start: &Path,
+    resolution: &PlatformToolsResolution,
+) -> Result<bool> {
+    let Some(lockfile) = find_ancestor_file(start, "Cargo.lock") else {
+        return Ok(false);
+    };
+    let text = fs::read_to_string(&lockfile)
+        .with_context(|| format!("Reading Cargo lockfile {}", lockfile.display()))?;
+    let lock: CargoLockHeader = toml::from_str(&text)
+        .with_context(|| format!("Parsing Cargo lockfile {}", lockfile.display()))?;
+    if lock.version != Some(4) {
+        return Ok(false);
+    }
+
+    match resolution.cargo_lock_v4 {
+        CargoLockV4Support::Unsupported => bail!(
+            "{} uses lockfile version 4, but platform-tools {} does not support it. Regenerate \
+             the lockfile in version 3 format or select a compatible Solana toolchain.",
+            lockfile.display(),
+            resolution.version
+        ),
+        CargoLockV4Support::OptIn => Ok(true),
+        CargoLockV4Support::Native => Ok(false),
     }
 }
 
@@ -632,6 +684,14 @@ mod tests {
                 .rustc,
             v("1.84.1")
         );
+        assert_eq!(
+            entries
+                .iter()
+                .find(|entry| entry.platform_tools == "v1.41")
+                .unwrap()
+                .cargo_lock_v4,
+            CargoLockV4Support::OptIn
+        );
     }
 
     #[test]
@@ -741,6 +801,31 @@ mod tests {
     #[test]
     fn known_transition_4_0_0_to_v1_54() {
         assert_eq!(lookup_for_solana_version(&v("4.0.0")).unwrap(), "v1.54");
+    }
+
+    #[test]
+    fn cargo_lock_v4_opt_in_is_scoped_to_compatible_legacy_cargo() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("Cargo.lock"), "version = 4\n").unwrap();
+
+        let unsupported = resolve_for_solana(&fake_solana("1.17.25"));
+        let error = cargo_lock_v4_requires_opt_in(dir.path(), &unsupported).unwrap_err();
+        assert!(error.to_string().contains("platform-tools v1.37"));
+
+        let opt_in = resolve_for_solana(&fake_solana("1.18.17"));
+        assert!(cargo_lock_v4_requires_opt_in(dir.path(), &opt_in).unwrap());
+
+        let native = resolve_for_solana(&fake_solana("2.1.0"));
+        assert!(!cargo_lock_v4_requires_opt_in(dir.path(), &native).unwrap());
+    }
+
+    #[test]
+    fn cargo_lock_v4_opt_in_ignores_older_lockfile_formats() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        let resolution = resolve_for_solana(&fake_solana("1.18.17"));
+
+        assert!(!cargo_lock_v4_requires_opt_in(dir.path(), &resolution).unwrap());
     }
 
     // ── URL + asset naming ──────────────────────────────────────────────────

--- a/avm/src/resolve.rs
+++ b/avm/src/resolve.rs
@@ -493,7 +493,7 @@ fn checked_inc(value: u64, req_str: &str) -> Result<u64> {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn find_ancestor_file(start: &Path, name: &str) -> Option<PathBuf> {
+pub(crate) fn find_ancestor_file(start: &Path, name: &str) -> Option<PathBuf> {
     let mut cur: Option<&Path> = Some(start);
     while let Some(dir) = cur {
         let candidate = dir.join(name);

--- a/avm/src/solana.rs
+++ b/avm/src/solana.rs
@@ -547,6 +547,13 @@ fn solana_install_data_dir() -> Result<std::path::PathBuf> {
         .join("install"))
 }
 
+/// Directory containing the active Solana release's executables.
+pub fn active_release_bin_path() -> Result<std::path::PathBuf> {
+    Ok(solana_install_data_dir()?
+        .join("active_release")
+        .join("bin"))
+}
+
 fn installer_command_available(installer: SolanaInstaller) -> Result<bool> {
     if read_command_version(installer.command())?.is_some() {
         return Ok(true);

--- a/avm/tests/resolution_flow.rs
+++ b/avm/tests/resolution_flow.rs
@@ -17,6 +17,7 @@ struct Fixture {
     anchor_stub: PathBuf,
     path_bin: PathBuf,
     log_path: PathBuf,
+    cargo_log_path: PathBuf,
     solana_log_path: PathBuf,
 }
 
@@ -39,6 +40,7 @@ impl Fixture {
             anchor_stub,
             path_bin,
             log_path: avm_bin.join("anchor.log"),
+            cargo_log_path: avm_bin.join("cargo.log"),
             solana_log_path: avm_bin.join("solana.log"),
         }
     }
@@ -65,9 +67,38 @@ impl Fixture {
 echo "version={version}" > "$AVM_TEST_ANCHOR_LOG"
 echo "args=$*" >> "$AVM_TEST_ANCHOR_LOG"
 echo "avm_active=${{AVM_ACTIVE:-}}" >> "$AVM_TEST_ANCHOR_LOG"
+echo "rustup_toolchain=${{RUSTUP_TOOLCHAIN:-}}" >> "$AVM_TEST_ANCHOR_LOG"
 echo "resolver=${{CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS:-}}" >> "$AVM_TEST_ANCHOR_LOG"
 "#
             ),
+        );
+    }
+
+    fn install_anchor_with_cargo_calls(&self, version: &str) {
+        write_executable(
+            &self.avm_home_bin().join(format!("anchor-{version}")),
+            r#"#!/bin/sh
+cargo build-sbf
+cargo +nightly test idl
+cargo +nightly-2026-07-01 test already-pinned
+"#,
+        );
+        write_executable(
+            &self.path_bin.join("cargo"),
+            r#"#!/bin/sh
+echo "$*" >> "$AVM_TEST_CARGO_LOG"
+"#,
+        );
+        write_executable(
+            &self.path_bin.join("rustup"),
+            r#"#!/bin/sh
+if [ "$*" = "toolchain list" ]; then
+  echo "nightly-2025-04-15-x86_64-unknown-linux-gnu"
+  echo "nightly-2026-06-10-x86_64-unknown-linux-gnu"
+  exit 0
+fi
+exit 1
+"#,
         );
     }
 
@@ -237,7 +268,9 @@ exit 0
             .current_dir(current_dir)
             .env("AVM_HOME", &self.avm_home)
             .env("PATH", path)
+            .env_remove("RUSTUP_TOOLCHAIN")
             .env("AVM_TEST_ANCHOR_LOG", &self.log_path)
+            .env("AVM_TEST_CARGO_LOG", &self.cargo_log_path)
             .env("AVM_TEST_SOLANA_LOG", &self.solana_log_path)
             .output()
             .expect("run anchor stub")
@@ -296,6 +329,7 @@ fn anchor_stub_prefers_anchor_toml_and_sets_launcher_env() {
     assert!(log.contains("version=1.0.2"), "{log}");
     assert!(log.contains("args=build -- --features mainnet"), "{log}");
     assert!(log.contains("avm_active=1"), "{log}");
+    assert!(log.contains("rustup_toolchain=\n"), "{log}");
     assert!(log.contains("resolver=fallback"), "{log}");
     assert_eq!(
         fs::read_to_string(&fixture.solana_log_path).unwrap(),
@@ -332,6 +366,51 @@ fn anchor_stub_falls_back_to_anchorversion_cargo_and_global_sources() {
     fixture.install_fake_solana("1.18.17");
     assert_success(&fixture.run_anchor(&global_project, ["--version"]));
     assert!(fixture.anchor_log().contains("version=0.30.1"));
+}
+
+#[test]
+fn anchor_stub_pins_only_unversioned_nightly_cargo_invocations() {
+    let fixture = Fixture::new();
+    let project = fixture.project("cargo-proxy");
+    fixture.install_anchor_with_cargo_calls("1.0.2");
+    fixture.install_fake_solana("4.1.2");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"1.0.2\"\nsolana_version = \"4.1.2\"\n",
+    )
+    .unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["build"]));
+
+    assert_eq!(
+        fs::read_to_string(&fixture.cargo_log_path).unwrap(),
+        "build-sbf\n+nightly-2026-06-10 test idl\n+nightly-2026-07-01 test already-pinned\n"
+    );
+}
+
+#[test]
+fn anchor_stub_uses_legacy_idl_nightly_for_locked_proc_macro2() {
+    let fixture = Fixture::new();
+    let project = fixture.project("legacy-cargo-proxy");
+    fixture.install_anchor_with_cargo_calls("0.30.1");
+    fixture.install_fake_solana("1.18.17");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"0.30.1\"\nsolana_version = \"1.18.17\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("Cargo.lock"),
+        "version = 4\n\n[[package]]\nname = \"proc-macro2\"\nversion = \"1.0.86\"\n",
+    )
+    .unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["build"]));
+
+    assert_eq!(
+        fs::read_to_string(&fixture.cargo_log_path).unwrap(),
+        "build-sbf\n+nightly-2025-04-15 test idl\n+nightly-2026-07-01 test already-pinned\n"
+    );
 }
 
 #[test]

--- a/avm/tests/resolution_flow.rs
+++ b/avm/tests/resolution_flow.rs
@@ -122,6 +122,7 @@ echo "args=$*" >> "$AVM_TEST_ANCHOR_LOG"
 echo "avm_active=${{AVM_ACTIVE:-}}" >> "$AVM_TEST_ANCHOR_LOG"
 echo "rustup_toolchain=${{RUSTUP_TOOLCHAIN:-}}" >> "$AVM_TEST_ANCHOR_LOG"
 echo "resolver=${{CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS:-}}" >> "$AVM_TEST_ANCHOR_LOG"
+echo "next_lockfile_bump=${{CARGO_UNSTABLE_NEXT_LOCKFILE_BUMP:-}}" >> "$AVM_TEST_ANCHOR_LOG"
 "#
             ),
         );
@@ -358,6 +359,7 @@ exit 0
             .env("HOME", self._temp.path().join("home"))
             .env("PATH", path)
             .env_remove("RUSTUP_TOOLCHAIN")
+            .env_remove("CARGO_UNSTABLE_NEXT_LOCKFILE_BUMP")
             .env("AVM_TEST_ANCHOR_LOG", &self.log_path)
             .env("AVM_TEST_CARGO_LOG", &self.cargo_log_path)
             .env("AVM_TEST_RUSTUP_LOG", &self.rustup_log_path)
@@ -538,6 +540,48 @@ fn anchor_stub_uses_legacy_idl_nightly_for_locked_proc_macro2() {
         rustup_log.contains("toolchain link solana "),
         "{rustup_log}"
     );
+}
+
+#[test]
+fn anchor_stub_enables_v4_lockfile_for_compatible_legacy_cargo() {
+    let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.41");
+    fixture.install_anchor("0.30.1");
+    fixture.install_fake_solana("1.18.17");
+    let project = fixture.project("legacy-v4-lockfile");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"0.30.1\"\nsolana_version = \"1.18.17\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("Cargo.lock"), "version = 4\n").unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["build"]));
+
+    let log = fixture.anchor_log();
+    assert!(log.contains("next_lockfile_bump=true"), "{log}");
+}
+
+#[test]
+fn anchor_stub_does_not_enable_v4_opt_in_for_native_cargo() {
+    let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.43");
+    fixture.install_anchor("0.31.1");
+    fixture.install_fake_solana("2.1.0");
+    let project = fixture.project("native-v4-lockfile");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"0.31.1\"\nsolana_version = \"2.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("Cargo.lock"), "version = 4\n").unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["build"]));
+
+    let log = fixture.anchor_log();
+    assert!(log.contains("next_lockfile_bump=\n"), "{log}");
 }
 
 #[test]

--- a/avm/tests/resolution_flow.rs
+++ b/avm/tests/resolution_flow.rs
@@ -18,6 +18,7 @@ struct Fixture {
     path_bin: PathBuf,
     log_path: PathBuf,
     cargo_log_path: PathBuf,
+    rustup_log_path: PathBuf,
     solana_log_path: PathBuf,
 }
 
@@ -33,6 +34,57 @@ impl Fixture {
         let anchor_stub = path_bin.join("anchor");
         fs::copy(env!("CARGO_BIN_EXE_avm"), &anchor_stub).expect("copy avm as anchor");
         make_executable(&anchor_stub);
+        let solana_bin = temp
+            .path()
+            .join("home/.local/share/solana/install/active_release/bin");
+        fs::create_dir_all(&solana_bin).expect("solana bin");
+        write_executable(
+            &solana_bin.join("cargo-build-sbf"),
+            r#"#!/bin/sh
+echo "$*" >> "$AVM_TEST_CARGO_LOG"
+if [ "$1" = "--help" ]; then
+  echo "    --install-only"
+  exit 0
+fi
+install_only=
+version=
+previous=
+for argument in "$@"; do
+  if [ "$previous" = "--tools-version" ]; then
+    version="$argument"
+  fi
+  if [ "$argument" = "--install-only" ]; then
+    install_only=1
+  fi
+  previous="$argument"
+done
+if [ -n "$install_only" ] && [ -n "$version" ]; then
+  mkdir -p "$HOME/.cache/solana/$version/platform-tools/rust"
+  : > "$HOME/.cache/solana/$version/platform-tools/rust/marker"
+fi
+"#,
+        );
+        write_executable(
+            &path_bin.join("rustup"),
+            r#"#!/bin/sh
+echo "$*" >> "$AVM_TEST_RUSTUP_LOG"
+if [ "$1" = "toolchain" ] && [ "$2" = "list" ]; then
+  echo "nightly-2025-04-15-x86_64-unknown-linux-gnu"
+  echo "nightly-2026-06-10-x86_64-unknown-linux-gnu"
+  exit 0
+fi
+if [ "$1" = "toolchain" ] && [ "$2" = "link" ]; then
+  exit 0
+fi
+if [ "$1" = "toolchain" ] && [ "$2" = "uninstall" ]; then
+  exit 0
+fi
+if [ "$1" = "toolchain" ] && [ "$2" = "install" ]; then
+  exit 0
+fi
+exit 1
+"#,
+        );
 
         Self {
             _temp: temp,
@@ -41,6 +93,7 @@ impl Fixture {
             path_bin,
             log_path: avm_bin.join("anchor.log"),
             cargo_log_path: avm_bin.join("cargo.log"),
+            rustup_log_path: avm_bin.join("rustup.log"),
             solana_log_path: avm_bin.join("solana.log"),
         }
     }
@@ -87,19 +140,54 @@ cargo +nightly-2026-07-01 test already-pinned
             &self.path_bin.join("cargo"),
             r#"#!/bin/sh
 echo "$*" >> "$AVM_TEST_CARGO_LOG"
+install_only=
+version=
+previous=
+for argument in "$@"; do
+  if [ "$previous" = "--tools-version" ]; then
+    version="$argument"
+  fi
+  if [ "$argument" = "--install-only" ]; then
+    install_only=1
+  fi
+  previous="$argument"
+done
+if [ -n "$install_only" ] && [ -n "$version" ]; then
+  mkdir -p "$HOME/.cache/solana/$version/platform-tools/rust"
+  : > "$HOME/.cache/solana/$version/platform-tools/rust/marker"
+fi
 "#,
         );
+    }
+
+    fn install_legacy_build_sbf(&self) {
+        let build_sbf = self
+            ._temp
+            .path()
+            .join("home/.local/share/solana/install/active_release/bin/cargo-build-sbf");
         write_executable(
-            &self.path_bin.join("rustup"),
+            &build_sbf,
             r#"#!/bin/sh
-if [ "$*" = "toolchain list" ]; then
-  echo "nightly-2025-04-15-x86_64-unknown-linux-gnu"
-  echo "nightly-2026-06-10-x86_64-unknown-linux-gnu"
+echo "$*" >> "$AVM_TEST_CARGO_LOG"
+if [ "$1" = "--help" ]; then
+  echo "legacy cargo-build-sbf"
   exit 0
 fi
 exit 1
 "#,
         );
+    }
+
+    fn cache_platform_tools(&self, version: &str) -> PathBuf {
+        let path = self
+            ._temp
+            .path()
+            .join("home/.cache/solana")
+            .join(version)
+            .join("platform-tools");
+        fs::create_dir_all(path.join("rust")).expect("platform-tools rust dir");
+        fs::write(path.join("rust/marker"), "cached").expect("platform-tools marker");
+        path
     }
 
     fn install_nightly_anchor_via_script(&self) {
@@ -267,10 +355,12 @@ exit 0
             .args(args)
             .current_dir(current_dir)
             .env("AVM_HOME", &self.avm_home)
+            .env("HOME", self._temp.path().join("home"))
             .env("PATH", path)
             .env_remove("RUSTUP_TOOLCHAIN")
             .env("AVM_TEST_ANCHOR_LOG", &self.log_path)
             .env("AVM_TEST_CARGO_LOG", &self.cargo_log_path)
+            .env("AVM_TEST_RUSTUP_LOG", &self.rustup_log_path)
             .env("AVM_TEST_SOLANA_LOG", &self.solana_log_path)
             .output()
             .expect("run anchor stub")
@@ -322,6 +412,8 @@ fn anchor_stub_prefers_anchor_toml_and_sets_launcher_env() {
          \"2021\"\n[dependencies]\nanchor-lang = \"0.31.1\"\n",
     )
     .unwrap();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "").unwrap();
 
     assert_success(&fixture.run_anchor(&project, ["build", "--", "--features", "mainnet"]));
 
@@ -335,11 +427,25 @@ fn anchor_stub_prefers_anchor_toml_and_sets_launcher_env() {
         fs::read_to_string(&fixture.solana_log_path).unwrap(),
         "--version\n"
     );
+    assert_eq!(
+        fs::read_to_string(&fixture.cargo_log_path).unwrap(),
+        "--help\nbuild-sbf --install-only --tools-version v1.52\n"
+    );
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert!(rustup_log.contains("toolchain list -v\n"), "{rustup_log}");
+    assert!(
+        rustup_log.contains("toolchain link 1.89.0-sbpf-solana-v1.52"),
+        "{rustup_log}"
+    );
 }
 
 #[test]
 fn anchor_stub_falls_back_to_anchorversion_cargo_and_global_sources() {
     let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.48");
+    fixture.cache_platform_tools("v1.43");
+    fixture.cache_platform_tools("v1.41");
     fixture.install_anchor("0.32.1");
     fixture.install_anchor("0.31.1");
     fixture.install_anchor("0.30.1");
@@ -359,6 +465,8 @@ fn anchor_stub_falls_back_to_anchorversion_cargo_and_global_sources() {
          \"2021\"\n[dependencies]\nanchor-lang = \"0.31.1\"\n",
     )
     .unwrap();
+    fs::create_dir_all(cargo_project.join("src")).unwrap();
+    fs::write(cargo_project.join("src/lib.rs"), "").unwrap();
     assert_success(&fixture.run_anchor(&cargo_project, ["idl", "build"]));
     assert!(fixture.anchor_log().contains("version=0.31.1"));
 
@@ -366,6 +474,12 @@ fn anchor_stub_falls_back_to_anchorversion_cargo_and_global_sources() {
     fixture.install_fake_solana("1.18.17");
     assert_success(&fixture.run_anchor(&global_project, ["--version"]));
     assert!(fixture.anchor_log().contains("version=0.30.1"));
+    assert!(
+        !fixture.cargo_log_path.exists(),
+        "a cached legacy toolchain must not invoke unsupported --install-only"
+    );
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert_eq!(rustup_log.matches("toolchain link solana ").count(), 3);
 }
 
 #[test]
@@ -384,13 +498,21 @@ fn anchor_stub_pins_only_unversioned_nightly_cargo_invocations() {
 
     assert_eq!(
         fs::read_to_string(&fixture.cargo_log_path).unwrap(),
-        "build-sbf\n+nightly-2026-06-10 test idl\n+nightly-2026-07-01 test already-pinned\n"
+        "--help\nbuild-sbf --install-only --tools-version v1.54\nbuild-sbf\n+nightly-2026-06-10 \
+         test idl\n+nightly-2026-07-01 test already-pinned\n"
+    );
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert!(
+        rustup_log.contains("toolchain link 1.89.0-sbpf-solana-v1.54"),
+        "{rustup_log}"
     );
 }
 
 #[test]
 fn anchor_stub_uses_legacy_idl_nightly_for_locked_proc_macro2() {
     let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.41");
     let project = fixture.project("legacy-cargo-proxy");
     fixture.install_anchor_with_cargo_calls("0.30.1");
     fixture.install_fake_solana("1.18.17");
@@ -410,6 +532,66 @@ fn anchor_stub_uses_legacy_idl_nightly_for_locked_proc_macro2() {
     assert_eq!(
         fs::read_to_string(&fixture.cargo_log_path).unwrap(),
         "build-sbf\n+nightly-2025-04-15 test idl\n+nightly-2026-07-01 test already-pinned\n"
+    );
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert!(
+        rustup_log.contains("toolchain link solana "),
+        "{rustup_log}"
+    );
+}
+
+#[test]
+fn anchor_stub_uses_versioned_link_for_early_agave_three() {
+    let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.51");
+    fixture.install_anchor("1.0.2");
+    fixture.install_fake_solana("3.0.0");
+    let project = fixture.project("early-agave-three");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"1.0.2\"\nsolana_version = \"3.0.0\"\n",
+    )
+    .unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["--version"]));
+
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert!(
+        rustup_log.contains("toolchain link 1.84.1-sbpf-solana-v1.51"),
+        "{rustup_log}"
+    );
+    assert!(
+        !fixture.cargo_log_path.exists(),
+        "a cached early 3.x toolchain must not invoke unsupported --install-only"
+    );
+}
+
+#[test]
+fn anchor_stub_supports_oldest_anchor_solana_mapping() {
+    let fixture = Fixture::new();
+    fixture.install_legacy_build_sbf();
+    fixture.cache_platform_tools("v1.37");
+    fixture.install_anchor("0.29.0");
+    fixture.install_fake_solana("1.17.25");
+    let project = fixture.project("anchor-029");
+    fs::write(
+        project.join("Anchor.toml"),
+        "[toolchain]\nanchor_version = \"0.29.0\"\nsolana_version = \"1.17.25\"\n",
+    )
+    .unwrap();
+
+    assert_success(&fixture.run_anchor(&project, ["--version"]));
+
+    let rustup_log = fs::read_to_string(&fixture.rustup_log_path).unwrap();
+    assert!(
+        rustup_log.contains("toolchain link solana "),
+        "{rustup_log}"
+    );
+    assert!(rustup_log.contains("/v1.37/platform-tools/rust"));
+    assert!(
+        !fixture.cargo_log_path.exists(),
+        "Solana 1.17 must not invoke unsupported --install-only"
     );
 }
 


### PR DESCRIPTION
New set of features for AVM resolution to support more projects:
- **`feat(avm): Pin compatible IDL nightly`** - Resolve a dated Rust nightly from the project’s locked `proc-macro2` versions, install it on demand, and pin unversioned `cargo +nightly` IDL invocations.
- **`fix(avm): Map Solana 1.17 to platform-tools v1.37`** - Add the oldest hosted Solana 1.17 release and its platform-tools bundle to the resolution map.
- **`feat(avm): Install project toolchains from Anchor stub`**- Resolve and install the project’s Solana CLI and platform-tools before launching Anchor, then expose the matching bundled Rust toolchain through Rustup.
- **`fix(avm): Defer dependency compatibility to build-sbf`** - Remove the Cargo metadata MSRV preflight and let the selected `cargo-build-sbf` toolchain report dependency incompatibilities directly.
- **`fix(avm): Support v4 lockfiles with legacy Cargo`** - Enable Cargo’s lockfile-v4 opt-in only for compatible legacy platform-tools bundles and report an actionable error for unsupported bundles.

Tested in: https://github.com/otter-sec/anchor/actions/runs/29965656707/job/89276824238