### PR TITLE
fix(lang-v2): align account deserialization surfaces

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -159,6 +159,10 @@ name = "to_cpi_accounts_derive"
 required-features = ["testing"]
 
 [[test]]
+name = "account_deserialize_surface"
+required-features = ["testing"]
+
+[[test]]
 name = "address_idl_surface"
 required-features = ["testing"]
 

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1981,9 +1981,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Client-side `AccountDeserialize` impl. Mode-dependent: borsh accounts
     // run wincode (with `BORSH_CONFIG`, borsh-wire-compatible) over the
-    // post-disc tail; pod accounts do a `bytemuck::pod_read_unaligned` on a
-    // sized slice. Both share the disc-check shape so a wrong-type fetch
-    // surfaces as `InvalidAccountData`.
+    // payload after the reserved discriminator region; pod accounts do a
+    // `bytemuck::pod_read_unaligned` on that same post-disc payload slice.
+    // `try_deserialize_unchecked` intentionally skips the discriminator bytes
+    // without validating them, matching Anchor v1 and the trait docs'
+    // "unchecked" contract for full account buffers.
     let account_deserialize_impl = if is_borsh {
         quote! {
             impl anchor_lang_v2::AccountDeserialize for #name {
@@ -1994,27 +1996,35 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                     if buf.len() < <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len() {
                         return Err(anchor_lang_v2::Error::AccountDataTooSmall);
                     }
-                    let (disc, rest) = buf.split_at(<Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len());
+                    let disc = &buf[..<Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len()];
                     if disc != <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR {
                         return Err(anchor_lang_v2::Error::InvalidAccountData);
                     }
-                    *buf = rest;
                     Self::try_deserialize_unchecked(buf)
                 }
                 fn try_deserialize_unchecked(
                     buf: &mut &[u8],
                 ) -> ::core::result::Result<Self, anchor_lang_v2::Error> {
+                    use anchor_lang_v2::Discriminator as _;
+                    let disc_len = <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len();
+                    if buf.len() < disc_len {
+                        return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+                    }
+                    let original = *buf;
                     // Use `SchemaRead::get` (reads from a `&mut &[u8]` Reader
                     // and advances it) rather than `config::deserialize`,
                     // which takes the input by value and would leave `*buf`
                     // unchanged — `AccountDeserialize`'s cursor contract
-                    // requires the post-disc slice to advance through the
-                    // payload so chained deserializations stay aligned.
-                    <Self as anchor_lang_v2::wincode::SchemaRead<
+                    // requires the full slice to advance through the
+                    // discriminator region and payload together.
+                    let mut data = &original[disc_len..];
+                    let value = <Self as anchor_lang_v2::wincode::SchemaRead<
                         '_,
                         anchor_lang_v2::BorshConfig,
-                    >>::get(buf)
-                        .map_err(|_| anchor_lang_v2::Error::InvalidAccountData)
+                    >>::get(&mut data)
+                        .map_err(|_| anchor_lang_v2::Error::InvalidAccountData)?;
+                    *buf = data;
+                    Ok(value)
                 }
             }
         }
@@ -2028,22 +2038,28 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                     if buf.len() < <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len() {
                         return Err(anchor_lang_v2::Error::AccountDataTooSmall);
                     }
-                    let (disc, rest) = buf.split_at(<Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len());
+                    let disc = &buf[..<Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len()];
                     if disc != <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR {
                         return Err(anchor_lang_v2::Error::InvalidAccountData);
                     }
-                    *buf = rest;
                     Self::try_deserialize_unchecked(buf)
                 }
                 fn try_deserialize_unchecked(
                     buf: &mut &[u8],
                 ) -> ::core::result::Result<Self, anchor_lang_v2::Error> {
-                    let n = ::core::mem::size_of::<Self>();
-                    if buf.len() < n {
+                    use anchor_lang_v2::Discriminator as _;
+                    let disc_len = <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len();
+                    if buf.len() < disc_len {
                         return Err(anchor_lang_v2::Error::AccountDataTooSmall);
                     }
-                    let value: Self = anchor_lang_v2::bytemuck::pod_read_unaligned(&buf[..n]);
-                    *buf = &buf[n..];
+                    let original = *buf;
+                    let data = &original[disc_len..];
+                    let n = ::core::mem::size_of::<Self>();
+                    if data.len() < n {
+                        return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+                    }
+                    let value: Self = anchor_lang_v2::bytemuck::pod_read_unaligned(&data[..n]);
+                    *buf = &data[n..];
                     Ok(value)
                 }
             }
@@ -3161,6 +3177,16 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     &idl_type_def,
                     idl_field_tys,
                 );
