### PR TITLE
Fix/v2 seeds program without seeds

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2340,6 +2340,35 @@ mod tests {
     }
 
     #[test]
+    fn seeds_program_without_seeds_is_rejected() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(seeds::program = other_program.key())]
+        )];
+        let err = match parse_account_attrs(&attrs) {
+            Ok(_) => panic!("seeds::program without seeds must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("seeds must be provided before seeds::program"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_seed_array_with_seeds_program_is_accepted() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(seeds = [], seeds::program = other_program.key())]
+        )];
+        let parsed = parse_account_attrs(&attrs).expect("empty seeds array remains valid");
+        let Expr::Array(arr) = parsed.seeds.expect("seed array should be preserved") else {
+            panic!("expected parsed seeds to stay as an array expression");
+        };
+        assert!(arr.elems.is_empty());
+        assert!(parsed.seeds_program.is_some());
+    }
+
+    #[test]
     fn close_does_not_imply_mutability() {
         let attrs: Vec<Attribute> = vec![syn::parse_quote!(
             #[account(close = receiver)]

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -361,6 +361,13 @@ pub fn parse_account_attrs(attrs: &[Attribute]) -> syn::Result<AccountAttrs> {
         })?;
     }
 
+    if result.seeds_program.is_some() && result.seeds.is_none() {
+        return Err(syn::Error::new(
+            result.seeds_program.as_ref().unwrap().span(),
+            "seeds must be provided before seeds::program",
+        ));
+    }
+
     // Reject `init` + `bump = <expr>` (mirroring Anchor v1). Account
     // creation requires an off-curve address, which is only guaranteed by
     // the canonical bump returned by `find_program_address`. A caller-


### PR DESCRIPTION
## Finding
`seeds::program = ...` without `seeds = [...]` was accepted in `lang-v2`, but it emitted no PDA verification at all. That silently disabled the intended seeds check.

## Fix
This PR rejects `seeds::program` unless `seeds` is also present, matching v1 behavior and preventing the missing-verification path.

Regression tests added.