### PR TITLE
fix(v2): point IDL arg-struct diagnostic at #[derive(IdlType)]

### DIFF
--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -78,7 +78,24 @@ jobs:
 
       # Match `tests-v2/src/lib.rs::build_program`. Pre-install so concurrent
       # `cargo build-sbf` invocations don't race on the platform-tools rename.
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      # Cache platform-tools so the matrix cells don't each re-download it via
+      # the GitHub releases API (unauthenticated, so shared runner IPs get
+      # rate-limited and the install dies with "Failed to parse Github
+      # response"); retry the cold-cache install for the same reason.
+      - uses: actions/cache@v4
+        name: Cache SBF platform tools
+        with:
+          path: ~/.cache/solana/v1.52/platform-tools
+          key: solana-platform-tools-${{ runner.os }}-v1.52
+      - uses: nick-fields/retry@v2
+        name: Install SBF platform tools
+        with:
+          retry_wait_seconds: 60
+          timeout_minutes: 10
+          max_attempts: 5
+          retry_on: error
+          shell: bash
+          command: cargo build-sbf --tools-version v1.52 --install-only
 
       # Cache the generated project's `target/` so subsequent runs reuse
       # compiled deps. Restored before `anchor init` (which is invoked with
@@ -179,7 +196,22 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cargo build-sbf --tools-version v1.52 --install-only
+      # Cache + retry for the same GitHub releases API rate-limit flake as in
+      # `template-rust-tests` above.
+      - uses: actions/cache@v4
+        name: Cache SBF platform tools
+        with:
+          path: ~/.cache/solana/v1.52/platform-tools
+          key: solana-platform-tools-${{ runner.os }}-v1.52
+      - uses: nick-fields/retry@v2
+        name: Install SBF platform tools
+        with:
+          retry_wait_seconds: 60
+          timeout_minutes: 10
+          max_attempts: 5
+          retry_on: error
+          shell: bash
+          command: cargo build-sbf --tools-version v1.52 --install-only
 
       # Cache cargo `target/` and `node_modules/` for the generated project.
       # `anchor init --force` leaves both alone, so the dirs survive a fresh

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2110,6 +2110,12 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// but has no corresponding entry in `types[]` — TS clients then fail to
 /// decode the nested field.
 ///
+/// The same applies to custom structs passed as `#[program]` instruction
+/// arguments: the IDL build resolves every arg type through
+/// `IdlAccountType`, so a plain args struct (typically deriving
+/// `wincode::SchemaRead` / `wincode::SchemaWrite` for the wire format)
+/// additionally needs this derive or `anchor idl build` fails to compile.
+///
 /// Unlike `#[account]`, this derive carries **none** of the account-kind
 /// baggage: no discriminator, no `Owner`, no `Discriminator` trait, no
 /// forced `#[repr(C)]`, no Pod/Zeroable derives. It only emits the
@@ -2138,6 +2144,22 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     Spot,
 ///     Futures(u64),
 ///     Margin { leverage: u8, symbol: [u8; 8] },
+/// }
+///
+/// // Custom instruction-argument struct.
+/// #[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+/// pub struct MyArgs {
+///     pub amount: u64,
+///     pub tag: [u8; 3],
+/// }
+///
+/// #[program]
+/// pub mod my_program {
+///     use super::*;
+///     pub fn defined_args(ctx: &mut Context<SetValue>, args: MyArgs) -> Result<()> {
+///         /* ... */
+///         Ok(())
+///     }
 /// }
 /// ```
 #[proc_macro_derive(IdlType)]

--- a/lang-v2/src/idl_build.rs
+++ b/lang-v2/src/idl_build.rs
@@ -35,7 +35,10 @@ extern crate alloc;
 /// pushes its own pair of strings, then recurses into field types so a
 /// nested `#[derive(IdlType)] struct Inner` referenced from an `#[account]`
 /// data type lands in `types[]` too.
-#[diagnostic::on_unimplemented(message = "Ensure that `{Self}` has an `#[account]` attribute")]
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` has no IDL type information",
+    note = "plain structs used as instruction arguments or nested fields need `#[derive(IdlType)]`; account and event types get this automatically from `#[account]` / `#[event]`"
+)]
 pub trait IdlAccountType {
     /// `{"name":"X","discriminator":[…]}` for the program-level `accounts[]`.
     /// `None` for types that don't appear there (`IdlType` plain types,

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -45,6 +45,15 @@ pub struct LedgerEntry {
     pub amount: u64,
 }
 
+/// Plain instruction-argument struct — not an account, not an event. The
+/// `IdlType` derive is what lets the idl-build arg-type walk resolve it
+/// (`IdlAccountType`); without it `--features idl-build` fails to compile.
+#[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct BumpArgs {
+    pub amount: u64,
+    pub tag: [u8; 4],
+}
+
 type LedgerAccount = Slab<Ledger, LedgerEntry>;
 
 #[program]
