### PR TITLE
Fix/spl-v2 untrusted bump curve check

### DIFF
--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -241,36 +241,21 @@ pub fn create_program_address(
 
 /// Verify that `expected` matches the PDA derived from `seeds` and `program_id`.
 ///
-/// On-chain this is hash-only and assumes the seeds are runtime-valid and the
-/// bump is canonical. Off-chain it uses `Address::create_program_address`,
-/// which also performs host-side seed and curve validation. For untrusted bumps
-/// use `find_and_verify_program_address`. Seeds should already include the bump
-/// byte.
+/// This verifies the exact PDA for the provided seeds, including the runtime's
+/// off-curve requirement. Use [`find_and_verify_program_address`] when the bump
+/// is not already included in `seeds` and needs to be discovered canonically.
 #[inline(always)]
 pub fn verify_program_address(
     seeds: &[&[u8]],
     program_id: &Address,
     expected: &Address,
 ) -> Result<(), ProgramError> {
-    #[cfg(target_os = "solana")]
-    {
-        let computed = hash_pda_seeds(seeds, program_id)?;
-        if pinocchio::address::address_eq(&computed, expected) {
-            Ok(())
-        } else {
-            Err(ProgramError::InvalidSeeds)
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    {
-        let computed = Address::create_program_address(seeds, program_id)
-            .map_err(|_| ProgramError::InvalidSeeds)?;
-        if pinocchio::address::address_eq(&computed, expected) {
-            Ok(())
-        } else {
-            Err(ProgramError::InvalidSeeds)
-        }
+    let computed =
+        create_program_address(seeds, program_id).map_err(|_| ProgramError::InvalidSeeds)?;
+    if pinocchio::address::address_eq(&computed, expected) {
+        Ok(())
+    } else {
+        Err(ProgramError::InvalidSeeds)
     }
 }
 

--- a/tests-v2/programs/seeds/src/lib.rs
+++ b/tests-v2/programs/seeds/src/lib.rs
@@ -110,6 +110,22 @@ pub mod seeds {
     ) -> Result<()> {
         Ok(())
     }
+
+    #[discrim = 12]
+    pub fn check_literal_untrusted_bump(
+        _ctx: &mut Context<CheckLiteralUntrustedBump>,
+        _untrusted_bump: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    #[discrim = 13]
+    pub fn check_fn_seeds_untrusted_bump(
+        _ctx: &mut Context<CheckFnSeedsUntrustedBump>,
+        _untrusted_bump: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 // -- Accounts structs --------------------------------------------------------
@@ -169,12 +185,30 @@ pub struct CheckFnSeedsExplicitBumpOptional {
     pub data: Option<Account<Data>>,
 }
 
+// 5c. Verify function-call seeds + explicit untrusted bump on UncheckedAccount.
+#[derive(Accounts)]
+#[instruction(untrusted_bump: u8)]
+pub struct CheckFnSeedsUntrustedBump {
+    pub payer: Signer,
+    #[account(seeds = tag_seeds(), bump = untrusted_bump)]
+    pub data: UncheckedAccount,
+}
+
 // 6. Verify const-item seeds + bare bump
 #[derive(Accounts)]
 pub struct CheckConstSeeds {
     pub payer: Signer,
     #[account(seeds = CONST_TAG_SEEDS, bump)]
     pub data: Account<Data>,
+}
+
+// 6b. Verify literal seeds + explicit untrusted bump on UncheckedAccount.
+#[derive(Accounts)]
+#[instruction(untrusted_bump: u8)]
+pub struct CheckLiteralUntrustedBump {
+    pub payer: Signer,
+    #[account(seeds = [b"data"], bump = untrusted_bump)]
+    pub data: UncheckedAccount,
 }
 
 // 7. Init + mixed seeds (literal + field ref)

--- a/tests-v2/tests/seeds.rs
+++ b/tests-v2/tests/seeds.rs
@@ -7,9 +7,11 @@
 use {
     anchor_lang_v2::solana_program::instruction::{AccountMeta, Instruction},
     litesvm::{types::TransactionResult, LiteSVM},
+    sha2::{Digest, Sha256},
+    solana_account::Account,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
-    solana_pubkey::Pubkey,
+    solana_pubkey::{bytes_are_curve_point, Pubkey},
     solana_signer::Signer,
     solana_transaction::versioned::VersionedTransaction,
     tests_v2::{build_program, keypair_for, send_instruction},
@@ -27,6 +29,31 @@ fn data_pda() -> Pubkey {
 
 fn user_pda(user: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"user", user.as_ref()], &program_id()).0
+}
+
+fn raw_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Pubkey {
+    let mut hasher = Sha256::new();
+    for seed in seeds {
+        hasher.update(seed);
+    }
+    hasher.update(program_id.as_ref());
+    hasher.update(b"ProgramDerivedAddress");
+    Pubkey::new_from_array(hasher.finalize().into())
+}
+
+fn find_on_curve_bump() -> (Pubkey, u8) {
+    for bump in 0..=u8::MAX {
+        let bump_seed = [bump];
+        let address = raw_program_address(&[b"data", &bump_seed], &program_id());
+        if bytes_are_curve_point(address.to_bytes()) {
+            assert!(
+                Pubkey::create_program_address(&[b"data", &bump_seed], &program_id()).is_err(),
+                "host PDA derivation should reject on-curve addresses",
+            );
+            return (address, bump);
+        }
+    }
+    panic!("expected at least one on-curve bump");
 }
 
 fn setup() -> (LiteSVM, Keypair) {
@@ -253,6 +280,20 @@ fn call_raw(
     svm.send_transaction(tx)
 }
 
+fn set_system_account(svm: &mut LiteSVM, address: Pubkey, lamports: u64, data_len: usize) {
+    svm.set_account(
+        address,
+        Account {
+            lamports,
+            data: vec![0u8; data_len],
+            owner: solana_sdk_ids::system_program::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+}
+
 #[test]
 fn wrong_bump_value_rejected() {
     let (mut svm, payer) = setup();
@@ -333,5 +374,51 @@ fn mixed_seeds_wrong_order_rejected() {
     assert!(
         result.is_err(),
         "PDA from wrong seed order should be rejected"
+    );
+}
+
+#[test]
+fn literal_untrusted_bump_rejects_on_curve_address() {
+    let (mut svm, payer) = setup();
+    let (fake_pda, bump) = find_on_curve_bump();
+    set_system_account(&mut svm, fake_pda, 1_000_000, 0);
+
+    let result = send_instruction(
+        &mut svm,
+        program_id(),
+        vec![12, bump],
+        vec![
+            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new_readonly(fake_pda, false),
+        ],
+        &payer,
+        &[],
+    );
+    assert!(
+        result.is_err(),
+        "on-curve address derived from explicit bump must be rejected",
+    );
+}
+
+#[test]
+fn fn_seed_untrusted_bump_rejects_on_curve_address() {
+    let (mut svm, payer) = setup();
+    let (fake_pda, bump) = find_on_curve_bump();
+    set_system_account(&mut svm, fake_pda, 1_000_000, 0);
+
+    let result = send_instruction(
+        &mut svm,
+        program_id(),
+        vec![13, bump],
+        vec![
+            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new_readonly(fake_pda, false),
+        ],
+        &payer,
+        &[],
+    );
+    assert!(
+        result.is_err(),
+        "on-curve address derived from explicit bump must be rejected",
     );
 }


### PR DESCRIPTION
Because explicit-bump PDA verification used a hash-only check, on-curve raw-hash addresses were accepted; I enforced off-curve verification and now those non-PDAs are rejected.