### PR TITLE
fix(lang-v2): reject overlapping interface discriminators

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2655,6 +2655,42 @@ fn validate_discriminator_prefixes(
     Ok(())
 }
 
+fn validate_instruction_discriminator_prefixes(
+    handlers: &[&syn::ItemFn],
+    discrim_attrs: &[Option<DiscrimAttr>],
+) -> syn::Result<()> {
+    let discriminators: Vec<_> = handlers
+        .iter()
+        .enumerate()
+        .map(|(i, handler)| {
+            let name = handler.sig.ident.to_string();
+            let bytes = discrim_attrs[i]
+                .as_ref()
+                .map(|d| d.bytes.clone())
+                .unwrap_or_else(|| default_instruction_discriminator(&to_snake_case(&name)));
+            (name, bytes, handler.sig.ident.span())
+        })
+        .collect();
+
+    for (outer_name, outer_disc, outer_span) in &discriminators {
+        for (inner_name, inner_disc, _) in &discriminators {
+            if outer_name != inner_name && outer_disc.starts_with(inner_disc) {
+                return Err(syn::Error::new(
+                    *outer_span,
+                    format!(
+                        "Ambiguous discriminators for instructions: `{inner_name}` discriminator \
+                         {} is a prefix of `{outer_name}` discriminator {}",
+                        format_discriminator_bytes(inner_disc),
+                        format_discriminator_bytes(outer_disc),
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn format_discriminator_bytes(discriminator: &[u8]) -> String {
     let bytes = discriminator
         .iter()
@@ -4336,20 +4372,8 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
             }
         }
     } else if config.mode == ProgramMode::Interface {
-        let mut seen: std::collections::HashMap<Vec<u8>, proc_macro2::Span> =
-            std::collections::HashMap::new();
-        for (i, d) in discrim_attrs.iter().enumerate() {
-            let Some(d) = d else { continue };
-            if let Some(_first_span) = seen.insert(d.bytes.clone(), d.span) {
-                return syn::Error::new(
-                    d.span,
-                    format!(
-                        "duplicate `#[discrim = ...]` on instruction `{}`",
-                        handlers[i].sig.ident
-                    ),
-                )
-                .to_compile_error();
-            }
+        if let Err(err) = validate_instruction_discriminator_prefixes(&handlers, &discrim_attrs) {
+            return err.to_compile_error();
         }
     }
     let discrim_attrs: Vec<Option<Vec<u8>>> = discrim_attrs
@@ -5934,6 +5958,41 @@ mod tests {
         assert!(
             !generated.contains("default_allocator"),
             "interface mode must not emit entrypoint runtime: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_interface_mode_rejects_prefix_overlapping_discriminators() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod external_program {
+                use super::*;
+
+                #[discrim = [1]]
+                pub fn short(_ctx: &mut Context<Short>) -> Result<()> {
+                    unreachable!()
+                }
+
+                #[discrim = [1, 2]]
+                pub fn long(_ctx: &mut Context<Long>) -> Result<()> {
+                    unreachable!()
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Interface,
+            program_id: syn::parse_quote!(super::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("Ambiguous discriminators for instructions"),
+            "expected prefix-overlap rejection: {generated}"
+        );
+        assert!(
+            generated
+                .contains("`short` discriminator [1] is a prefix of `long` discriminator [1, 2]"),
+            "expected targeted prefix diagnostic: {generated}"
         );
     }
 }

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -309,7 +309,77 @@ pub mod program_interface_duplicate_discriminator {
 }
 "#,
     )
-    .expect_fail(&["duplicate `#[discrim = ...]`"]);
+    .expect_fail(&["Ambiguous discriminators for instructions"]);
+}
+
+#[test]
+fn program_interface_allows_distinct_discriminators_with_shared_prefix_bytes() {
+    CompileCase::new(
+        "program_interface_shared_prefix_distinct",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+const EXTERNAL_ID: Address =
+    anchor_lang_v2::address!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[derive(Accounts)]
+pub struct Empty {}
+
+#[program(interface, program_id = EXTERNAL_ID)]
+pub mod program_interface_shared_prefix_distinct {
+    use super::*;
+
+    #[discrim = [1, 2, 3]]
+    pub fn first(ctx: &mut Context<Empty>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+
+    #[discrim = [1, 2, 4]]
+    pub fn second(ctx: &mut Context<Empty>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+"#,
+    )
+    .expect_pass();
+}
+
+#[test]
+fn program_interface_rejects_prefix_overlapping_discriminators() {
+    CompileCase::new(
+        "program_interface_prefix_overlap",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+const EXTERNAL_ID: Address =
+    anchor_lang_v2::address!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
+
+#[derive(Accounts)]
+pub struct Empty {}
+
+#[program(interface, program_id = EXTERNAL_ID)]
+pub mod program_interface_prefix_overlap {
+    use super::*;
+
+    #[discrim = [1, 2]]
+    pub fn short(ctx: &mut Context<Empty>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+
+    #[discrim = [1, 2, 3]]
+    pub fn long(ctx: &mut Context<Empty>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+"#,
+    )
+    .expect_fail(&["Ambiguous discriminators for instructions"]);
 }
 
 #[test]


### PR DESCRIPTION
#### Finding
`#[program(interface)]` accepted discriminator sets with prefix overlap, which let ambiguous discriminator bytes flow into generated IDL even though imported program surfaces reject that ambiguity later.
#### Fix
This PR rejects ambiguous interface discriminators in the derive layer, covering both exact duplicates and true prefix-overlap cases while still allowing distinct discriminators with shared leading bytes. Added compile regression tests for allowed and rejected cases.