### PR TITLE
Fix/v2 pda seed limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "quote",
  "serde_json",
  "sha2 0.10.9",
+ "solana-address 2.6.0",
  "syn 2.0.117",
 ]
 

--- a/lang-v2/derive/Cargo.toml
+++ b/lang-v2/derive/Cargo.toml
@@ -20,4 +20,5 @@ sha2 = "0.10"
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
 bs58 = "0.5"
 serde_json = "1"
+solana-address = "2.0"
 anchor-lang-idl = { path = "../../idl", version = "0.1.2", features = ["convert"] }

--- a/lang-v2/derive/src/pda.rs
+++ b/lang-v2/derive/src/pda.rs
@@ -232,4 +232,26 @@ mod tests {
         assert!(seeds_as_byte_literals(&refs).is_none());
     }
 
+    #[test]
+    fn precompute_pda_rejects_more_than_fifteen_user_seeds() {
+        let program_id = [3u8; 32];
+        let seeds = vec![b"x".as_ref(); MAX_PDA_SEEDS_TOTAL];
+
+        assert!(
+            precompute_pda(&seeds, &program_id).is_none(),
+            "precompute_pda must mirror runtime finder limits and reserve one slot for the bump"
+        );
+    }
+
+    #[test]
+    fn precompute_pda_rejects_seed_longer_than_thirty_two_bytes() {
+        let program_id = [4u8; 32];
+        let long_seed = [7u8; MAX_PDA_SEED_LEN + 1];
+
+        assert!(
+            precompute_pda(&[&long_seed], &program_id).is_none(),
+            "precompute_pda must reject literal seeds that runtime PDA derivation would reject"
+        );
+    }
+
 }

