### PR TITLE
Fix/token22 extension cpi helper cleanup

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1024,49 +1024,41 @@ fn generate_constraint_init_group(
                                 match e {
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::GroupPointer => {
                                         ::anchor_spl::token_interface::group_pointer_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::GroupPointerInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #group_pointer_authority, #group_pointer_group_address)?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::GroupMemberPointer => {
                                         ::anchor_spl::token_interface::group_member_pointer_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::GroupMemberPointerInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #group_member_pointer_authority, #group_member_pointer_member_address)?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::MetadataPointer => {
                                         ::anchor_spl::token_interface::metadata_pointer_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::MetadataPointerInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #metadata_pointer_authority, #metadata_pointer_metadata_address)?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::MintCloseAuthority => {
                                         ::anchor_spl::token_interface::mint_close_authority_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::MintCloseAuthorityInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #close_authority)?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::TransferHook => {
                                         ::anchor_spl::token_interface::transfer_hook_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::TransferHookInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #transfer_hook_authority, #transfer_hook_program_id)?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::NonTransferable => {
                                         ::anchor_spl::token_interface::non_transferable_mint_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::NonTransferableMintInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }))?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::PermanentDelegate => {
                                         ::anchor_spl::token_interface::permanent_delegate_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::PermanentDelegateInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #permanent_delegate.unwrap())?;
                                     },
                                     ::anchor_spl::token_interface::spl_token_2022::extension::ExtensionType::Pausable => {
                                         ::anchor_spl::token_interface::pausable_initialize(anchor_lang::context::CpiContext::new(cpi_program_id, ::anchor_spl::token_interface::PausableInitialize {
-                                            token_program_id: #token_program.to_account_info(),
                                             mint: #field.to_account_info(),
                                         }), #pausable_authority.unwrap())?;
                                     },

--- a/spl/src/token_2022_extensions/cpi_guard.rs
+++ b/spl/src/token_2022_extensions/cpi_guard.rs
@@ -17,18 +17,14 @@ use {
 )]
 pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::enable_cpi_guard(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.account.key,
         ctx.accounts.owner.key,
         &[],
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.account,
-            ctx.accounts.owner,
-        ],
+        &[ctx.accounts.account, ctx.accounts.owner],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -42,7 +38,7 @@ pub fn cpi_guard_enable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info
 )]
 pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'info>>) -> Result<()> {
     let ix = spl_token_2022::extension::cpi_guard::instruction::disable_cpi_guard(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.account.key,
         ctx.accounts.owner.key,
         &[],
@@ -50,11 +46,7 @@ pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'inf
 
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.account,
-            ctx.accounts.owner,
-        ],
+        &[ctx.accounts.account, ctx.accounts.owner],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -67,7 +59,6 @@ pub fn cpi_guard_disable<'info>(ctx: CpiContext<'_, '_, '_, 'info, CpiGuard<'inf
 )]
 #[derive(Accounts)]
 pub struct CpiGuard<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub account: AccountInfo<'info>,
     pub owner: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/default_account_state.rs