@@ -734,6 +743,15 @@ pub mod accounts_test {
 
         ledger.checksum = ledger.as_slice().iter().map(|entry| entry.amount).sum();
         ledger.last_space = ledger.current_space() as u64;
+        Ok(())
+    }
+
+    /// Bumps the counter by a caller-provided amount passed in a plain
+    /// `#[derive(IdlType)]` struct, so the idl-build pass exercises the
+    /// instruction-arg `IdlAccountType` walk on a user-defined type.
+    #[discrim = 37]
+    pub fn bump_boxed_by(ctx: &mut Context<BumpBoxed>, args: BumpArgs) -> Result<()> {
+        ctx.accounts.counter.value = ctx.accounts.counter.value.wrapping_add(args.amount);
         Ok(())
     }
 }

--- a/tests-v2/programs/declare-program/cpi/programs/external-cpi/src/lib.rs
+++ b/tests-v2/programs/declare-program/cpi/programs/external-cpi/src/lib.rs
@@ -16,7 +16,7 @@ pub struct Store {
     pub last_tag: [u8; 3],
 }
 
-#[derive(Clone, Copy, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
 pub struct MyArgs {
     pub amount: u64,
     pub tag: [u8; 3],

--- a/tests-v2/tests/accounts.rs
+++ b/tests-v2/tests/accounts.rs
@@ -781,6 +781,38 @@ fn bump_boxed_accumulates_across_calls() {
 }
 
 #[test]
+fn bump_boxed_by_applies_amount_from_arg_struct() {
+    let (mut svm, payer) = setup();
+    let counter = do_initialize(&mut svm, &payer);
+
+    // bump_boxed_by (discrim = 37) — BumpArgs { amount, tag } serializes as
+    // amount (u64 LE) followed by the raw 4-byte tag.
+    let mut data = vec![37];
+    data.extend_from_slice(&5u64.to_le_bytes());
+    data.extend_from_slice(b"idl!");
+    let metas = vec![AccountMeta::new(counter, false)];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("bump_boxed_by should succeed");
+
+    let account = svm.get_account(&counter).expect("counter exists");
+    let value = u64::from_le_bytes(account.data[8..16].try_into().unwrap());
+    assert_eq!(value, 6, "counter starts at 1 and bumps by the arg amount");
+
+    // A second bump with u64::MAX must wrap, not panic — the handler uses
+    // wrapping_add.
+    let mut data = vec![37];
+    data.extend_from_slice(&u64::MAX.to_le_bytes());
+    data.extend_from_slice(b"idl!");
+    let metas = vec![AccountMeta::new(counter, false)];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("bump_boxed_by with u64::MAX should succeed");
+
+    let account = svm.get_account(&counter).expect("counter exists");
+    let value = u64::from_le_bytes(account.data[8..16].try_into().unwrap());
+    assert_eq!(value, 5, "6 + u64::MAX wraps to 5");
+}
+
+#[test]
 fn bump_boxed_rejects_wrong_owner() {
     let (mut svm, payer) = setup();
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -3,6 +3,10 @@ use std::{fs, path::PathBuf, process::Command};
 #[derive(Clone, Copy)]
 enum CargoMode {
     Check,
+    /// `cargo check --tests` — compiles the lib's unit-test target so
+    /// `#[cfg(all(test, feature = "idl-build"))]` codegen (the hidden
+    /// `__anchor_private_idl` module) gets type-checked.
+    CheckTests,
     Build,
 }
 
@@ -37,6 +41,11 @@ impl<'a> CompileCase<'a> {
 
     fn build(mut self) -> Self {
         self.mode = CargoMode::Build;
+        self
+    }
+
+    fn check_tests(mut self) -> Self {
+        self.mode = CargoMode::CheckTests;
         self
     }
 
@@ -78,6 +87,7 @@ wincode = {{ version = "0.5", features = ["derive"] }}
 
 [features]
 cpi = []
+idl-build = []
 
 [workspace]
 "#,
@@ -98,6 +108,7 @@ cpi = []
         let mut command = Command::new("cargo");
         match self.mode {
             CargoMode::Check => command.arg("check"),
+            CargoMode::CheckTests => command.args(["check", "--tests"]),
             CargoMode::Build => command.arg("build"),
         };
         command.args(["--offline", "--manifest-path"]);
@@ -1449,4 +1460,61 @@ pub struct Resize {
 "#,
     )
     .expect_pass();
+}
+
+// otter-sec/anchor#4850 — a plain arg struct with only the wincode schema
+// derives has no `IdlAccountType` impl, so idl-build compilation must fail
+// with a diagnostic that points at `#[derive(IdlType)]` (the old message
+// suggested `#[account]`, which drags in Pod/discriminator baggage).
+const DEFINED_ARGS_PROGRAM: &str = r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Clone, Copy, DERIVE_LIST)]
+pub struct MyArgs {
+    pub amount: u64,
+    pub tag: [u8; 3],
+}
+
+#[derive(Accounts)]
+pub struct Apply {
+    pub authority: Signer,
+}
+
+#[program]
+pub mod defined_args {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn apply(ctx: &mut Context<Apply>, args: MyArgs) -> Result<()> {
+        let _ = (ctx, args);
+        Ok(())
+    }
+}
+"#;
+
+#[test]
+fn idl_build_rejects_arg_struct_without_idl_type_derive() {
+    let source =
+        DEFINED_ARGS_PROGRAM.replace("DERIVE_LIST", "wincode::SchemaRead, wincode::SchemaWrite");
+    CompileCase::new("idl_build_arg_struct_missing_idl_type", &source)
+        .features(&["idl-build"])
+        .check_tests()
+        .expect_fail(&[
+            "`MyArgs` has no IDL type information",
+            "`#[derive(IdlType)]`",
+        ]);
+}
+
+#[test]
+fn idl_build_accepts_arg_struct_with_idl_type_derive() {
+    let source = DEFINED_ARGS_PROGRAM.replace(
+        "DERIVE_LIST",
+        "IdlType, wincode::SchemaRead, wincode::SchemaWrite",
+    );
+    CompileCase::new("idl_build_arg_struct_with_idl_type", &source)
+        .features(&["idl-build"])
+        .check_tests()
+        .expect_pass();
 }

