### PR TITLE
Fix/spl-v2 metadata cpi mutability

### DIFF
--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -17,6 +17,7 @@ use {
     core::ops::Deref,
     pinocchio::account::AccountView,
     solana_address::Address,
+    solana_instruction::AccountMeta,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
 };
@@ -211,14 +212,7 @@ pub fn mint_new_edition_from_master_edition_via_token<'info>(
 pub fn revoke_collection_authority<'info>(
     ctx: CpiContext<'info, RevokeCollectionAuthority<'info>>,
 ) -> Result<()> {
-    let ix = mpl_token_metadata::instructions::RevokeCollectionAuthority {
-        collection_authority_record: *ctx.accounts.collection_authority_record.address(),
-        delegate_authority: *ctx.accounts.delegate_authority.address(),
-        metadata: *ctx.accounts.metadata.address(),
-        mint: *ctx.accounts.mint.address(),
-        revoke_authority: *ctx.accounts.revoke_authority.address(),
-    }
-    .instruction();
+    let ix = revoke_collection_authority_ix(&ctx.accounts);
     ctx.invoke_ix(ix)
 }
 
@@ -227,18 +221,43 @@ pub fn set_collection_size<'info>(
     collection_authority_record: Option<Pubkey>,
     size: u64,
 ) -> Result<()> {
-    let ix = mpl_token_metadata::instructions::SetCollectionSize {
-        collection_authority: *ctx.accounts.update_authority.address(),
+    let ix = set_collection_size_ix(&ctx.accounts, collection_authority_record, size);
+    ctx.invoke_ix(ix)
+}
+
+fn revoke_collection_authority_ix(
+    accounts: &RevokeCollectionAuthority<'_>,
+) -> solana_instruction::Instruction {
+    let mut ix = mpl_token_metadata::instructions::RevokeCollectionAuthority {
+        collection_authority_record: *accounts.collection_authority_record.address(),
+        delegate_authority: *accounts.delegate_authority.address(),
+        metadata: *accounts.metadata.address(),
+        mint: *accounts.mint.address(),
+        revoke_authority: *accounts.revoke_authority.address(),
+    }
+    .instruction();
+    ix.accounts[1] = AccountMeta::new_readonly(*accounts.delegate_authority.address(), false);
+    ix
+}
+
+fn set_collection_size_ix(
+    accounts: &SetCollectionSize<'_>,
+    collection_authority_record: Option<Pubkey>,
+    size: u64,
+) -> solana_instruction::Instruction {
+    let mut ix = mpl_token_metadata::instructions::SetCollectionSize {
+        collection_authority: *accounts.update_authority.address(),
         collection_authority_record,
-        collection_metadata: *ctx.accounts.metadata.address(),
-        collection_mint: *ctx.accounts.mint.address(),
+        collection_metadata: *accounts.metadata.address(),
+        collection_mint: *accounts.mint.address(),
     }
     .instruction(
         mpl_token_metadata::instructions::SetCollectionSizeInstructionArgs {
             set_collection_size_args: mpl_token_metadata::types::SetCollectionSizeArgs { size },
         },
     );
-    ctx.invoke_ix(ix)
+    ix.accounts[1] = AccountMeta::new_readonly(*accounts.update_authority.address(), true);
+    ix
 }
 
 pub fn verify_collection<'info>(
@@ -556,7 +575,7 @@ pub struct MintNewEditionFromMasterEditionViaToken<'info> {
 #[derive(ToCpiAccounts)]
 pub struct RevokeCollectionAuthority<'info> {
     pub collection_authority_record: CpiHandleMut<'info>,
-    pub delegate_authority: CpiHandleMut<'info>,
+    pub delegate_authority: CpiHandle<'info>,
     #[signer]
     pub revoke_authority: CpiHandleMut<'info>,
     pub metadata: CpiHandle<'info>,
@@ -567,7 +586,7 @@ pub struct RevokeCollectionAuthority<'info> {
 pub struct SetCollectionSize<'info> {
     pub metadata: CpiHandleMut<'info>,
     #[signer]
-    pub update_authority: CpiHandleMut<'info>,
+    pub update_authority: CpiHandle<'info>,
     pub mint: CpiHandle<'info>,
 }
 

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -906,3 +906,91 @@ impl Id for Metadata {
 
     const IDL_ADDRESS: &'static str = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anchor_lang_v2::{
+        testing::{AccountBuffer, MIN_ACCOUNT_BUF},
+        ToCpiHandle, ToCpiHandleMut,
+    };
+
+    fn account(
+        address: [u8; 32],
+        signer: bool,
+        writable: bool,
+    ) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
+        let buffer = AccountBuffer::new();
+        buffer.init(address, [1; 32], 8, signer, writable, false);
+        buffer
+    }
+
+    #[test]
+    fn revoke_collection_authority_keeps_delegate_readonly() {
+        let record_buffer = account([1; 32], false, true);
+        let delegate_buffer = account([2; 32], false, false);
+        let revoke_buffer = account([3; 32], true, true);
+        let metadata_buffer = account([4; 32], false, false);
+        let mint_buffer = account([5; 32], false, false);
+
+        let mut record_view = unsafe { record_buffer.view() };
+        let delegate_view = unsafe { delegate_buffer.view() };
+        let mut revoke_view = unsafe { revoke_buffer.view() };
+        let metadata_view = unsafe { metadata_buffer.view() };
+        let mint_view = unsafe { mint_buffer.view() };
+
+        let accounts = RevokeCollectionAuthority {
+            collection_authority_record: record_view.to_cpi_handle_mut(),
+            delegate_authority: delegate_view.to_cpi_handle(),
+            revoke_authority: revoke_view.to_cpi_handle_mut(),
+            metadata: metadata_view.to_cpi_handle(),
+            mint: mint_view.to_cpi_handle(),
+        };
+
+        let metas = accounts.to_instruction_accounts();
+        assert!(metas[0].is_writable);
+        assert!(!metas[1].is_writable);
+        assert!(metas[2].is_writable);
+
+        let handles = accounts.to_cpi_handles();
+        assert!(handles[0].is_writable());
+        assert!(!handles[1].is_writable());
+        assert!(handles[2].is_writable());
+
+        let ix = revoke_collection_authority_ix(&accounts);
+        assert!(ix.accounts[0].is_writable);
+        assert!(!ix.accounts[1].is_writable);
+        assert!(ix.accounts[2].is_writable);
+    }
+
+    #[test]
+    fn set_collection_size_keeps_update_authority_readonly() {
+        let metadata_buffer = account([6; 32], false, true);
+        let update_authority_buffer = account([7; 32], true, false);
+        let mint_buffer = account([8; 32], false, false);
+
+        let mut metadata_view = unsafe { metadata_buffer.view() };
+        let update_authority_view = unsafe { update_authority_buffer.view() };
+        let mint_view = unsafe { mint_buffer.view() };
+
+        let accounts = SetCollectionSize {
+            metadata: metadata_view.to_cpi_handle_mut(),
+            update_authority: update_authority_view.to_cpi_handle(),
+            mint: mint_view.to_cpi_handle(),
+        };
+
+        let metas = accounts.to_instruction_accounts();
+        assert!(metas[0].is_writable);
+        assert!(!metas[1].is_writable);
+        assert!(metas[1].is_signer);
+
+        let handles = accounts.to_cpi_handles();
+        assert!(handles[0].is_writable());
+        assert!(!handles[1].is_writable());
+
+        let ix = set_collection_size_ix(&accounts, None, 9);
+        assert!(ix.accounts[0].is_writable);
+        assert!(!ix.accounts[1].is_writable);
+        assert!(ix.accounts[1].is_signer);
+    }
+}

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -4,7 +4,6 @@ use {
     anchor_lang_v2::{testing::AccountBuffer, AccountDeserialize, AnchorAccount},
     anchor_spl_v2::metadata::{self, MetadataAccount},
     borsh::to_vec,
-    solana_address::Address,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
 };
