### PR TITLE
Fix/v2 update hook order

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -160,6 +160,9 @@ required-features = ["testing"]
 
 [[test]]
 name = "address_idl_surface"
+
+[[test]]
+name = "update_hook_order"
 required-features = ["testing"]
 
 [[test]]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -117,9 +117,6 @@ pub(crate) fn find_unsupported_wincode_attr(
     Ok(None)
 }
 
-// Rewrites supported handler context patterns so generated handlers can call
-// `TryAccounts::update_accounts(...)`. Unsupported destructuring now returns a
-// targeted compile error instead of silently omitting the update phase.
 fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt> {
     let update_stmt = |expr: TokenStream2| {
         syn::parse_quote! {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -117,6 +117,46 @@ pub(crate) fn find_unsupported_wincode_attr(
     Ok(None)
 }
 
+fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> Option<syn::Stmt> {
+    let update_stmt = |expr: TokenStream2| {
+        syn::parse_quote! {
+            anchor_lang_v2::TryAccounts::update_accounts(#expr)?;
+        }
+    };
+
+    match pat {
+        Pat::Ident(pi) => {
+            let ctx_ident = &pi.ident;
+            Some(update_stmt(quote! { &mut #ctx_ident.accounts }))
+        }
+        Pat::Struct(ps) => {
+            let Some(accounts_field) = ps.fields.iter_mut().find(|field| {
+                matches!(&field.member, syn::Member::Named(ident) if ident == "accounts")
+            }) else {
+                return None;
+            };
+
+            let accounts_ident = match accounts_field.pat.as_mut() {
+                Pat::Ident(pi) => pi.ident.clone(),
+                Pat::Wild(_) => {
+                    let ident = Ident::new("__anchor_accounts", accounts_field.pat.span());
+                    accounts_field.pat = Box::new(syn::parse_quote!(#ident));
+                    ident
+                }
+                _ => return None,
+            };
+
+            Some(update_stmt(quote! { #accounts_ident }))
+        }
+        Pat::Wild(_) => {
+            let ident = Ident::new("__anchor_ctx", pat.span());
+            *pat = syn::parse_quote!(#ident);
+            Some(update_stmt(quote! { &mut #ident.accounts }))
+        }
+        _ => None,
+    }
+}
+
 fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
     let fields = match &input.data {
         Data::Struct(s) => match &s.fields {
@@ -1870,6 +1910,26 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
 
             #[inline]
             fn try_accounts<'ix>(
+                __program_id: &anchor_lang_v2::Address,
+                __views: &[anchor_lang_v2::AccountView],
+                __duplicates: ::core::option::Option<&anchor_lang_v2::AccountBitvec>,
+                __base_offset: usize,
+                __ix_data: &'ix [u8],
+            ) -> anchor_lang_v2::Result<(Self, #bumps_name, Self::IxArgs<'ix>)> {
+                let (mut __accounts, __bumps, __ix_args) =
+                    <Self as anchor_lang_v2::TryAccounts>::validate_accounts(
+                        __program_id,
+                        __views,
+                        __duplicates,
+                        __base_offset,
+                        __ix_data,
+                    )?;
+                <Self as anchor_lang_v2::TryAccounts>::update_accounts(&mut __accounts)?;
+                Ok((__accounts, __bumps, __ix_args))
+            }
+
+            #[inline]
+            fn validate_accounts<'ix>(
                 __program_id: &anchor_lang_v2::Address,
                 __views: &[anchor_lang_v2::AccountView],
                 __duplicates: ::core::option::Option<&anchor_lang_v2::AccountBitvec>,
@@ -5008,15 +5068,9 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                     true
                 }
             });
-            if let Some(syn::FnArg::Typed(pt)) = func.sig.inputs.first() {
-                if let syn::Pat::Ident(pi) = &*pt.pat {
-                    let ctx_ident = &pi.ident;
-                    func.block.stmts.insert(
-                        0,
-                        syn::parse_quote! {
-                            anchor_lang_v2::TryAccounts::update_accounts(&mut #ctx_ident.accounts)?;
-                        },
-                    );
+            if let Some(syn::FnArg::Typed(pt)) = func.sig.inputs.first_mut() {
+                if let Some(stmt) = update_accounts_stmt_for_handler_pat(pt.pat.as_mut()) {
+                    func.block.stmts.insert(0, stmt);
                 }
             }
             func
@@ -6535,6 +6589,62 @@ mod tests {
         assert!(
             generated.contains("access_control"),
             "expected access_control attr to remain on the generated handler, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_inject_update_phase_for_destructured_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(Context { accounts, .. }: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work(accounts)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("anchor_lang_v2 :: TryAccounts :: update_accounts (accounts) ? ;"),
+            "expected destructured handler body to call update_accounts via accounts binding, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_inject_update_phase_for_wildcard_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(_: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work()?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut __anchor_ctx . accounts) ? ;"
+            ),
+            "expected wildcard handler body to call update_accounts via synthesized ctx binding, got: {generated}"
+        );
+        assert!(
+            generated.contains("fn rotate (__anchor_ctx : & mut Context < RotateAuthority >)"),
+            "expected wildcard handler signature to be rewritten to a concrete ctx binding, got: {generated}"
         );
     }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -143,7 +143,7 @@ fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt>
                     other => {
                         return Err(syn::Error::new_spanned(
                             other,
-                            "handlers with `update(...)` must bind `Context.accounts` to an identifier or `_`",
+                            "`update(...)` handlers that destructure `Context { .. }` must bind `accounts` as a name or `_`, for example `Context { accounts, .. }` or `Context { accounts: _, .. }`",
                         ));
                     }
                 }
@@ -167,7 +167,7 @@ fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt>
         }
         _ => Err(syn::Error::new_spanned(
             pat,
-            "handlers with `update(...)` must bind context as `ctx`, `_`, or `Context { .. }`",
+            "`update(...)` handlers must take `&mut Context<T>` as an identifier like `ctx`, `_`, or `Context { .. }`, for example `ctx: &mut Context<T>` or `Context { accounts, .. }: &mut Context<T>`",
         )),
     }
 }
@@ -6729,8 +6729,39 @@ mod tests {
             "expected unsupported nested accounts destructuring to emit a compile error, got: {generated}"
         );
         assert!(
-            generated.contains("bind `Context.accounts` to an identifier or `_`"),
+            generated.contains("must bind `accounts` as a name or `_`"),
             "expected targeted unsupported-pattern error, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_reject_non_binding_update_hook_context_patterns() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(
+                    &mut ctx: &mut Context<RotateAuthority>
+                ) -> Result<()> {
+                    do_work(ctx.accounts.vault)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "expected unsupported reference-pattern context to emit a compile error, got: {generated}"
+        );
+        assert!(
+            generated.contains("must take `&mut Context<T>` as an identifier like `ctx`, `_`, or `Context { .. }`"),
+            "expected targeted top-level pattern error, got: {generated}"
         );
     }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -6505,4 +6505,36 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("invalid IDL array generic"));
     }
+
+    #[test]
+    fn program_handlers_inject_update_phase_into_handler_body() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                #[access_control(validate(&ctx))]
+                pub fn rotate(ctx: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work()?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (& mut ctx . accounts) ? ;"
+            ),
+            "expected handler body to call update_accounts after access-control expansion, got: {generated}"
+        );
+        assert!(
+            generated.contains("access_control"),
+            "expected access_control attr to remain on the generated handler, got: {generated}"
+        );
+    }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -117,6 +117,9 @@ pub(crate) fn find_unsupported_wincode_attr(
     Ok(None)
 }
 
+// Rewrites supported handler context patterns so generated handlers can call
+// `TryAccounts::update_accounts(...)`. Unsupported destructuring now returns a
+// targeted compile error instead of silently omitting the update phase.
 fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt> {
     let update_stmt = |expr: TokenStream2| {
         syn::parse_quote! {

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -117,7 +117,7 @@ pub(crate) fn find_unsupported_wincode_attr(
     Ok(None)
 }
 
-fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> Option<syn::Stmt> {
+fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> syn::Result<syn::Stmt> {
     let update_stmt = |expr: TokenStream2| {
         syn::parse_quote! {
             anchor_lang_v2::TryAccounts::update_accounts(#expr)?;
@@ -127,33 +127,48 @@ fn update_accounts_stmt_for_handler_pat(pat: &mut Pat) -> Option<syn::Stmt> {
     match pat {
         Pat::Ident(pi) => {
             let ctx_ident = &pi.ident;
-            Some(update_stmt(quote! { &mut #ctx_ident.accounts }))
+            Ok(update_stmt(quote! { &mut #ctx_ident.accounts }))
         }
         Pat::Struct(ps) => {
-            let Some(accounts_field) = ps.fields.iter_mut().find(|field| {
+            let accounts_ident = if let Some(accounts_field) = ps.fields.iter_mut().find(|field| {
                 matches!(&field.member, syn::Member::Named(ident) if ident == "accounts")
-            }) else {
-                return None;
-            };
-
-            let accounts_ident = match accounts_field.pat.as_mut() {
-                Pat::Ident(pi) => pi.ident.clone(),
-                Pat::Wild(_) => {
-                    let ident = Ident::new("__anchor_accounts", accounts_field.pat.span());
-                    accounts_field.pat = Box::new(syn::parse_quote!(#ident));
-                    ident
+            }) {
+                match accounts_field.pat.as_mut() {
+                    Pat::Ident(pi) => pi.ident.clone(),
+                    Pat::Wild(_) => {
+                        let ident = Ident::new("__anchor_accounts", accounts_field.pat.span());
+                        accounts_field.pat = Box::new(syn::parse_quote!(#ident));
+                        ident
+                    }
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "handlers with `update(...)` must bind `Context.accounts` to an identifier or `_`",
+                        ));
+                    }
                 }
-                _ => return None,
+            } else {
+                let ident = Ident::new("__anchor_accounts", ps.path.span());
+                ps.fields.push(syn::FieldPat {
+                    attrs: Vec::new(),
+                    member: syn::Member::Named(Ident::new("accounts", ps.path.span())),
+                    colon_token: Some(Default::default()),
+                    pat: Box::new(syn::parse_quote!(#ident)),
+                });
+                ident
             };
 
-            Some(update_stmt(quote! { #accounts_ident }))
+            Ok(update_stmt(quote! { #accounts_ident }))
         }
         Pat::Wild(_) => {
             let ident = Ident::new("__anchor_ctx", pat.span());
             *pat = syn::parse_quote!(#ident);
-            Some(update_stmt(quote! { &mut #ident.accounts }))
+            Ok(update_stmt(quote! { &mut #ident.accounts }))
         }
-        _ => None,
+        _ => Err(syn::Error::new_spanned(
+            pat,
+            "handlers with `update(...)` must bind context as `ctx`, `_`, or `Context { .. }`",
+        )),
     }
 }
 
@@ -5057,6 +5072,7 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
 
     // Strip #[discrim = N] attributes from handler outputs so rustc
     // doesn't complain about an unknown attribute.
+    let mut handler_update_errors = Vec::new();
     let handlers: Vec<_> = handlers
         .iter()
         .map(|func| {
@@ -5069,13 +5085,21 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                 }
             });
             if let Some(syn::FnArg::Typed(pt)) = func.sig.inputs.first_mut() {
-                if let Some(stmt) = update_accounts_stmt_for_handler_pat(pt.pat.as_mut()) {
-                    func.block.stmts.insert(0, stmt);
+                match update_accounts_stmt_for_handler_pat(pt.pat.as_mut()) {
+                    Ok(stmt) => {
+                        func.block.stmts.insert(0, stmt);
+                    }
+                    Err(err) => handler_update_errors.push(err.to_compile_error()),
                 }
             }
             func
         })
         .collect();
+    if !handler_update_errors.is_empty() {
+        return quote! {
+            #(#handler_update_errors)*
+        };
+    }
 
     let interface_account_reexports = if config.mode == ProgramMode::Interface {
         quote! { pub use super::*; }
@@ -6618,6 +6642,37 @@ mod tests {
     }
 
     #[test]
+    fn program_handlers_synthesize_accounts_binding_for_struct_context() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(Context { bumps, .. }: &mut Context<RotateAuthority>) -> Result<()> {
+                    do_work(bumps)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains(
+                "anchor_lang_v2 :: TryAccounts :: update_accounts (__anchor_accounts) ? ;"
+            ),
+            "expected struct-pattern handler body to call update_accounts via synthesized accounts binding, got: {generated}"
+        );
+        assert!(
+            generated.contains("Context { bumps , accounts : __anchor_accounts , .. }"),
+            "expected struct-pattern handler signature to include synthesized accounts binding, got: {generated}"
+        );
+    }
+
+    #[test]
     fn program_handlers_inject_update_phase_for_wildcard_context() {
         let module: syn::ItemMod = syn::parse_quote! {
             pub mod demo_program {
@@ -6645,6 +6700,37 @@ mod tests {
         assert!(
             generated.contains("fn rotate (__anchor_ctx : & mut Context < RotateAuthority >)"),
             "expected wildcard handler signature to be rewritten to a concrete ctx binding, got: {generated}"
+        );
+    }
+
+    #[test]
+    fn program_handlers_reject_unsupported_update_hook_context_patterns() {
+        let module: syn::ItemMod = syn::parse_quote! {
+            pub mod demo_program {
+                use super::*;
+
+                pub fn rotate(
+                    Context { accounts: RotateAuthority { vault, .. }, .. }: &mut Context<RotateAuthority>
+                ) -> Result<()> {
+                    do_work(vault)?;
+                    Ok(())
+                }
+            }
+        };
+        let config = ProgramConfig {
+            mode: ProgramMode::Executable,
+            program_id: syn::parse_quote!(crate::ID),
+        };
+
+        let generated = impl_program(&module, &config).to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "expected unsupported nested accounts destructuring to emit a compile error, got: {generated}"
+        );
+        assert!(
+            generated.contains("bind `Context.accounts` to an identifier or `_`"),
+            "expected targeted unsupported-pattern error, got: {generated}"
         );
     }
 }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1013,7 +1013,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .filter_map(|f| f.deferred_load.as_ref())
         .collect();
     let constraints: Vec<_> = fields.iter().flat_map(|f| &f.constraints).collect();
-    let updates: Vec<_> = fields.iter().flat_map(|f| &f.updates).collect();
+    let updates: Vec<_> = fields.iter().filter_map(|f| f.update.as_ref()).collect();
     let exits: Vec<_> = fields.iter().filter_map(|f| f.exit.as_ref()).collect();
     // Bumps fields. Optional accounts get `Option<u8>` so the default
     // (`None`) maps cleanly to the sentinel-`None` load path; the seeds
@@ -1881,8 +1881,13 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 #(#loads)*
                 #(#deferred_loads)*
                 #(#constraints)*
-                #(#updates)*
                 Ok((Self { #(#field_names),* }, __bumps, #ix_args_return))
+            }
+
+            #[inline(always)]
+            fn update_accounts(&mut self) -> anchor_lang_v2::Result<()> {
+                #(#updates)*
+                Ok(())
             }
 
             //
@@ -5003,6 +5008,17 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                     true
                 }
             });
+            if let Some(syn::FnArg::Typed(pt)) = func.sig.inputs.first() {
+                if let syn::Pat::Ident(pi) = &*pt.pat {
+                    let ctx_ident = &pi.ident;
+                    func.block.stmts.insert(
+                        0,
+                        syn::parse_quote! {
+                            anchor_lang_v2::TryAccounts::update_accounts(&mut #ctx_ident.accounts)?;
+                        },
+                    );
+                }
+            }
             func
         })
         .collect();

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -926,7 +926,7 @@ pub struct AccountField {
     pub load: TokenStream2,
     pub deferred_load: Option<TokenStream2>,
     pub constraints: Vec<TokenStream2>,
-    pub updates: Vec<TokenStream2>,
+    pub update: Option<TokenStream2>,
     /// Duplicate-mutable-account check. Collected separately from
     /// `constraints` so all mut-field dup checks can share a single outer
     /// `if let Some(__dups) = __duplicates` gate — non-dup txs pay one
@@ -1913,7 +1913,9 @@ pub fn parse_field(
             load,
             deferred_load: None,
             constraints: vec![],
-            updates: vec![],
+            update: Some(quote! {
+                self.#field_name.0.update_accounts()?;
+            }),
             dup_check: None,
             exit,
             has_bump: false,
@@ -2526,9 +2528,8 @@ pub fn parse_field(
     //
     // The `init` dispatch is embedded inline into the init body by
     // `wrap_init_body_with_constraints` above so the hook only fires on
-    // actual creation. `check` emits into the validation phase here;
-    // `update` is deferred into a later post-validation phase so sibling
-    // field constraints still observe the pre-update state.
+    // actual creation. Only `check` and `update` emit out here in the
+    // constraint phase.
     //
     // Field refs thread through `AsRef::as_ref` so the call-site's
     // `V` is inferred from the `AccountConstraint::Value` associated
@@ -2551,17 +2552,21 @@ pub fn parse_field(
             let update_target = if is_optional {
                 quote! { #field_name }
             } else {
-                quote! { &mut #field_name }
+                quote! { &mut self.#field_name }
             };
-            // `update(...)` — fires regardless of init state, but only after
-            // all account validations have completed.
+            let update_expected =
+                if nc.is_field_ref && (nc.namespace == "mint" || nc.namespace == "token") {
+                    quote! { anchor_lang_v2::AccountAddress::account_address(&self.#value) }
+                } else if nc.is_field_ref {
+                    quote! { AsRef::as_ref(&self.#value) }
+                } else {
+                    quote! { &#value }
+            };
+            // `update(...)` runs after validation + access-control.
             updates.push(quote! {
-                {
-                    #expected_binding
-                    <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
-                        #update_target, #expected_arg,
-                    )?;
-                }
+                <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
+                    #update_target, #update_expected,
+                )?;
             });
             continue;
         }
@@ -2713,7 +2718,7 @@ pub fn parse_field(
     // Mutable fields use `ref mut` so constraint bodies that need `&mut self`
     // (e.g. BorshAccount::release_borrow in the realloc path) can work.
     // Read-only methods still resolve via auto-deref from `&mut T` to `&T`.
-    let (constraints, updates, exit) = if is_optional {
+    let (constraints, update, exit) = if is_optional {
         let constraints = constraints
             .into_iter()
             .map(|c| {
@@ -2742,17 +2747,16 @@ pub fn parse_field(
                 }
             })
             .collect();
-        let updates = updates
-            .into_iter()
-            .map(|u| {
-                quote! {
-                    if let Some(ref mut #field_name) = #field_name {
-                        let _ = &#field_name;
-                        #u
-                    }
+        let update = if updates.is_empty() {
+            None
+        } else {
+            Some(quote! {
+                if let Some(ref mut #field_name) = self.#field_name {
+                    let _ = &#field_name;
+                    #(#updates)*
                 }
             })
-            .collect();
+        };
         let exit = exit.map(|e| {
             // `e` was built against `self.#field_name` (e.g.
             // `AnchorAccount::exit(&mut self.#field_name)`). For optional
@@ -2813,9 +2817,14 @@ pub fn parse_field(
                 }
             }
         });
-        (constraints, updates, exit)
+        (constraints, update, exit)
     } else {
-        (constraints, updates, exit)
+        let update = if updates.is_empty() {
+            None
+        } else {
+            Some(quote! { #(#updates)* })
+        };
+        (constraints, update, exit)
     };
 
     let contributes_mut_bit = attrs.is_mut && !attrs.is_dup && !is_optional;
@@ -2830,7 +2839,7 @@ pub fn parse_field(
         load,
         deferred_load,
         constraints,
-        updates,
+        update,
         dup_check,
         exit,
         has_bump,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -927,6 +927,11 @@ pub struct AccountField {
     pub deferred_load: Option<TokenStream2>,
     pub constraints: Vec<TokenStream2>,
     pub updates: Vec<TokenStream2>,
+    /// Duplicate-mutable-account check. Collected separately from
+    /// `constraints` so all mut-field dup checks can share a single outer
+    /// `if let Some(__dups) = __duplicates` gate — non-dup txs pay one
+    /// Option-tag branch regardless of field count.
+    pub dup_check: Option<TokenStream2>,
     pub exit: Option<TokenStream2>,
     pub has_bump: bool,
     /// True when the field type is `Option<T>` (optional account).
@@ -1909,6 +1914,7 @@ pub fn parse_field(
             deferred_load: None,
             constraints: vec![],
             updates: vec![],
+            dup_check: None,
             exit,
             has_bump: false,
             is_optional: false,
@@ -2805,6 +2811,7 @@ pub fn parse_field(
         deferred_load,
         constraints,
         updates,
+        dup_check,
         exit,
         has_bump,
         is_optional,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2683,6 +2683,26 @@ pub fn parse_field(
         None
     };
 
+    // Dup-check emission: only `Option<_>` mut fields keep a gated
+    // per-field `get()` check — a `None` slot (the client encodes
+    // `program_id` as the address) must stay silent even when that slot
+    // is also the dup target of another account, and the
+    // `if let Some(...)` wrapper built below preserves that. Non-`Option`
+    // mut fields are folded into the enclosing struct's `MUT_MASK` const
+    // and checked once per dispatch by `run_handler`. Stored separately
+    // from `constraints` so the struct-level codegen can aggregate all
+    // mut fields' dup checks under a single outer
+    // `if let Some(__dups) = __duplicates { ... }` gate.
+    let dup_check = if attrs.is_mut && !attrs.is_dup && is_optional {
+        Some(quote! {
+            if __dups.get((__base_offset + #offset_expr) as u8) {
+                return Err(anchor_lang_v2::ErrorCode::ConstraintDuplicateMutableAccount.into());
+            }
+        })
+    } else {
+        None
+    };
+
     // For `Option<T>` fields, each constraint body was generated against the
     // unwrapped inner — we wrap it in `if let Some(#field_name) = #field_name`
     // so `#field_name.account()`, `#field_name.authority`, etc. resolve on the

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1880,13 +1880,15 @@ pub fn parse_field(
 
         let inner_ty = extract_nested_inner_type(field_ty)
             .expect("is_nested_type was true but extract_nested_inner_type returned None");
-        // Nested<Inner> — delegate to Inner::try_accounts, which advances the
-        // shared cursor by Inner::HEADER_SIZE. The outer walk_n covers only
-        // direct (non-nested) fields; the nested try_accounts picks up where
-        // the outer left off.
+        // Nested<Inner> — delegate to Inner::validate_accounts, which advances
+        // the shared cursor by Inner::HEADER_SIZE without firing inner
+        // update-hooks yet. The outer walk_n covers only direct
+        // (non-nested) fields; the nested validate_accounts picks up where
+        // the outer left off, and the outer update phase later calls
+        // Inner::update_accounts exactly once.
         //
         // Constraint processing and exit are handled by the inner struct's own
-        // try_accounts / exit_accounts — the outer derives don't need to
+        // validate_accounts / exit_accounts — the outer derives don't need to
         // re-check them.
         // TODO: passing `__base_offset + #offset_expr` means the nested
         // struct's bitvec lookups hit the correct global indices. This is
@@ -1895,7 +1897,7 @@ pub fn parse_field(
         // or use a wrapper that offsets transparently.
         let load = quote! {
             let (__nested_inner, _, _) =
-                <#inner_ty as anchor_lang_v2::TryAccounts>::try_accounts(
+                <#inner_ty as anchor_lang_v2::TryAccounts>::validate_accounts(
                     __program_id,
                     &__views[#offset_expr .. #offset_expr + <#inner_ty as anchor_lang_v2::TryAccounts>::HEADER_SIZE],
                     __duplicates,

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -927,11 +927,6 @@ pub struct AccountField {
     pub deferred_load: Option<TokenStream2>,
     pub constraints: Vec<TokenStream2>,
     pub update: Option<TokenStream2>,
-    /// Duplicate-mutable-account check. Collected separately from
-    /// `constraints` so all mut-field dup checks can share a single outer
-    /// `if let Some(__dups) = __duplicates` gate — non-dup txs pay one
-    /// Option-tag branch regardless of field count.
-    pub dup_check: Option<TokenStream2>,
     pub exit: Option<TokenStream2>,
     pub has_bump: bool,
     /// True when the field type is `Option<T>` (optional account).
@@ -1918,7 +1913,6 @@ pub fn parse_field(
             update: Some(quote! {
                 self.#field_name.0.update_accounts()?;
             }),
-            dup_check: None,
             exit,
             has_bump: false,
             is_optional: false,
@@ -2556,19 +2550,22 @@ pub fn parse_field(
             } else {
                 quote! { &mut self.#field_name }
             };
-            let update_expected =
-                if nc.is_field_ref && (nc.namespace == "mint" || nc.namespace == "token") {
-                    quote! { anchor_lang_v2::AccountAddress::account_address(&self.#value) }
-                } else if nc.is_field_ref {
-                    quote! { AsRef::as_ref(&self.#value) }
-                } else {
-                    quote! { &#value }
-            };
+            let (update_expected_binding, update_expected_arg) = emit_constraint_expected_binding(
+                &ns,
+                &key,
+                nc,
+                field_names,
+                field_summaries,
+                true,
+            );
             // `update(...)` runs after validation + access-control.
             updates.push(quote! {
-                <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
-                    #update_target, #update_expected,
-                )?;
+                {
+                    #update_expected_binding
+                    <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
+                        #update_target, #update_expected_arg,
+                    )?;
+                }
             });
             continue;
         }
@@ -2685,26 +2682,6 @@ pub fn parse_field(
         // that only needs to run post-instruction).
         Some(quote! {
             #(#constraint_exits)*
-        })
-    } else {
-        None
-    };
-
-    // Dup-check emission: only `Option<_>` mut fields keep a gated
-    // per-field `get()` check — a `None` slot (the client encodes
-    // `program_id` as the address) must stay silent even when that slot
-    // is also the dup target of another account, and the
-    // `if let Some(...)` wrapper built below preserves that. Non-`Option`
-    // mut fields are folded into the enclosing struct's `MUT_MASK` const
-    // and checked once per dispatch by `run_handler`. Stored separately
-    // from `constraints` so the struct-level codegen can aggregate all
-    // mut fields' dup checks under a single outer
-    // `if let Some(__dups) = __duplicates { ... }` gate.
-    let dup_check = if attrs.is_mut && !attrs.is_dup && is_optional {
-        Some(quote! {
-            if __dups.get((__base_offset + #offset_expr) as u8) {
-                return Err(anchor_lang_v2::ErrorCode::ConstraintDuplicateMutableAccount.into());
-            }
         })
     } else {
         None
@@ -2842,7 +2819,6 @@ pub fn parse_field(
         deferred_load,
         constraints,
         update,
-        dup_check,
         exit,
         has_bump,
         is_optional,

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -57,6 +57,8 @@ pub trait TryAccounts: Bumps + Sized {
         ix_data: &'ix [u8],
     ) -> Result<(Self, Self::Bumps, Self::IxArgs<'ix>), ProgramError>;
 
+    fn update_accounts(&mut self) -> Result<(), ProgramError>;
+
     fn exit_accounts<'ix>(&mut self, ix_data: &'ix [u8]) -> Result<(), ProgramError>;
 }
 

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -57,6 +57,22 @@ pub trait TryAccounts: Bumps + Sized {
         ix_data: &'ix [u8],
     ) -> Result<(Self, Self::Bumps, Self::IxArgs<'ix>), ProgramError>;
 
+    /// Validation-only account construction path used by the dispatcher so it
+    /// can run `update(...)` hooks after access-control. Manual callers should
+    /// continue to use [`Self::try_accounts`], which preserves the historical
+    /// "validate + update" behavior by default.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn validate_accounts<'ix>(
+        program_id: &Address,
+        views: &[AccountView],
+        duplicates: Option<&AccountBitvec>,
+        base_offset: usize,
+        ix_data: &'ix [u8],
+    ) -> Result<(Self, Self::Bumps, Self::IxArgs<'ix>), ProgramError> {
+        Self::try_accounts(program_id, views, duplicates, base_offset, ix_data)
+    }
+
     fn update_accounts(&mut self) -> Result<(), ProgramError>;
 
     fn exit_accounts<'ix>(&mut self, ix_data: &'ix [u8]) -> Result<(), ProgramError>;
@@ -94,7 +110,7 @@ pub fn run_handler<'a, T: TryAccounts, R>(
                 return Err(crate::ErrorCode::ConstraintDuplicateMutableAccount.into());
             }
         }
-        T::try_accounts(program_id, views, duplicates, 0, ix_data)?
+        T::validate_accounts(program_id, views, duplicates, 0, ix_data)?
     };
     const _: () = assert!(pinocchio::MAX_TX_ACCOUNTS <= u8::MAX as usize);
     let remaining_num = (num_accounts - T::HEADER_SIZE) as u8;

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -12,8 +12,8 @@ use {
 ///
 /// `try_accounts` receives a pre-walked `&[AccountView]` slice (from a
 /// single `walk_n(HEADER_SIZE)` in [`run_handler`]) rather than the raw
-/// cursor.  This lets `Nested<Inner>` fields pass a sub-slice to
-/// `Inner::try_accounts` without re-walking the cursor or fighting
+/// cursor. This lets `Nested<Inner>` fields pass a sub-slice to
+/// `Inner::validate_accounts` without re-walking the cursor or fighting
 /// borrow-checker splits.
 ///
 /// `HEADER_SIZE` is computed recursively at compile time: 1 per direct
@@ -81,9 +81,9 @@ pub trait TryAccounts: Bumps + Sized {
 /// Run a handler inside a fully-constructed [`Context`].
 ///
 /// Walks all declared accounts in one `walk_n(HEADER_SIZE)` call, then
-/// passes the views slice to `T::try_accounts` for per-field loading and
-/// constraint checking.  The residual cursor (past the declared accounts)
-/// is handed to `Context` for lazy `remaining_accounts()` access.
+/// passes the views slice to `T::validate_accounts` for per-field loading and
+/// constraint checking. The residual cursor (past the declared accounts) is
+/// handed to `Context` for lazy `remaining_accounts()` access.
 #[inline(always)]
 pub fn run_handler<'a, T: TryAccounts, R>(
     program_id: &'a Address,

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -3,7 +3,8 @@ use {
         accounts::{BorshAccount, Signer, UncheckedAccount},
         testing::AccountBuffer,
         wincode::{SchemaRead, SchemaWrite},
-        AccountConstraint, Accounts, AnchorAccount, Discriminator, ErrorCode, Owner, TryAccounts,
+        AccountConstraint, Accounts, AnchorAccount, Discriminator, ErrorCode, Nested, Owner,
+        TryAccounts,
     },
     core::{mem::size_of, ptr},
     pinocchio::address::Address,
@@ -30,6 +31,19 @@ impl Discriminator for Vault {
     const DISCRIMINATOR: &'static [u8] = &[0x41, 0x75, 0x74, 0x68, 0x56, 0x61, 0x75, 0x6c];
 }
 
+#[derive(SchemaRead, SchemaWrite, Clone, Copy)]
+struct StepCounter {
+    value: u64,
+}
+
+impl Owner for StepCounter {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for StepCounter {
+    const DISCRIMINATOR: &'static [u8] = &[0x53, 0x74, 0x65, 0x70, 0x43, 0x74, 0x72, 0x21];
+}
+
 mod role {
     use super::*;
 
@@ -48,12 +62,51 @@ mod role {
     }
 }
 
+mod counter_ns {
+    use super::*;
+
+    pub struct IncrementConstraint;
+
+    impl AccountConstraint<BorshAccount<StepCounter>> for IncrementConstraint {
+        type Value = u64;
+
+        fn update(
+            account: &mut BorshAccount<StepCounter>,
+            amount: &Self::Value,
+        ) -> Result<(), ProgramError> {
+            account.value = account
+                .value
+                .checked_add(*amount)
+                .ok_or(ProgramError::ArithmeticOverflow)?;
+            Ok(())
+        }
+    }
+}
+
 #[derive(Accounts)]
 struct RotateAuthority {
     #[account(mut, has_one = current_authority, update(role::set_authority = new_authority))]
     vault: BorshAccount<Vault>,
     current_authority: Signer,
     new_authority: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+struct InnerIncrement {
+    #[account(mut, update(counter_ns::increment = 1u64))]
+    counter: BorshAccount<StepCounter>,
+}
+
+#[derive(Accounts)]
+struct OuterNestedIncrement {
+    inner: Nested<InnerIncrement>,
+}
+
+#[derive(Accounts)]
+struct OuterNestedGate {
+    inner: Nested<InnerIncrement>,
+    #[account(constraint = inner.counter.value == 1u64)]
+    witness: UncheckedAccount,
 }
 
 #[anchor_lang_v2::program]
@@ -100,6 +153,21 @@ fn unchecked_account(address: [u8; 32]) -> AccountBuffer<128> {
 fn read_vault_authority(buf: &AccountBuffer<128>) -> [u8; 32] {
     let data = buf.read_data();
     data[8..40].try_into().unwrap()
+}
+
+fn counter_account(value: u64) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    let mut data = [0u8; 16];
+    data[..8].copy_from_slice(StepCounter::DISCRIMINATOR);
+    data[8..16].copy_from_slice(&value.to_le_bytes());
+    buf.init([0xAC; 32], PROGRAM_ID, data.len(), false, true, false);
+    buf.write_data(&data);
+    buf
+}
+
+fn read_counter_value(buf: &AccountBuffer<128>) -> u64 {
+    let data = buf.read_data();
+    u64::from_le_bytes(data[8..16].try_into().unwrap())
 }
 
 fn build_dispatch_input<const N: usize>(accounts: &[&AccountBuffer<N>]) -> Vec<u64> {
@@ -244,4 +312,50 @@ fn generated_dispatch_runs_update_phase_before_user_handler() {
         NEW_AUTHORITY,
         "generated dispatch must persist update-phase mutations when exit_accounts runs"
     );
+}
+
+#[test]
+fn nested_validate_accounts_keeps_inner_updates_after_outer_validation() {
+    let counter = counter_account(0);
+    let witness = unchecked_account([0x33; 32]);
+    let views = [unsafe { counter.view() }, unsafe { witness.view() }];
+
+    let err = expect_err(<OuterNestedGate as TryAccounts>::validate_accounts(
+        &Address::new_from_array(PROGRAM_ID),
+        &views,
+        None,
+        0,
+        &[],
+    ));
+
+    assert_eq!(err, ErrorCode::ConstraintRaw.into());
+    assert_eq!(
+        read_counter_value(&counter),
+        0,
+        "nested validate_accounts must not run inner update hooks before outer validation"
+    );
+}
+
+#[test]
+fn nested_try_accounts_runs_inner_updates_once() {
+    let counter = counter_account(0);
+    let views = [unsafe { counter.view() }];
+
+    let (mut accounts, _, _) = OuterNestedIncrement::try_accounts(
+        &Address::new_from_array(PROGRAM_ID),
+        &views,
+        None,
+        0,
+        &[],
+    )
+    .expect("nested try_accounts should succeed");
+
+    assert_eq!(
+        accounts.inner.counter.value,
+        1,
+        "nested update hooks should run exactly once"
+    );
+
+    accounts.exit_accounts().unwrap();
+    assert_eq!(read_counter_value(&counter), 1);
 }

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -5,9 +5,13 @@ use {
         wincode::{SchemaRead, SchemaWrite},
         AccountConstraint, Accounts, AnchorAccount, Discriminator, ErrorCode, Owner, TryAccounts,
     },
+    core::{mem::size_of, ptr},
     pinocchio::address::Address,
+    pinocchio::account::{MAX_PERMITTED_DATA_INCREASE, RuntimeAccount},
     solana_program_error::ProgramError,
 };
+
+anchor_lang_v2::declare_id!("11111111111111111111111111111111");
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 const OLD_AUTHORITY: [u8; 32] = [0x10; 32];
@@ -52,6 +56,18 @@ struct RotateAuthority {
     new_authority: UncheckedAccount,
 }
 
+#[anchor_lang_v2::program]
+mod demo_program {
+    use super::*;
+
+    pub fn rotate(ctx: &mut anchor_lang_v2::Context<RotateAuthority>) -> anchor_lang_v2::Result<()> {
+        if ctx.accounts.vault.current_authority.to_bytes() != NEW_AUTHORITY {
+            return Err(anchor_lang_v2::ErrorCode::ConstraintAddress.into());
+        }
+        Ok(())
+    }
+}
+
 fn expect_err<T>(result: Result<T, ProgramError>) -> ProgramError {
     match result {
         Ok(_) => panic!("expected Err, got Ok"),
@@ -84,6 +100,54 @@ fn unchecked_account(address: [u8; 32]) -> AccountBuffer<128> {
 fn read_vault_authority(buf: &AccountBuffer<128>) -> [u8; 32] {
     let data = buf.read_data();
     data[8..40].try_into().unwrap()
+}
+
+fn build_dispatch_input<const N: usize>(accounts: &[&AccountBuffer<N>]) -> Vec<u64> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&(accounts.len() as u64).to_le_bytes());
+
+    for account in accounts {
+        while bytes.len() % 8 != 0 {
+            bytes.push(0);
+        }
+
+        let raw = account.raw();
+        let header = unsafe {
+            core::slice::from_raw_parts(raw as *const u8, size_of::<RuntimeAccount>())
+        };
+        bytes.extend_from_slice(header);
+        bytes.extend_from_slice(account.read_data());
+        bytes.extend(core::iter::repeat_n(0u8, MAX_PERMITTED_DATA_INCREASE));
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+    }
+
+    let mut backing = vec![0u64; bytes.len().div_ceil(8)];
+    unsafe {
+        ptr::copy_nonoverlapping(bytes.as_ptr(), backing.as_mut_ptr() as *mut u8, bytes.len());
+    }
+    backing
+}
+
+fn read_vault_authority_from_dispatch_input(input: &[u64]) -> [u8; 32] {
+    unsafe {
+        let account = input.as_ptr().cast::<u8>().add(size_of::<u64>()) as *const RuntimeAccount;
+        let data_len = (*account).data_len as usize;
+        let data = core::slice::from_raw_parts(
+            (account as *const u8).add(size_of::<RuntimeAccount>()),
+            data_len,
+        );
+        data[8..40].try_into().unwrap()
+    }
+}
+
+fn build_rotate_ix_data() -> Vec<u8> {
+    let ix = crate::instruction::Rotate {};
+    let data = <crate::instruction::Rotate as anchor_lang_v2::InstructionData>::data(&ix);
+    let mut buf = Vec::with_capacity(size_of::<u64>() + data.len() + 32);
+    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    buf.extend_from_slice(&data);
+    buf.extend_from_slice(&crate::ID.to_bytes());
+    buf
 }
 
 #[test]
@@ -148,4 +212,26 @@ fn try_accounts_still_runs_updates_for_direct_callers() {
             .expect("direct callers should still receive updated accounts");
 
     assert_eq!(accounts.vault.current_authority.to_bytes(), NEW_AUTHORITY);
+}
+
+#[test]
+fn generated_dispatch_runs_update_phase_before_user_handler() {
+    let vault = vault_account(OLD_AUTHORITY);
+    let current = signer_account(OLD_AUTHORITY, true);
+    let replacement = unchecked_account(NEW_AUTHORITY);
+    let mut input = build_dispatch_input(&[&vault, &current, &replacement]);
+    let ix_buf = build_rotate_ix_data();
+
+    let result =
+        unsafe { crate::__anchor_dispatch(input.as_mut_ptr() as *mut u8, ix_buf.as_ptr().add(8)) };
+
+    assert_eq!(
+        result, 0,
+        "generated dispatch must run updates before the user handler observes accounts"
+    );
+    assert_eq!(
+        read_vault_authority_from_dispatch_input(&input),
+        NEW_AUTHORITY,
+        "generated dispatch must persist update-phase mutations when exit_accounts runs"
+    );
 }

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -140,14 +140,20 @@ fn read_vault_authority_from_dispatch_input(input: &[u64]) -> [u8; 32] {
     }
 }
 
-fn build_rotate_ix_data() -> Vec<u8> {
+fn build_rotate_ix_data() -> Vec<u64> {
     let ix = crate::instruction::Rotate {};
     let data = <crate::instruction::Rotate as anchor_lang_v2::InstructionData>::data(&ix);
-    let mut buf = Vec::with_capacity(size_of::<u64>() + data.len() + 32);
-    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
-    buf.extend_from_slice(&data);
-    buf.extend_from_slice(&crate::ID.to_bytes());
-    buf
+    let byte_len = size_of::<u64>() + data.len() + 32;
+    let mut bytes = Vec::with_capacity(byte_len);
+    bytes.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&data);
+    bytes.extend_from_slice(&crate::ID.to_bytes());
+
+    let mut backing = vec![0u64; bytes.len().div_ceil(8)];
+    unsafe {
+        ptr::copy_nonoverlapping(bytes.as_ptr(), backing.as_mut_ptr() as *mut u8, bytes.len());
+    }
+    backing
 }
 
 #[test]
@@ -222,8 +228,12 @@ fn generated_dispatch_runs_update_phase_before_user_handler() {
     let mut input = build_dispatch_input(&[&vault, &current, &replacement]);
     let ix_buf = build_rotate_ix_data();
 
-    let result =
-        unsafe { crate::__anchor_dispatch(input.as_mut_ptr() as *mut u8, ix_buf.as_ptr().add(8)) };
+    let result = unsafe {
+        crate::__anchor_dispatch(
+            input.as_mut_ptr() as *mut u8,
+            ix_buf.as_ptr().cast::<u8>().add(8),
+        )
+    };
 
     assert_eq!(
         result, 0,

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -1,0 +1,130 @@
+use {
+    anchor_lang_v2::{
+        accounts::{BorshAccount, Signer, UncheckedAccount},
+        testing::AccountBuffer,
+        wincode::{SchemaRead, SchemaWrite},
+        AccountConstraint, Accounts, AnchorAccount, Discriminator, ErrorCode, Owner, TryAccounts,
+    },
+    pinocchio::address::Address,
+    solana_program_error::ProgramError,
+};
+
+const PROGRAM_ID: [u8; 32] = [0x42; 32];
+const OLD_AUTHORITY: [u8; 32] = [0x10; 32];
+const NEW_AUTHORITY: [u8; 32] = [0x20; 32];
+
+#[derive(SchemaRead, SchemaWrite, Clone, Copy)]
+struct Vault {
+    current_authority: Address,
+}
+
+impl Owner for Vault {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for Vault {
+    const DISCRIMINATOR: &'static [u8] = &[0x41, 0x75, 0x74, 0x68, 0x56, 0x61, 0x75, 0x6c];
+}
+
+mod role {
+    use super::*;
+
+    pub struct SetAuthorityConstraint;
+
+    impl AccountConstraint<BorshAccount<Vault>> for SetAuthorityConstraint {
+        type Value = pinocchio::account::AccountView;
+
+        fn update(
+            account: &mut BorshAccount<Vault>,
+            new_authority: &Self::Value,
+        ) -> Result<(), ProgramError> {
+            account.current_authority = *new_authority.address();
+            Ok(())
+        }
+    }
+}
+
+#[derive(Accounts)]
+struct RotateAuthority {
+    #[account(mut, has_one = current_authority, update(role::set_authority = new_authority))]
+    vault: BorshAccount<Vault>,
+    current_authority: Signer,
+    new_authority: UncheckedAccount,
+}
+
+fn expect_err<T>(result: Result<T, ProgramError>) -> ProgramError {
+    match result {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(err) => err,
+    }
+}
+
+fn vault_account(authority: [u8; 32]) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    let mut data = [0u8; 40];
+    data[..8].copy_from_slice(Vault::DISCRIMINATOR);
+    data[8..40].copy_from_slice(&authority);
+    buf.init([0xAA; 32], PROGRAM_ID, data.len(), false, true, false);
+    buf.write_data(&data);
+    buf
+}
+
+fn signer_account(address: [u8; 32], signer: bool) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    buf.init(address, PROGRAM_ID, 0, signer, false, false);
+    buf
+}
+
+fn unchecked_account(address: [u8; 32]) -> AccountBuffer<128> {
+    let buf = AccountBuffer::<128>::new();
+    buf.init(address, PROGRAM_ID, 0, false, false, false);
+    buf
+}
+
+fn read_vault_authority(buf: &AccountBuffer<128>) -> [u8; 32] {
+    let data = buf.read_data();
+    data[8..40].try_into().unwrap()
+}
+
+#[test]
+fn try_accounts_checks_authority_before_running_updates() {
+    let vault = vault_account(OLD_AUTHORITY);
+    let current = signer_account(NEW_AUTHORITY, true);
+    let replacement = unchecked_account(NEW_AUTHORITY);
+    let views = [unsafe { vault.view() }, unsafe { current.view() }, unsafe {
+        replacement.view()
+    }];
+
+    let err = expect_err(RotateAuthority::try_accounts(
+        &Address::new_from_array(PROGRAM_ID),
+        &views,
+        None,
+        0,
+        &[],
+    ));
+
+    assert_eq!(err, ErrorCode::ConstraintHasOne.into());
+    assert_eq!(read_vault_authority(&vault), OLD_AUTHORITY);
+}
+
+#[test]
+fn update_accounts_runs_after_validation_and_persists_on_exit() {
+    let vault = vault_account(OLD_AUTHORITY);
+    let current = signer_account(OLD_AUTHORITY, true);
+    let replacement = unchecked_account(NEW_AUTHORITY);
+    let views = [unsafe { vault.view() }, unsafe { current.view() }, unsafe {
+        replacement.view()
+    }];
+
+    let (mut accounts, _, _) =
+        RotateAuthority::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
+            .expect("authority check should pass before updates");
+
+    assert_eq!(accounts.vault.current_authority.to_bytes(), OLD_AUTHORITY);
+
+    accounts.update_accounts().unwrap();
+    assert_eq!(accounts.vault.current_authority.to_bytes(), NEW_AUTHORITY);
+
+    accounts.exit_accounts().unwrap();
+    assert_eq!(read_vault_authority(&vault), NEW_AUTHORITY);
+}

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -116,9 +116,14 @@ fn update_accounts_runs_after_validation_and_persists_on_exit() {
         replacement.view()
     }];
 
-    let (mut accounts, _, _) =
-        RotateAuthority::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
-            .expect("authority check should pass before updates");
+    let (mut accounts, _, _) = <RotateAuthority as TryAccounts>::validate_accounts(
+        &Address::new_from_array(PROGRAM_ID),
+        &views,
+        None,
+        0,
+        &[],
+    )
+    .expect("authority check should pass before updates");
 
     assert_eq!(accounts.vault.current_authority.to_bytes(), OLD_AUTHORITY);
 
@@ -127,4 +132,20 @@ fn update_accounts_runs_after_validation_and_persists_on_exit() {
 
     accounts.exit_accounts().unwrap();
     assert_eq!(read_vault_authority(&vault), NEW_AUTHORITY);
+}
+
+#[test]
+fn try_accounts_still_runs_updates_for_direct_callers() {
+    let vault = vault_account(OLD_AUTHORITY);
+    let current = signer_account(OLD_AUTHORITY, true);
+    let replacement = unchecked_account(NEW_AUTHORITY);
+    let views = [unsafe { vault.view() }, unsafe { current.view() }, unsafe {
+        replacement.view()
+    }];
+
+    let (accounts, _, _) =
+        RotateAuthority::try_accounts(&Address::new_from_array(PROGRAM_ID), &views, None, 0, &[])
+            .expect("direct callers should still receive updated accounts");
+
+    assert_eq!(accounts.vault.current_authority.to_bytes(), NEW_AUTHORITY);
 }

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, deprecated, unexpected_cfgs)]
+
 use {
     anchor_lang_v2::{
         accounts::{BorshAccount, Signer, UncheckedAccount},
@@ -268,7 +270,7 @@ fn update_accounts_runs_after_validation_and_persists_on_exit() {
     accounts.update_accounts().unwrap();
     assert_eq!(accounts.vault.current_authority.to_bytes(), NEW_AUTHORITY);
 
-    accounts.exit_accounts().unwrap();
+    accounts.exit_accounts(&[]).unwrap();
     assert_eq!(read_vault_authority(&vault), NEW_AUTHORITY);
 }
 
@@ -356,6 +358,6 @@ fn nested_try_accounts_runs_inner_updates_once() {
         "nested update hooks should run exactly once"
     );
 
-    accounts.exit_accounts().unwrap();
+    accounts.exit_accounts(&[]).unwrap();
     assert_eq!(read_counter_value(&counter), 1);
 }


### PR DESCRIPTION
## Finding
`AccountConstraint::update` hooks ran during account parsing in field order, before later account validations and authorization checks. An earlier update could therefore modify state that a later check relied on.

## Fix
This PR moves update hooks out of account parsing and into a dedicated post-validation phase, so later checks observe the original on-chain state instead of partially mutated parser state. It also adds regression tests covering both later field checks and handler-level authorization guard paths.
