### PR TITLE
fix(lang-v2): preserve nested and declared program idl metadata

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1279,13 +1279,26 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         })
         .collect();
     let idl_accounts_fn = idl::build_accounts_emission(&accounts_fields);
-    // Only path-typed fields drive the IDL dep walk. `idl_field_ty` is
-    // already the post-Option-unwrap base type (see `parse::parse_field`),
-    // and is `None` for non-Path fields — filter those out so the emitted
-    // trait call has a concrete type to dispatch on.
-    let idl_field_tys: Vec<&syn::Type> = fields
+    // Most field types register transitive IDL deps through
+    // `IdlAccountType::__register_idl_deps`. `Nested<Inner>` is special:
+    // `#[derive(Accounts)]` emits an inherent `Inner::__idl_register_deps`
+    // helper, not an `IdlAccountType` impl for `Inner`, so route those
+    // fields to the inner helper directly.
+    let idl_dep_walkers: Vec<TokenStream2> = fields
         .iter()
-        .filter_map(|f| f.idl_field_ty.as_ref())
+        .filter_map(|f| {
+            if let Some(inner_ty) = parse::extract_nested_inner_type(&f.ty) {
+                Some(quote! {
+                    <#inner_ty>::__idl_register_deps(accounts, types);
+                })
+            } else {
+                f.idl_field_ty.as_ref().map(|ty| {
+                    quote! {
+                        <#ty as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
+                    }
+                })
+            }
+        })
         .collect();
 
     let (ix_deser, ix_args_assoc, ix_args_return) = if ix_args.is_empty() {
@@ -1992,9 +2005,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 accounts: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
                 types: &mut anchor_lang_v2::__alloc::vec::Vec<&'static str>,
             ) {
-                #(
-                    <#idl_field_tys as anchor_lang_v2::IdlAccountType>::__register_idl_deps(accounts, types);
-                )*
+                #(#idl_dep_walkers)*
             }
         }
     }
@@ -6666,11 +6677,16 @@ mod tests {
         let generated = impl_accounts(&input).to_string();
 
         assert!(
-            generated.contains(
+            generated.contains("< Inner > :: __idl_register_deps"),
+            "nested accounts should forward IDL dep registration through the inner helper: \
+             {generated}"
+        );
+        assert!(
+            !generated.contains(
                 "< anchor_lang_v2 :: Nested < Inner > as anchor_lang_v2 :: IdlAccountType > \
                  :: __register_idl_deps"
             ),
-            "nested accounts should forward IDL dep registration through the Nested wrapper: \
+            "nested accounts should not require an IdlAccountType impl on Inner via Nested: \
              {generated}"
         );
     }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2782,6 +2782,8 @@ fn gen_declared_program(
                 pub struct #marker_name;
 
                 impl anchor_lang_v2::Id for #marker_name {
+                    const IDL_ADDRESS: &'static str = #address_lit;
+
                     fn id() -> anchor_lang_v2::Address {
                         super::ID
                     }
@@ -6654,6 +6656,26 @@ mod tests {
     }
 
     #[test]
+    fn nested_accounts_register_idl_deps_through_nested_wrapper() {
+        let input: syn::DeriveInput = syn::parse_quote! {
+            pub struct Outer {
+                pub nested: anchor_lang_v2::Nested<Inner>,
+            }
+        };
+
+        let generated = impl_accounts(&input).to_string();
+
+        assert!(
+            generated.contains(
+                "< anchor_lang_v2 :: Nested < Inner > as anchor_lang_v2 :: IdlAccountType > \
+                 :: __register_idl_deps"
+            ),
+            "nested accounts should forward IDL dep registration through the Nested wrapper: \
+             {generated}"
+        );
+    }
+
+    #[test]
     fn event_authority_dispatch_uses_precomputed_const_when_available() {
         let generated = event_authority_dispatch_check(Some([7; 32])).to_string();
 
@@ -6876,6 +6898,39 @@ mod tests {
         assert!(
             generated.contains("must take `&mut Context<T>` as an identifier like `ctx`, `_`, or `Context { .. }`"),
             "expected targeted top-level pattern error, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn declare_program_markers_emit_known_idl_addresses() {
+        let idl = serde_json::json!({
+            "address": "Externa1111111111111111111111111111111111111",
+            "metadata": {
+                "name": "fixture",
+                "version": "0.1.0",
+                "spec": "0.1.0"
+            },
+            "instructions": [{
+                "name": "ping",
+                "discriminator": [1, 2, 3, 4, 5, 6, 7, 8],
+                "accounts": [],
+                "args": []
+            }],
+            "accounts": [],
+            "types": []
+        });
+        let name: syn::Ident = syn::parse_quote!(fixture);
+
+        let generated = gen_declared_program(&name, &idl)
+            .expect("fixture IDL should generate")
+            .to_string();
+
+        assert!(
+            generated.contains(
+                "const IDL_ADDRESS : & 'static str = \"Externa1111111111111111111111111111111111111\""
+            ),
+            "declare_program markers should expose their known address for IDL emission: \
+             {generated}"
         );
     }
 }

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1962,7 +1962,7 @@ pub fn parse_field(
             idl_address_v1_source: None,
             idl_docs: vec![],
             idl_pda: None,
-            idl_field_ty: None,
+            idl_field_ty: Some(field_ty.clone()),
         });
     }
 

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -1119,13 +1119,6 @@ pub struct NestedIdlDepsInner {
     pub vault: Account<NestedVault>,
 }
 
-#[cfg(feature = "idl-build")]
-impl IdlAccountType for NestedIdlDepsInner {
-    fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
-        <Account<NestedVault> as IdlAccountType>::__register_idl_deps(accounts, types);
-    }
-}
-
 #[derive(Accounts)]
 pub struct NestedIdlDepsOuter {
     pub inner: Nested<NestedIdlDepsInner>,
@@ -1134,13 +1127,6 @@ pub struct NestedIdlDepsOuter {
 #[derive(Accounts)]
 pub struct NestedNoDepsInner {
     pub authority: Signer,
-}
-
-#[cfg(feature = "idl-build")]
-impl IdlAccountType for NestedNoDepsInner {
-    fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
-        <Signer as IdlAccountType>::__register_idl_deps(accounts, types);
-    }
 }
 
 #[derive(Accounts)]

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -1108,3 +1108,40 @@ pub struct CheckAssociatedTokenProgramSeed {
     #[account(seeds = [b"vault"], bump, seeds::program = AssociatedToken::id())]
     pub data: UncheckedAccount,
 }
+
+#[account]
+pub struct NestedVault {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct NestedIdlDepsInner {
+    pub vault: Account<NestedVault>,
+}
+
+impl IdlAccountType for NestedIdlDepsInner {
+    fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
+        Self::__idl_register_deps(accounts, types);
+    }
+}
+
+#[derive(Accounts)]
+pub struct NestedIdlDepsOuter {
+    pub inner: Nested<NestedIdlDepsInner>,
+}
+
+#[derive(Accounts)]
+pub struct NestedNoDepsInner {
+    pub authority: Signer,
+}
+
+impl IdlAccountType for NestedNoDepsInner {
+    fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
+        Self::__idl_register_deps(accounts, types);
+    }
+}
+
+#[derive(Accounts)]
+pub struct NestedNoDepsOuter {
+    pub inner: Nested<NestedNoDepsInner>,
+}

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -1119,9 +1119,10 @@ pub struct NestedIdlDepsInner {
     pub vault: Account<NestedVault>,
 }
 
