### PR TITLE
chore(ci): test expanded downstream corpus

### DIFF
--- a/.github/workflows/downstream-builds.yaml
+++ b/.github/workflows/downstream-builds.yaml
@@ -141,42 +141,15 @@ jobs:
           echo "path=$project_dir" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - name: Resolve Solana CLI version
-        id: solana
-        working-directory: ${{ steps.project.outputs.path }}
-        run: |
-          set -euo pipefail
-
-          resolution="$(avm solana resolve)"
-          echo "$resolution"
-          version="$(awk '{print $2}' <<< "$resolution")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         name: Cache Solana Tool Suite
         with:
           path: |
             ~/.cache/solana/
             ~/.local/share/solana/
-          key: downstream-solana-${{ runner.os }}-v0002-${{ matrix.directory }}-${{ steps.solana.outputs.version }}
+          key: downstream-solana-${{ runner.os }}-v0003-${{ matrix.directory }}-${{ hashFiles(format('{0}/Cargo.lock', matrix.build_path), 'avm-source/avm/anchor-solana-map.toml', 'avm-source/avm/platform-tools-map.toml') }}
           restore-keys: |
-            downstream-solana-${{ runner.os }}-v0002-${{ matrix.directory }}-
-
-      - name: Install project Solana CLI
-        working-directory: ${{ steps.project.outputs.path }}
-        run: |
-          set -euo pipefail
-
-          solana_bin="$HOME/.local/share/solana/install/active_release/bin"
-          export PATH="$solana_bin:$PATH"
-          avm solana install "${{ steps.solana.outputs.version }}"
-          echo "$solana_bin" >> "$GITHUB_PATH"
-          "$solana_bin/solana" --version
-        shell: bash
-
-      - run: solana-keygen new --no-bip39-passphrase
-      - run: solana config set --url localhost
+            downstream-solana-${{ runner.os }}-v0003-${{ matrix.directory }}-
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         name: Cache ${{ matrix.name }} target
@@ -192,6 +165,7 @@ jobs:
         env:
           BUILD_COMMAND: ${{ matrix.build_command }}
           BUILD_NAME: ${{ matrix.name }}
+          PROJECT_PATH: ${{ steps.project.outputs.path }}
           NO_COLOR: "1"
           TERM: dumb
         run: |
@@ -259,6 +233,17 @@ jobs:
             avm install "$anchor_version"
             avm use "$anchor_version"
           fi
+
+          # The first Anchor-stub invocation installs and activates the
+          # project-resolved Solana CLI and platform-tools.
+          solana_bin="$HOME/.local/share/solana/install/active_release/bin"
+          export PATH="$solana_bin:$PATH"
+          (
+            cd "$PROJECT_PATH"
+            anchor --version
+            solana-keygen new --no-bip39-passphrase
+            solana config set --url localhost
+          )
 
           log="$RUNNER_TEMP/downstream-build.log"
           set +e

--- a/.github/workflows/downstream-builds.yaml
+++ b/.github/workflows/downstream-builds.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: otter-sec/anchor-community
-          ref: refs/pull/5/head
+          ref: main
           path: anchor-community
           persist-credentials: false
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: otter-sec/anchor-community
-          ref: refs/pull/5/head
+          ref: main
           path: anchor-community
           persist-credentials: false
 

--- a/.github/workflows/downstream-builds.yaml
+++ b/.github/workflows/downstream-builds.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: otter-sec/anchor
-          ref: master
+          ref: refs/pull/4824/head
           path: avm-source
           persist-credentials: false
 

--- a/.github/workflows/downstream-builds.yaml
+++ b/.github/workflows/downstream-builds.yaml
@@ -1,6 +1,7 @@
 name: Downstream Builds
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -22,7 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: otter-sec/anchor-community
-          ref: main
+          ref: refs/pull/5/head
           path: anchor-community
           persist-credentials: false
 
@@ -62,7 +63,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: otter-sec/anchor-community
-          ref: main
+          ref: refs/pull/5/head
           path: anchor-community
           persist-credentials: false
 


### PR DESCRIPTION
Temporarily test the expanded downstream corpus before it is merged.

- source `otter-sec/anchor-community#5` via `refs/pull/5/head`
- source the AVM attestation fix from `otter-sec/anchor#4835` via `refs/pull/4835/head`
- run the downstream-builds workflow on pull requests

Validation:
- `git diff --check`
- parsed workflow refs and triggers with `yq`
- verified both pull refs resolve to their current PR heads
- zizmor v1.23.1: no medium-or-higher findings