--- a/lang-v2/derive/src/pda.rs
+++ b/lang-v2/derive/src/pda.rs
@@ -17,6 +17,9 @@ use {
 };
 
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
+const MAX_PDA_SEEDS_TOTAL: usize = 16;
+const MAX_PDA_SEED_LEN: usize = 32;
+const MAX_PDA_SEEDS_WITHOUT_BUMP: usize = MAX_PDA_SEEDS_TOTAL - 1;
 
 thread_local! {
     /// `None`   = not yet attempted.
@@ -145,6 +148,12 @@ pub(crate) fn seeds_as_byte_literals(seeds: &[&syn::Expr]) -> Option<Vec<Vec<u8>
 pub(crate) fn precompute_pda(seeds: &[&[u8]], program_id: &[u8; 32]) -> Option<(u8, [u8; 32])> {
     use curve25519_dalek::edwards::CompressedEdwardsY;
 
+    if seeds.len() > MAX_PDA_SEEDS_WITHOUT_BUMP
+        || seeds.iter().any(|seed| seed.len() > MAX_PDA_SEED_LEN)
+    {
+        return None;
+    }
+
     let mut bump: i32 = u8::MAX as i32;
     while bump >= 0 {
         let mut hasher = Sha256::new();
@@ -222,4 +231,5 @@ mod tests {
         let refs: Vec<&syn::Expr> = seeds.iter().collect();
         assert!(seeds_as_byte_literals(&refs).is_none());
     }
+
 }

--- a/lang-v2/derive/src/pda.rs
+++ b/lang-v2/derive/src/pda.rs
@@ -21,6 +21,11 @@ const MAX_PDA_SEEDS_TOTAL: usize = 16;
 const MAX_PDA_SEED_LEN: usize = 32;
 const MAX_PDA_SEEDS_WITHOUT_BUMP: usize = MAX_PDA_SEEDS_TOTAL - 1;
 
+const _: () = {
+    assert!(MAX_PDA_SEEDS_TOTAL == solana_address::MAX_SEEDS);
+    assert!(MAX_PDA_SEED_LEN == solana_address::MAX_SEED_LEN);
+};
+
 thread_local! {
     /// `None`   = not yet attempted.
     /// `Some(x)` = attempted once; `x` is the discovery result.
@@ -253,5 +258,4 @@ mod tests {
             "precompute_pda must reject literal seeds that runtime PDA derivation would reject"
         );
     }
-
 }

--- a/lang-v2/derive/src/pda.rs
+++ b/lang-v2/derive/src/pda.rs
@@ -17,14 +17,9 @@ use {
 };
 
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
-const MAX_PDA_SEEDS_TOTAL: usize = 16;
-const MAX_PDA_SEED_LEN: usize = 32;
+const MAX_PDA_SEEDS_TOTAL: usize = solana_address::MAX_SEEDS;
+const MAX_PDA_SEED_LEN: usize =  solana_address::MAX_SEED_LEN;
 const MAX_PDA_SEEDS_WITHOUT_BUMP: usize = MAX_PDA_SEEDS_TOTAL - 1;
-
-const _: () = {
-    assert!(MAX_PDA_SEEDS_TOTAL == solana_address::MAX_SEEDS);
-    assert!(MAX_PDA_SEED_LEN == solana_address::MAX_SEED_LEN);
-};
 
 thread_local! {
     /// `None`   = not yet attempted.

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -24,6 +24,13 @@ const SYSTEM_TRANSFER_VARIANT: u8 = 2;
 // the same constant).
 const _: () = assert!(SYSTEM_TRANSFER_VARIANT == 2);
 
+/// Solana PDA derivation accepts at most 16 total seeds, each no longer than
+/// 32 bytes. Finder APIs append the bump as an extra seed, so callers may only
+/// provide 15 seed slices on those paths.
+const MAX_PDA_SEEDS_TOTAL: usize = solana_address::MAX_SEEDS;
+const MAX_PDA_SEED_LEN: usize = solana_address::MAX_SEED_LEN;
+const MAX_PDA_SEEDS_WITHOUT_BUMP: usize = MAX_PDA_SEEDS_TOTAL - 1;
+
 /// Encode a System program `Transfer` instruction body.
 ///
 /// Extracted as a pure helper so the Kani harness in this module can verify
@@ -36,6 +43,14 @@ fn encode_system_transfer(lamports: u64) -> [u8; 12] {
     data[0] = SYSTEM_TRANSFER_VARIANT;
     data[4..12].copy_from_slice(&lamports.to_le_bytes());
     data
+}
+
+#[inline(always)]
+fn validate_pda_seeds(seeds: &[&[u8]], max_seed_count: usize) -> Result<(), ProgramError> {
+    if seeds.len() > max_seed_count || seeds.iter().any(|seed| seed.len() > MAX_PDA_SEED_LEN) {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    Ok(())
 }
 
 /// Transfer lamports via the System program without consulting Pinocchio's
@@ -164,9 +179,7 @@ pub fn try_find_program_address(
     seeds: &[&[u8]],
     program_id: &Address,
 ) -> Result<(Address, u8), ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_WITHOUT_BUMP)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -189,9 +202,7 @@ pub fn find_and_verify_program_address(
     program_id: &Address,
     expected: &Address,
 ) -> Result<u8, ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_WITHOUT_BUMP)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -226,6 +237,8 @@ pub fn create_program_address(
     seeds: &[&[u8]],
     program_id: &Address,
 ) -> Result<Address, ProgramError> {
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;
+
     #[cfg(target_os = "solana")]
     {
         let computed = hash_pda_seeds(seeds, program_id)?;
@@ -250,12 +263,27 @@ pub fn verify_program_address(
     program_id: &Address,
     expected: &Address,
 ) -> Result<(), ProgramError> {
-    let computed =
-        create_program_address(seeds, program_id).map_err(|_| ProgramError::InvalidSeeds)?;
-    if pinocchio::address::address_eq(&computed, expected) {
-        Ok(())
-    } else {
-        Err(ProgramError::InvalidSeeds)
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;
+
+    #[cfg(target_os = "solana")]
+    {
+        let computed = hash_pda_seeds(seeds, program_id)?;
+        if pinocchio::address::address_eq(&computed, expected) {
+            Ok(())
+        } else {
+            Err(ProgramError::InvalidSeeds)
+        }
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        let computed = Address::create_program_address(seeds, program_id)
+            .map_err(|_| ProgramError::InvalidSeeds)?;
+        if pinocchio::address::address_eq(&computed, expected) {
+            Ok(())
+        } else {
+            Err(ProgramError::InvalidSeeds)
+        }
     }
 }
 
@@ -272,9 +300,7 @@ pub fn find_and_verify_program_address_skip_curve(
     program_id: &Address,
     expected: &Address,
 ) -> Result<u8, ProgramError> {
-    if seeds.len() > 16 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_WITHOUT_BUMP)?;
 
     #[cfg(target_os = "solana")]
     {
@@ -361,9 +387,7 @@ fn hash_pda_seeds(seeds: &[&[u8]], program_id: &Address) -> Result<Address, Prog
     use solana_define_syscall::definitions::sol_sha256;
     const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
-    if seeds.len() > 17 {
-        return Err(ProgramError::InvalidSeeds);
-    }
+    validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;
 
     let n = seeds.len();
     let mut slices = core::mem::MaybeUninit::<[&[u8]; 19]>::uninit();

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -48,7 +48,7 @@ fn encode_system_transfer(lamports: u64) -> [u8; 12] {
 #[inline(always)]
 fn validate_pda_seeds(seeds: &[&[u8]], max_seed_count: usize) -> Result<(), ProgramError> {
     if seeds.len() > max_seed_count || seeds.iter().any(|seed| seed.len() > MAX_PDA_SEED_LEN) {
-        return Err(ProgramError::InvalidSeeds);
+        return Err(ProgramError::MaxSeedLengthExceeded);
     }
     Ok(())
 }

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -417,6 +417,69 @@ fn hash_pda_seeds(seeds: &[&[u8]], program_id: &Address) -> Result<Address, Prog
     Ok(Address::new_from_array(unsafe { hash.assume_init() }))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn program_id() -> Address {
+        Address::new_from_array([7; 32])
+    }
+
+    #[test]
+    fn finder_paths_reject_more_than_fifteen_user_seeds() {
+        let program_id = program_id();
+        let seeds = vec![b"x".as_ref(); MAX_PDA_SEEDS_TOTAL];
+
+        let err = try_find_program_address(&seeds, &program_id).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+
+        let err =
+            find_and_verify_program_address(&seeds, &program_id, &Address::new_from_array([0; 32]))
+                .unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+
+        let err = find_and_verify_program_address_skip_curve(
+            &seeds,
+            &program_id,
+            &Address::new_from_array([0; 32]),
+        )
+        .unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+    }
+
+    #[test]
+    fn explicit_bump_paths_reject_more_than_sixteen_total_seeds() {
+        let program_id = program_id();
+        let seeds = vec![b"x".as_ref(); MAX_PDA_SEEDS_TOTAL + 1];
+
+        let err = create_program_address(&seeds, &program_id).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+
+        let err = verify_program_address(&seeds, &program_id, &Address::new_from_array([0; 32]))
+            .unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+    }
+
+    #[test]
+    fn pda_helpers_reject_seed_longer_than_thirty_two_bytes() {
+        let program_id = program_id();
+        let long_seed = [9u8; MAX_PDA_SEED_LEN + 1];
+        let explicit = [&long_seed[..]];
+        let finder = [&long_seed[..]];
+
+        let err = create_program_address(&explicit, &program_id).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+
+        let err = verify_program_address(&explicit, &program_id, &Address::new_from_array([0; 32]))
+            .unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+
+        let err = try_find_program_address(&finder, &program_id).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidSeeds);
+    }
+}
+
 /// Create a new account via system program CPI (no PDA signing).
 #[inline(always)]
 fn signer_from_seeds<'a>(seeds: &'a [&'a [u8]]) -> pinocchio::cpi::Signer<'a, 'a> {

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -432,12 +432,12 @@ mod tests {
         let seeds = vec![b"x".as_ref(); MAX_PDA_SEEDS_TOTAL];
 
         let err = try_find_program_address(&seeds, &program_id).unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
 
         let err =
             find_and_verify_program_address(&seeds, &program_id, &Address::new_from_array([0; 32]))
                 .unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
 
         let err = find_and_verify_program_address_skip_curve(
             &seeds,
@@ -445,7 +445,7 @@ mod tests {
             &Address::new_from_array([0; 32]),
         )
         .unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
     }
 
     #[test]
@@ -454,11 +454,11 @@ mod tests {
         let seeds = vec![b"x".as_ref(); MAX_PDA_SEEDS_TOTAL + 1];
 
         let err = create_program_address(&seeds, &program_id).unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
 
         let err = verify_program_address(&seeds, &program_id, &Address::new_from_array([0; 32]))
             .unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
     }
 
     #[test]
@@ -469,14 +469,14 @@ mod tests {
         let finder = [&long_seed[..]];
 
         let err = create_program_address(&explicit, &program_id).unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
 
         let err = verify_program_address(&explicit, &program_id, &Address::new_from_array([0; 32]))
             .unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
 
         let err = try_find_program_address(&finder, &program_id).unwrap_err();
-        assert_eq!(err, ProgramError::InvalidSeeds);
+        assert_eq!(err, ProgramError::MaxSeedLengthExceeded);
     }
 }
 

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -265,25 +265,12 @@ pub fn verify_program_address(
 ) -> Result<(), ProgramError> {
     validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;
 
-    #[cfg(target_os = "solana")]
-    {
-        let computed = hash_pda_seeds(seeds, program_id)?;
-        if pinocchio::address::address_eq(&computed, expected) {
-            Ok(())
-        } else {
-            Err(ProgramError::InvalidSeeds)
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    {
-        let computed = Address::create_program_address(seeds, program_id)
-            .map_err(|_| ProgramError::InvalidSeeds)?;
-        if pinocchio::address::address_eq(&computed, expected) {
-            Ok(())
-        } else {
-            Err(ProgramError::InvalidSeeds)
-        }
+    let computed =
+        create_program_address(seeds, program_id).map_err(|_| ProgramError::InvalidSeeds)?;
+    if pinocchio::address::address_eq(&computed, expected) {
+        Ok(())
+    } else {
+        Err(ProgramError::InvalidSeeds)
     }
 }
 


### PR DESCRIPTION
#### Finding
`lang-v2` PDA helpers accepted seed counts and seed lengths that were looser than Solana runtime limits. That could allow derivations that compile locally but fail once the runtime enforces the real bounds.

#### Fix
This PR enforces the runtime PDA limits across the helper surface: each seed is capped at 32 bytes and total seed counts now match Solana’s limits, including bump-aware paths. It also adds boundary tests covering accepted maximum sizes and rejected oversized or overcounted seeds.

replaces https://github.com/otter-sec/anchor/pull/4813
