### PR TITLE
fix(spl-v2): correct writable burn_nft doc example

### DIFF
--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -89,7 +89,7 @@ pub fn burn_edition_nft<'info>(ctx: CpiContext<'info, BurnEditionNft<'info>>) ->
 ///
 /// ```ignore
 /// CpiContext::new(program, BurnNft { .. })
-///     .with_remaining_accounts(vec![ctx.accounts.collection_metadata.cpi_handle()]);
+///     .with_remaining_accounts(vec![ctx.accounts.collection_metadata.cpi_handle_mut().into()]);
 /// ```
 pub fn burn_nft<'info>(
     ctx: CpiContext<'info, BurnNft<'info>>,


### PR DESCRIPTION
the example in `spl-v2/src/metadata.rs:92`was using a readonly handle, but Metaplex BurnNft marks collection_metadata as `[writable, optional]`. So the example should pass a writable handle erased into `CpiHandle`, i.e. `cpi_handle_mut().into()`.