### PR TITLE
fix(lang-v2): resolve static idl address constraints

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -137,3 +137,7 @@ required-features = ["testing"]
 [[test]]
 name = "to_cpi_accounts_derive"
 required-features = ["testing"]
+
+[[test]]
+name = "address_idl_surface"
+required-features = ["testing"]

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -169,10 +169,12 @@ pub struct AccountsJsonField<'a> {
     pub field_ty: &'a Option<Type>,
     /// Stringified RHS of `#[account(address = <expr>)]`. When `Some`,
     /// takes precedence over `IdlAccountType::__IDL_ADDRESS` at emission.
-    /// Holds either a resolvable constant path / const-fn call (which the
-    /// Anchor CLI can turn into a base58 pubkey) or a dotted field path
-    /// like `data.authority` that clients walk at resolution time.
+    /// Holds only dotted field paths like `data.authority` that clients walk
+    /// at resolution time.
     pub address_override: Option<&'a str>,
+    /// Runtime-resolved static address expression. Evaluated inside
+    /// `__idl_accounts()` and rendered as base58.
+    pub address_override_expr: Option<&'a TokenStream2>,
     /// Set when this field is a `Nested<Inner>`, carrying the inner
     /// struct type. The emission splices the inner struct's own
     /// `__idl_accounts()` into the outer array instead of producing a
@@ -255,17 +257,22 @@ pub fn build_accounts_emission(fields: &[AccountsJsonField<'_>]) -> TokenStream2
                         anchor_lang_v2::__alloc::string::String::new();
                 },
             };
