### PR TITLE
lang: Support module-qualified paths in `Context<T>` accounts types

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -502,6 +502,8 @@ jobs:
             path: tests/custom-coder
           - cmd: cd tests/custom-discriminator && anchor test --skip-lint && npx tsc --noEmit
             path: tests/custom-discriminator
+          - cmd: cd tests/modularized-program && anchor test --skip-lint && npx tsc --noEmit
+            path: tests/modularized-program
           - cmd: cd tests/validator-clone && anchor test --skip-lint && npx tsc --noEmit
             path: tests/validator-clone
           - cmd: cd tests/cpi-returns && anchor test --skip-lint && npx tsc --noEmit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- lang: Support module-qualified paths for the accounts type in `Context<...>` (e.g. `Context<instructions::init::Init>`) instead of resolving only the first path segment ([#4836](https://github.com/otter-sec/anchor/pull/4836)).
 - spl: Fix `anchor-spl` failing to build with only the `metadata` feature ([#4742](https://github.com/solana-foundation/anchor/pull/4742)).
 - client: Fix ignored commitment level ([#4666](https://github.com/solana-foundation/anchor/pull/4666)).
 - lang: Remove cloning `AccountInfo` to read lamports in `init_if_needed` codegen ([#4675](https://github.com/solana-foundation/anchor/pull/4675)).

--- a/lang/syn/src/codegen/program/accounts.rs
+++ b/lang/syn/src/codegen/program/accounts.rs
@@ -1,31 +1,24 @@
-use {crate::Program, heck::SnakeCase, quote::quote};
+use {
+    crate::{codegen::program::common::generated_accounts_mod_path, Program},
+    quote::quote,
+};
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let mut accounts = std::collections::HashMap::new();
 
     // Go through instruction accounts.
     for ix in &program.ixs {
-        let anchor_ident = &ix.anchor_ident;
-        // TODO: move to fn and share with accounts.rs.
-        let macro_name = format!(
-            "__client_accounts_{}",
-            anchor_ident.to_string().to_snake_case()
-        );
-        accounts.insert(macro_name, ix.cfgs.as_slice());
+        let mod_path = generated_accounts_mod_path(&ix.anchor_path(), "__client_accounts_");
+        accounts.insert(mod_path, ix.cfgs.as_slice());
     }
 
     // Build the tokens from all accounts
     let account_structs: Vec<proc_macro2::TokenStream> = accounts
         .iter()
-        .map(|(macro_name, cfgs)| {
-            #[allow(
-                clippy::unwrap_used,
-                reason = "computed from valid Rust identifier via snake_case"
-            )]
-            let macro_name: proc_macro2::TokenStream = macro_name.parse().unwrap();
+        .map(|(mod_path, cfgs)| {
             quote! {
                 #(#cfgs)*
-                pub use crate::#macro_name::*;
+                pub use #mod_path::*;
             }
         })
         .collect();

--- a/lang/syn/src/codegen/program/common.rs
+++ b/lang/syn/src/codegen/program/common.rs
@@ -47,3 +47,63 @@ pub fn generate_ix_variant(name: &str, args: &[IxArg]) -> Result<proc_macro2::To
 pub fn generate_ix_variant_name(name: &str) -> Result<syn::Ident> {
     syn::parse_str(&name.to_camel_case())
 }
+
+/// Path to the `__client_accounts_*` or `__cpi_client_accounts_*` module that
+/// `#[derive(Accounts)]` emits next to the accounts struct definition.
+///
+/// `instructions::init::Init` with prefix `__client_accounts_` becomes
+/// `crate::instructions::init::__client_accounts_init`.
+pub fn generated_accounts_mod_path(anchor_path: &syn::Path, prefix: &str) -> syn::Path {
+    use heck::SnakeCase;
+
+    let mut path = anchor_path.clone();
+    if let Some(last) = path.segments.last_mut() {
+        last.ident = syn::Ident::new(
+            &format!("{}{}", prefix, last.ident.to_string().to_snake_case()),
+            last.ident.span(),
+        );
+    }
+    path.segments.insert(
+        0,
+        syn::PathSegment::from(syn::Ident::new("crate", proc_macro2::Span::call_site())),
+    );
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, quote::ToTokens};
+
+    fn rewrite(path: &str, prefix: &str) -> String {
+        #[allow(clippy::unwrap_used, reason = "test inputs are valid paths")]
+        let path = syn::parse_str::<syn::Path>(path).unwrap();
+        generated_accounts_mod_path(&path, prefix)
+            .to_token_stream()
+            .to_string()
+            .replace(' ', "")
+    }
+
+    #[test]
+    fn single_segment() {
+        assert_eq!(
+            rewrite("Initialize", "__client_accounts_"),
+            "crate::__client_accounts_initialize"
+        );
+    }
+
+    #[test]
+    fn multi_segment() {
+        assert_eq!(
+            rewrite("instructions::init::Init", "__cpi_client_accounts_"),
+            "crate::instructions::init::__cpi_client_accounts_init"
+        );
+    }
+
+    #[test]
+    fn snake_cases_multi_word_ident() {
+        assert_eq!(
+            rewrite("ix::UpdateCounter", "__client_accounts_"),
+            "crate::ix::__client_accounts_update_counter"
+        );
+    }
+}

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -1,9 +1,10 @@
 use {
     crate::{
-        codegen::program::common::{generate_ix_variant, generate_ix_variant_name},
+        codegen::program::common::{
+            generate_ix_variant, generate_ix_variant_name, generated_accounts_mod_path,
+        },
         Program,
     },
-    heck::SnakeCase,
     quote::{quote, ToTokens},
 };
 
@@ -129,28 +130,17 @@ pub fn generate_accounts(program: &Program) -> proc_macro2::TokenStream {
 
     // Go through instruction accounts.
     for ix in &program.ixs {
-        let anchor_ident = &ix.anchor_ident;
-        // TODO: move to fn and share with accounts.rs.
-        let macro_name = format!(
-            "__cpi_client_accounts_{}",
-            anchor_ident.to_string().to_snake_case()
-        );
-        let cfgs = &ix.cfgs;
-        accounts.insert(macro_name, cfgs.as_slice());
+        let mod_path = generated_accounts_mod_path(&ix.anchor_path(), "__cpi_client_accounts_");
+        accounts.insert(mod_path, ix.cfgs.as_slice());
     }
 
     // Build the tokens from all accounts
     let account_structs: Vec<proc_macro2::TokenStream> = accounts
         .iter()
-        .map(|(macro_name, cfgs)| {
-            #[allow(
-                clippy::unwrap_used,
-                reason = "computed from valid Rust identifier via snake_case"
-            )]
-            let macro_name: proc_macro2::TokenStream = macro_name.parse().unwrap();
+        .map(|(mod_path, cfgs)| {
             quote! {
                 #(#cfgs)*
-                pub use crate::#macro_name::*;
+                pub use #mod_path::*;
             }
         })
         .collect();

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -42,7 +42,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             };
 
             let ix_name_log = format!("Instruction: {ix_name}");
-            let accounts_struct_name = &ix.anchor_ident;
+            let accounts_struct_name = ix.anchor_path();
+            let accounts_struct_display = accounts_struct_name
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::");
             let ret_type = &ix.returns.ty.to_token_stream();
             let cfgs = &ix.cfgs;
             let maybe_set_return_data = match ret_type.to_string().as_str() {
@@ -59,7 +65,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             let actual_param_count = ix.args.len();
             let count_error_msg = format!(
                 "#[instruction(...)] on Account `{}<'_>` expects MORE args, the ix `{}(...)` has only {} args.",
-                accounts_struct_name,
+                accounts_struct_display,
                 ix_method_name_str,
                 actual_param_count,
             );

--- a/lang/syn/src/codegen/program/mod.rs
+++ b/lang/syn/src/codegen/program/mod.rs
@@ -23,7 +23,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     #[allow(clippy::let_and_return)]
     let ret = {
         quote! {
-            // TODO: remove once we allow segmented paths in `Accounts` structs.
+            // Segmented paths are now allowed in `Accounts` structs, but this
+            // re-export is kept for backwards compatibility with programs
+            // importing handler functions from the crate root.
             use self::#mod_name::*;
 
             #entry

--- a/lang/syn/src/idl/program.rs
+++ b/lang/syn/src/idl/program.rs
@@ -35,7 +35,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
         .map(|ix| {
             let name = ix.ident.to_string();
             let name_pascal = format_ident!("{}", name.to_camel_case());
-            let ctx_ident = &ix.anchor_ident;
+            let ctx_path = ix.anchor_path();
             let cfgs = &ix.cfgs;
 
             let docs = match &ix.docs {
@@ -85,7 +85,7 @@ pub fn gen_idl_print_fn_program(program: &Program) -> TokenStream {
                         name: #name.into(),
                         docs: #docs,
                         discriminator: crate::instruction::#name_pascal::DISCRIMINATOR.into(),
-                        accounts: #ctx_ident::__anchor_private_gen_idl_accounts(
+                        accounts: #ctx_path::__anchor_private_gen_idl_accounts(
                             &mut accounts,
                             &mut types,
                         ),

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -104,7 +104,8 @@ pub struct Ix {
     pub cfgs: Vec<Attribute>,
     pub args: Vec<IxArg>,
     pub returns: IxReturn,
-    // The ident for the struct deriving Accounts.
+    // The ident for the struct deriving Accounts (the last segment of the
+    // path written in `Context<...>`).
     pub anchor_ident: Ident,
     /// Overrides coming from the `#[instruction]` attribute
     pub overrides: Option<Overrides>,

--- a/lang/syn/src/parser/program/instructions.rs
+++ b/lang/syn/src/parser/program/instructions.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         parser::{
             docs,
-            program::{ctx_accounts_ident, function_type, FunctionType},
+            program::{ctx_accounts_path, function_type, FunctionType},
         },
         FallbackFn, Ix, IxArg, IxReturn, Overrides,
     },
@@ -39,7 +39,13 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
         .into_iter()
         .map(|method| {
             let (ctx, args) = parse_args(method)?;
-            let anchor_ident = ctx_accounts_ident(&ctx.raw_arg)?;
+            let anchor_path = ctx_accounts_path(&ctx.raw_arg)?;
+            let anchor_ident = anchor_path
+                .segments
+                .last()
+                .ok_or_else(|| ParseError::new(anchor_path.span(), "expected a path segment"))?
+                .ident
+                .clone();
             let overrides = parse_overrides(&method.attrs)?;
             let docs = docs::parse(&method.attrs);
             let cfgs = parse_cfg(method);
@@ -57,6 +63,31 @@ pub fn parse(program_mod: &syn::ItemMod) -> ParseResult<(Vec<Ix>, Option<Fallbac
         })
         .filter_map(|ix| ix.transpose())
         .collect::<ParseResult<Vec<Ix>>>()?;
+
+    // The generated `accounts` and `cpi::accounts` modules are flat, so two
+    // different Accounts structs with the same name would produce ambiguous
+    // re-exports there.
+    let mut anchor_paths = std::collections::HashMap::new();
+    for ix in &ixs {
+        let anchor_path = ix.anchor_path();
+        match anchor_paths.entry(ix.anchor_ident.to_string()) {
+            std::collections::hash_map::Entry::Occupied(entry) if *entry.get() != anchor_path => {
+                return Err(ParseError::new(
+                    anchor_path.span(),
+                    format!(
+                        "two `Accounts` structs named `{}` are used by this program's \
+                         instructions; rename one of them, as the generated `accounts` and \
+                         `cpi::accounts` modules are flat",
+                        ix.anchor_ident
+                    ),
+                ));
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {}
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(anchor_path);
+            }
+        }
+    }
 
     let fallback_fn = match *fallback.as_slice() {
         [] => None,

--- a/lang/syn/src/parser/program/mod.rs
+++ b/lang/syn/src/parser/program/mod.rs
@@ -85,14 +85,36 @@ fn function_type(method: &syn::ItemFn) -> FunctionType {
     }
 }
 
-fn ctx_accounts_ident(path_ty: &syn::PatType) -> ParseResult<proc_macro2::Ident> {
+impl crate::Ix {
+    /// Path to the struct deriving `Accounts`, as written in `Context<...>`,
+    /// normalized to be relative to the crate root.
+    ///
+    /// Recomputed from `raw_method` instead of being stored as a field so that
+    /// `Ix` remains constructible with the same fields as before.
+    pub(crate) fn anchor_path(&self) -> syn::Path {
+        #[allow(
+            clippy::expect_used,
+            reason = "the instruction was validated when the program was parsed"
+        )]
+        let (ctx, _) = instructions::parse_args(&self.raw_method)
+            .expect("`Ix::raw_method` has a `Context<...>` argument");
+        #[allow(
+            clippy::expect_used,
+            reason = "the instruction was validated when the program was parsed"
+        )]
+        ctx_accounts_path(&ctx.raw_arg)
+            .expect("`Ix::raw_method` has a valid `Context<...>` accounts path")
+    }
+}
+
+fn ctx_accounts_path(path_ty: &syn::PatType) -> ParseResult<syn::Path> {
     let p = match &*path_ty.ty {
         syn::Type::Path(p) => &p.path,
         _ => return Err(ParseError::new(path_ty.ty.span(), "invalid type")),
     };
     let segment = p
         .segments
-        .first()
+        .last()
         .ok_or_else(|| ParseError::new(p.segments.span(), "expected generic arguments here"))?;
 
     let generic_args = match &segment.arguments {
@@ -118,10 +140,91 @@ fn ctx_accounts_ident(path_ty: &syn::PatType) -> ParseResult<proc_macro2::Ident>
             ));
         }
     };
-    Ok(path
+    if path.leading_colon.is_some() {
+        return Err(ParseError::new(
+            path.span(),
+            "paths with a leading `::` are not supported in `Context<...>`; use a path relative \
+             to the crate root",
+        ));
+    }
+
+    // Strip generic arguments (e.g. `Foo<'info>`) from all segments so the
+    // path can be interpolated in non-generic positions (e.g.
+    // `#path::try_accounts`), and strip a leading `crate` segment so the path
+    // is always relative to the crate root.
+    let mut segments = path
         .segments
+        .iter()
+        .map(|segment| syn::PathSegment::from(segment.ident.clone()))
+        .collect::<Vec<_>>();
+    if segments
         .first()
-        .ok_or_else(|| ParseError::new(path.span(), "expected a path segment"))?
-        .ident
-        .clone())
+        .is_some_and(|segment| segment.ident == "crate")
+    {
+        segments.remove(0);
+    }
+    if segments.iter().any(|segment| {
+        segment.ident == "self" || segment.ident == "super" || segment.ident == "crate"
+    }) {
+        return Err(ParseError::new(
+            path.span(),
+            "`self` and `super` are not supported in `Context<...>` accounts paths; use a path \
+             relative to the crate root",
+        ));
+    }
+    if segments.is_empty() {
+        return Err(ParseError::new(path.span(), "expected a path segment"));
+    }
+
+    Ok(syn::Path {
+        leading_colon: None,
+        segments: segments.into_iter().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn anchor_path_is_normalized_relative_to_the_crate_root() {
+        let program = syn::parse_str::<crate::Program>(
+            r#"
+            pub mod example {
+                pub fn init(ctx: Context<instructions::init::Init>) -> Result<()> {
+                    Ok(())
+                }
+
+                pub fn update(ctx: Context<crate::instructions::Update<'info>>) -> Result<()> {
+                    Ok(())
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let segments = |path: &syn::Path| {
+            path.segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+        };
+
+        let mut ixs = program.ixs.iter();
+
+        let init = ixs.next().unwrap();
+        assert_eq!(init.anchor_ident, "Init");
+        assert_eq!(
+            segments(&init.anchor_path()),
+            ["instructions", "init", "Init"]
+        );
+
+        // A leading `crate` segment and generic arguments are stripped.
+        let update = ixs.next().unwrap();
+        assert_eq!(update.anchor_ident, "Update");
+        let update_path = update.anchor_path();
+        assert_eq!(segments(&update_path), ["instructions", "Update"]);
+        assert!(update_path
+            .segments
+            .iter()
+            .all(|segment| segment.arguments.is_none()));
+    }
 }

--- a/lang/syn/tests/program_parse.rs
+++ b/lang/syn/tests/program_parse.rs
@@ -57,3 +57,62 @@ fn underscore_instruction_arg_is_rejected() {
     let err = program.unwrap_err().to_string();
     assert_eq!(err, "expected named argument");
 }
+
+#[test]
+fn context_accepts_module_qualified_accounts_paths() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            pub fn init(ctx: Context<instructions::init::Init>) -> Result<()> {
+                Ok(())
+            }
+
+            pub fn update(ctx: Context<crate::instructions::Update<'info>>) -> Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let mut ixs = program.ixs.iter();
+    // `anchor_ident` is the last segment of the path, even for
+    // module-qualified (and `crate::`-prefixed, generic) paths.
+    assert_eq!(ixs.next().unwrap().anchor_ident, "Init");
+    assert_eq!(ixs.next().unwrap().anchor_ident, "Update");
+}
+
+#[test]
+fn context_rejects_same_named_accounts_structs_in_different_modules() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            pub fn foo(ctx: Context<a::Init>) -> Result<()> {
+                Ok(())
+            }
+
+            pub fn bar(ctx: Context<b::Init>) -> Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    );
+
+    let err = program.unwrap_err().to_string();
+    assert!(err.contains("two `Accounts` structs named `Init`"), "{err}");
+}
+
+#[test]
+fn context_rejects_super_qualified_accounts_paths() {
+    let program = syn::parse_str::<anchor_syn::Program>(
+        r#"
+        pub mod example {
+            pub fn init(ctx: Context<super::Init>) -> Result<()> {
+                Ok(())
+            }
+        }
+        "#,
+    );
+
+    assert!(program.is_err());
+}

--- a/tests/modularized-program/Anchor.toml
+++ b/tests/modularized-program/Anchor.toml
@@ -1,0 +1,14 @@
+[features]
+resolution = true
+skip-lint = false
+
+[programs.localnet]
+modularized = "Modu1arized11111111111111111111111111111111"
+caller = "Modu1arizedCa11er11111111111111111111111111"
+
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/modularized-program/Cargo.toml
+++ b/tests/modularized-program/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tests/modularized-program/package.json
+++ b/tests/modularized-program/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "modularized-program",
+  "version": "0.1.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/otter-sec/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/otter-sec/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/otter-sec/anchor.git"
+  },
+  "engines": {
+    "node": ">=20.18"
+  }
+}

--- a/tests/modularized-program/programs/caller/Cargo.toml
+++ b/tests/modularized-program/programs/caller/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "caller"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "caller"
+
+[features]
+no-entrypoint = []
+
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+modularized = { path = "../modularized", features = ["cpi"] }

--- a/tests/modularized-program/programs/caller/Xargo.toml
+++ b/tests/modularized-program/programs/caller/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/modularized-program/programs/caller/src/lib.rs
+++ b/tests/modularized-program/programs/caller/src/lib.rs
@@ -1,0 +1,36 @@
+//! CPIs into the `modularized` program, exercising the generated
+//! `cpi::accounts` module for `Accounts` structs defined in nested modules.
+
+use anchor_lang::prelude::*;
+use modularized::program::Modularized;
+
+declare_id!("Modu1arizedCa11er11111111111111111111111111");
+
+#[program]
+pub mod caller {
+    use super::*;
+
+    pub fn proxy_init(ctx: Context<ProxyInit>, data: u64) -> Result<()> {
+        let cpi_ctx = CpiContext::new(
+            ctx.accounts.modularized_program.key(),
+            modularized::cpi::accounts::Init {
+                counter: ctx.accounts.counter.to_account_info(),
+                payer: ctx.accounts.payer.to_account_info(),
+                system_program: ctx.accounts.system_program.to_account_info(),
+            },
+        );
+        modularized::cpi::init(cpi_ctx, data)?;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct ProxyInit<'info> {
+    /// CHECK: Initialized by the modularized program via CPI.
+    #[account(mut)]
+    pub counter: UncheckedAccount<'info>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    pub modularized_program: Program<'info, Modularized>,
+}

--- a/tests/modularized-program/programs/modularized/Cargo.toml
+++ b/tests/modularized-program/programs/modularized/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "modularized"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "modularized"
+
+[features]
+no-entrypoint = []
+
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/modularized-program/programs/modularized/Xargo.toml
+++ b/tests/modularized-program/programs/modularized/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/modularized-program/programs/modularized/src/instructions/init.rs
+++ b/tests/modularized-program/programs/modularized/src/instructions/init.rs
@@ -1,0 +1,25 @@
+use crate::state::Counter;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+#[instruction(data: u64)]
+pub struct Init<'info> {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + 8 + 1,
+        seeds = [b"counter", payer.key().as_ref()],
+        bump
+    )]
+    pub counter: Account<'info, Counter>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<Init>, data: u64) -> Result<()> {
+    let counter = &mut ctx.accounts.counter;
+    counter.count = data;
+    counter.bump = ctx.bumps.counter;
+    Ok(())
+}

--- a/tests/modularized-program/programs/modularized/src/instructions/mod.rs
+++ b/tests/modularized-program/programs/modularized/src/instructions/mod.rs
@@ -1,0 +1,2 @@
+pub mod init;
+pub mod update;

--- a/tests/modularized-program/programs/modularized/src/instructions/update.rs
+++ b/tests/modularized-program/programs/modularized/src/instructions/update.rs
@@ -1,0 +1,18 @@
+use crate::state::Counter;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct Update<'info> {
+    #[account(
+        mut,
+        seeds = [b"counter", payer.key().as_ref()],
+        bump = counter.bump,
+    )]
+    pub counter: Account<'info, Counter>,
+    pub payer: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<Update>, data: u64) -> Result<()> {
+    ctx.accounts.counter.count = data;
+    Ok(())
+}

--- a/tests/modularized-program/programs/modularized/src/lib.rs
+++ b/tests/modularized-program/programs/modularized/src/lib.rs
@@ -1,0 +1,32 @@
+//! This program's `Accounts` structs live in nested modules and are referenced
+//! with module-qualified paths in `Context<...>`, without any glob re-exports
+//! at the crate root.
+
+use anchor_lang::prelude::*;
+
+pub mod instructions;
+pub mod state;
+
+declare_id!("Modu1arized11111111111111111111111111111111");
+
+#[program]
+pub mod modularized {
+    use super::*;
+
+    pub fn init(ctx: Context<instructions::init::Init>, data: u64) -> Result<()> {
+        instructions::init::handler(ctx, data)
+    }
+
+    pub fn update(ctx: Context<crate::instructions::update::Update>, data: u64) -> Result<()> {
+        instructions::update::handler(ctx, data)
+    }
+
+    pub fn ping(_ctx: Context<Ping>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Ping<'info> {
+    pub payer: Signer<'info>,
+}

--- a/tests/modularized-program/programs/modularized/src/state.rs
+++ b/tests/modularized-program/programs/modularized/src/state.rs
@@ -1,0 +1,7 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Counter {
+    pub count: u64,
+    pub bump: u8,
+}

--- a/tests/modularized-program/tests/modularized-program.ts
+++ b/tests/modularized-program/tests/modularized-program.ts
@@ -1,0 +1,70 @@
+import * as anchor from "@anchor-lang/core";
+import assert from "assert";
+import BN from "bn.js";
+
+import type { Modularized } from "../target/types/modularized";
+import type { Caller } from "../target/types/caller";
+
+describe("modularized-program", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+  const program: anchor.Program<Modularized> = anchor.workspace.modularized;
+  const caller: anchor.Program<Caller> = anchor.workspace.caller;
+
+  const counterPda = (payer: anchor.web3.PublicKey) =>
+    anchor.web3.PublicKey.findProgramAddressSync(
+      [Buffer.from("counter"), payer.toBuffer()],
+      program.programId
+    )[0];
+
+  it("Initializes via a module-qualified Accounts struct", async () => {
+    // `counter` is resolved from the IDL seeds, exercising IDL generation
+    // for accounts structs in nested modules.
+    const { pubkeys, signature } = await program.methods
+      .init(new BN(42))
+      .rpcAndKeys();
+    await provider.connection.confirmTransaction(signature, "confirmed");
+
+    const counter = await program.account.counter.fetch(
+      pubkeys.counter as anchor.web3.PublicKey
+    );
+    assert.strictEqual(counter.count.toNumber(), 42);
+  });
+
+  it("Updates via a crate-qualified Accounts struct", async () => {
+    await program.methods.update(new BN(43)).rpc();
+
+    const counter = await program.account.counter.fetch(
+      counterPda(provider.wallet.publicKey)
+    );
+    assert.strictEqual(counter.count.toNumber(), 43);
+  });
+
+  it("Works with a plain (single-segment) Accounts struct", async () => {
+    await program.methods.ping().rpc();
+  });
+
+  it("CPIs into an instruction with a module-qualified Accounts struct", async () => {
+    const payer = anchor.web3.Keypair.generate();
+    const airdrop = await provider.connection.requestAirdrop(
+      payer.publicKey,
+      anchor.web3.LAMPORTS_PER_SOL
+    );
+    await provider.connection.confirmTransaction(airdrop, "confirmed");
+
+    const counterAddress = counterPda(payer.publicKey);
+    await caller.methods
+      .proxyInit(new BN(44))
+      .accounts({
+        counter: counterAddress,
+        payer: payer.publicKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        modularizedProgram: program.programId,
+      })
+      .signers([payer])
+      .rpc();
+
+    const counter = await program.account.counter.fetch(counterAddress);
+    assert.strictEqual(counter.count.toNumber(), 44);
+  });
+});

--- a/tests/modularized-program/tsconfig.json
+++ b/tests/modularized-program/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -50,6 +50,7 @@
     "lazy-account",
     "lockup",
     "misc",
+    "modularized-program",
     "multisig",
     "optional",
     "permissioned-markets",


### PR DESCRIPTION
Fixes #1483.

## Problem

The `#[program]` macro cannot handle module-qualified paths in `Context<T>`:

```rust
#[program]
pub mod my_program {
    use super::*;

    // error: `#[program]` "not found in `instructions`"
    pub fn init(ctx: Context<instructions::init::Init>) -> Result<()> { ... }
}
```

Root cause: `ctx_accounts_ident` in `lang/syn/src/parser/program/mod.rs` returned `path.segments.first().ident` — the **first** segment of the accounts type path — so `instructions::init::Init` resolved to `instructions`. Every downstream codegen site (handler dispatch, IDL generation, and the generated `accounts` / `cpi::accounts` modules) then referenced a module name as if it were the `Accounts` struct.

As a result, every `Accounts` struct must currently be importable as a bare identifier inside the program module (the `use super::*;` + crate-root glob re-export pattern), which defeats attempts to modularize programs. The codebase already anticipated this fix:

```rust
// lang/syn/src/codegen/program/mod.rs
// TODO: remove once we allow segmented paths in `Accounts` structs.
use self::#mod_name::*;
```

## Fix

- `Ix` now carries `anchor_path: syn::Path` — the full path to the `Accounts` struct, normalized once in the parser: generic arguments are stripped from all segments (so the path can be interpolated in non-generic positions like `#path::try_accounts`), a leading `crate` segment is removed, and `self` / `super` / leading-`::` paths are rejected with a clear error. `anchor_ident` is retained as the last segment of that path.
- Handler dispatch (`handlers.rs`) and IDL generation (`idl/program.rs`) interpolate the full path directly.
- The generated `accounts` and `cpi::accounts` modules re-export the derive-generated `__client_accounts_*` / `__cpi_client_accounts_*` modules from the struct's actual module: a shared helper (`generated_accounts_mod_path`) rewrites the last path segment, e.g. `instructions::init::Init` → `crate::instructions::init::__client_accounts_init`. This also removes the two long-standing `TODO: move to fn and share with accounts.rs` duplications.
- Because the generated `accounts` / `cpi::accounts` modules are flat, two *different* `Accounts` structs with the same name would produce ambiguous glob re-exports; the parser now rejects that case with a descriptive error instead of letting users hit a cryptic ambiguity error. (This cannot break existing code — such programs could never have compiled.)

## Backwards compatibility

- Single-segment paths (`Context<Init>`) generate **token-identical** code (verified by diffing `cargo expand` output of an existing test program before/after — the only difference is `HashMap` iteration order of re-exports, which was already nondeterministic).
- `Ix.anchor_ident` is kept in the public `anchor-syn` API (now defined as the last path segment — identical for all previously-compiling programs).
- The public CPI API is unchanged: CPI methods still take `crate::cpi::accounts::Foo`.
- The `use self::#mod_name::*;` crate-root re-export of the program module is kept, so existing imports of handler functions keep working.

## Constraints

- The path must be resolvable from the crate root (bare `Init`, `instructions::init::Init`, or `crate::instructions::init::Init`). `self::` / `super::` / leading-`::` paths are rejected with a descriptive parse error. Accounts structs from other crates remain unsupported (the derive-generated modules are `pub(crate)`), as before.

## Tests

- New parser unit/integration tests in `lang/syn` (`codegen/program/common.rs` and `tests/program_parse.rs`): path rewriting, `crate::`-prefix and generic-argument normalization, duplicate-name rejection, `super::` rejection.
- New integration test suite `tests/modularized-program`: a program whose `Accounts` structs live in nested modules (no glob re-exports at crate root), exercising handler dispatch, `#[instruction]` args, PDA + bumps, IDL-based account resolution from TS, and a second program that CPIs into it via `cpi::accounts` (registered in the CI matrix and the `tests/package.json` workspaces).
- `cargo test -p anchor-syn` (with and without `idl-build`), `cargo clippy -p anchor-syn`, and compile checks of existing suites (`tests/events`, `tests/cpi-returns`, `tests/composite`) pass.