+++ b/spl/src/token_2022_extensions/default_account_state.rs
@@ -15,21 +15,16 @@ pub fn default_account_state_initialize<'info>(
     state: &AccountState,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::default_account_state::instruction::initialize_default_account_state(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         state
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct DefaultAccountStateInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -38,7 +33,7 @@ pub fn default_account_state_update<'info>(
     state: &AccountState,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::default_account_state::instruction::update_default_account_state(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.freeze_authority.key,
         &[],
@@ -47,11 +42,7 @@ pub fn default_account_state_update<'info>(
 
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.freeze_authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.freeze_authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -59,7 +50,6 @@ pub fn default_account_state_update<'info>(
 
 #[derive(Accounts)]
 pub struct DefaultAccountStateUpdate<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub freeze_authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/group_member_pointer.rs
+++ b/spl/src/token_2022_extensions/group_member_pointer.rs
@@ -15,22 +15,17 @@ pub fn group_member_pointer_initialize<'info>(
     member_address: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::group_member_pointer::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         authority,
         member_address,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct GroupMemberPointerInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -39,7 +34,7 @@ pub fn group_member_pointer_update<'info>(
     member_address: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::group_member_pointer::instruction::update(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
@@ -47,11 +42,7 @@ pub fn group_member_pointer_update<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -59,7 +50,6 @@ pub fn group_member_pointer_update<'info>(
 
 #[derive(Accounts)]
 pub struct GroupMemberPointerUpdate<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -15,22 +15,17 @@ pub fn group_pointer_initialize<'info>(
     group_address: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::group_pointer::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         authority,
         group_address,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct GroupPointerInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -39,7 +34,7 @@ pub fn group_pointer_update<'info>(
     group_address: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::group_pointer::instruction::update(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[ctx.accounts.authority.key],
@@ -47,11 +42,7 @@ pub fn group_pointer_update<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -59,7 +50,6 @@ pub fn group_pointer_update<'info>(
 
 #[derive(Accounts)]
 pub struct GroupPointerUpdate<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/immutable_owner.rs
+++ b/spl/src/token_2022_extensions/immutable_owner.rs
@@ -13,12 +13,12 @@ pub fn immutable_owner_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, ImmutableOwnerInitialize<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::instruction::initialize_immutable_owner(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.token_account.key,
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.token_account],
+        &[ctx.accounts.token_account],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -26,6 +26,5 @@ pub fn immutable_owner_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct ImmutableOwnerInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub token_account: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl/src/token_2022_extensions/interest_bearing_mint.rs
@@ -15,22 +15,17 @@ pub fn interest_bearing_mint_initialize<'info>(
     rate: i16,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::interest_bearing_mint::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         rate_authority,
         rate,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct InterestBearingMintInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -39,7 +34,7 @@ pub fn interest_bearing_mint_update_rate<'info>(
     rate: i16,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::interest_bearing_mint::instruction::update_rate(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.rate_authority.key,
         &[],
@@ -47,11 +42,7 @@ pub fn interest_bearing_mint_update_rate<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.rate_authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.rate_authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -59,7 +50,6 @@ pub fn interest_bearing_mint_update_rate<'info>(
 
 #[derive(Accounts)]
 pub struct InterestBearingMintUpdateRate<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub rate_authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/memo_transfer.rs
+++ b/spl/src/token_2022_extensions/memo_transfer.rs
@@ -13,18 +13,14 @@ pub fn memo_transfer_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, MemoTransfer<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::memo_transfer::instruction::enable_required_transfer_memos(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.account.key,
         ctx.accounts.owner.key,
         &[],
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.account,
-            ctx.accounts.owner,
-        ],
+        &[ctx.accounts.account, ctx.accounts.owner],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -35,18 +31,14 @@ pub fn memo_transfer_disable<'info>(
 ) -> Result<()> {
     let ix =
         spl_token_2022::extension::memo_transfer::instruction::disable_required_transfer_memos(
-            ctx.accounts.token_program_id.key,
+            &ctx.program_id,
             ctx.accounts.account.key,
             ctx.accounts.owner.key,
             &[],
         )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.account,
-            ctx.accounts.owner,
-        ],
+        &[ctx.accounts.account, ctx.accounts.owner],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -54,7 +46,6 @@ pub fn memo_transfer_disable<'info>(
 
 #[derive(Accounts)]
 pub struct MemoTransfer<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub account: AccountInfo<'info>,
     pub owner: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl/src/token_2022_extensions/metadata_pointer.rs
@@ -15,21 +15,16 @@ pub fn metadata_pointer_initialize<'info>(
     metadata_address: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::metadata_pointer::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         authority,
         metadata_address,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct MetadataPointerInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/mint_close_authority.rs
+++ b/spl/src/token_2022_extensions/mint_close_authority.rs
@@ -14,20 +14,15 @@ pub fn mint_close_authority_initialize<'info>(
     authority: Option<&Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::instruction::initialize_mint_close_authority(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         authority,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct MintCloseAuthorityInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/non_transferable.rs
+++ b/spl/src/token_2022_extensions/non_transferable.rs
@@ -13,19 +13,14 @@ pub fn non_transferable_mint_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, NonTransferableMintInitialize<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::instruction::initialize_non_transferable_mint(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct NonTransferableMintInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/pausable.rs
+++ b/spl/src/token_2022_extensions/pausable.rs
@@ -14,20 +14,15 @@ pub fn pausable_initialize<'info>(
     authority: Pubkey,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::pausable::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         &authority,
     )?;
-    anchor_lang::solana_program::program::invoke(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct PausableInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -35,18 +30,14 @@ pub fn pausable_resume<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, PausableToggle<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::pausable::instruction::resume(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -56,18 +47,14 @@ pub fn pausable_pause<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, PausableToggle<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::pausable::instruction::pause(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -75,7 +62,6 @@ pub fn pausable_pause<'info>(
 
 #[derive(Accounts)]
 pub struct PausableToggle<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/permanent_delegate.rs
+++ b/spl/src/token_2022_extensions/permanent_delegate.rs
@@ -14,20 +14,15 @@ pub fn permanent_delegate_initialize<'info>(
     permanent_delegate: &Pubkey,
 ) -> Result<()> {
     let ix = spl_token_2022::instruction::initialize_permanent_delegate(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         permanent_delegate,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct PermanentDelegateInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/token_group.rs
+++ b/spl/src/token_2022_extensions/token_group.rs
@@ -12,7 +12,7 @@ pub fn token_group_initialize<'info>(
     max_size: u64,
 ) -> Result<()> {
     let ix = spl_token_group_interface::instruction::initialize_group(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.group.key,
         ctx.accounts.mint.key,
         ctx.accounts.mint_authority.key,
@@ -22,7 +22,6 @@ pub fn token_group_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.program_id,
             ctx.accounts.group,
             ctx.accounts.mint,
             ctx.accounts.mint_authority,
@@ -34,7 +33,6 @@ pub fn token_group_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenGroupInitialize<'info> {
-    pub program_id: AccountInfo<'info>,
     pub group: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
@@ -44,7 +42,7 @@ pub fn token_member_initialize<'info>(
     ctx: CpiContext<'_, '_, '_, 'info, TokenMemberInitialize<'info>>,
 ) -> Result<()> {
     let ix = spl_token_group_interface::instruction::initialize_member(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.member.key,
         ctx.accounts.member_mint.key,
         ctx.accounts.member_mint_authority.key,
@@ -54,7 +52,6 @@ pub fn token_member_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.program_id,
             ctx.accounts.member,
             ctx.accounts.member_mint,
             ctx.accounts.member_mint_authority,
@@ -68,7 +65,6 @@ pub fn token_member_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMemberInitialize<'info> {
-    pub program_id: AccountInfo<'info>,
     pub member: AccountInfo<'info>,
     pub member_mint: AccountInfo<'info>,
     pub member_mint_authority: AccountInfo<'info>,

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -69,7 +69,6 @@ pub fn token_metadata_update_authority<'info>(
 pub struct TokenMetadataUpdateAuthority<'info> {
     pub metadata: AccountInfo<'info>,
     pub current_authority: AccountInfo<'info>,
-    pub new_authority: AccountInfo<'info>,
 }
 
 pub fn token_metadata_update_field<'info>(

--- a/spl/src/token_2022_extensions/token_metadata.rs
+++ b/spl/src/token_2022_extensions/token_metadata.rs
@@ -17,7 +17,7 @@ pub fn token_metadata_initialize<'info>(
     uri: String,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::initialize(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.metadata.key,
         ctx.accounts.update_authority.key,
         ctx.accounts.mint.key,
@@ -29,7 +29,6 @@ pub fn token_metadata_initialize<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.program_id,
             ctx.accounts.metadata,
             ctx.accounts.update_authority,
             ctx.accounts.mint,
@@ -42,7 +41,6 @@ pub fn token_metadata_initialize<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataInitialize<'info> {
-    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
     pub mint_authority: AccountInfo<'info>,
@@ -54,18 +52,14 @@ pub fn token_metadata_update_authority<'info>(
     new_authority: OptionalNonZeroPubkey,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::update_authority(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.metadata.key,
         ctx.accounts.current_authority.key,
         new_authority,
     );
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.program_id,
-            ctx.accounts.metadata,
-            ctx.accounts.current_authority,
-        ],
+        &[ctx.accounts.metadata, ctx.accounts.current_authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -73,7 +67,6 @@ pub fn token_metadata_update_authority<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataUpdateAuthority<'info> {
-    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub current_authority: AccountInfo<'info>,
     pub new_authority: AccountInfo<'info>,
@@ -85,7 +78,7 @@ pub fn token_metadata_update_field<'info>(
     value: String,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::update_field(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.metadata.key,
         ctx.accounts.update_authority.key,
         field,
@@ -93,11 +86,7 @@ pub fn token_metadata_update_field<'info>(
     );
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.program_id,
-            ctx.accounts.metadata,
-            ctx.accounts.update_authority,
-        ],
+        &[ctx.accounts.metadata, ctx.accounts.update_authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -105,7 +94,6 @@ pub fn token_metadata_update_field<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataUpdateField<'info> {
-    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
 }
@@ -116,7 +104,7 @@ pub fn token_metadata_remove_key<'info>(
     idempotent: bool,
 ) -> Result<()> {
     let ix = spl_token_metadata_interface::instruction::remove_key(
-        ctx.accounts.program_id.key,
+        &ctx.program_id,
         ctx.accounts.metadata.key,
         ctx.accounts.update_authority.key,
         key,
@@ -124,11 +112,7 @@ pub fn token_metadata_remove_key<'info>(
     );
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.program_id,
-            ctx.accounts.metadata,
-            ctx.accounts.update_authority,
-        ],
+        &[ctx.accounts.metadata, ctx.accounts.update_authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -136,7 +120,6 @@ pub fn token_metadata_remove_key<'info>(
 
 #[derive(Accounts)]
 pub struct TokenMetadataRemoveKey<'info> {
-    pub program_id: AccountInfo<'info>,
     pub metadata: AccountInfo<'info>,
     pub update_authority: AccountInfo<'info>,
 }

--- a/spl/src/token_2022_extensions/transfer_fee.rs
+++ b/spl/src/token_2022_extensions/transfer_fee.rs
@@ -17,24 +17,19 @@ pub fn transfer_fee_initialize<'info>(
     maximum_fee: u64,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_fee::instruction::initialize_transfer_fee_config(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         transfer_fee_config_authority,
         withdraw_withheld_authority,
         transfer_fee_basis_points,
         maximum_fee,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct TransferFeeInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -44,7 +39,7 @@ pub fn transfer_fee_set<'info>(
     maximum_fee: u64,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_fee::instruction::set_transfer_fee(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
@@ -53,11 +48,7 @@ pub fn transfer_fee_set<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -65,7 +56,6 @@ pub fn transfer_fee_set<'info>(
 
 #[derive(Accounts)]
 pub struct TransferFeeSetTransferFee<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }
@@ -77,7 +67,7 @@ pub fn transfer_checked_with_fee<'info>(
     fee: u64,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_fee::instruction::transfer_checked_with_fee(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.source.key,
         ctx.accounts.mint.key,
         ctx.accounts.destination.key,
@@ -90,7 +80,6 @@ pub fn transfer_checked_with_fee<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
             ctx.accounts.source,
             ctx.accounts.mint,
             ctx.accounts.destination,
@@ -103,7 +92,6 @@ pub fn transfer_checked_with_fee<'info>(
 
 #[derive(Accounts)]
 pub struct TransferCheckedWithFee<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub source: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub destination: AccountInfo<'info>,
@@ -115,12 +103,12 @@ pub fn harvest_withheld_tokens_to_mint<'info>(
     sources: Vec<AccountInfo<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_fee::instruction::harvest_withheld_tokens_to_mint(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         sources.iter().map(|a| a.key).collect::<Vec<_>>().as_slice(),
     )?;
 
-    let mut account_infos = vec![ctx.accounts.token_program_id, ctx.accounts.mint];
+    let mut account_infos = vec![ctx.accounts.mint];
     account_infos.extend_from_slice(&sources);
 
     anchor_lang::solana_program::program::invoke_signed(&ix, &account_infos, ctx.signer_seeds)
@@ -129,7 +117,6 @@ pub fn harvest_withheld_tokens_to_mint<'info>(
 
 #[derive(Accounts)]
 pub struct HarvestWithheldTokensToMint<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -138,7 +125,7 @@ pub fn withdraw_withheld_tokens_from_mint<'info>(
 ) -> Result<()> {
     let ix =
         spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_mint(
-            ctx.accounts.token_program_id.key,
+            &ctx.program_id,
             ctx.accounts.mint.key,
             ctx.accounts.destination.key,
             ctx.accounts.authority.key,
@@ -147,7 +134,6 @@ pub fn withdraw_withheld_tokens_from_mint<'info>(
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.token_program_id,
             ctx.accounts.mint,
             ctx.accounts.destination,
             ctx.accounts.authority,
@@ -159,7 +145,6 @@ pub fn withdraw_withheld_tokens_from_mint<'info>(
 
 #[derive(Accounts)]
 pub struct WithdrawWithheldTokensFromMint<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub destination: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
@@ -170,7 +155,7 @@ pub fn withdraw_withheld_tokens_from_accounts<'info>(
     sources: Vec<AccountInfo<'info>>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_accounts(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.destination.key,
         ctx.accounts.authority.key,
@@ -179,7 +164,6 @@ pub fn withdraw_withheld_tokens_from_accounts<'info>(
     )?;
 
     let mut account_infos = vec![
-        ctx.accounts.token_program_id,
         ctx.accounts.mint,
         ctx.accounts.destination,
         ctx.accounts.authority,
@@ -192,7 +176,6 @@ pub fn withdraw_withheld_tokens_from_accounts<'info>(
 
 #[derive(Accounts)]
 pub struct WithdrawWithheldTokensFromAccounts<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub destination: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,

--- a/spl/src/token_2022_extensions/transfer_hook.rs
+++ b/spl/src/token_2022_extensions/transfer_hook.rs
@@ -15,22 +15,17 @@ pub fn transfer_hook_initialize<'info>(
     transfer_hook_program_id: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_hook::instruction::initialize(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         authority,
         transfer_hook_program_id,
     )?;
-    anchor_lang::solana_program::program::invoke_signed(
-        &ix,
-        &[ctx.accounts.token_program_id, ctx.accounts.mint],
-        ctx.signer_seeds,
-    )
-    .map_err(Into::into)
+    anchor_lang::solana_program::program::invoke_signed(&ix, &[ctx.accounts.mint], ctx.signer_seeds)
+        .map_err(Into::into)
 }
 
 #[derive(Accounts)]
 pub struct TransferHookInitialize<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
 }
 
@@ -39,7 +34,7 @@ pub fn transfer_hook_update<'info>(
     transfer_hook_program_id: Option<Pubkey>,
 ) -> Result<()> {
     let ix = spl_token_2022::extension::transfer_hook::instruction::update(
-        ctx.accounts.token_program_id.key,
+        &ctx.program_id,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
@@ -47,11 +42,7 @@ pub fn transfer_hook_update<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[
-            ctx.accounts.token_program_id,
-            ctx.accounts.mint,
-            ctx.accounts.authority,
-        ],
+        &[ctx.accounts.mint, ctx.accounts.authority],
         ctx.signer_seeds,
     )
     .map_err(Into::into)
@@ -59,7 +50,6 @@ pub fn transfer_hook_update<'info>(
 
 #[derive(Accounts)]
 pub struct TransferHookUpdate<'info> {
-    pub token_program_id: AccountInfo<'info>,
     pub mint: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }

--- a/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/instructions.rs
@@ -93,7 +93,6 @@ impl<'info> CreateMintAccount<'info> {
         uri: String,
     ) -> ProgramResult {
         let cpi_accounts = TokenMetadataInitialize {
-            program_id: self.token_program.to_account_info(),
             mint: self.mint.to_account_info(),
             metadata: self.mint.to_account_info(), // metadata account is the mint, since data is stored in mint
             mint_authority: self.authority.to_account_info(),
@@ -195,6 +194,93 @@ pub struct CheckMintExtensionConstraints<'info> {
 }
 
 #[derive(Accounts)]
+pub struct CreateSimpleExtensionMint<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub authority: Signer<'info>,
+    #[account(
+        init,
+        signer,
+        payer = payer,
+        mint::token_program = token_program,
+        mint::decimals = 0,
+        mint::authority = authority,
+        mint::freeze_authority = authority,
+        extensions::metadata_pointer::authority = authority,
+        extensions::metadata_pointer::metadata_address = mint,
+        extensions::group_member_pointer::authority = authority,
+        extensions::group_member_pointer::member_address = mint,
+        extensions::transfer_hook::authority = authority,
+        extensions::transfer_hook::program_id = crate::ID,
+        extensions::close_authority::authority = authority,
+        extensions::permanent_delegate::delegate = authority,
+        extensions::pausable::authority = authority,
+    )]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+pub fn create_simple_extension_mint_handler(
+    ctx: Context<CreateSimpleExtensionMint>,
+) -> Result<()> {
+    let mint_data = &mut ctx.accounts.mint.to_account_info();
+    let mint_key: Option<Pubkey> = Some(ctx.accounts.mint.key());
+    let authority_key: Option<Pubkey> = Some(ctx.accounts.authority.key());
+
+    let metadata_pointer = get_mint_extension_data::<MetadataPointer>(mint_data)?;
+    assert_eq!(
+        metadata_pointer.metadata_address,
+        OptionalNonZeroPubkey::try_from(mint_key)?
+    );
+    assert_eq!(
+        metadata_pointer.authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+
+    let permanent_delegate = get_mint_extension_data::<PermanentDelegate>(mint_data)?;
+    assert_eq!(
+        permanent_delegate.delegate,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+
+    let close_authority = get_mint_extension_data::<MintCloseAuthority>(mint_data)?;
+    assert_eq!(
+        close_authority.close_authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+
+    let transfer_hook = get_mint_extension_data::<TransferHook>(mint_data)?;
+    let program_id: Option<Pubkey> = Some(ctx.program_id.key());
+    assert_eq!(
+        transfer_hook.authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+    assert_eq!(
+        transfer_hook.program_id,
+        OptionalNonZeroPubkey::try_from(program_id)?
+    );
+
+    let group_member_pointer = get_mint_extension_data::<GroupMemberPointer>(mint_data)?;
+    assert_eq!(
+        group_member_pointer.authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+    assert_eq!(
+        group_member_pointer.member_address,
+        OptionalNonZeroPubkey::try_from(mint_key)?
+    );
+
+    let pausable_extension = get_mint_extension_data::<PausableConfig>(mint_data)?;
+    assert_eq!(
+        pausable_extension.authority,
+        OptionalNonZeroPubkey::try_from(authority_key)?
+    );
+
+    Ok(())
+}
+
+#[derive(Accounts)]
 pub struct CreateGroupPointerMint<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
@@ -227,7 +313,6 @@ pub fn update_group_pointer_handler(
     new_group_address: Option<Pubkey>,
 ) -> Result<()> {
     let cpi_accounts = token_2022_extensions::group_pointer::GroupPointerUpdate {
-        token_program_id: ctx.accounts.token_program.to_account_info(),
         mint: ctx.accounts.mint.to_account_info(),
         authority: ctx.accounts.authority.to_account_info(),
     };
@@ -258,7 +343,6 @@ pub fn toggle_pause_handler(ctx: Context<CheckTogglePause>) -> Result<()> {
     pausable_pause(CpiContext::new(
         Token2022::id(),
         PausableToggle {
-            token_program_id: ctx.accounts.token_program.to_account_info(),
             mint: ctx.accounts.mint.to_account_info(),
             authority: ctx.accounts.authority.to_account_info(),
         },
@@ -270,7 +354,6 @@ pub fn toggle_pause_handler(ctx: Context<CheckTogglePause>) -> Result<()> {
     pausable_resume(CpiContext::new(
         Token2022::id(),
         PausableToggle {
-            token_program_id: ctx.accounts.token_program.to_account_info(),
             mint: ctx.accounts.mint.to_account_info(),
             authority: ctx.accounts.authority.to_account_info(),
         },
@@ -308,7 +391,6 @@ pub struct UpdateAndRemoveTokenMetadata<'info> {
 impl<'info> UpdateAndRemoveTokenMetadata<'info> {
     fn update_token_metadata(&self, field: String, value: String) -> ProgramResult {
         let cpi_accounts = TokenMetadataUpdateField {
-            program_id: self.token_program.to_account_info(),
             metadata: self.mint.to_account_info(), // metadata account is the mint, since data is stored in mint
             update_authority: self.authority.to_account_info(),
         };
@@ -319,7 +401,6 @@ impl<'info> UpdateAndRemoveTokenMetadata<'info> {
 
     fn remove_token_metadata(&self, key: String) -> ProgramResult {
         let cpi_accounts = TokenMetadataRemoveKey {
-            program_id: self.token_program.to_account_info(),
             metadata: self.mint.to_account_info(), // metadata account is the mint, since data is stored in mint
             update_authority: self.authority.to_account_info(),
         };

--- a/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
+++ b/tests/spl/token-extensions/programs/token-extensions/src/lib.rs
@@ -29,6 +29,10 @@ pub mod token_extensions {
         Ok(())
     }
 
+    pub fn create_simple_extension_mint(ctx: Context<CreateSimpleExtensionMint>) -> Result<()> {
+        instructions::create_simple_extension_mint_handler(ctx)
+    }
+
     pub fn create_group_pointer_mint(_ctx: Context<CreateGroupPointerMint>) -> Result<()> {
         Ok(())
     }

--- a/tests/spl/token-extensions/tests/token-extensions.ts
+++ b/tests/spl/token-extensions/tests/token-extensions.ts
@@ -91,6 +91,35 @@ describe("token extensions", () => {
       .rpc();
   });
 
+  describe("generated_extension_init_cpis", () => {
+    let extensionMint = new Keypair();
+
+    it("Creates a mint with generated Token-2022 extension init CPIs", async () => {
+      await program.methods
+        .createSimpleExtensionMint()
+        .accountsStrict({
+          payer: payer.publicKey,
+          authority: payer.publicKey,
+          mint: extensionMint.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+          tokenProgram: TOKEN_2022_PROGRAM_ID,
+        })
+        .signers([payer, extensionMint])
+        .rpc();
+    });
+
+    it("Accepts the generated-extension mint in the existing constraint checks", async () => {
+      await program.methods
+        .checkMintExtensionsConstraints()
+        .accountsStrict({
+          authority: payer.publicKey,
+          mint: extensionMint.publicKey,
+        })
+        .signers([payer])
+        .rpc();
+    });
+  });
+
   describe("group_pointer_update", () => {
     let groupPointerMint = new Keypair();
 


### PR DESCRIPTION
removed the redundant `program_id` / `token_program_id` accounts from the `Token-2022` extension CPI helpers, switched them to use `ctx.program_id`, and updated the generated init callsites so `invoke/invoke_signed` only receive the real instruction accounts.