+                let account_deserialize_impl = account_entry
+                    .as_ref()
+                    .map(|_| {
+                        gen_declare_program_account_deserialize_impl(
+                            &ident,
+                            &generics,
+                            serialization,
+                        )
+                    })
+                    .unwrap_or_default();
                 let pod_impls = serialization
                     .is_bytemuck()
                     .then(|| gen_declare_program_pod_impls(&ident, &generics, &fields))
@@ -3176,6 +3202,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         }
                         #pod_impls
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                     DeclareTypeFields::Named { fields, .. } => quote! {
@@ -3186,6 +3213,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                             #(#fields)*
                         }
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                     DeclareTypeFields::Tuple { fields, .. } if serialization.is_bytemuck() => quote! {
@@ -3195,6 +3223,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         pub struct #ident #impl_generics(#(#fields),*);
                         #pod_impls
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                     DeclareTypeFields::Tuple { fields, .. } => quote! {
@@ -3203,6 +3232,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         #[derive(Clone, anchor_lang_v2::wincode::SchemaRead, anchor_lang_v2::wincode::SchemaWrite)]
                         pub struct #ident #impl_generics(#(#fields),*);
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                     DeclareTypeFields::Unit if serialization.is_bytemuck() => quote! {
@@ -3212,6 +3242,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         pub struct #ident #impl_generics;
                         #pod_impls
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                     DeclareTypeFields::Unit => quote! {
@@ -3220,6 +3251,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                         #[derive(Clone, anchor_lang_v2::wincode::SchemaRead, anchor_lang_v2::wincode::SchemaWrite)]
                         pub struct #ident #impl_generics;
                         #discriminator_impl
+                        #account_deserialize_impl
                         #idl_impl
                     },
                 });
@@ -3842,6 +3874,88 @@ fn gen_declare_program_idl_account_type_impl(
                 )*
             }
         }
+    }
+}
+
+fn gen_declare_program_account_deserialize_impl(
+    ident: &Ident,
+    generics: &DeclareTypeGenerics,
+    serialization: DeclareTypeSerialization,
+) -> TokenStream2 {
+    let impl_generics = &generics.impl_generics;
+    let ty_generics = &generics.ty_generics;
+    let try_deserialize = quote! {
+        fn try_deserialize(
+            buf: &mut &[u8],
+        ) -> ::core::result::Result<Self, anchor_lang_v2::Error> {
+            use anchor_lang_v2::Discriminator as _;
+            if buf.len() < <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len() {
+                return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+            }
+            let given_disc = &buf[..<Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len()];
+            if given_disc != <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR {
+                return Err(anchor_lang_v2::Error::InvalidAccountData);
+            }
+            Self::try_deserialize_unchecked(buf)
+        }
+    };
+
+    match serialization {
+        DeclareTypeSerialization::Borsh => quote! {
+            impl #impl_generics anchor_lang_v2::AccountDeserialize for #ident #ty_generics
+            where
+                for<'__de> Self:
+                    anchor_lang_v2::wincode::SchemaRead<'__de, anchor_lang_v2::BorshConfig, Dst = Self>,
+            {
+                #try_deserialize
+
+                fn try_deserialize_unchecked(
+                    buf: &mut &[u8],
+                ) -> ::core::result::Result<Self, anchor_lang_v2::Error> {
+                    use anchor_lang_v2::Discriminator as _;
+                    let disc_len = <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len();
+                    if buf.len() < disc_len {
+                        return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+                    }
+                    let original = *buf;
+                    let mut data = &original[disc_len..];
+                    let value = <Self as anchor_lang_v2::wincode::SchemaRead<
+                        '_,
+                        anchor_lang_v2::BorshConfig,
+                    >>::get(&mut data)
+                        .map_err(|_| anchor_lang_v2::Error::InvalidAccountData)?;
+                    *buf = data;
+                    Ok(value)
+                }
+            }
+        },
+        DeclareTypeSerialization::Bytemuck | DeclareTypeSerialization::BytemuckUnsafe => quote! {
+            impl #impl_generics anchor_lang_v2::AccountDeserialize for #ident #ty_generics
+            where
+                Self: anchor_lang_v2::bytemuck::Pod,
+            {
+                #try_deserialize
+
+                fn try_deserialize_unchecked(
+                    buf: &mut &[u8],
+                ) -> ::core::result::Result<Self, anchor_lang_v2::Error> {
+                    use anchor_lang_v2::Discriminator as _;
+                    let disc_len = <Self as anchor_lang_v2::Discriminator>::DISCRIMINATOR.len();
+                    if buf.len() < disc_len {
+                        return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+                    }
+                    let original = *buf;
+                    let data = &original[disc_len..];
+                    let size = ::core::mem::size_of::<Self>();
+                    if data.len() < size {
+                        return Err(anchor_lang_v2::Error::AccountDataTooSmall);
+                    }
+                    let value = anchor_lang_v2::bytemuck::pod_read_unaligned(&data[..size]);
+                    *buf = &data[size..];
+                    Ok(value)
+                }
+            }
+        },
     }
 }
 