+#[cfg(feature = "idl-build")]
 impl IdlAccountType for NestedIdlDepsInner {
     fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
-        Self::__idl_register_deps(accounts, types);
+        <Account<NestedVault> as IdlAccountType>::__register_idl_deps(accounts, types);
     }
 }
 
@@ -1135,9 +1136,10 @@ pub struct NestedNoDepsInner {
     pub authority: Signer,
 }
 
+#[cfg(feature = "idl-build")]
 impl IdlAccountType for NestedNoDepsInner {
     fn __register_idl_deps(accounts: &mut Vec<&'static str>, types: &mut Vec<&'static str>) {
-        Self::__idl_register_deps(accounts, types);
+        <Signer as IdlAccountType>::__register_idl_deps(accounts, types);
     }
 }
 

--- a/tests-v2/tests/idl_metadata.rs
+++ b/tests-v2/tests/idl_metadata.rs
@@ -1,6 +1,7 @@
 use {
     anchor_lang_idl_spec::{IdlInstructionAccount, IdlInstructionAccountItem, IdlSeed},
     anchor_lang_v2::{programs::AssociatedToken, Id},
+    declare_program_surface::surface,
 };
 
 fn parse_accounts(json: &str) -> Vec<IdlInstructionAccountItem> {
@@ -86,11 +87,45 @@ fn unsupported_runtime_seed_omits_pda_metadata() {
 }
 
 #[test]
+fn nested_accounts_register_transitive_idl_deps() {
+    let mut accounts = Vec::new();
+    let mut types = Vec::new();
+    accounts_test::NestedIdlDepsOuter::__idl_register_deps(&mut accounts, &mut types);
+
+    assert!(
+        accounts.iter().any(|entry| entry.contains("\"name\":\"NestedVault\"")),
+        "nested account data should register its account entry: {accounts:?}"
+    );
+    assert!(
+        types.iter().any(|entry| entry.contains("\"name\":\"NestedVault\"")),
+        "nested account data should register its type entry: {types:?}"
+    );
+}
+
+#[test]
 fn wrapped_runtime_arg_seed_omits_pda_metadata() {
     let items = parse_accounts(&seeds::InitWrappedArgSeed::__idl_accounts());
     let account = single_account(&items, 1);
     assert!(
         account.pda.is_none(),
         "wrapped runtime arg seed should omit unsupported pda metadata"
+    );
+}
+
+#[test]
+fn nested_accounts_without_data_do_not_invent_idl_deps() {
+    let mut accounts = Vec::new();
+    let mut types = Vec::new();
+    accounts_test::NestedNoDepsOuter::__idl_register_deps(&mut accounts, &mut types);
+
+    assert!(accounts.is_empty(), "expected no account deps, got {accounts:?}");
+    assert!(types.is_empty(), "expected no type deps, got {types:?}");
+}
+
+#[test]
+fn declared_program_markers_expose_known_idl_address() {
+    assert_eq!(
+        surface::program::Surface::IDL_ADDRESS,
+        "D9t6cEFPTDWmTZfcikokLbnuuyeJT6oXnpEbyXB45LU2"
     );
 }


### PR DESCRIPTION
#### Finding
Nested accounts flattened their fields into IDL, but the nested account data types were not registered as IDL dependencies. declare_program! markers also exposed id() without surfacing their known IDL address.
#### Fix
This PR preserves nested IDL dependency registration and exposes IDL_ADDRESS for declared program markers, so generated IDL keeps the missing account metadata. Added regression tests for nested deps and marker addresses.