### PR TITLE
Fix/v2 token record deserialize cursor

### DIFF
--- a/spl-v2/src/metadata.rs
+++ b/spl-v2/src/metadata.rs
@@ -827,17 +827,42 @@ pub struct TokenRecordAccount {
 
 impl TokenRecordAccount {
     pub const LEN: usize = mpl_token_metadata::accounts::TokenRecord::LEN;
+    const LEGACY_LEN: usize = Self::LEN - 33;
 
     #[inline]
     fn parse(data: &[u8]) -> Result<mpl_token_metadata::accounts::TokenRecord> {
         mpl_token_metadata::accounts::TokenRecord::safe_deserialize(data)
             .map_err(|_| ProgramError::InvalidAccountData)
     }
+
+    #[inline]
+    fn parse_prefix(data: &[u8]) -> Result<(mpl_token_metadata::accounts::TokenRecord, usize)> {
+        // Token records exist in both the current fixed-size layout and an
+        // older shorter layout without the `locked_transfer` tail. Client-side
+        // `AccountDeserialize` must consume exactly one record and leave any
+        // following bytes untouched, so decode the first valid token-record
+        // prefix and report its consumed length.
+        if data.len() >= Self::LEN {
+            let prefix = &data[..Self::LEN];
+            if let Ok(record) = Self::parse(prefix) {
+                return Ok((record, Self::LEN));
+            }
+        }
+
+        if data.len() < Self::LEGACY_LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let prefix = &data[..Self::LEGACY_LEN];
+        let record = Self::parse(prefix)?;
+        Ok((record, Self::LEGACY_LEN))
+    }
 }
 
 impl AccountDeserialize for TokenRecordAccount {
     fn try_deserialize(buf: &mut &[u8]) -> Result<Self> {
-        let data = Self::parse(buf)?;
+        let (data, consumed) = Self::parse_prefix(buf)?;
+        *buf = &buf[consumed..];
         Ok(Self { view: None, data })
     }
 

--- a/spl-v2/tests/metadata.rs
+++ b/spl-v2/tests/metadata.rs
@@ -2,9 +2,8 @@
 
 use {
     anchor_lang_v2::{testing::AccountBuffer, AccountDeserialize, AnchorAccount},
-    anchor_spl_v2::metadata::{self, MetadataAccount},
+    anchor_spl_v2::metadata::{self, MetadataAccount, TokenRecordAccount},
     borsh::to_vec,
-    solana_address::Address,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
 };
@@ -33,6 +32,30 @@ fn sample_metadata() -> mpl_token_metadata::accounts::Metadata {
         collection_details: None,
         programmable_config: None,
     }
+}
+
+fn sample_token_record() -> mpl_token_metadata::accounts::TokenRecord {
+    mpl_token_metadata::accounts::TokenRecord {
+        key: mpl_token_metadata::types::Key::TokenRecord,
+        bump: 7,
+        state: mpl_token_metadata::types::TokenState::Unlocked,
+        rule_set_revision: Some(9),
+        delegate: Some(Pubkey::from([3u8; 32])),
+        delegate_role: Some(mpl_token_metadata::types::TokenDelegateRole::Transfer),
+        locked_transfer: Some(Pubkey::from([4u8; 32])),
+    }
+}
+
+fn sample_legacy_token_record_bytes() -> Vec<u8> {
+    let record = sample_token_record();
+    let mut data = Vec::new();
+    data.extend_from_slice(&to_vec(&record.key).unwrap());
+    data.extend_from_slice(&to_vec(&record.bump).unwrap());
+    data.extend_from_slice(&to_vec(&record.state).unwrap());
+    data.extend_from_slice(&to_vec(&record.rule_set_revision).unwrap());
+    data.extend_from_slice(&to_vec(&record.delegate).unwrap());
+    data.extend_from_slice(&to_vec(&record.delegate_role).unwrap());
+    data
 }
 
 #[test]
@@ -72,7 +95,7 @@ fn metadata_account_load_validates_owner_and_raw_data() {
     );
     account.write_data(&data);
 
-    let loaded = MetadataAccount::load(unsafe { account.view() }, &Address::default()).unwrap();
+    let loaded = MetadataAccount::load(unsafe { account.view() }).unwrap();
     assert_eq!(loaded.update_authority, expected.update_authority);
     assert_eq!(loaded.seller_fee_basis_points, 250);
 }
@@ -84,7 +107,7 @@ fn metadata_account_rejects_wrong_owner() {
     account.init([9u8; 32], [3u8; 32], data.len(), false, false, false);
     account.write_data(&data);
 
-    let err = MetadataAccount::load(unsafe { account.view() }, &Address::default()).unwrap_err();
+    let err = MetadataAccount::load(unsafe { account.view() }).unwrap_err();
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
@@ -95,4 +118,34 @@ fn metadata_account_rejects_non_metadata_key_without_anchor_discriminator() {
 
     let err = MetadataAccount::try_deserialize(&mut data.as_slice()).unwrap_err();
     assert_eq!(err, ProgramError::InvalidAccountData);
+}
+
+#[test]
+fn token_record_account_deserialize_consumes_full_prefix_with_trailing_bytes() {
+    let mut data = to_vec(&sample_token_record()).unwrap();
+    let trailing = [0xAA, 0xBB, 0xCC];
+    data.extend_from_slice(&trailing);
+
+    let mut cursor = data.as_slice();
+    let account = TokenRecordAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.key, mpl_token_metadata::types::Key::TokenRecord);
+    assert_eq!(account.bump, 7);
+    assert_eq!(account.locked_transfer, Some(Pubkey::from([4u8; 32])));
+    assert_eq!(cursor, trailing.as_slice());
+}
+
+#[test]
+fn token_record_account_deserialize_consumes_legacy_prefix_with_trailing_bytes() {
+    let mut data = sample_legacy_token_record_bytes();
+    let trailing = [0xFF, 0xEE, 0xDD];
+    data.extend_from_slice(&trailing);
+
+    let mut cursor = data.as_slice();
+    let account = TokenRecordAccount::try_deserialize(&mut cursor).unwrap();
+
+    assert_eq!(account.key, mpl_token_metadata::types::Key::TokenRecord);
+    assert_eq!(account.bump, 7);
+    assert_eq!(account.locked_transfer, None);
+    assert_eq!(cursor, trailing.as_slice());
 }


### PR DESCRIPTION
`TokenRecordAccount::try_deserialize` never advances `*buf,` and upstream `TokenRecord::safe_deserialize` rejects trailing bytes. conflicting with lang-v2’s documented `AccountDeserialize` cursor contract for chained decoding. so Im updating `TokenRecordAccount` so  `TokenRecordAccount::try_deserialize` consumes a token-record prefix and advances the shared cursor instead of parsing the entire remaining slice.