--- a/lang-v2/idls/deserialize_surface.json
+++ b/lang-v2/idls/deserialize_surface.json
@@ -1,0 +1,37 @@
+{
+  "address": "11111111111111111111111111111111",
+  "metadata": {
+    "name": "deserialize_surface",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "noop",
+      "discriminator": [1, 1, 1, 1, 1, 1, 1, 1],
+      "accounts": [],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "DeclaredCounter",
+      "discriminator": [9, 8, 7, 6, 5, 4, 3, 2]
+    }
+  ],
+  "types": [
+    {
+      "name": "DeclaredCounter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -601,8 +601,9 @@ pub trait Discriminator {
 
 /// Client-side account deserialization. Mirrors v1 anchor-lang's trait so
 /// `anchor-client` can fetch raw account bytes and decode them into the
-/// user's `#[account]` struct. The `#[account]` macro emits two impl
-/// bodies:
+/// user's `#[account]` struct. Generated account impls expect `buf` to start
+/// at the full account bytes, including the reserved discriminator prefix. The
+/// `#[account]` macro emits two impl bodies:
 ///
 ///   - Borsh mode (`#[account(borsh)]`): check disc, run `BorshDeserialize`.
 ///   - Pod mode (default): check disc, `bytemuck::pod_read_unaligned` on
@@ -619,8 +620,11 @@ pub trait AccountDeserialize: Sized {
         Self::try_deserialize_unchecked(buf)
     }
 
-    /// Decode without verifying the discriminator. Used during initialization
-    /// when the bytes are zero or otherwise not yet stamped with the disc.
+    /// Decode without verifying the discriminator. Generated account impls
+    /// still skip over the reserved discriminator region before decoding the
+    /// payload, but they do not check the prefix bytes. Used during
+    /// initialization when the bytes are zero or otherwise not yet stamped
+    /// with the disc.
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self, ProgramError>;
 }
 

--- a/lang-v2/tests/account_deserialize_surface.rs
+++ b/lang-v2/tests/account_deserialize_surface.rs
@@ -1,0 +1,86 @@
+#![allow(dead_code)]
+
+use anchor_lang_v2::{
+    account, declare_id, declare_program, AccountDeserialize, Discriminator, BORSH_CONFIG,
+};
+
+declare_id!("11111111111111111111111111111111");
+declare_program!(deserialize_surface);
+
+#[account]
+#[derive(Debug, PartialEq)]
+pub struct PodCounter {
+    pub value: u64,
+}
+
+#[account(borsh)]
+#[derive(Debug, PartialEq)]
+pub struct BorshCounter {
+    pub value: u64,
+}
+
+fn full_account_bytes<T>(payload: &[u8]) -> Vec<u8>
+where
+    T: Discriminator,
+{
+    [T::DISCRIMINATOR, payload].concat()
+}
+
+#[test]
+fn pod_account_deserializes_full_bytes_in_checked_and_unchecked_modes() {
+    let full = full_account_bytes::<PodCounter>(&7u64.to_le_bytes());
+
+    let mut checked = full.as_slice();
+    let checked_value = PodCounter::try_deserialize(&mut checked).unwrap();
+    assert_eq!(checked_value.value, 7);
+    assert!(checked.is_empty());
+
+    let mut unchecked = full.as_slice();
+    let unchecked_value = PodCounter::try_deserialize_unchecked(&mut unchecked).unwrap();
+    assert_eq!(unchecked_value.value, 7);
+    assert!(unchecked.is_empty());
+}
+
+#[test]
+fn borsh_account_deserializes_full_bytes_in_checked_and_unchecked_modes() {
+    let payload =
+        anchor_lang_v2::wincode::config::serialize(&BorshCounter { value: 11 }, BORSH_CONFIG)
+            .unwrap();
+    let full = full_account_bytes::<BorshCounter>(&payload);
+
+    let mut checked = full.as_slice();
+    let checked_value = BorshCounter::try_deserialize(&mut checked).unwrap();
+    assert_eq!(checked_value.value, 11);
+    assert!(checked.is_empty());
+
+    let mut unchecked = full.as_slice();
+    let unchecked_value = BorshCounter::try_deserialize_unchecked(&mut unchecked).unwrap();
+    assert_eq!(unchecked_value.value, 11);
+    assert!(unchecked.is_empty());
+}
+
+#[test]
+fn declared_program_accounts_implement_account_deserialize() {
+    let payload = anchor_lang_v2::wincode::config::serialize(
+        &deserialize_surface::DeclaredCounter { value: 19 },
+        BORSH_CONFIG,
+    )
+    .unwrap();
+    let full = full_account_bytes::<deserialize_surface::DeclaredCounter>(&payload);
+
+    let mut checked = full.as_slice();
+    let checked_value =
+        <deserialize_surface::DeclaredCounter as AccountDeserialize>::try_deserialize(&mut checked)
+            .unwrap();
+    assert_eq!(checked_value.value, 19);
+    assert!(checked.is_empty());
+
+    let mut unchecked = full.as_slice();
+    let unchecked_value =
+        <deserialize_surface::DeclaredCounter as AccountDeserialize>::try_deserialize_unchecked(
+            &mut unchecked,
+        )
+        .unwrap();
+    assert_eq!(unchecked_value.value, 19);
+    assert!(unchecked.is_empty());
+}

--- a/tests-v2/src/declare-program/serialization.rs
+++ b/tests-v2/src/declare-program/serialization.rs
@@ -1,5 +1,5 @@
 use {
-    anchor_lang_v2::{Discriminator, Id, InstructionData},
+    anchor_lang_v2::{AccountDeserialize, Discriminator, Id, InstructionData, BORSH_CONFIG},
     declare_program_serialization::serialization,
     solana_pubkey::Pubkey,
 };
@@ -25,6 +25,7 @@ fn declared_program_type_serialization_controls_account_traits() {
     where
         T: anchor_lang_v2::Owner
             + anchor_lang_v2::Discriminator
+            + anchor_lang_v2::AccountDeserialize
             + anchor_lang_v2::IdlAccountType
             + anchor_lang_v2::wincode::SchemaWrite<anchor_lang_v2::BorshConfig, Src = T>
             + for<'de> anchor_lang_v2::wincode::SchemaRead<'de, anchor_lang_v2::BorshConfig, Dst = T>,
@@ -122,4 +123,45 @@ fn declared_program_type_serialization_controls_account_traits() {
     assert_eq!(&zero_bytes[..8], &0x0102_0304_0506_0708u64.to_le_bytes());
     assert_eq!(&zero_bytes[8..12], &0x1112_1314u32.to_le_bytes());
     assert_eq!(&zero_bytes[12..16], b"zero");
+}
+
+#[test]
+fn declared_account_deserialize_unchecked_skips_discriminator_prefix() {
+    let original = serialization::ImplicitBorshAccount {
+        count: 9,
+        label: "decoded".to_string(),
+        items: vec![5, 6, 7],
+    };
+    let payload =
+        anchor_lang_v2::wincode::config::serialize(&original, BORSH_CONFIG).unwrap();
+    let mut bytes = Vec::from(serialization::ImplicitBorshAccount::DISCRIMINATOR);
+    bytes.extend_from_slice(&payload);
+
+    let mut buf = bytes.as_slice();
+    let decoded = serialization::ImplicitBorshAccount::try_deserialize_unchecked(&mut buf)
+        .expect("full account bytes should deserialize without checking the discriminator");
+
+    assert_eq!(decoded.count, original.count);
+    assert_eq!(decoded.label, original.label);
+    assert_eq!(decoded.items, original.items);
+    assert!(buf.is_empty(), "decoder should consume the full account buffer");
+}
+
+#[test]
+fn declared_account_deserialize_rejects_wrong_discriminator() {
+    let original = serialization::ImplicitBorshAccount {
+        count: 1,
+        label: "wrong-disc".to_string(),
+        items: vec![8, 9],
+    };
+    let payload =
+        anchor_lang_v2::wincode::config::serialize(&original, BORSH_CONFIG).unwrap();
+    let mut bytes = vec![0u8; serialization::ImplicitBorshAccount::DISCRIMINATOR.len()];
+    bytes.extend_from_slice(&payload);
+
+    let mut buf = bytes.as_slice();
+    assert!(
+        serialization::ImplicitBorshAccount::try_deserialize(&mut buf).is_err(),
+        "checked deserialize must reject a wrong discriminator"
+    );
 }


### PR DESCRIPTION
#### Finding
The public `AccountDeserialize` contract said `try_deserialize_unchecked` skips discriminator verification, but generated implementations decoded from the full buffer incorrectly, and `declare_program!` account types did not implement AccountDeserialize.
#### Fix
This PR makes generated deserializers consume full account bytes while skipping discriminator validation only in unchecked mode, and it adds `AccountDeserialize` for declared account types. Added regression tests for checked and unchecked decode surfaces.