### PR TITLE
Fix/spl-v2 token metadata update authority field

### DIFF
--- a/spl-v2/src/token_2022_extensions/token_metadata.rs
+++ b/spl-v2/src/token_2022_extensions/token_metadata.rs
@@ -23,8 +23,6 @@ pub struct TokenMetadataUpdateAuthority<'a> {
     pub metadata: CpiHandleMut<'a>,
     #[signer]
     pub current_authority: CpiHandle<'a>,
-    #[account_meta(skip)]
-    pub new_authority: CpiHandle<'a>,
 }
 
 #[derive(ToCpiAccounts)]

--- a/tests-v2/programs/spl/src/lib.rs
+++ b/tests-v2/programs/spl/src/lib.rs
@@ -1356,17 +1356,14 @@ pub mod spl_test {
     #[discrim = 49]
     pub fn token_2022_token_metadata_update_authority(
         ctx: &mut Context<Token2022TokenMetadataUpdateAuthority>,
+        new_authority: Address,
     ) -> Result<()> {
         let accs = token_2022_ext_cpi::TokenMetadataUpdateAuthority {
             metadata: ctx.accounts.metadata.cpi_handle_mut(),
             current_authority: ctx.accounts.current_authority.cpi_handle(),
-            new_authority: ctx.accounts.new_authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.token_program.address(), accs);
-        token_2022_ext_cpi::token_metadata_update_authority(
-            cpi_ctx,
-            Some(ctx.accounts.new_authority.address()),
-        )?;
+        token_2022_ext_cpi::token_metadata_update_authority(cpi_ctx, Some(&new_authority))?;
         Ok(())
     }
 
@@ -2101,7 +2098,6 @@ pub struct Token2022TokenMetadataUpdateAuthority {
     #[account(mut)]
     pub metadata: UncheckedAccount,
     pub current_authority: Signer,
-    pub new_authority: UncheckedAccount,
     pub token_program: UncheckedAccount,
 }
 

--- a/tests-v2/programs/token-2022-extensions/token-metadata/src/lib.rs
+++ b/tests-v2/programs/token-2022-extensions/token-metadata/src/lib.rs
@@ -24,15 +24,17 @@ pub mod token_2022_ext_token_metadata {
     }
 
     #[discrim = 1]
-    pub fn update_authority(ctx: &mut Context<UpdateAuthority>) -> Result<()> {
+    pub fn update_authority(
+        ctx: &mut Context<UpdateAuthority>,
+        new_authority: Address,
+    ) -> Result<()> {
         let accs = token_2022_ext::TokenMetadataUpdateAuthority {
             metadata: ctx.accounts.metadata.cpi_handle_mut(),
             current_authority: ctx.accounts.current_authority.cpi_handle(),
-            new_authority: ctx.accounts.new_authority.cpi_handle(),
         };
         token_2022_ext::token_metadata_update_authority(
             CpiContext::new(ctx.accounts.token_program.address(), accs),
-            Some(ctx.accounts.new_authority.address()),
+            Some(&new_authority),
         )?;
         Ok(())
     }
@@ -82,7 +84,6 @@ pub struct UpdateAuthority {
     #[account(mut)]
     pub metadata: UncheckedAccount,
     pub current_authority: Signer,
-    pub new_authority: UncheckedAccount,
     pub token_program: UncheckedAccount,
 }
 

--- a/tests-v2/tests/spl.rs
+++ b/tests-v2/tests/spl.rs
@@ -4988,19 +4988,19 @@ fn token_metadata_update_authority_helper_rejects_non_token_2022_program() {
     let new_authority = Pubkey::new_unique();
 
     seed_token_owned_account(&mut svm, metadata, token_2022_program_id(), vec![0; 8]);
-    seed_token_owned_account(&mut svm, new_authority, token_2022_program_id(), vec![0; 8]);
 
+    let mut data = vec![49];
+    data.extend_from_slice(&new_authority.to_bytes());
     let metas = vec![
         AccountMeta::new(metadata, false),
         AccountMeta::new_readonly(current_authority.pubkey(), true),
-        AccountMeta::new_readonly(new_authority, false),
         AccountMeta::new_readonly(wrong_token_2022_program_id(), false),
     ];
     assert_incorrect_token_2022_program_error(
         send_instruction(
             &mut svm,
             program_id(),
-            vec![49],
+            data,
             metas,
             &payer,
             &[&current_authority],

--- a/tests-v2/tests/token_2022_extensions/common.rs
+++ b/tests-v2/tests/token_2022_extensions/common.rs
@@ -84,10 +84,6 @@ pub fn seed_token_2022_account(svm: &mut LiteSVM, address: Pubkey, data: Vec<u8>
     .expect("seed token-2022-owned account");
 }
 
-pub fn seed_account(svm: &mut LiteSVM, address: Pubkey) {
-    seed_token_2022_account(svm, address, vec![0; 256]);
-}
-
 pub fn seed_mint_with_extensions(svm: &mut LiteSVM, address: Pubkey, extensions: &[ExtensionType]) {
     let len = ExtensionType::try_calculate_account_len::<Mint>(extensions)
         .expect("calculate token-2022 mint account length");

--- a/tests-v2/tests/token_2022_extensions/token_metadata.rs
+++ b/tests-v2/tests/token_2022_extensions/token_metadata.rs
@@ -36,7 +36,6 @@ fn initializes_updates_and_removes_metadata_on_the_mint() {
         extension.metadata_address = Some(mint).try_into().unwrap();
     }
     seed_token_2022_account(&mut svm, mint, mint_data);
-    seed_account(&mut svm, new_authority);
     svm.airdrop(&mint_authority.pubkey(), 1_000_000_000)
         .unwrap();
     svm.airdrop(&update_authority.pubkey(), 1_000_000_000)
@@ -95,16 +94,17 @@ fn initializes_updates_and_removes_metadata_on_the_mint() {
     assert_token_2022_cpi_succeeded(&metadata, "token metadata remove_key");
     assert_metadata_field(&svm, mint, "field", None);
 
+    let mut update_authority_data = vec![1];
+    update_authority_data.extend_from_slice(&address_bytes(new_authority));
     let update_authority_metas = vec![
         Meta::new(mint, false),
         Meta::new_readonly(update_authority.pubkey(), true),
-        Meta::new_readonly(new_authority, false),
         Meta::new_readonly(token_2022_program_id(), false),
     ];
     let metadata = send(
         &mut svm,
         id,
-        vec![1],
+        update_authority_data,
         update_authority_metas,
         &payer,
         &[&update_authority],
@@ -143,7 +143,6 @@ fn token_metadata_helpers_reject_wrong_program_before_state_changes() {
         extension.metadata_address = Some(mint).try_into().unwrap();
     }
     seed_token_2022_account(&mut svm, mint, mint_data);
-    seed_account(&mut svm, new_authority);
     svm.airdrop(&mint_authority.pubkey(), 1_000_000_000)
         .unwrap();
     svm.airdrop(&update_authority.pubkey(), 1_000_000_000)
@@ -180,11 +179,14 @@ fn token_metadata_helpers_reject_wrong_program_before_state_changes() {
             vec![&mint_authority],
         ),
         (
-            vec![1],
+            {
+                let mut data = vec![1];
+                data.extend_from_slice(&address_bytes(new_authority));
+                data
+            },
             vec![
                 Meta::new(mint, false),
                 Meta::new_readonly(update_authority.pubkey(), true),
-                Meta::new_readonly(new_authority, false),
                 Meta::new_readonly(wrong_token_program_id(), false),
             ],
             vec![&update_authority],


### PR DESCRIPTION
removed the redundant CPI field and token metadata authority updates no longer require an extra account.