### PR TITLE
fix(lang-v2): preserve nested account bump caches

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -163,6 +163,10 @@ name = "account_deserialize_surface"
 required-features = ["testing"]
 
 [[test]]
+name = "nested_bumps"
+required-features = ["testing"]
+
+[[test]]
 name = "address_idl_surface"
 
 [[test]]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1058,20 +1058,83 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
     let constraints: Vec<_> = fields.iter().flat_map(|f| &f.constraints).collect();
     let updates: Vec<_> = fields.iter().filter_map(|f| f.update.as_ref()).collect();
     let exits: Vec<_> = fields.iter().filter_map(|f| f.exit.as_ref()).collect();
-    // Bumps fields. Optional accounts get `Option<u8>` so the default
-    // (`None`) maps cleanly to the sentinel-`None` load path; the seeds
-    // check assigns `Some(bump)` only when the inner is `Some`. Mirrors
-    // v1's `bumps.rs:36` Optional handling.
+    // Collect per-field dup checks under a single outer `if let Some(__dups)`
+    // gate so non-dup txs pay one Option-tag branch for the whole struct,
+    // not one per mut field.
+    let dup_checks: Vec<_> = fields.iter().filter_map(|f| f.dup_check.as_ref()).collect();
+    let dup_check_block = if dup_checks.is_empty() {
+        quote::quote! {}
+    } else {
+        quote::quote! {
+            if let Some(__dups) = __duplicates {
+                #(#dup_checks)*
+            }
+        }
+    };
+    // Bump-cache surface:
+    //   - direct PDA fields keep their existing `u8` / `Option<u8>` entries;
+    //     optional accounts still use `Option<u8>` so the sentinel-`None`
+    //     path mirrors v1's `bumps.rs:36` handling
+    //   - `Nested<Inner>` fields preserve the inner `Inner::Bumps` payload so
+    //     handlers can reach it through `ctx.bumps.<nested>.*`
+    //
+    // Direct fields still use per-field mutable locals during parsing; nested
+    // fields bind the inner bumps value returned by `Inner::try_accounts`.
     let bump_fields: Vec<proc_macro2::TokenStream> = fields