--- a/tests-v2/tests/idl_defined_args.rs
+++ b/tests-v2/tests/idl_defined_args.rs
@@ -1,0 +1,52 @@
+//! Plain `#[derive(IdlType)]` structs used as instruction arguments must
+//! resolve through `IdlAccountType` and land in the IDL's `types[]`.
+//! Regression coverage for otter-sec/anchor#4850 — an arg struct deriving
+//! only the wincode schema traits used to fail `--features idl-build`
+//! compilation with an unsatisfied `IdlAccountType` bound.
+
+use {
+    anchor_lang_idl_spec::{IdlArrayLen, IdlDefinedFields, IdlType, IdlTypeDef, IdlTypeDefTy},
+    anchor_lang_v2::IdlAccountType,
+};
+
+#[test]
+fn plain_arg_struct_emits_type_def() {
+    let json = <accounts_test::BumpArgs as IdlAccountType>::__IDL_TYPE_DEF
+        .expect("IdlType derive should set __IDL_TYPE_DEF");
+    let type_def: IdlTypeDef = serde_json::from_str(json)
+        .unwrap_or_else(|err| panic!("failed to parse type def JSON: {err}\njson: {json}"));
+
+    assert_eq!(type_def.name, "BumpArgs");
+    let IdlTypeDefTy::Struct {
+        fields: Some(IdlDefinedFields::Named(fields)),
+    } = &type_def.ty
+    else {
+        panic!(
+            "expected named-field struct type def, got {:?}",
+            type_def.ty
+        );
+    };
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "amount");
+    assert_eq!(fields[0].ty, IdlType::U64);
+    assert_eq!(fields[1].name, "tag");
+    assert_eq!(
+        fields[1].ty,
+        IdlType::Array(Box::new(IdlType::U8), IdlArrayLen::Value(4))
+    );
+}
+
+#[test]
+fn plain_arg_struct_registers_as_type_not_account() {
+    let mut accounts: Vec<&'static str> = Vec::new();
+    let mut types: Vec<&'static str> = Vec::new();
+    <accounts_test::BumpArgs as IdlAccountType>::__register_idl_deps(&mut accounts, &mut types);
+
+    assert!(
+        accounts.is_empty(),
+        "plain IdlType structs must not appear in accounts[]"
+    );
+    assert_eq!(types.len(), 1);
+    let type_def: IdlTypeDef = serde_json::from_str(types[0]).unwrap();
+    assert_eq!(type_def.name, "BumpArgs");
+}


### PR DESCRIPTION
Fixes #4850

The E0277 you get when a custom arg struct goes through `anchor idl build` was telling people to add `#[account]`, which is the wrong fix — plain arg structs just need `#[derive(IdlType)]` (it's already in the prelude). Changed the diagnostic to say that.

Turns out the example the issue followed was also part of the problem: `external-cpi` in tests-v2 derives only the wincode schema traits on `MyArgs`, but it never gets caught because that crate ships a hand-written IDL json and has no `idl-build` feature, so the idl-build pass never compiles it. Copying it into a real project breaks exactly like the issue describes. Added the missing derive there.

Coverage so this can't silently regress:
- `accounts-test` (which CI does run with `--features idl-build`) now has an instruction taking a plain `#[derive(IdlType)]` struct, so the arg-type walk from the issue actually compiles in CI, and the emitted IDL gets `BumpArgs` in `types[]`
- two compile cases: the wincode-only struct must fail with the new message pointing at `IdlType`, and the same struct with the derive must pass (needed a small harness addition to check the cfg(test) idl module)
- a test asserting the `types[]` entry parses to the right `IdlTypeDef`

Also extended the `IdlType` rustdoc to mention instruction args, since it only talked about nested fields.