### PR TITLE
Fix/spl-v2 token cpi ext pda signers

### DIFF
--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -322,6 +322,8 @@ pub use {
     },
 };
 
+pub type TokenSignerSeeds<'a> = &'a [&'a [&'a [u8]]];
+
 #[inline]
 fn token_2022_authority_type(
     authority_type: spl_token::instruction::AuthorityType,
@@ -342,6 +344,18 @@ fn token_2022_authority_type(
     }
 }
 
+#[inline]
+fn token_cpi_ctx<'a, T>(
+    program: &'a Address,
+    accounts: T,
+    signer_seeds: TokenSignerSeeds<'a>,
+) -> CpiContext<'a, T>
+where
+    T: anchor_lang_v2::ToCpiAccounts<'a>,
+{
+    CpiContext::new_with_signer(program, accounts, signer_seeds)
+}
+
 pub fn set_authority<'a>(
     ctx: CpiContext<'a, accounts::SetAuthority<'a>>,
     authority_type: spl_token::instruction::AuthorityType,
@@ -359,12 +373,15 @@ pub fn set_authority<'a>(
 /// These methods are a thin layer over the existing account structs and free
 /// functions. They keep the same account ordering and validation path while
 /// letting callers avoid manually building `CpiContext` for simple Token CPIs.