+        .iter()
+        .filter_map(|f| {
+            let n = &f.name;
+            if f.has_bump {
+                Some(if f.is_optional {
+                    quote! { pub #n: Option<u8> }
+                } else {
+                    quote! { pub #n: u8 }
+                })
+            } else {
+                parse::extract_nested_inner_type(&f.ty)
+                    .map(|inner_ty| quote! { pub #n: <#inner_ty as anchor_lang_v2::Bumps>::Bumps })
+            }
+        })
+        .collect();
+    let nested_bump_default_bounds: Vec<proc_macro2::TokenStream> = fields
+        .iter()
+        .filter_map(|f| {
+            parse::extract_nested_inner_type(&f.ty).map(|inner_ty| {
+                quote! { <#inner_ty as anchor_lang_v2::Bumps>::Bumps: ::core::default::Default }
+            })
+        })
+        .collect();
+    let bump_cache_locals: Vec<proc_macro2::TokenStream> = fields
         .iter()
         .filter(|f| f.has_bump)
         .map(|f| {
-            let n = &f.name;
+            let bump_cache = parse::bump_cache_ident(&f.name);
             if f.is_optional {
-                quote! { #n: Option<u8> }
+                quote! {
+                    let mut #bump_cache: ::core::option::Option<u8> = ::core::default::Default::default();
+                }
             } else {
-                quote! { #n: u8 }
+                quote! {
+                    let mut #bump_cache: u8 = ::core::default::Default::default();
+                }
             }
+        })
+        .collect();
+    let bump_cache_fields: Vec<proc_macro2::TokenStream> = fields
+        .iter()
+        .filter(|f| f.has_bump || parse::extract_nested_inner_type(&f.ty).is_some())
+        .map(|f| {
+            let n = &f.name;
+            let bump_cache = parse::bump_cache_ident(n);
+            quote! { #n: #bump_cache }
+        })
+        .collect();
+    let bump_default_fields: Vec<proc_macro2::TokenStream> = fields
+        .iter()
+        .filter(|f| f.has_bump || parse::extract_nested_inner_type(&f.ty).is_some())
+        .map(|f| {
+            let n = &f.name;
+            quote! { #n: ::core::default::Default::default() }
         })
         .collect();
 
@@ -1307,14 +1370,27 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
     let has_bumps = !bump_fields.is_empty();
     let bumps_def = if has_bumps {
         quote! {
-            #[derive(Default, Clone)]
-            pub struct #bumps_name { #(pub #bump_fields,)* }
+            #[derive(Clone)]
+            pub struct #bumps_name { #(#bump_fields,)* }
+
+            impl ::core::default::Default for #bumps_name
+            where
+                #(#nested_bump_default_bounds,)*
+            {
+                fn default() -> Self {
+                    Self {
+                        #(#bump_default_fields,)*
+                    }
+                }
+            }
         }
     } else {
         quote! { pub type #bumps_name = (); }
     };
-    let bumps_init = if has_bumps {
-        quote! { let mut __bumps = #bumps_name::default(); }
+    let bumps_build = if has_bumps {
+        quote! {
+            let __bumps = #bumps_name { #(#bump_cache_fields,)* };
+        }
     } else {
         quote! { let __bumps = #bumps_name::default(); }
     };
@@ -1953,10 +2029,12 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 __ix_data: &'ix [u8],
             ) -> anchor_lang_v2::Result<(Self, #bumps_name, Self::IxArgs<'ix>)> {
                 #ix_deser
-                #bumps_init
+                #(#bump_cache_locals)*
                 #(#loads)*
                 #(#deferred_loads)*
+                #dup_check_block
                 #(#constraints)*
+                #bumps_build
                 Ok((Self { #(#field_names),* }, __bumps, #ix_args_return))
             }
 
@@ -6942,6 +7020,37 @@ mod tests {
             ),
             "declare_program markers should expose their known address for IDL emission: \
              {generated}"
+        );
+    }
+
+    fn nested_accounts_preserve_inner_bumps_in_generated_surface() {
+        let input: syn::DeriveInput = syn::parse_quote! {
+            pub struct Outer {
+                pub authority: anchor_lang_v2::accounts::UncheckedAccount,
+                pub inner: anchor_lang_v2::Nested<Inner>,
+            }
+        };
+
+        let generated = impl_accounts(&input).to_string();
+
+        assert!(
+            generated.contains("pub struct OuterBumps"),
+            "expected outer bumps struct: {generated}"
+        );
+        assert!(
+            generated.contains("pub inner : < Inner as anchor_lang_v2 :: Bumps > :: Bumps"),
+            "expected nested field to retain the inner bumps type: {generated}"
+        );
+        assert!(
+            generated.contains(
+                "let (__nested_inner , __anchor_bump_cache_inner , _) = < Inner as anchor_lang_v2 :: TryAccounts > :: validate_accounts"
+            ),
+            "expected nested validate_accounts call to keep the returned bumps value: {generated}"
+        );
+        assert!(
+            generated
+                .contains("let __bumps = OuterBumps { inner : __anchor_bump_cache_inner , } ;"),
+            "expected final outer bumps assembly to include the nested bump cache: {generated}"
         );
     }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1058,19 +1058,6 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
     let constraints: Vec<_> = fields.iter().flat_map(|f| &f.constraints).collect();
     let updates: Vec<_> = fields.iter().filter_map(|f| f.update.as_ref()).collect();
     let exits: Vec<_> = fields.iter().filter_map(|f| f.exit.as_ref()).collect();
-    // Collect per-field dup checks under a single outer `if let Some(__dups)`
-    // gate so non-dup txs pay one Option-tag branch for the whole struct,
-    // not one per mut field.
-    let dup_checks: Vec<_> = fields.iter().filter_map(|f| f.dup_check.as_ref()).collect();
-    let dup_check_block = if dup_checks.is_empty() {
-        quote::quote! {}
-    } else {
-        quote::quote! {
-            if let Some(__dups) = __duplicates {
-                #(#dup_checks)*
-            }
-        }
-    };
     // Bump-cache surface:
     //   - direct PDA fields keep their existing `u8` / `Option<u8>` entries;
     //     optional accounts still use `Option<u8>` so the sentinel-`None`
@@ -2032,7 +2019,6 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 #(#bump_cache_locals)*
                 #(#loads)*
                 #(#deferred_loads)*
-                #dup_check_block
                 #(#constraints)*
                 #bumps_build
                 Ok((Self { #(#field_names),* }, __bumps, #ix_args_return))

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1503,6 +1503,24 @@ pub fn validate_account_fields(fields: &[FieldSummary]) -> syn::Result<()> {
     Ok(())
 }
 
+pub fn bump_cache_ident(field_name: &Ident) -> Ident {
+    Ident::new(
+        &format!("__anchor_bump_cache_{}", field_name.unraw()),
+        field_name.span(),
+    )
+}
+
+/// Turn the RHS of `#[account(address = <expr>)]` into the string form the
+/// IDL emits. Whitespace from `quote!`'s token reassembly is stripped so
+/// `crate :: ID` → `crate::ID`, `data . authority` → `data.authority`, and
+/// `crate :: id ()` → `crate::id()` — matching what a user would hand-write
+/// and what downstream tooling (the Anchor CLI resolver, TS client path
+/// walkers) expect to parse.
+fn stringify_address_expr(expr: &Expr) -> String {
+    let s = quote!(#expr).to_string();
+    s.split_whitespace().collect()
+}
+
 /// If `expr` is the v1-encodable shape `<sibling>.<field>` where both:
 ///   - `<sibling>` is a sibling field name, and
 ///   - `<field>` matches `self_name` (the field carrying this constraint),
@@ -1630,6 +1648,7 @@ fn emit_seeds_check(
     using_our_program_id: bool,
     is_optional: bool,
 ) -> TokenStream2 {
+    let bump_cache = bump_cache_ident(field_name);
     let (seed_bindings, seed_refs) = materialize_seed_refs(seeds, field_names);
     // For optional fields the bumps struct field is `Option<u8>`, so the
     // assignment wraps in `Some(...)`. Non-optional fields assign the bump
@@ -1663,7 +1682,7 @@ fn emit_seeds_check(
                         if !anchor_lang_v2::address_eq(#target_addr_ref, &#pda_const) {
                             return Err(anchor_lang_v2::ErrorCode::ConstraintSeeds.into());
                         }
-                        __bumps.#field_name = #bump_assign;
+                        #bump_cache = #bump_assign;
                     };
                     return if for_init {
                         quote! {
@@ -1683,14 +1702,35 @@ fn emit_seeds_check(
         }
     }
 
-    // Fallback: runtime canonical find loop fused with the equality check.
+    // Fallback: runtime find loop fused with the equality check.
+    //
+    // Skip `sol_curve_validate_point` when the account is provably
+    // signed-for (`MIN_DATA_LEN > 0`), since account creation already
+    // validates the PDA via `create_program_address`.
+    //
+    // Otherwise (`UncheckedAccount` with zero data, non-init): the curve
+    // check is the only proof the address is a real PDA.
+    //
+    // `MIN_DATA_LEN` is a trait const, so the branch is resolved at
+    // compile time — LLVM eliminates the dead path entirely.
+    // TODO: decide whether init paths should assume the subsequent
+    // CreateAccount CPI guarantees the address is off-curve, letting
+    // us skip `sol_curve_validate_point`. Currently we always run the
+    // curve check on init to avoid relying on the trait impl's CPI.
+    let skip_curve = quote! { false };
     let bump_assign = wrap_bump(quote! { __bump });
     let find = quote! {
         #(#seed_bindings)*
-        let __bump = anchor_lang_v2::find_and_verify_program_address(
-            &[#(#seed_refs),*], #pda_program, #target_addr_ref,
-        ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?;
-        __bumps.#field_name = #bump_assign;
+        let __bump = if #skip_curve {
+            anchor_lang_v2::find_and_verify_program_address_skip_curve(
+                &[#(#seed_refs),*], #pda_program, #target_addr_ref,
+            ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?
+        } else {
+            anchor_lang_v2::find_and_verify_program_address(
+                &[#(#seed_refs),*], #pda_program, #target_addr_ref,
+            ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?
+        };
+        #bump_cache = #bump_assign;
     };
     if for_init {
         quote! {
@@ -1745,6 +1785,7 @@ fn emit_payer_signer_seeds_binding(
     }
 
     let bump_field = &payer_field.name;
+    let bump_cache = bump_cache_ident(bump_field);
     if let Expr::Array(arr) = seeds_expr {
         let seed_elems: Vec<&Expr> = arr.elems.iter().collect();
         let (seed_bindings, seed_refs) = materialize_seed_refs(&seed_elems, field_names);
@@ -1761,7 +1802,7 @@ fn emit_payer_signer_seeds_binding(
                     __program_id,
                     __payer.address(),
                 )?;
-                __bumps.#bump_field = __payer_bump;
+                #bump_cache = __payer_bump;
                 let __payer_bump_seed = [__payer_bump];
                 let __payer_signer_seeds: Option<&[&[u8]]> =
                     Some(&[#(#seed_refs),* , __payer_bump_seed.as_ref()]);
@@ -1777,7 +1818,7 @@ fn emit_payer_signer_seeds_binding(
                 anchor_lang_v2::find_and_verify_program_address(
                     &[#(#seed_refs),*], __program_id, __payer.address(),
                 ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?;
-            __bumps.#bump_field = __payer_bump;
+            #bump_cache = __payer_bump;
             let __payer_bump_seed = [__payer_bump];
             let __payer_signer_seeds: Option<&[&[u8]]> =
                 Some(&[#(#seed_refs),* , __payer_bump_seed.as_ref()]);
@@ -1803,7 +1844,7 @@ fn emit_payer_signer_seeds_binding(
                 __program_id,
                 __payer.address(),
             )?;
-            __bumps.#bump_field = __payer_bump;
+            #bump_cache = __payer_bump;
             let __payer_signer_seeds: Option<&[&[u8]]> =
                 Some(&__payer_seed_buf[..__payer_seed_count + 1]);
         });
@@ -1816,7 +1857,7 @@ fn emit_payer_signer_seeds_binding(
             anchor_lang_v2::find_and_verify_program_address(
                 __payer_seed_ref, __program_id, __payer.address(),
             ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?;
-        __bumps.#bump_field = __payer_bump;
+        #bump_cache = __payer_bump;
         let __payer_bump_bytes = [__payer_bump];
         let mut __payer_seed_buf: [&[u8]; anchor_lang_v2::MAX_PAYER_SEEDS_WITH_BUMP] =
             [&[]; anchor_lang_v2::MAX_PAYER_SEEDS_WITH_BUMP];
@@ -1935,6 +1976,7 @@ fn emit_init_body(
             } else {
                 quote! { __bump }
             };
+            let bump_cache = bump_cache_ident(field_name);
             quote! {
                 let __seed_expr_val = #seeds_expr;
                 let __seed_ref: &[&[u8]] = __seed_expr_val.as_ref();
@@ -1942,7 +1984,7 @@ fn emit_init_body(
                     anchor_lang_v2::find_and_verify_program_address(
                         __seed_ref, #pda_program, &__target.address(),
                     ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?;
-                __bumps.#field_name = #bump_assign;
+                #bump_cache = #bump_assign;
                 let __bump_bytes = [__bump];
                 let mut __seed_buf: [&[u8]; 17] = [&[]; 17];
                 let __n = __seed_ref.len();
@@ -2281,6 +2323,7 @@ pub fn parse_field(
 
         let inner_ty = extract_nested_inner_type(field_ty)
             .expect("is_nested_type was true but extract_nested_inner_type returned None");
+        let nested_bumps = bump_cache_ident(field_name);
         // Nested<Inner> — delegate to Inner::validate_accounts, which advances
         // the shared cursor by Inner::HEADER_SIZE without firing inner
         // update-hooks yet. The outer walk_n covers only direct
@@ -2297,7 +2340,7 @@ pub fn parse_field(
         // nested struct. A future optimization could pre-shift the bitvec
         // or use a wrapper that offsets transparently.
         let load = quote! {
-            let (__nested_inner, _, _) =
+            let (__nested_inner, #nested_bumps, _) =
                 <#inner_ty as anchor_lang_v2::TryAccounts>::validate_accounts(
                     __program_id,
                     &__views[#offset_expr .. #offset_expr + <#inner_ty as anchor_lang_v2::TryAccounts>::HEADER_SIZE],
@@ -2665,6 +2708,7 @@ pub fn parse_field(
                 // Array-literal seeds: `seeds = [b"vault", user.address().as_ref()]`
                 let seed_elems: Vec<&Expr> = arr.elems.iter().collect();
                 let seed_constraint = if let Some(Some(ref bump_expr)) = attrs.bump {
+                    let bump_cache = bump_cache_ident(field_name);
                     let bump_assign = if is_optional {
                         quote! { Some(__bump_val) }
                     } else {
@@ -2681,7 +2725,7 @@ pub fn parse_field(
                                 #pda_program,
                                 #field_name.account().address(),
                             )?;
-                            __bumps.#field_name = #bump_assign;
+                            #bump_cache = #bump_assign;
                         }
                     }
                 } else {
@@ -2714,6 +2758,7 @@ pub fn parse_field(
                     quote! { __bump }
                 };
                 let seed_constraint = if let Some(Some(ref bump_expr)) = attrs.bump {
+                    let bump_cache = bump_cache_ident(field_name);
                     // Explicit bump + expression seeds: verify with appended bump
                     quote! {
                         {
@@ -2733,20 +2778,31 @@ pub fn parse_field(
                                 #pda_program,
                                 #field_name.account().address(),
                             )?;
-                            __bumps.#field_name = #bump_assign;
+                            #bump_cache = #bump_assign;
                         }
                     }
                 } else {
-                    // Bare bump: find and verify the canonical PDA.
+                    let bump_cache = bump_cache_ident(field_name);
+                    // Bare bump: use find_and_verify with skip_curve
+                    // when the account type guarantees non-zero data.
+                    let skip_curve = quote! {
+                        <#field_ty as anchor_lang_v2::AnchorAccount>::MIN_DATA_LEN > 0
+                    };
                     let target_addr = quote! { #field_name.account().address() };
                     quote! {
                         {
                             let __seed_val = #seeds_expr;
                             let __seed_ref: &[&[u8]] = __seed_val.as_ref();
-                            let __bump = anchor_lang_v2::find_and_verify_program_address(
-                                __seed_ref, #pda_program, #target_addr,
-                            ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?;
-                            __bumps.#field_name = #bump_assign;
+                            let __bump = if #skip_curve {
+                                anchor_lang_v2::find_and_verify_program_address_skip_curve(
+                                    __seed_ref, #pda_program, #target_addr,
+                                ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?
+                            } else {
+                                anchor_lang_v2::find_and_verify_program_address(
+                                    __seed_ref, #pda_program, #target_addr,
+                                ).map_err(|_| anchor_lang_v2::ErrorCode::ConstraintSeeds)?
+                            };
+                            #bump_cache = #bump_assign;
                         }
                     }
                 };

--- a/lang-v2/tests/nested_bumps.rs
+++ b/lang-v2/tests/nested_bumps.rs
@@ -1,0 +1,26 @@
+#![allow(dead_code)]
+
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Inner {
+    #[account(seeds = [b"vault"], bump)]
+    pub vault: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct Outer {
+    pub authority: UncheckedAccount,
+    pub inner: Nested<Inner>,
+}
+
+fn nested_bump(ctx: &Context<'_, Outer>) -> u8 {
+    ctx.bumps.inner.vault
+}
+
+#[test]
+fn nested_bumps_are_available_through_context() {
+    let _: fn(&Context<'_, Outer>) -> u8 = nested_bump;
+}

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -914,6 +914,64 @@ pub struct Bad {
 }
 
 #[test]
+fn nested_bumps_compile_through_nested_context_surface() {
+    CompileCase::new(
+        "nested_bumps_context_surface",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Inner {
+    #[account(seeds = [b"vault"], bump)]
+    pub vault: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct Outer {
+    pub authority: UncheckedAccount,
+    pub inner: Nested<Inner>,
+}
+
+pub fn nested_bump(ctx: &Context<'_, Outer>) -> u8 {
+    ctx.bumps.inner.vault
+}
+"#,
+    )
+    .expect_pass();
+}
+
+#[test]
+fn nested_bumps_reject_flat_access_for_nested_accounts() {
+    CompileCase::new(
+        "nested_bumps_flat_access",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Inner {
+    #[account(seeds = [b"vault"], bump)]
+    pub vault: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct Outer {
+    pub authority: UncheckedAccount,
+    pub inner: Nested<Inner>,
+}
+
+pub fn nested_bump(ctx: &Context<'_, Outer>) -> u8 {
+    ctx.bumps.vault
+}
+"#,
+    )
+    .expect_fail(&["no field `vault`"]);
+}
+
+#[test]
 fn associated_token_rejects_unknown_constraint_key() {
     CompileCase::new(
         "associated_token_unknown_constraint_key",


### PR DESCRIPTION
#### Finding
Nested Accounts parsing preserved inner PDA validation, but it discarded the inner bump cache, so `ctx.bumps` only exposed direct account bumps and hid nested PDA bumps.
#### Fix
This PR threads nested bump caches into the generated parent `ctx.bumps` surface, so inner PDA bumps remain available as `ctx.bumps.inner.*`. Added regression tests for nested bump access and invalid flat access.