@@ -72,7 +71,7 @@ fn metadata_account_load_validates_owner_and_raw_data() {
     );
     account.write_data(&data);
 
-    let loaded = MetadataAccount::load(unsafe { account.view() }, &Address::default()).unwrap();
+    let loaded = MetadataAccount::load(unsafe { account.view() }).unwrap();
     assert_eq!(loaded.update_authority, expected.update_authority);
     assert_eq!(loaded.seller_fee_basis_points, 250);
 }
@@ -84,7 +83,7 @@ fn metadata_account_rejects_wrong_owner() {
     account.init([9u8; 32], [3u8; 32], data.len(), false, false, false);
     account.write_data(&data);
 
-    let err = MetadataAccount::load(unsafe { account.view() }, &Address::default()).unwrap_err();
+    let err = MetadataAccount::load(unsafe { account.view() }).unwrap_err();
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 


### PR DESCRIPTION
#### Finding
`spl-v2` treated `RevokeCollectionAuthority.delegate_authority` and `SetCollectionSize.update_authority` as writable CPI accounts. Those accounts are not required to be writable by the Metaplex collection instructions, so the wrapper over-constrained callers and required unnecessary mutable borrows.

#### Fix
Changed both fields to readonly `CpiHandle`s and normalized the emitted CPI instruction metas to readonly for those slots. This keeps the v2 metadata CPI surface aligned with the underlying instruction contract. 