+/// Pass `&[]` for transaction signers, or PDA signer seeds for program-signed
+/// authorities.
 pub trait TokenCpiExt {
     fn mint_to<'a, M, T, A>(
         &'a self,
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -377,6 +394,7 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -390,6 +408,7 @@ pub trait TokenCpiExt {
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -404,6 +423,7 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -416,6 +436,7 @@ pub trait TokenCpiExt {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -423,7 +444,12 @@ pub trait TokenCpiExt {
         D: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized;
 
-    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(
+        &'a self,
+        source: &'a mut S,
+        authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
+    ) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized;
@@ -433,6 +459,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -444,6 +471,7 @@ pub trait TokenCpiExt {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -457,6 +485,7 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -471,6 +500,7 @@ pub trait TokenCpiExt {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -485,6 +515,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -496,6 +527,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -556,6 +588,7 @@ pub trait TokenCpiExt {
         &'a self,
         account_or_mint: &'a mut Acc,
         current_authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         authority_type: spl_token::instruction::AuthorityType,
         new_authority: Option<Address>,
     ) -> Result<(), ProgramError>
@@ -570,6 +603,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -578,13 +612,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         mint_to(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::MintTo {
                     mint: mint.try_to_cpi_handle_mut()?,
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
@@ -595,6 +630,7 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -603,13 +639,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         transfer(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::Transfer {
                     from: from.try_to_cpi_handle_mut()?,
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
@@ -621,6 +658,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -631,7 +669,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         transfer_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::TransferChecked {
                     from: from.try_to_cpi_handle_mut()?,
@@ -639,6 +677,7 @@ impl TokenCpiExt for Program<Token> {
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -650,6 +689,7 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -658,13 +698,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::Burn {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
@@ -675,6 +716,7 @@ impl TokenCpiExt for Program<Token> {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -683,29 +725,36 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::Approve {
                     to: source.try_to_cpi_handle_mut()?,
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
     }
 
-    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(
+        &'a self,
+        source: &'a mut S,
+        authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
+    ) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        revoke(CpiContext::new(
+        revoke(token_cpi_ctx(
             self.address(),
             accounts::Revoke {
                 source: source.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -714,19 +763,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         Dest: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        close_account(CpiContext::new(
+        close_account(token_cpi_ctx(
             self.address(),
             accounts::CloseAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 destination: destination.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -735,6 +786,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -744,13 +796,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         mint_to_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::MintToChecked {
                     mint: mint.try_to_cpi_handle_mut()?,
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -762,6 +815,7 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -771,13 +825,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::BurnChecked {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -790,6 +845,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -800,7 +856,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::ApproveChecked {
                     to: source.try_to_cpi_handle_mut()?,
@@ -808,6 +864,7 @@ impl TokenCpiExt for Program<Token> {
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -819,19 +876,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        freeze_account(CpiContext::new(
+        freeze_account(token_cpi_ctx(
             self.address(),
             accounts::FreezeAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -840,19 +899,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        thaw_account(CpiContext::new(
+        thaw_account(token_cpi_ctx(
             self.address(),
             accounts::ThawAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -966,6 +1027,7 @@ impl TokenCpiExt for Program<Token> {
         &'a self,
         account_or_mint: &'a mut Acc,
         current_authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         authority_type: spl_token::instruction::AuthorityType,
         new_authority: Option<Address>,
     ) -> Result<(), ProgramError>
@@ -974,12 +1036,13 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         set_authority(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::SetAuthority {
                     account_or_mint: account_or_mint.try_to_cpi_handle_mut()?,
                     current_authority: current_authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             authority_type,
             new_authority,

--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -374,7 +374,7 @@ pub fn set_authority<'a>(
 /// functions. They keep the same account ordering and validation path while
 /// letting callers avoid manually building `CpiContext` for simple Token CPIs.
 /// Pass `&[]` for transaction signers, or PDA signer seeds for program-signed
-/// authorities.
+/// authorities on methods that support PDA signing.
 pub trait TokenCpiExt {
     fn mint_to<'a, M, T, A>(
         &'a self,
@@ -408,7 +408,6 @@ pub trait TokenCpiExt {
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -423,7 +422,6 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -436,7 +434,6 @@ pub trait TokenCpiExt {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -444,12 +441,7 @@ pub trait TokenCpiExt {
         D: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized;
 
-    fn revoke<'a, S, A>(
-        &'a self,
-        source: &'a mut S,
-        authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
-    ) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized;
@@ -459,7 +451,6 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -471,7 +462,6 @@ pub trait TokenCpiExt {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -485,7 +475,6 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -500,7 +489,6 @@ pub trait TokenCpiExt {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -515,7 +503,6 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -527,7 +514,6 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -658,7 +644,6 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -669,7 +654,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         transfer_checked(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::TransferChecked {
                     from: from.try_to_cpi_handle_mut()?,
@@ -677,7 +662,6 @@ impl TokenCpiExt for Program<Token> {
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
             decimals,
@@ -689,7 +673,6 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -698,14 +681,13 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::Burn {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
         )
@@ -716,7 +698,6 @@ impl TokenCpiExt for Program<Token> {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -725,36 +706,29 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::Approve {
                     to: source.try_to_cpi_handle_mut()?,
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
         )
     }
 
-    fn revoke<'a, S, A>(
-        &'a self,
-        source: &'a mut S,
-        authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
-    ) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        revoke(token_cpi_ctx(
+        revoke(CpiContext::new(
             self.address(),
             accounts::Revoke {
                 source: source.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
-            signer_seeds,
         ))
     }
 
@@ -763,21 +737,19 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         Dest: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        close_account(token_cpi_ctx(
+        close_account(CpiContext::new(
             self.address(),
             accounts::CloseAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 destination: destination.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
-            signer_seeds,
         ))
     }
 
@@ -786,7 +758,6 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -796,14 +767,13 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         mint_to_checked(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::MintToChecked {
                     mint: mint.try_to_cpi_handle_mut()?,
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
             decimals,
@@ -815,7 +785,6 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -825,14 +794,13 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn_checked(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::BurnChecked {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
             decimals,
@@ -845,7 +813,6 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -856,7 +823,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve_checked(
-            token_cpi_ctx(
+            CpiContext::new(
                 self.address(),
                 accounts::ApproveChecked {
                     to: source.try_to_cpi_handle_mut()?,
@@ -864,7 +831,6 @@ impl TokenCpiExt for Program<Token> {
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
-                signer_seeds,
             ),
             amount,
             decimals,
@@ -876,21 +842,19 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        freeze_account(token_cpi_ctx(
+        freeze_account(CpiContext::new(
             self.address(),
             accounts::FreezeAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
-            signer_seeds,
         ))
     }
 
@@ -899,21 +863,19 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
-        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        thaw_account(token_cpi_ctx(
+        thaw_account(CpiContext::new(
             self.address(),
             accounts::ThawAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
-            signer_seeds,
         ))
     }
 

--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -402,12 +402,14 @@ pub trait TokenCpiExt {
         T: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized;
 
+    #[allow(clippy::too_many_arguments)]
     fn transfer_checked<'a, F, M, T, A>(
         &'a self,
         from: &'a mut F,
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -422,6 +424,7 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -434,6 +437,7 @@ pub trait TokenCpiExt {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -441,7 +445,12 @@ pub trait TokenCpiExt {
         D: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized;
 
-    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(
+        &'a self,
+        source: &'a mut S,
+        authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
+    ) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized;
@@ -451,6 +460,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -462,6 +472,7 @@ pub trait TokenCpiExt {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -475,6 +486,7 @@ pub trait TokenCpiExt {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -489,6 +501,7 @@ pub trait TokenCpiExt {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -503,6 +516,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -514,6 +528,7 @@ pub trait TokenCpiExt {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
@@ -644,6 +659,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -654,7 +670,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         transfer_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::TransferChecked {
                     from: from.try_to_cpi_handle_mut()?,
@@ -662,6 +678,7 @@ impl TokenCpiExt for Program<Token> {
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -673,6 +690,7 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -681,13 +699,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::Burn {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
@@ -698,6 +717,7 @@ impl TokenCpiExt for Program<Token> {
         source: &'a mut S,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
     ) -> Result<(), ProgramError>
     where
@@ -706,29 +726,36 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::Approve {
                     to: source.try_to_cpi_handle_mut()?,
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
         )
     }
 
-    fn revoke<'a, S, A>(&'a self, source: &'a mut S, authority: &'a A) -> Result<(), ProgramError>
+    fn revoke<'a, S, A>(
+        &'a self,
+        source: &'a mut S,
+        authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
+    ) -> Result<(), ProgramError>
     where
         S: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        revoke(CpiContext::new(
+        revoke(token_cpi_ctx(
             self.address(),
             accounts::Revoke {
                 source: source.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -737,19 +764,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         destination: &'a mut Dest,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         Dest: ToCpiHandleMut + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        close_account(CpiContext::new(
+        close_account(token_cpi_ctx(
             self.address(),
             accounts::CloseAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 destination: destination.try_to_cpi_handle_mut()?,
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -758,6 +787,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a mut M,
         to: &'a mut T,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -767,13 +797,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         mint_to_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::MintToChecked {
                     mint: mint.try_to_cpi_handle_mut()?,
                     to: to.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -785,6 +816,7 @@ impl TokenCpiExt for Program<Token> {
         from: &'a mut F,
         mint: &'a mut M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -794,13 +826,14 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         burn_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::BurnChecked {
                     from: from.try_to_cpi_handle_mut()?,
                     mint: mint.try_to_cpi_handle_mut()?,
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -813,6 +846,7 @@ impl TokenCpiExt for Program<Token> {
         mint: &'a M,
         delegate: &'a D,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
         amount: u64,
         decimals: u8,
     ) -> Result<(), ProgramError>
@@ -823,7 +857,7 @@ impl TokenCpiExt for Program<Token> {
         A: ToCpiHandle + ?Sized,
     {
         approve_checked(
-            CpiContext::new(
+            token_cpi_ctx(
                 self.address(),
                 accounts::ApproveChecked {
                     to: source.try_to_cpi_handle_mut()?,
@@ -831,6 +865,7 @@ impl TokenCpiExt for Program<Token> {
                     delegate: delegate.to_cpi_handle(),
                     authority: authority.to_cpi_handle(),
                 },
+                signer_seeds,
             ),
             amount,
             decimals,
@@ -842,19 +877,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        freeze_account(CpiContext::new(
+        freeze_account(token_cpi_ctx(
             self.address(),
             accounts::FreezeAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 
@@ -863,19 +900,21 @@ impl TokenCpiExt for Program<Token> {
         account: &'a mut Acc,
         mint: &'a M,
         authority: &'a A,
+        signer_seeds: TokenSignerSeeds<'a>,
     ) -> Result<(), ProgramError>
     where
         Acc: ToCpiHandleMut + ?Sized,
         M: ToCpiHandle + ?Sized,
         A: ToCpiHandle + ?Sized,
     {
-        thaw_account(CpiContext::new(
+        thaw_account(token_cpi_ctx(
             self.address(),
             accounts::ThawAccount {
                 account: account.try_to_cpi_handle_mut()?,
                 mint: mint.to_cpi_handle(),
                 authority: authority.to_cpi_handle(),
             },
+            signer_seeds,
         ))
     }
 

--- a/tests-v2/programs/spl/src/lib.rs
+++ b/tests-v2/programs/spl/src/lib.rs
@@ -80,6 +80,7 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -93,6 +94,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -105,6 +107,7 @@ pub mod spl_test {
             &mut ctx.accounts.source,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -113,9 +116,11 @@ pub mod spl_test {
     /// Revokes the current delegate from `source`.
     #[discrim = 7]
     pub fn do_revoke(ctx: &mut Context<DoRevoke>) -> Result<()> {
-        ctx.accounts
-            .token_program
-            .revoke(&mut ctx.accounts.source, &ctx.accounts.authority)?;
+        ctx.accounts.token_program.revoke(
+            &mut ctx.accounts.source,
+            &ctx.accounts.authority,
+            &[],
+        )?;
         Ok(())
     }
 
@@ -126,6 +131,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.destination,
             &ctx.accounts.authority,
+            &[],
         )?;
 
         Ok(())
@@ -142,6 +148,7 @@ pub mod spl_test {
             &mut ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -159,6 +166,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -177,6 +185,7 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -191,6 +200,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
         )?;
         Ok(())
     }
@@ -201,6 +211,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
         )?;
         Ok(())
     }
@@ -337,6 +348,81 @@ pub mod spl_test {
             signer_seeds,
             token::spl_token::instruction::AuthorityType::CloseAccount,
             Some(new_authority),
+        )?;
+        Ok(())
+    }
+
+    /// TransferChecked through TokenCpiExt using a PDA token-account owner.
+    #[discrim = 96]
+    pub fn do_transfer_checked_pda_authority(
+        ctx: &mut Context<DoTransferCheckedPdaAuthority>,
+        amount: u64,
+        decimals: u8,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.transfer_checked(
+            &mut ctx.accounts.from,
+            &ctx.accounts.mint,
+            &mut ctx.accounts.to,
+            &ctx.accounts.authority,
+            signer_seeds,
+            amount,
+            decimals,
+        )?;
+        Ok(())
+    }
+
+    /// Burn through TokenCpiExt using a PDA token-account owner.
+    #[discrim = 97]
+    pub fn do_burn_pda_authority(
+        ctx: &mut Context<DoBurnPdaAuthority>,
+        amount: u64,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.burn(
+            &mut ctx.accounts.account,
+            &mut ctx.accounts.mint,
+            &ctx.accounts.authority,
+            signer_seeds,
+            amount,
+        )?;
+        Ok(())
+    }
+
+    /// Approve through TokenCpiExt using a PDA token-account owner.
+    #[discrim = 98]
+    pub fn do_approve_pda_authority(
+        ctx: &mut Context<DoApprovePdaAuthority>,
+        amount: u64,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.approve(
+            &mut ctx.accounts.source,
+            &ctx.accounts.delegate,
+            &ctx.accounts.authority,
+            signer_seeds,
+            amount,
+        )?;
+        Ok(())
+    }
+
+    /// Thaw through TokenCpiExt using a PDA freeze authority.
+    #[discrim = 99]
+    pub fn do_thaw_account_pda_authority(ctx: &mut Context<DoThawAccountPdaAuthority>) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.thaw_account(
+            &mut ctx.accounts.account,
+            &ctx.accounts.mint,
+            &ctx.accounts.authority,
+            signer_seeds,
         )?;
         Ok(())
     }
@@ -1741,6 +1827,49 @@ pub struct DoTransferPdaAuthority {
 pub struct DoSetAuthorityPda {
     #[account(mut)]
     pub account_or_mint: Account<TokenAccount>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoTransferCheckedPdaAuthority {
+    #[account(mut)]
+    pub from: Account<TokenAccount>,
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub to: Account<TokenAccount>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoBurnPdaAuthority {
+    #[account(mut)]
+    pub account: Account<TokenAccount>,
+    #[account(mut)]
+    pub mint: Account<Mint>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoApprovePdaAuthority {
+    #[account(mut)]
+    pub source: Account<TokenAccount>,
+    pub delegate: UncheckedAccount,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoThawAccountPdaAuthority {
+    #[account(mut)]
+    pub account: Account<TokenAccount>,
+    pub mint: Account<Mint>,
     #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
     pub authority: UncheckedAccount,
     pub token_program: Program<Token>,

--- a/tests-v2/programs/spl/src/lib.rs
+++ b/tests-v2/programs/spl/src/lib.rs
@@ -80,7 +80,6 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
-            &[],
             amount,
             decimals,
         )?;
@@ -94,7 +93,6 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
-            &[],
             amount,
         )?;
         Ok(())
@@ -107,7 +105,6 @@ pub mod spl_test {
             &mut ctx.accounts.source,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
-            &[],
             amount,
         )?;
         Ok(())
@@ -116,11 +113,9 @@ pub mod spl_test {
     /// Revokes the current delegate from `source`.
     #[discrim = 7]
     pub fn do_revoke(ctx: &mut Context<DoRevoke>) -> Result<()> {
-        ctx.accounts.token_program.revoke(
-            &mut ctx.accounts.source,
-            &ctx.accounts.authority,
-            &[],
-        )?;
+        ctx.accounts
+            .token_program
+            .revoke(&mut ctx.accounts.source, &ctx.accounts.authority)?;
         Ok(())
     }
 
@@ -131,7 +126,6 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.destination,
             &ctx.accounts.authority,
-            &[],
         )?;
 
         Ok(())
@@ -148,7 +142,6 @@ pub mod spl_test {
             &mut ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
-            &[],
             amount,
             decimals,
         )?;
@@ -166,7 +159,6 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
-            &[],
             amount,
             decimals,
         )?;
@@ -185,7 +177,6 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
-            &[],
             amount,
             decimals,
         )?;
@@ -200,7 +191,6 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
-            &[],
         )?;
         Ok(())
     }
@@ -211,7 +201,6 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
-            &[],
         )?;
         Ok(())
     }

--- a/tests-v2/programs/spl/src/lib.rs
+++ b/tests-v2/programs/spl/src/lib.rs
@@ -22,6 +22,8 @@ use {
 
 declare_id!("SpL1111111111111111111111111111111111111111");
 
+const TOKEN_CPI_EXT_AUTHORITY_SEED: &[u8] = b"token-cpi-ext-authority";
+
 #[program]
 pub mod spl_test {
     use super::*;
@@ -47,6 +49,7 @@ pub mod spl_test {
             &mut ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -59,6 +62,7 @@ pub mod spl_test {
             &mut ctx.accounts.from,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -76,6 +80,7 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -89,6 +94,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -101,6 +107,7 @@ pub mod spl_test {
             &mut ctx.accounts.source,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
+            &[],
             amount,
         )?;
         Ok(())
@@ -109,9 +116,11 @@ pub mod spl_test {
     /// Revokes the current delegate from `source`.
     #[discrim = 7]
     pub fn do_revoke(ctx: &mut Context<DoRevoke>) -> Result<()> {
-        ctx.accounts
-            .token_program
-            .revoke(&mut ctx.accounts.source, &ctx.accounts.authority)?;
+        ctx.accounts.token_program.revoke(
+            &mut ctx.accounts.source,
+            &ctx.accounts.authority,
+            &[],
+        )?;
         Ok(())
     }
 
@@ -122,6 +131,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.destination,
             &ctx.accounts.authority,
+            &[],
         )?;
 
         Ok(())
@@ -138,6 +148,7 @@ pub mod spl_test {
             &mut ctx.accounts.mint,
             &mut ctx.accounts.to,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -155,6 +166,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &mut ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -173,6 +185,7 @@ pub mod spl_test {
             &ctx.accounts.mint,
             &ctx.accounts.delegate,
             &ctx.accounts.authority,
+            &[],
             amount,
             decimals,
         )?;
@@ -187,6 +200,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
         )?;
         Ok(())
     }
@@ -197,6 +211,7 @@ pub mod spl_test {
             &mut ctx.accounts.account,
             &ctx.accounts.mint,
             &ctx.accounts.authority,
+            &[],
         )?;
         Ok(())
     }
@@ -273,6 +288,64 @@ pub mod spl_test {
         ctx.accounts.token_program.set_authority(
             &mut ctx.accounts.account_or_mint,
             &ctx.accounts.current_authority,
+            &[],
+            token::spl_token::instruction::AuthorityType::CloseAccount,
+            Some(new_authority),
+        )?;
+        Ok(())
+    }
+
+    /// MintTo through TokenCpiExt using a PDA authority.
+    #[discrim = 93]
+    pub fn do_mint_to_pda_authority(
+        ctx: &mut Context<DoMintToPdaAuthority>,
+        amount: u64,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.mint_to(
+            &mut ctx.accounts.mint,
+            &mut ctx.accounts.to,
+            &ctx.accounts.authority,
+            signer_seeds,
+            amount,
+        )?;
+        Ok(())
+    }
+
+    /// Transfer through TokenCpiExt using a PDA token-account owner.
+    #[discrim = 94]
+    pub fn do_transfer_pda_authority(
+        ctx: &mut Context<DoTransferPdaAuthority>,
+        amount: u64,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.transfer(
+            &mut ctx.accounts.from,
+            &mut ctx.accounts.to,
+            &ctx.accounts.authority,
+            signer_seeds,
+            amount,
+        )?;
+        Ok(())
+    }
+
+    /// Set close authority through TokenCpiExt using a PDA current authority.
+    #[discrim = 95]
+    pub fn do_set_close_authority_pda(
+        ctx: &mut Context<DoSetAuthorityPda>,
+        new_authority: Address,
+    ) -> Result<()> {
+        let bump = [ctx.bumps.authority];
+        let authority_seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED, &bump];
+        let signer_seeds = &[&authority_seeds[..]];
+        ctx.accounts.token_program.set_authority(
+            &mut ctx.accounts.account_or_mint,
+            &ctx.accounts.authority,
+            signer_seeds,
             token::spl_token::instruction::AuthorityType::CloseAccount,
             Some(new_authority),
         )?;
@@ -1650,6 +1723,37 @@ pub struct DoSetAuthority {
     #[account(mut)]
     pub account_or_mint: Account<TokenAccount>,
     pub current_authority: Signer,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoMintToPdaAuthority {
+    #[account(mut)]
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub to: Account<TokenAccount>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoTransferPdaAuthority {
+    #[account(mut)]
+    pub from: Account<TokenAccount>,
+    #[account(mut)]
+    pub to: Account<TokenAccount>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+}
+
+#[derive(Accounts)]
+pub struct DoSetAuthorityPda {
+    #[account(mut)]
+    pub account_or_mint: Account<TokenAccount>,
+    #[account(seeds = [TOKEN_CPI_EXT_AUTHORITY_SEED], bump)]
+    pub authority: UncheckedAccount,
     pub token_program: Program<Token>,
 }
 

--- a/tests-v2/tests/spl.rs
+++ b/tests-v2/tests/spl.rs
@@ -800,6 +800,166 @@ fn token_cpi_ext_set_authority_supports_pda_authority() {
     );
 }
 
+#[test]
+fn token_cpi_ext_transfer_checked_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let recipient = keypair_for("token-cpi-ext-pda-transfer-checked-recipient");
+    let mint = Pubkey::new_unique();
+    let from = Pubkey::new_unique();
+    let to = Pubkey::new_unique();
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        mint,
+        token_program_id(),
+        pack_base_mint(&authority, 6, 0).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        from,
+        token_program_id(),
+        pack_base_token_account(&mint, &authority, 80).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        to,
+        token_program_id(),
+        pack_base_token_account(&mint, &recipient.pubkey(), 0).to_vec(),
+    );
+
+    let mut data = vec![96];
+    data.extend_from_slice(&25u64.to_le_bytes());
+    data.push(6);
+    let metas = vec![
+        AccountMeta::new(from, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new(to, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::transfer_checked should sign for PDA authorities");
+
+    let from_state = SplTokenAccount::unpack(&svm.get_account(&from).unwrap().data).unwrap();
+    let to_state = SplTokenAccount::unpack(&svm.get_account(&to).unwrap().data).unwrap();
+    assert_eq!(from_state.amount, 55);
+    assert_eq!(to_state.amount, 25);
+}
+
+#[test]
+fn token_cpi_ext_burn_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let mint = Pubkey::new_unique();
+    let token = Pubkey::new_unique();
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        mint,
+        token_program_id(),
+        pack_base_mint(&authority, 6, 80).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        token,
+        token_program_id(),
+        pack_base_token_account(&mint, &authority, 80).to_vec(),
+    );
+
+    let mut data = vec![97];
+    data.extend_from_slice(&30u64.to_le_bytes());
+    let metas = vec![
+        AccountMeta::new(token, false),
+        AccountMeta::new(mint, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::burn should sign for PDA authorities");
+
+    let mint_state = SplMint::unpack(&svm.get_account(&mint).unwrap().data).unwrap();
+    let token_state = SplTokenAccount::unpack(&svm.get_account(&token).unwrap().data).unwrap();
+    assert_eq!(mint_state.supply, 50);
+    assert_eq!(token_state.amount, 50);
+}
+
+#[test]
+fn token_cpi_ext_approve_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let mint = Pubkey::new_unique();
+    let source = Pubkey::new_unique();
+    let delegate = keypair_for("token-cpi-ext-pda-approve-delegate");
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        mint,
+        token_program_id(),
+        pack_base_mint(&authority, 6, 0).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        source,
+        token_program_id(),
+        pack_base_token_account(&mint, &authority, 80).to_vec(),
+    );
+
+    let mut data = vec![98];
+    data.extend_from_slice(&40u64.to_le_bytes());
+    let metas = vec![
+        AccountMeta::new(source, false),
+        AccountMeta::new_readonly(delegate.pubkey(), false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::approve should sign for PDA authorities");
+
+    let state = SplTokenAccount::unpack(&svm.get_account(&source).unwrap().data).unwrap();
+    assert_eq!(state.delegate, COption::Some(to_spl(&delegate.pubkey())));
+    assert_eq!(state.delegated_amount, 40);
+}
+
+#[test]
+fn token_cpi_ext_thaw_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let owner = keypair_for("token-cpi-ext-pda-thaw-owner");
+    let mint = Pubkey::new_unique();
+    let token = Pubkey::new_unique();
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        mint,
+        token_program_id(),
+        pack_base_mint_with_freeze(&owner.pubkey(), &authority, 6, 0).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        token,
+        token_program_id(),
+        pack_frozen_token_account(&mint, &owner.pubkey(), 10).to_vec(),
+    );
+
+    let data = vec![99];
+    let metas = vec![
+        AccountMeta::new(token, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::thaw_account should sign for PDA authorities");
+
+    let state = SplTokenAccount::unpack(&svm.get_account(&token).unwrap().data).unwrap();
+    assert_eq!(state.state, AccountState::Initialized);
+}
+
 // ---- Accessor methods ------------------------------------------------------
 
 #[test]
@@ -1629,6 +1789,26 @@ fn pack_base_token_account(
         amount,
         delegate: COption::None,
         state: AccountState::Initialized,
+        is_native: COption::None,
+        delegated_amount: 0,
+        close_authority: COption::None,
+    };
+    let mut base = [0u8; SplTokenAccount::LEN];
+    state.pack_into_slice(&mut base);
+    base
+}
+
+fn pack_frozen_token_account(
+    mint: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+) -> [u8; SplTokenAccount::LEN] {
+    let state = SplTokenAccount {
+        mint: to_spl(mint),
+        owner: to_spl(owner),
+        amount,
+        delegate: COption::None,
+        state: AccountState::Frozen,
         is_native: COption::None,
         delegated_amount: 0,
         close_authority: COption::None,

--- a/tests-v2/tests/spl.rs
+++ b/tests-v2/tests/spl.rs
@@ -64,6 +64,10 @@ fn token_2022_program_id() -> Pubkey {
         .unwrap()
 }
 
+fn token_cpi_ext_authority_pda() -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[b"token-cpi-ext-authority"], &program_id())
+}
+
 fn native_mint_id() -> Pubkey {
     "So11111111111111111111111111111111111111112"
         .parse()
@@ -681,6 +685,118 @@ fn set_close_authority_helper_updates_token_account() {
     assert_eq!(
         state.close_authority,
         COption::Some(to_spl(&close_authority.pubkey()))
+    );
+}
+
+#[test]
+fn token_cpi_ext_mint_to_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let recipient = keypair_for("token-cpi-ext-pda-mint-recipient");
+    let mint = Pubkey::new_unique();
+    let token = Pubkey::new_unique();
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        mint,
+        token_program_id(),
+        pack_base_mint(&authority, 6, 0).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        token,
+        token_program_id(),
+        pack_base_token_account(&mint, &recipient.pubkey(), 0).to_vec(),
+    );
+
+    let mut data = vec![93];
+    data.extend_from_slice(&50u64.to_le_bytes());
+    let metas = vec![
+        AccountMeta::new(mint, false),
+        AccountMeta::new(token, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::mint_to should sign for PDA authorities");
+
+    let mint_state = SplMint::unpack(&svm.get_account(&mint).unwrap().data).unwrap();
+    let token_state = SplTokenAccount::unpack(&svm.get_account(&token).unwrap().data).unwrap();
+    assert_eq!(mint_state.supply, 50);
+    assert_eq!(token_state.amount, 50);
+}
+
+#[test]
+fn token_cpi_ext_transfer_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let recipient = keypair_for("token-cpi-ext-pda-transfer-recipient");
+    let mint = Pubkey::new_unique();
+    let from = Pubkey::new_unique();
+    let to = Pubkey::new_unique();
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        from,
+        token_program_id(),
+        pack_base_token_account(&mint, &authority, 80).to_vec(),
+    );
+    seed_token_owned_account(
+        &mut svm,
+        to,
+        token_program_id(),
+        pack_base_token_account(&mint, &recipient.pubkey(), 0).to_vec(),
+    );
+
+    let mut data = vec![94];
+    data.extend_from_slice(&25u64.to_le_bytes());
+    let metas = vec![
+        AccountMeta::new(from, false),
+        AccountMeta::new(to, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::transfer should sign for PDA authorities");
+
+    let from_state = SplTokenAccount::unpack(&svm.get_account(&from).unwrap().data).unwrap();
+    let to_state = SplTokenAccount::unpack(&svm.get_account(&to).unwrap().data).unwrap();
+    assert_eq!(from_state.amount, 55);
+    assert_eq!(to_state.amount, 25);
+}
+
+#[test]
+fn token_cpi_ext_set_authority_supports_pda_authority() {
+    let (mut svm, payer) = setup();
+    let mint = Pubkey::new_unique();
+    let token = Pubkey::new_unique();
+    let new_close_authority = keypair_for("token-cpi-ext-pda-set-authority-new-close");
+    let (authority, _bump) = token_cpi_ext_authority_pda();
+
+    seed_token_owned_account(&mut svm, authority, program_id(), vec![0; 8]);
+    seed_token_owned_account(
+        &mut svm,
+        token,
+        token_program_id(),
+        pack_base_token_account_with_close_authority(&mint, &authority, 0, &authority).to_vec(),
+    );
+
+    let mut data = vec![95];
+    data.extend_from_slice(&new_close_authority.pubkey().to_bytes());
+    let metas = vec![
+        AccountMeta::new(token, false),
+        AccountMeta::new_readonly(authority, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("TokenCpiExt::set_authority should sign for PDA authorities");
+
+    let state = SplTokenAccount::unpack(&svm.get_account(&token).unwrap().data).unwrap();
+    assert_eq!(
+        state.close_authority,
+        COption::Some(to_spl(&new_close_authority.pubkey()))
     );
 }
 
@@ -1516,6 +1632,27 @@ fn pack_base_token_account(
         is_native: COption::None,
         delegated_amount: 0,
         close_authority: COption::None,
+    };
+    let mut base = [0u8; SplTokenAccount::LEN];
+    state.pack_into_slice(&mut base);
+    base
+}
+
+fn pack_base_token_account_with_close_authority(
+    mint: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+    close_authority: &Pubkey,
+) -> [u8; SplTokenAccount::LEN] {
+    let state = SplTokenAccount {
+        mint: to_spl(mint),
+        owner: to_spl(owner),
+        amount,
+        delegate: COption::None,
+        state: AccountState::Initialized,
+        is_native: COption::None,
+        delegated_amount: 0,
+        close_authority: COption::Some(to_spl(close_authority)),
     };
     let mut base = [0u8; SplTokenAccount::LEN];
     state.pack_into_slice(&mut base);


### PR DESCRIPTION
#### Finding
`TokenCpiExt` convenience methods always built unsigned `CPI` contexts, so `PDA` authorities could not sign authority-gated SPL Token CPIs.
#### Fix
thread signer seeds through authority-gated `TokenCpiExt` methods, invoke them with `CpiContext::new_with_signer`, and add PDA-authority regressions for `mint_to`, `transfer`, and `set_authority`.