-            // `#[account(address = <expr>)]` override, pre-formatted as a
-            // JSON fragment. When set, takes precedence over the wrapper
-            // type's `__IDL_ADDRESS` — emitted at macro time so no runtime
-            // branch is needed to pick one.
+            // `#[account(address = <expr>)]` override. Static address
+            // expressions are evaluated at IDL-build time; dotted field
+            // paths stay as pre-formatted client-side hints.
             let address_override_json = f
                 .address_override
                 .map(|s| format!(",\"address\":\"{s}\""))
                 .unwrap_or_default();
             let init_signer = f.init_signer;
             if let Some(ty) = f.field_ty {
-                let addr_json_expr = if f.address_override.is_some() {
+                let addr_json_expr = if let Some(address_expr) = f.address_override_expr {
+                    quote! {
+                        let __addr: anchor_lang_v2::Address = #address_expr;
+                        let __addr_json: anchor_lang_v2::__alloc::string::String =
+                            anchor_lang_v2::__alloc::format!(",\"address\":\"{}\"", __addr);
+                    }
+                } else if f.address_override.is_some() {
                     quote! {
                         let __addr_json: anchor_lang_v2::__alloc::string::String =
                             anchor_lang_v2::__alloc::string::String::from(#address_override_json);

--- a/lang-v2/derive/src/idl.rs
+++ b/lang-v2/derive/src/idl.rs
@@ -268,7 +268,8 @@ pub fn build_accounts_emission(fields: &[AccountsJsonField<'_>]) -> TokenStream2
             if let Some(ty) = f.field_ty {
                 let addr_json_expr = if let Some(address_expr) = f.address_override_expr {
                     quote! {
-                        let __addr: anchor_lang_v2::Address = #address_expr;
+                        let __addr: anchor_lang_v2::Address =
+                            ::core::convert::Into::into(#address_expr);
                         let __addr_json: anchor_lang_v2::__alloc::string::String =
                             anchor_lang_v2::__alloc::format!(",\"address\":\"{}\"", __addr);
                     }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1126,6 +1126,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 pda_json: pda_jsons[i].clone(),
                 field_ty: &f.idl_field_ty,
                 address_override: f.idl_address.as_deref(),
+                address_override_expr: f.idl_address_expr.as_ref(),
                 // `Nested<Inner>` flattens at IDL emission time by calling
                 // into `Inner::__idl_accounts()`. Grab the inner `Type` so
                 // the emitter can synthesize that call.

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -679,14 +679,20 @@ pub struct AccountField {
     /// build the inverse mapping (matches v1's `get_relations`).
     pub idl_has_one: Vec<String>,
     /// Stringified RHS of `#[account(address = <expr>)]`. Emitted verbatim
-    /// as the `address` key of this field in the accounts JSON. `None` when
-    /// the attr is absent *or* when the RHS was v1-encodable (see
-    /// `idl_address_v1_source`) — in that case the constraint is surfaced
-    /// through `relations` instead, matching v1's IDL shape. Wrapper types
-    /// that carry a compile-time address via `IdlAccountType::__IDL_ADDRESS`
-    /// still emit the trait value when this override is `None`
-    /// (fields like `Program<System>`).
+    /// as the `address` key of this field in the accounts JSON for
+    /// client-resolved dotted paths like `data.authority`. `None` when the
+    /// attr is absent, when the RHS was v1-encodable (see
+    /// `idl_address_v1_source`), or when the RHS is resolved from a static
+    /// expression at IDL-build time (see `idl_address_expr`) — in those cases
+    /// the constraint is surfaced through `relations` / runtime evaluation
+    /// instead. Wrapper types that carry a compile-time address via
+    /// `IdlAccountType::__IDL_ADDRESS` still emit the trait value when both
+    /// overrides are `None` (fields like `Program<System>`).
     pub idl_address: Option<String>,
+    /// Runtime-resolved static `#[account(address = <expr>)]` override.
+    /// Holds constant paths / const-fn calls that can be evaluated inside the
+    /// generated `__idl_accounts()` function and rendered as base58.
+    pub idl_address_expr: Option<TokenStream2>,
     /// Set when `#[account(address = <sibling>.<self_name>)]` was used,
     /// i.e. the same relationship `#[has_one = <self_name>]` on `<sibling>`
     /// would have expressed. The outer derive turns this into an inverse
@@ -718,15 +724,109 @@ pub struct FieldSummary {
     pub attrs: AccountAttrs,
 }
 
-/// Turn the RHS of `#[account(address = <expr>)]` into the string form the
-/// IDL emits. Whitespace from `quote!`'s token reassembly is stripped so
-/// `crate :: ID` → `crate::ID`, `data . authority` → `data.authority`, and
-/// `crate :: id ()` → `crate::id()` — matching what a user would hand-write
-/// and what downstream tooling (the Anchor CLI resolver, TS client path
-/// walkers) expect to parse.
-fn stringify_address_expr(expr: &Expr) -> String {
-    let s = quote!(#expr).to_string();
-    s.split_whitespace().collect()
+fn is_static_idl_address_path(
+    path: &syn::ExprPath,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> bool {
+    if path.qself.is_some() {
+        return false;
+    }
+    if path.path.leading_colon.is_some() || path.path.segments.len() != 1 {
+        return true;
+    }
+    let seg = &path.path.segments[0];
+    if !seg.arguments.is_empty() {
+        return false;
+    }
+    let ident = seg.ident.to_string();
+    !field_names.contains(&ident) && !ix_arg_names.contains(&ident)
+}
+
+fn static_idl_address_expr(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> Option<TokenStream2> {
+    match expr {
+        Expr::Group(group) => static_idl_address_expr(&group.expr, field_names, ix_arg_names),
+        Expr::Paren(paren) => static_idl_address_expr(&paren.expr, field_names, ix_arg_names),
+        Expr::Path(path) if is_static_idl_address_path(path, field_names, ix_arg_names) => {
+            Some(quote! { #expr })
+        }
+        Expr::Call(call) if call.args.is_empty() => match &*call.func {
+            Expr::Path(path) if is_static_idl_address_path(path, field_names, ix_arg_names) => {
+                Some(quote! { #expr })
+            }
+            Expr::Group(group) => {
+                let grouped = static_idl_address_expr(&group.expr, field_names, ix_arg_names)?;
+                Some(grouped)
+            }
+            Expr::Paren(paren) => {
+                let grouped = static_idl_address_expr(&paren.expr, field_names, ix_arg_names)?;
+                Some(grouped)
+            }
+            _ => None,
+        },
+        Expr::Macro(_) => Some(quote! { #expr }),
+        _ => None,
+    }
+}
+
+fn dotted_address_hint(
+    expr: &Expr,
+    field_names: &[String],
+    ix_arg_names: &[String],
+) -> Option<String> {
+    fn walk(
+        expr: &Expr,
+        field_names: &[String],
+        ix_arg_names: &[String],
+        suffix: &mut Vec<String>,
+    ) -> bool {
+        match expr {
+            Expr::Field(field) => {
+                let member = match &field.member {
+                    syn::Member::Named(ident) => ident.to_string(),
+                    syn::Member::Unnamed(_) => return false,
+                };
+                if !walk(&field.base, field_names, ix_arg_names, suffix) {
+                    return false;
+                }
+                suffix.push(member);
+                true
+            }
+            Expr::Path(path) => {
+                if path.qself.is_some()
+                    || path.path.leading_colon.is_some()
+                    || path.path.segments.len() != 1
+                {
+                    return false;
+                }
+                let seg = &path.path.segments[0];
+                if !seg.arguments.is_empty() {
+                    return false;
+                }
+                let ident = seg.ident.to_string();
+                if field_names.contains(&ident) || ix_arg_names.contains(&ident) {
+                    suffix.push(ident);
+                    true
+                } else {
+                    false
+                }
+            }
+            Expr::Group(group) => walk(&group.expr, field_names, ix_arg_names, suffix),
+            Expr::Paren(paren) => walk(&paren.expr, field_names, ix_arg_names, suffix),
+            _ => false,
+        }
+    }
+
+    let mut segments = Vec::new();
+    if walk(expr, field_names, ix_arg_names, &mut segments) && segments.len() >= 2 {
+        Some(segments.join("."))
+    } else {
+        None
+    }
 }
 
 /// If `expr` is the v1-encodable shape `<sibling>.<field>` where both:
@@ -1344,19 +1444,28 @@ pub fn parse_field(
     //     already speaks v1 output sees the same shape for both spellings.
     //     `idl_address` stays `None` to avoid double-encoding the same
     //     check.
-    //   * Anything else — constant path, const-fn call, or a field access
-    //     whose subfield doesn't match self's ident. Emit verbatim under
-    //     the `address` key; the Anchor CLI resolves constants to base58
-    //     pubkeys at IDL-build time, and dotted paths flow through as
-    //     client-side resolution hints.
-    let (idl_address, idl_address_v1_source) = match attrs.address.as_ref() {
+    //   * Constant path / const-fn call / address! macro — evaluate at
+    //     IDL-build time and emit the resolved base58 address.
+    //   * Other dotted field paths — keep as client-side resolution hints.
+    //   * Anything else — omit from the IDL rather than emitting raw Rust
+    //     source that clients cannot resolve faithfully.
+    let (idl_address, idl_address_expr, idl_address_v1_source) = match attrs.address.as_ref() {
         Some(addr) => {
             match address_v1_relation_source(addr, &field_name.to_string(), field_names) {
-                Some(sibling) => (None, Some(sibling)),
-                None => (Some(stringify_address_expr(addr)), None),
+                Some(sibling) => (None, None, Some(sibling)),
+                None => {
+                    if let Some(expr) = static_idl_address_expr(addr, field_names, ix_arg_names) {
+                        (None, Some(expr), None)
+                    } else if let Some(hint) = dotted_address_hint(addr, field_names, ix_arg_names)
+                    {
+                        (Some(hint), None, None)
+                    } else {
+                        (None, None, None)
+                    }
+                }
             }
         }
-        None => (None, None),
+        None => (None, None, None),
     };
     let idl_docs = crate::idl::extract_doc_lines(&field.attrs);
     let idl_pda = attrs.seeds.as_ref().map(|seeds_expr| {
@@ -1461,6 +1570,7 @@ pub fn parse_field(
             idl_init_signer: false,
             idl_has_one: vec![],
             idl_address: None,
+            idl_address_expr: None,
             idl_address_v1_source: None,
             idl_docs: vec![],
             idl_pda: None,
@@ -2309,6 +2419,7 @@ pub fn parse_field(
         idl_init_signer,
         idl_has_one,
         idl_address,
+        idl_address_expr,
         idl_address_v1_source,
         idl_docs,
         idl_pda,
@@ -2494,5 +2605,47 @@ mod tests {
                 .contains("unknown account constraint `bumpp`"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn address_constraint_static_paths_resolve_at_idl_build_time() {
+        use syn::parse::Parser;
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(address = EXPECTED_PROGRAM)]
+                pub program: UncheckedAccount
+            })
+            .unwrap();
+        let parsed = parse_field(&field, &[], &[], quote::quote!(0usize), &[], &[]).unwrap();
+
+        assert!(parsed.idl_address.is_none());
+        assert!(parsed.idl_address_expr.is_some());
+        assert!(parsed.idl_address_v1_source.is_none());
+    }
+
+    #[test]
+    fn address_constraint_dotted_paths_remain_client_hints() {
+        use syn::parse::Parser;
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(address = data.expected_program)]
+                pub program: UncheckedAccount
+            })
+            .unwrap();
+        let parsed = parse_field(
+            &field,
+            &["data".into(), "program".into()],
+            &[],
+            quote::quote!(0usize),
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(parsed.idl_address.as_deref(), Some("data.expected_program"));
+        assert!(parsed.idl_address_expr.is_none());
+        assert!(parsed.idl_address_v1_source.is_none());
     }
 }

--- a/lang-v2/tests/address_idl_surface.rs
+++ b/lang-v2/tests/address_idl_surface.rs
@@ -1,0 +1,96 @@
+use std::{fs, path::PathBuf, process::Command};
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes a temporary workspace; covered by normal cargo test"
+)]
+fn idl_build_resolves_static_address_constraints() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = manifest_dir.join("target/address-idl-surface");
+    let src_dir = crate_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "address-idl-surface"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+idl-build = []
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+
+[workspace]
+"#,
+            manifest_dir.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+const EXPECTED_PROGRAM: anchor_lang_v2::Address =
+    anchor_lang_v2::address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+#[account]
+pub struct Holder {
+    pub expected_program: anchor_lang_v2::Address,
+}
+
+#[derive(Accounts)]
+pub struct StaticAddress {
+    #[account(address = EXPECTED_PROGRAM)]
+    pub program: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct DynamicAddress {
+    pub data: Account<Holder>,
+    #[account(address = data.expected_program)]
+    pub program: UncheckedAccount,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_addresses_emit_base58() {
+        let json = StaticAddress::__idl_accounts();
+        assert!(json.contains("\"address\":\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\""));
+        assert!(!json.contains("EXPECTED_PROGRAM"));
+    }
+
+    #[test]
+    fn dotted_paths_remain_client_hints() {
+        let json = DynamicAddress::__idl_accounts();
+        assert!(json.contains("\"address\":\"data.expected_program\""));
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new("cargo")
+        .args(["test", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .args(["--features", "idl-build"])
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo test for address-idl-surface: {err}"));
+
+    assert!(
+        output.status.success(),
+        "address-idl-surface failed:\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/tests-v2/programs/constraints/src/lib.rs
+++ b/tests-v2/programs/constraints/src/lib.rs
@@ -526,7 +526,8 @@ mod idl_tests {
             let items = parse(&CheckAddress::__idl_accounts());
             let account = single(&items, 0);
             assert_eq!(account.name, "pinned");
-            assert_eq!(account.address.as_deref(), Some("PINNED_ADDRESS"));
+            let expected = PINNED_ADDRESS.to_string();
+            assert_eq!(account.address.as_deref(), Some(expected.as_str()));
         }
 
         #[test]
@@ -537,7 +538,8 @@ mod idl_tests {
             let items = parse(&CheckAddressCustomErr::__idl_accounts());
             let account = single(&items, 0);
             assert_eq!(account.name, "pinned");
-            assert_eq!(account.address.as_deref(), Some("PINNED_ADDRESS"));
+            let expected = PINNED_ADDRESS.to_string();
+            assert_eq!(account.address.as_deref(), Some(expected.as_str()));
         }
 
         #[test]

--- a/tests-v2/tests/account_address_constraints.rs
+++ b/tests-v2/tests/account_address_constraints.rs
@@ -1,4 +1,123 @@
+use std::{fs, path::PathBuf, process::Command};
+
 #[test]
 fn account_address_constraint_fixture_links() {
     let _ = account_address_constraints::ID;
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes a temporary workspace; covered by normal cargo test"
+)]
+fn idl_build_resolves_static_addresses_and_omits_unsupported_exprs() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lang_v2 = manifest_dir
+        .parent()
+        .expect("tests-v2 lives under the workspace root")
+        .join("lang-v2");
+    let crate_dir = manifest_dir.join("target/address-idl-surface");
+    let src_dir = crate_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "address-idl-surface"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+idl-build = []
+
+[dependencies]
+anchor-lang-v2 = {{ path = "{}" }}
+
+[workspace]
+"#,
+            lang_v2.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        src_dir.join("lib.rs"),
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+const EXPECTED_PROGRAM: anchor_lang_v2::Address =
+    anchor_lang_v2::address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+#[account]
+pub struct Holder {
+    pub expected_program: anchor_lang_v2::Address,
+}
+
+fn choose_program(data: &Holder) -> anchor_lang_v2::Address {
+    data.expected_program
+}
+
+#[derive(Accounts)]
+pub struct StaticAddress {
+    #[account(address = EXPECTED_PROGRAM)]
+    pub program: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct DynamicAddress {
+    pub data: Account<Holder>,
+    #[account(address = data.expected_program)]
+    pub program: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct UnsupportedAddress {
+    pub data: Account<Holder>,
+    #[account(address = choose_program(&data))]
+    pub program: UncheckedAccount,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_addresses_emit_base58() {
+        let json = StaticAddress::__idl_accounts();
+        assert!(json.contains("\"address\":\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\""));
+        assert!(!json.contains("EXPECTED_PROGRAM"));
+    }
+
+    #[test]
+    fn dotted_paths_remain_client_hints() {
+        let json = DynamicAddress::__idl_accounts();
+        assert!(json.contains("\"address\":\"data.expected_program\""));
+    }
+
+    #[test]
+    fn unsupported_runtime_expressions_are_omitted() {
+        let json = UnsupportedAddress::__idl_accounts();
+        assert!(!json.contains("\"address\":"));
+        assert!(!json.contains("choose_program"));
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new("cargo")
+        .args(["test", "--offline", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .args(["--features", "idl-build"])
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run cargo test for address-idl-surface: {err}"));
+
+    assert!(
+        output.status.success(),
+        "address-idl-surface failed:\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 }


### PR DESCRIPTION
#### Finding
`#[account(address = ...)]` recorded source text like `EXPECTED_PROGRAM` in `IDL` instead of the resolved `base58` address, and unsupported runtime expressions could leak unusable address text into the client surface.
#### Fix
This PR resolves static address expressions to concrete `base58` values at IDL-build time, keeps supported dotted field paths as client hints, and omits unsupported runtime expressions from IDL. Added regression tests for static, dynamic, and omitted address forms.