### PR TITLE
Fix/spl-v2 metadata deserialize cursor

### DIFF
--- a/spl-v2/Cargo.toml
+++ b/spl-v2/Cargo.toml
@@ -21,6 +21,7 @@ pinocchio = { workspace = true }
 pinocchio-token = "0.6"
 pinocchio-token-2022 = "0.3"
 bytemuck = { version = "1", features = ["derive"] }
+borsh = "1.6.1"
 solana-address = { version = "2.0", features = ["bytemuck"] }
 solana-instruction = "3.0"
 solana-program-error = "3.0"

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -744,6 +744,10 @@ impl MetadataAccount {
             return Err(ProgramError::InvalidAccountData);
         }
 
+        // Metaplex stores MetadataV1 accounts on chain in this exact order:
+        // key, update_authority, mint, data, primary_sale_happened,
+        // is_mutable, edition_nonce, token_standard, collection, uses,
+        // collection_details, programmable_config.
         let key: Key =
             BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
         let update_authority: Pubkey =

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -735,6 +735,23 @@ pub struct MetadataAccount {
 
 impl MetadataAccount {
     #[inline]
+    fn deserialize_trailing<T>(buf: &mut &[u8]) -> Result<T>
+    where
+        T: BorshDeserialize + Default,
+    {
+        let start = *buf;
+        let mut cursor = start;
+        match BorshDeserialize::deserialize(&mut cursor) {
+            Ok(value) => {
+                *buf = cursor;
+                Ok(value)
+            }
+            Err(_) if cursor.len() == start.len() => Ok(T::default()),
+            Err(_) => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    #[inline]
     fn parse(buf: &mut &[u8]) -> Result<mpl_token_metadata::accounts::Metadata> {
         use mpl_token_metadata::types::{
             Collection, CollectionDetails, Data, Key, ProgrammableConfig, TokenStandard, Uses,
@@ -763,31 +780,11 @@ impl MetadataAccount {
         let edition_nonce: Option<u8> =
             BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
 
-        let token_standard_res: core::result::Result<Option<TokenStandard>, borsh::io::Error> =
-            BorshDeserialize::deserialize(buf);
-        let collection_res: core::result::Result<Option<Collection>, borsh::io::Error> =
-            BorshDeserialize::deserialize(buf);
-        let uses_res: core::result::Result<Option<Uses>, borsh::io::Error> =
-            BorshDeserialize::deserialize(buf);
-        let collection_details_res: core::result::Result<
-            Option<CollectionDetails>,
-            borsh::io::Error,
-        > = BorshDeserialize::deserialize(buf);
-        let programmable_config_res: core::result::Result<
-            Option<ProgrammableConfig>,
-            borsh::io::Error,
-        > = BorshDeserialize::deserialize(buf);
-
-        let (token_standard, collection, uses) =
-            match (token_standard_res, collection_res, uses_res) {
-                (Ok(token_standard), Ok(collection), Ok(uses)) => {
-                    (token_standard, collection, uses)
-                }
-                _ => (None, None, None),
-            };
-
-        let collection_details = collection_details_res.unwrap_or(None);
-        let programmable_config = programmable_config_res.unwrap_or(None);
+        let token_standard: Option<TokenStandard> = Self::deserialize_trailing(buf)?;
+        let collection: Option<Collection> = Self::deserialize_trailing(buf)?;
+        let uses: Option<Uses> = Self::deserialize_trailing(buf)?;
+        let collection_details: Option<CollectionDetails> = Self::deserialize_trailing(buf)?;
+        let programmable_config: Option<ProgrammableConfig> = Self::deserialize_trailing(buf)?;
 
         Ok(mpl_token_metadata::accounts::Metadata {
             key,

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -1001,7 +1001,7 @@ impl AnchorAccount for TokenRecordAccount {
     fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
-        let data = Self::parse(&mut &data_ref[..])?;
+        let (data, _) = Self::parse_prefix(&data_ref[..])?;
         drop(data_ref);
         Ok(Self {
             view: Some(view),

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -970,8 +970,8 @@ impl TokenRecordAccount {
         // following bytes untouched, so decode the first valid token-record
         // prefix and report its consumed length.
         if data.len() >= Self::LEN {
-            let prefix = &data[..Self::LEN];
-            if let Ok(record) = Self::parse(prefix) {
+            let mut prefix = &data[..Self::LEN];
+            if let Ok(record) = Self::parse(&mut prefix) {
                 return Ok((record, Self::LEN));
             }
         }
@@ -980,8 +980,8 @@ impl TokenRecordAccount {
             return Err(ProgramError::InvalidAccountData);
         }
 
-        let prefix = &data[..Self::LEGACY_LEN];
-        let record = Self::parse(prefix)?;
+        let mut prefix = &data[..Self::LEGACY_LEN];
+        let record = Self::parse(&mut prefix)?;
         Ok((record, Self::LEGACY_LEN))
     }
 }

--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -14,6 +14,7 @@ use {
         require, AccountDeserialize, AnchorAccount, CpiContext, CpiHandle, CpiHandleMut, Id,
         IdlAccountType, Result, ToCpiAccounts,
     },
+    borsh::BorshDeserialize,
     core::ops::Deref,
     pinocchio::account::AccountView,
     solana_address::Address,
@@ -734,9 +735,74 @@ pub struct MetadataAccount {
 
 impl MetadataAccount {
     #[inline]
-    fn parse(data: &[u8]) -> Result<mpl_token_metadata::accounts::Metadata> {
-        mpl_token_metadata::accounts::Metadata::safe_deserialize(data)
-            .map_err(|_| ProgramError::InvalidAccountData)
+    fn parse(buf: &mut &[u8]) -> Result<mpl_token_metadata::accounts::Metadata> {
+        use mpl_token_metadata::types::{
+            Collection, CollectionDetails, Data, Key, ProgrammableConfig, TokenStandard, Uses,
+        };
+
+        if buf.is_empty() || buf[0] != Key::MetadataV1 as u8 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let key: Key =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let update_authority: Pubkey =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let mint: Pubkey =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let data: Data =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let primary_sale_happened: bool =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let is_mutable: bool =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let edition_nonce: Option<u8> =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+
+        let token_standard_res: core::result::Result<Option<TokenStandard>, borsh::io::Error> =
+            BorshDeserialize::deserialize(buf);
+        let collection_res: core::result::Result<Option<Collection>, borsh::io::Error> =
+            BorshDeserialize::deserialize(buf);
+        let uses_res: core::result::Result<Option<Uses>, borsh::io::Error> =
+            BorshDeserialize::deserialize(buf);
+        let collection_details_res: core::result::Result<
+            Option<CollectionDetails>,
+            borsh::io::Error,
+        > = BorshDeserialize::deserialize(buf);
+        let programmable_config_res: core::result::Result<
+            Option<ProgrammableConfig>,
+            borsh::io::Error,
+        > = BorshDeserialize::deserialize(buf);
+
+        let (token_standard, collection, uses) =
+            match (token_standard_res, collection_res, uses_res) {
+                (Ok(token_standard), Ok(collection), Ok(uses)) => {
+                    (token_standard, collection, uses)
+                }
+                _ => (None, None, None),
+            };
+
+        let collection_details = collection_details_res.unwrap_or(None);
+        let programmable_config = programmable_config_res.unwrap_or(None);
+
+        Ok(mpl_token_metadata::accounts::Metadata {
+            key,
+            update_authority,
+            mint,
+            name: data.name,
+            symbol: data.symbol,
+            uri: data.uri,
+            seller_fee_basis_points: data.seller_fee_basis_points,
+            creators: data.creators,
+            primary_sale_happened,
+            is_mutable,
+            edition_nonce,
+            token_standard,
+            collection,
+            uses,
+            collection_details,
+            programmable_config,
+        })
     }
 }
 
@@ -757,7 +823,7 @@ impl AnchorAccount for MetadataAccount {
     fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
-        let data = Self::parse(&data_ref)?;
+        let data = Self::parse(&mut &data_ref[..])?;
         drop(data_ref);
         Ok(Self {
             view: Some(view),
@@ -790,8 +856,12 @@ pub struct MasterEditionAccount {
 
 impl MasterEditionAccount {
     #[inline]
-    fn parse(data: &[u8]) -> Result<mpl_token_metadata::accounts::MasterEdition> {
-        mpl_token_metadata::accounts::MasterEdition::safe_deserialize(data)
+    fn parse(buf: &mut &[u8]) -> Result<mpl_token_metadata::accounts::MasterEdition> {
+        if buf.is_empty() || buf[0] != mpl_token_metadata::types::Key::MasterEditionV2 as u8 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        mpl_token_metadata::accounts::MasterEdition::deserialize(buf)
             .map_err(|_| ProgramError::InvalidAccountData)
     }
 }
@@ -813,7 +883,7 @@ impl AnchorAccount for MasterEditionAccount {
     fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
-        let data = Self::parse(&data_ref)?;
+        let data = Self::parse(&mut &data_ref[..])?;
         drop(data_ref);
         Ok(Self {
             view: Some(view),
@@ -849,9 +919,43 @@ impl TokenRecordAccount {
     const LEGACY_LEN: usize = Self::LEN - 33;
 
     #[inline]
-    fn parse(data: &[u8]) -> Result<mpl_token_metadata::accounts::TokenRecord> {
-        mpl_token_metadata::accounts::TokenRecord::safe_deserialize(data)
-            .map_err(|_| ProgramError::InvalidAccountData)
+    fn parse(buf: &mut &[u8]) -> Result<mpl_token_metadata::accounts::TokenRecord> {
+        const LOCKED_TRANSFER_SIZE: i64 = 33;
+
+        let length = Self::LEN as i64 - buf.len() as i64;
+        if !(length == 0 || length == LOCKED_TRANSFER_SIZE)
+            || buf.first().copied() != Some(mpl_token_metadata::types::Key::TokenRecord as u8)
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let key =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let bump =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let state =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let rule_set_revision =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let delegate =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let delegate_role =
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?;
+        let locked_transfer = if length == 0 {
+            BorshDeserialize::deserialize(buf).map_err(|_| ProgramError::InvalidAccountData)?
+        } else {
+            None
+        };
+
+        Ok(mpl_token_metadata::accounts::TokenRecord {
+            key,
+            bump,
+            state,
+            rule_set_revision,
+            delegate,
+            delegate_role,
+            locked_transfer,
+        })
     }
 
     #[inline]
@@ -896,7 +1000,7 @@ impl AnchorAccount for TokenRecordAccount {
     fn load(view: AccountView) -> Result<Self> {
         require!(view.owned_by(&ID), ProgramError::IllegalOwner);
         let data_ref = view.try_borrow()?;
-        let data = Self::parse(&data_ref)?;
+        let data = Self::parse(&mut &data_ref[..])?;
         drop(data_ref);
         Ok(Self {
             view: Some(view),

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -231,6 +231,26 @@ fn master_edition_account_deserialize_advances_cursor() {
 }
 
 #[test]
+fn master_edition_account_load_accepts_padded_accounts() {
+    let data = to_vec(&sample_master_edition()).unwrap();
+    let account = AccountBuffer::<4096>::new();
+    account.init(
+        [6u8; 32],
+        metadata::ID.to_bytes(),
+        data.len() + 8,
+        false,
+        false,
+        false,
+    );
+    account.write_data(&data);
+
+    let loaded = MasterEditionAccount::load(unsafe { account.view() }).unwrap();
+    assert_eq!(loaded.key, mpl_token_metadata::types::Key::MasterEditionV2);
+    assert_eq!(loaded.supply, 42);
+    assert_eq!(loaded.max_supply, Some(100));
+}
+
+#[test]
 fn token_record_account_deserialize_advances_cursor() {
     let data = to_vec(&sample_token_record()).unwrap();
     let mut cursor = data.as_slice();
@@ -261,6 +281,26 @@ fn token_record_account_load_accepts_padded_accounts() {
 }
 
 #[test]
+fn token_record_account_load_accepts_legacy_padded_accounts() {
+    let data = sample_legacy_token_record_bytes();
+    let account = AccountBuffer::<4096>::new();
+    account.init(
+        [5u8; 32],
+        metadata::ID.to_bytes(),
+        data.len() + 8,
+        false,
+        false,
+        false,
+    );
+    account.write_data(&data);
+
+    let loaded = TokenRecordAccount::load(unsafe { account.view() }).unwrap();
+    assert_eq!(loaded.key, mpl_token_metadata::types::Key::TokenRecord);
+    assert_eq!(loaded.bump, 7);
+    assert_eq!(loaded.locked_transfer, None);
+}
+
+#[test]
 fn metadata_account_load_validates_owner_and_raw_data() {
     let expected = sample_metadata();
     let data = to_vec(&expected).unwrap();
@@ -278,6 +318,27 @@ fn metadata_account_load_validates_owner_and_raw_data() {
     let loaded = MetadataAccount::load(unsafe { account.view() }).unwrap();
     assert_eq!(loaded.update_authority, expected.update_authority);
     assert_eq!(loaded.seller_fee_basis_points, 250);
+}
+
+#[test]
+fn metadata_account_load_accepts_padded_accounts() {
+    let expected = sample_metadata_with_programmable_config();
+    let data = to_vec(&expected).unwrap();
+    let account = AccountBuffer::<4096>::new();
+    account.init(
+        [4u8; 32],
+        metadata::ID.to_bytes(),
+        data.len() + 8,
+        false,
+        false,
+        false,
+    );
+    account.write_data(&data);
+
+    let loaded = MetadataAccount::load(unsafe { account.view() }).unwrap();
+    assert_eq!(loaded.token_standard, expected.token_standard);
+    assert_eq!(loaded.collection, expected.collection);
+    assert_eq!(loaded.programmable_config, expected.programmable_config);
 }
 
 #[test]

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -65,6 +65,29 @@ fn sample_metadata_with_programmable_config() -> mpl_token_metadata::accounts::M
     metadata
 }
 
+fn sample_metadata_with_collection_without_uses_bytes() -> Vec<u8> {
+    let metadata = sample_metadata_with_v1_2_fields();
+    let data = mpl_token_metadata::types::Data {
+        name: metadata.name,
+        symbol: metadata.symbol,
+        uri: metadata.uri,
+        seller_fee_basis_points: metadata.seller_fee_basis_points,
+        creators: metadata.creators,
+    };
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&to_vec(&metadata.key).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.update_authority).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.mint).unwrap());
+    bytes.extend_from_slice(&to_vec(&data).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.primary_sale_happened).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.is_mutable).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.edition_nonce).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.token_standard).unwrap());
+    bytes.extend_from_slice(&to_vec(&metadata.collection).unwrap());
+    bytes
+}
+
 fn sample_legacy_metadata() -> LegacyMetadataAccount {
     let creator = Pubkey::from([7u8; 32]);
     LegacyMetadataAccount {
@@ -166,6 +189,21 @@ fn metadata_account_preserves_v1_2_fields_when_uses_is_none() {
     assert_eq!(account.token_standard, expected.token_standard);
     assert_eq!(account.collection, expected.collection);
     assert_eq!(account.uses, None);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn metadata_account_preserves_v1_2_fields_when_uses_field_is_absent() {
+    let expected = sample_metadata_with_v1_2_fields();
+    let data = sample_metadata_with_collection_without_uses_bytes();
+    let mut cursor = data.as_slice();
+    let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.token_standard, expected.token_standard);
+    assert_eq!(account.collection, expected.collection);
+    assert_eq!(account.uses, None);
+    assert_eq!(account.collection_details, None);
+    assert_eq!(account.programmable_config, None);
     assert!(cursor.is_empty());
 }
 

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -2,7 +2,7 @@
 
 use {
     anchor_lang_v2::{testing::AccountBuffer, AccountDeserialize, AnchorAccount},
-    anchor_spl_v2::metadata::{self, MetadataAccount, TokenRecordAccount},
+    anchor_spl_v2::metadata::{self, MasterEditionAccount, MetadataAccount, TokenRecordAccount},
     borsh::to_vec,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
@@ -34,6 +34,13 @@ fn sample_metadata() -> mpl_token_metadata::accounts::Metadata {
     }
 }
 
+fn sample_master_edition() -> mpl_token_metadata::accounts::MasterEdition {
+    mpl_token_metadata::accounts::MasterEdition {
+        key: mpl_token_metadata::types::Key::MasterEditionV2,
+        supply: 42,
+        max_supply: Some(100),
+    }
+}
 fn sample_token_record() -> mpl_token_metadata::accounts::TokenRecord {
     mpl_token_metadata::accounts::TokenRecord {
         key: mpl_token_metadata::types::Key::TokenRecord,
@@ -57,7 +64,6 @@ fn sample_legacy_token_record_bytes() -> Vec<u8> {
     data.extend_from_slice(&to_vec(&record.delegate_role).unwrap());
     data
 }
-
 #[test]
 fn fixture_is_real_metadata_program_elf() {
     let fixture = include_bytes!("fixtures/metaplex_token_metadata.so");
@@ -78,6 +84,36 @@ fn metadata_account_deserializes_raw_metaplex_bytes() {
         account.creators.as_ref().unwrap()[0].address,
         Pubkey::from([7u8; 32])
     );
+}
+
+#[test]
+fn metadata_account_deserialize_advances_cursor() {
+    let data = to_vec(&sample_metadata()).unwrap();
+    let mut cursor = data.as_slice();
+    let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.key, mpl_token_metadata::types::Key::MetadataV1);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn master_edition_account_deserialize_advances_cursor() {
+    let data = to_vec(&sample_master_edition()).unwrap();
+    let mut cursor = data.as_slice();
+    let account = MasterEditionAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.key, mpl_token_metadata::types::Key::MasterEditionV2);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn token_record_account_deserialize_advances_cursor() {
+    let data = to_vec(&sample_token_record()).unwrap();
+    let mut cursor = data.as_slice();
+    let account = TokenRecordAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.key, mpl_token_metadata::types::Key::TokenRecord);
+    assert!(cursor.is_empty());
 }
 
 #[test]

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -3,10 +3,21 @@
 use {
     anchor_lang_v2::{testing::AccountBuffer, AccountDeserialize, AnchorAccount},
     anchor_spl_v2::metadata::{self, MasterEditionAccount, MetadataAccount, TokenRecordAccount},
-    borsh::to_vec,
+    borsh::{to_vec, BorshSerialize},
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
 };
+
+#[derive(BorshSerialize)]
+struct LegacyMetadataAccount {
+    key: mpl_token_metadata::types::Key,
+    update_authority: Pubkey,
+    mint: Pubkey,
+    data: mpl_token_metadata::types::Data,
+    primary_sale_happened: bool,
+    is_mutable: bool,
+    edition_nonce: Option<u8>,
+}
 
 fn sample_metadata() -> mpl_token_metadata::accounts::Metadata {
     let creator = Pubkey::from([7u8; 32]);
@@ -31,6 +42,39 @@ fn sample_metadata() -> mpl_token_metadata::accounts::Metadata {
         uses: None,
         collection_details: None,
         programmable_config: None,
+    }
+}
+
+fn sample_metadata_with_v1_2_fields() -> mpl_token_metadata::accounts::Metadata {
+    let mut metadata = sample_metadata();
+    metadata.token_standard = Some(mpl_token_metadata::types::TokenStandard::NonFungible);
+    metadata.collection = Some(mpl_token_metadata::types::Collection {
+        verified: true,
+        key: Pubkey::from([11u8; 32]),
+    });
+    metadata
+}
+
+fn sample_legacy_metadata() -> LegacyMetadataAccount {
+    let creator = Pubkey::from([7u8; 32]);
+    LegacyMetadataAccount {
+        key: mpl_token_metadata::types::Key::MetadataV1,
+        update_authority: Pubkey::from([1u8; 32]),
+        mint: Pubkey::from([2u8; 32]),
+        data: mpl_token_metadata::types::Data {
+            name: "Pump AMM".to_string(),
+            symbol: "PUMP".to_string(),
+            uri: "https://example.invalid/pump.json".to_string(),
+            seller_fee_basis_points: 250,
+            creators: Some(vec![mpl_token_metadata::types::Creator {
+                address: creator,
+                verified: true,
+                share: 100,
+            }]),
+        },
+        primary_sale_happened: false,
+        is_mutable: true,
+        edition_nonce: Some(255),
     }
 }
 
@@ -93,6 +137,31 @@ fn metadata_account_deserialize_advances_cursor() {
     let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
 
     assert_eq!(account.key, mpl_token_metadata::types::Key::MetadataV1);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn metadata_account_legacy_bytes_leave_v1_2_fields_absent() {
+    let data = to_vec(&sample_legacy_metadata()).unwrap();
+    let mut cursor = data.as_slice();
+    let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.token_standard, None);
+    assert_eq!(account.collection, None);
+    assert_eq!(account.uses, None);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn metadata_account_preserves_v1_2_fields_when_uses_is_none() {
+    let expected = sample_metadata_with_v1_2_fields();
+    let data = to_vec(&expected).unwrap();
+    let mut cursor = data.as_slice();
+    let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.token_standard, expected.token_standard);
+    assert_eq!(account.collection, expected.collection);
+    assert_eq!(account.uses, None);
     assert!(cursor.is_empty());
 }
 

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -55,6 +55,16 @@ fn sample_metadata_with_v1_2_fields() -> mpl_token_metadata::accounts::Metadata 
     metadata
 }
 
+fn sample_metadata_with_programmable_config() -> mpl_token_metadata::accounts::Metadata {
+    let mut metadata = sample_metadata_with_v1_2_fields();
+    metadata.token_standard =
+        Some(mpl_token_metadata::types::TokenStandard::ProgrammableNonFungible);
+    metadata.programmable_config = Some(mpl_token_metadata::types::ProgrammableConfig::V1 {
+        rule_set: Some(Pubkey::from([12u8; 32])),
+    });
+    metadata
+}
+
 fn sample_legacy_metadata() -> LegacyMetadataAccount {
     let creator = Pubkey::from([7u8; 32]);
     LegacyMetadataAccount {
@@ -121,13 +131,7 @@ fn metadata_account_deserializes_raw_metaplex_bytes() {
     let data = to_vec(&expected).unwrap();
     let account = MetadataAccount::try_deserialize(&mut data.as_slice()).unwrap();
 
-    assert_eq!(account.key, mpl_token_metadata::types::Key::MetadataV1);
-    assert_eq!(account.name, "Pump AMM");
-    assert_eq!(account.mint, expected.mint);
-    assert_eq!(
-        account.creators.as_ref().unwrap()[0].address,
-        Pubkey::from([7u8; 32])
-    );
+    assert_eq!(&*account, &expected);
 }
 
 #[test]
@@ -162,6 +166,19 @@ fn metadata_account_preserves_v1_2_fields_when_uses_is_none() {
     assert_eq!(account.token_standard, expected.token_standard);
     assert_eq!(account.collection, expected.collection);
     assert_eq!(account.uses, None);
+    assert!(cursor.is_empty());
+}
+
+#[test]
+fn metadata_account_preserves_programmable_config_fields() {
+    let expected = sample_metadata_with_programmable_config();
+    let data = to_vec(&expected).unwrap();
+    let mut cursor = data.as_slice();
+    let account = MetadataAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.token_standard, expected.token_standard);
+    assert_eq!(account.collection, expected.collection);
+    assert_eq!(account.programmable_config, expected.programmable_config);
     assert!(cursor.is_empty());
 }
 

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -241,6 +241,26 @@ fn token_record_account_deserialize_advances_cursor() {
 }
 
 #[test]
+fn token_record_account_load_accepts_padded_accounts() {
+    let data = to_vec(&sample_token_record()).unwrap();
+    let account = AccountBuffer::<4096>::new();
+    account.init(
+        [8u8; 32],
+        metadata::ID.to_bytes(),
+        data.len() + 8,
+        false,
+        false,
+        false,
+    );
+    account.write_data(&data);
+
+    let loaded = TokenRecordAccount::load(unsafe { account.view() }).unwrap();
+    assert_eq!(loaded.key, mpl_token_metadata::types::Key::TokenRecord);
+    assert_eq!(loaded.bump, 7);
+    assert_eq!(loaded.locked_transfer, Some(Pubkey::from([4u8; 32])));
+}
+
+#[test]
 fn metadata_account_load_validates_owner_and_raw_data() {
     let expected = sample_metadata();
     let data = to_vec(&expected).unwrap();


### PR DESCRIPTION
#### finding
The metadata account wrappers in `spl-v2` deserialized from a copied slice and did not advance the caller's input cursor. That contradicts the `AccountDeserialize` contract and can misalign chained deserialization.

#### Fix
Implemented cursor-advancing deserialization for `MetadataAccount`, `MasterEditionAccount`, and `TokenRecordAccount`. This restores the expected `AccountDeserialize` semantics while preserving the existing type checks.
