### PR TITLE
Fix/spl-v2 group pointer empty signers

### DIFF
--- a/spl-v2/src/token_2022_extensions/group_pointer.rs
+++ b/spl-v2/src/token_2022_extensions/group_pointer.rs
@@ -62,3 +62,58 @@ fn group_pointer_update_ix(
         group_address.copied(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        anchor_lang_v2::{
+            programs::Token2022,
+            testing::{AccountBuffer, MIN_ACCOUNT_BUF},
+            Address, Id,
+        },
+    };
+
+    fn account(
+        address: [u8; 32],
+        signer: bool,
+        writable: bool,
+    ) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
+        let buffer = AccountBuffer::new();
+        buffer.init(address, [9; 32], 8, signer, writable, false);
+        buffer
+    }
+
+    #[test]
+    fn group_pointer_update_uses_single_authority_layout() {
+        let program = Token2022::id();
+        let mint = Address::new_from_array([1; 32]);
+        let authority = Address::new_from_array([2; 32]);
+        let group = Address::new_from_array([3; 32]);
+
+        let ix = group_pointer_update_ix(&program, &mint, &authority, Some(&group))
+            .expect("group pointer update ix should build");
+        assert_eq!(ix.accounts.len(), 2);
+        assert!(ix.accounts[0].is_writable);
+        assert!(!ix.accounts[0].is_signer);
+        assert_eq!(ix.accounts[0].pubkey.as_ref(), mint.as_ref());
+        assert!(!ix.accounts[1].is_writable);
+        assert!(ix.accounts[1].is_signer);
+        assert_eq!(ix.accounts[1].pubkey.as_ref(), authority.as_ref());
+    }
+
+    #[test]
+    fn group_pointer_update_accounts_do_not_duplicate_authority() {
+        let mint_buffer = account([1; 32], false, true);
+        let authority_buffer = account([2; 32], true, false);
+        let mut mint_view = unsafe { mint_buffer.view() };
+        let authority_view = unsafe { authority_buffer.view() };
+
+        let accounts = GroupPointerUpdate {
+            mint: CpiHandleMut::writable(&mut mint_view),
+            authority: CpiHandle::readonly(&authority_view),
+        };
+
+        assert_eq!(accounts.to_cpi_handles().len(), 2);
+    }
+}

--- a/spl-v2/src/token_2022_extensions/group_pointer.rs
+++ b/spl-v2/src/token_2022_extensions/group_pointer.rs
@@ -3,6 +3,7 @@ use {
     crate::token_2022::spl_token_2022,
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
+    solana_instruction::Instruction,
     solana_program_error::ProgramError,
 };
 
@@ -14,7 +15,6 @@ pub struct GroupPointerInitialize<'a> {
 #[derive(ToCpiAccounts)]
 pub struct GroupPointerUpdate<'a> {
     pub mint: CpiHandleMut<'a>,
-    #[account_meta(duplicate_readonly)]
     #[signer]
     pub authority: CpiHandle<'a>,
 }
@@ -39,12 +39,26 @@ pub fn group_pointer_update<'a>(
     group_address: Option<&Address>,
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
-    let ix = spl_token_2022::extension::group_pointer::instruction::update(
+    let ix = group_pointer_update_ix(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[ctx.accounts.authority.address()],
-        group_address.copied(),
+        group_address,
     )?;
     ctx.invoke_ix(ix)
+}
+
+fn group_pointer_update_ix(
+    program: &Address,
+    mint: &Address,
+    authority: &Address,
+    group_address: Option<&Address>,
+) -> Result<Instruction, ProgramError> {
+    spl_token_2022::extension::group_pointer::instruction::update(
+        program,
+        mint,
+        authority,
+        &[],
+        group_address.copied(),
+    )
 }


### PR DESCRIPTION
For the non-multisig path, `spl-token-2022` expects `signers: &[]`; passing `[authority]` switches the builder into the multisig layout and duplicates the authority meta.