### PR TITLE
Fix/v2 cpi context borrow check

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4607,7 +4607,10 @@ fn process_handler(
                 },
             )
         } else {
-            (quote! {}, quote! {})
+            (
+                quote! { -> anchor_lang_v2::Result<()> },
+                quote! { Ok(()) },
+            )
         };
         quote! {
             #(#handler_cfg_attrs)*

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4622,7 +4622,7 @@ fn process_handler(
                     super::instruction::#ix_struct_name #ix_lt_use_local
                     as anchor_lang_v2::InstructionData
                 >::data(&__ix);
-                __ctx.invoke(&__data);
+                __ctx.invoke(&__data)?;
                 #ret_value
             }
         }
@@ -5771,7 +5771,7 @@ pub fn emit_cpi(input: TokenStream) -> TokenStream {
                 ctx.program_id,
                 __AnchorEventCpiAccounts { event_authority: __event_authority },
                 __event_authority_signers,
-            ).invoke(&__ix_data);
+            ).invoke(&__ix_data)?;
         }
     })
 }

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -465,6 +465,44 @@ fn field_offset_expr(
         })
 }
 
+fn type_uses_manual_readonly_cpi_relax(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return false;
+    };
+
+    match segment.ident.to_string().as_str() {
+        "Account" | "InterfaceAccount" | "Slab" => true,
+        "Box" => {
+            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                    return type_uses_manual_readonly_cpi_relax(inner);
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn field_needs_readonly_cpi_relax(
+    field_summaries: &[FieldSummary],
+    ident: &Ident,
+) -> syn::Result<bool> {
+    field_summaries
+        .iter()
+        .find(|summary| summary.name == *ident)
+        .map(|summary| summary.attrs.is_mut && type_uses_manual_readonly_cpi_relax(&summary.ty))
+        .ok_or_else(|| {
+            syn::Error::new(
+                ident.span(),
+                format!("missing field summary for `{ident}` in account parser"),
+            )
+        })
+}
+
 fn parse_associated_token_init(
     attrs: &AccountAttrs,
     field_names: &[String],
@@ -1335,6 +1373,14 @@ fn emit_associated_token_init_body(
     let system_program_offset = field_offset_expr(field_offsets, &system_program)?;
     let associated_token_program_offset =
         field_offset_expr(field_offsets, &associated_token_program)?;
+    let authority_needs_relax =
+        field_needs_readonly_cpi_relax(field_summaries, &associated_token.authority)?;
+    let mint_needs_relax =
+        field_needs_readonly_cpi_relax(field_summaries, &associated_token.mint)?;
+    let token_program_needs_relax =
+        field_needs_readonly_cpi_relax(field_summaries, &associated_token.token_program)?;
+    let system_program_needs_relax =
+        field_needs_readonly_cpi_relax(field_summaries, &system_program)?;
     let payer_signer_seeds = emit_payer_signer_seeds_binding(payer, field_names, field_summaries)?;
 
     Ok(quote! {
@@ -1378,10 +1424,22 @@ fn emit_associated_token_init_body(
             let __create_accounts = anchor_spl_v2::associated_token::Create {
                 payer: __payer_account.cpi_handle_mut(),
                 associated_token: __associated_token.cpi_handle_mut(),
-                authority: __authority.cpi_handle(),
-                mint: __mint.cpi_handle(),
-                system_program: __system_program.cpi_handle(),
-                token_program: __token_program.cpi_handle(),
+                authority: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
+                    __authority.account(),
+                    #authority_needs_relax,
+                ),
+                mint: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
+                    __mint.account(),
+                    #mint_needs_relax,
+                ),
+                system_program: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
+                    __system_program.account(),
+                    #system_program_needs_relax,
+                ),
+                token_program: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
+                    __token_program.account(),
+                    #token_program_needs_relax,
+                ),
             };
             match __payer_signer_seeds {
                 Some(__payer_signer) => {

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -465,36 +465,45 @@ fn field_offset_expr(
         })
 }
 
-fn type_uses_manual_readonly_cpi_relax(ty: &Type) -> bool {
+fn anchor_account_field_type(ty: &Type) -> &Type {
     let Type::Path(type_path) = ty else {
-        return false;
+        return ty;
     };
     let Some(segment) = type_path.path.segments.last() else {
-        return false;
+        return ty;
     };
 
-    match segment.ident.to_string().as_str() {
-        "Account" | "InterfaceAccount" | "Slab" => true,
-        "Box" => {
-            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                    return type_uses_manual_readonly_cpi_relax(inner);
-                }
+    if matches!(segment.ident.to_string().as_str(), "Box" | "Option") {
+        if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+            if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                return anchor_account_field_type(inner);
             }
-            false
         }
-        _ => false,
     }
+
+    ty
 }
 
-fn field_needs_readonly_cpi_relax(
+fn field_readonly_cpi_handle_expr(
     field_summaries: &[FieldSummary],
     ident: &Ident,
-) -> syn::Result<bool> {
+    view: TokenStream2,
+) -> syn::Result<TokenStream2> {
     field_summaries
         .iter()
         .find(|summary| summary.name == *ident)
-        .map(|summary| summary.attrs.is_mut && type_uses_manual_readonly_cpi_relax(&summary.ty))
+        .map(|summary| {
+            let field_ty = anchor_account_field_type(&summary.ty);
+            let is_mut = summary.attrs.is_mut;
+            quote! {
+                anchor_lang_v2::__private::readonly_cpi_handle_for_account_field(
+                    #view,
+                    #is_mut
+                        && <#field_ty as anchor_lang_v2::AnchorAccount>
+                            ::RELAX_READONLY_CPI_BORROW_FROM_MUT,
+                )
+            }
+        })
         .ok_or_else(|| {
             syn::Error::new(
                 ident.span(),
@@ -1373,14 +1382,26 @@ fn emit_associated_token_init_body(
     let system_program_offset = field_offset_expr(field_offsets, &system_program)?;
     let associated_token_program_offset =
         field_offset_expr(field_offsets, &associated_token_program)?;
-    let authority_needs_relax =
-        field_needs_readonly_cpi_relax(field_summaries, &associated_token.authority)?;
-    let mint_needs_relax =
-        field_needs_readonly_cpi_relax(field_summaries, &associated_token.mint)?;
-    let token_program_needs_relax =
-        field_needs_readonly_cpi_relax(field_summaries, &associated_token.token_program)?;
-    let system_program_needs_relax =
-        field_needs_readonly_cpi_relax(field_summaries, &system_program)?;
+    let authority_handle = field_readonly_cpi_handle_expr(
+        field_summaries,
+        &associated_token.authority,
+        quote! { __authority.account() },
+    )?;
+    let mint_handle = field_readonly_cpi_handle_expr(
+        field_summaries,
+        &associated_token.mint,
+        quote! { __mint.account() },
+    )?;
+    let token_program_handle = field_readonly_cpi_handle_expr(
+        field_summaries,
+        &associated_token.token_program,
+        quote! { __token_program.account() },
+    )?;
+    let system_program_handle = field_readonly_cpi_handle_expr(
+        field_summaries,
+        &system_program,
+        quote! { __system_program.account() },
+    )?;
     let payer_signer_seeds = emit_payer_signer_seeds_binding(payer, field_names, field_summaries)?;
 
     Ok(quote! {
@@ -1424,22 +1445,10 @@ fn emit_associated_token_init_body(
             let __create_accounts = anchor_spl_v2::associated_token::Create {
                 payer: __payer_account.cpi_handle_mut(),
                 associated_token: __associated_token.cpi_handle_mut(),
-                authority: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
-                    __authority.account(),
-                    #authority_needs_relax,
-                ),
-                mint: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
-                    __mint.account(),
-                    #mint_needs_relax,
-                ),
-                system_program: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
-                    __system_program.account(),
-                    #system_program_needs_relax,
-                ),
-                token_program: anchor_lang_v2::__private::readonly_cpi_handle_for_manual_mut_borrow(
-                    __token_program.account(),
-                    #token_program_needs_relax,
-                ),
+                authority: #authority_handle,
+                mint: #mint_handle,
+                system_program: #system_program_handle,
+                token_program: #token_program_handle,
             };
             match __payer_signer_seeds {
                 Some(__payer_signer) => {

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -222,6 +222,7 @@ where
     S: AnchorAccountSerialize<T>,
 {
     type Data = T;
+    const RELAX_READONLY_CPI_BORROW_FROM_MUT: bool = true;
     const MIN_DATA_LEN: usize = 8;
 
     fn load(view: AccountView) -> Result<Self, ProgramError> {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -762,6 +762,7 @@ where
 {
     type Data = H;
     const MIN_DATA_LEN: usize = Slab::<H, T>::MIN_DATA_LEN;
+    const RELAX_READONLY_CPI_BORROW_FROM_MUT: bool = true;
 
     #[inline(always)]
     fn load(view: AccountView) -> Result<Self, ProgramError> {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -811,6 +811,12 @@ where
     fn account(&self) -> &AccountView {
         &self.view
     }
+
+    #[inline(always)]
+    fn try_cpi_handle_mut(&mut self) -> Result<crate::CpiHandleMut<'_>, ProgramError> {
+        require!(self.account().is_writable(), ProgramError::InvalidArgument);
+        Ok(crate::CpiHandleMut::without_borrow_check(self.account()))
+    }
 }
 
 impl<H, T> crate::AccountClose for Slab<H, T>

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -813,6 +813,15 @@ where
     }
 
     #[inline(always)]
+    fn cpi_handle(&self) -> crate::CpiHandle<'_> {
+        crate::CpiHandle::readonly_with_flags(
+            self.account(),
+            !self.is_mutable,
+            self.is_mutable,
+        )
+    }
+
+    #[inline(always)]
     fn try_cpi_handle_mut(&mut self) -> Result<crate::CpiHandleMut<'_>, ProgramError> {
         require!(self.account().is_writable(), ProgramError::InvalidArgument);
         Ok(crate::CpiHandleMut::without_borrow_check(self.account()))

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -88,29 +88,12 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
             handles.push(*handle);
         }
 
-        let mut handle_index = 0;
-        for account in &instruction_accounts {
-            if !account.is_writable
-                && !account.is_signer
-                && crate::address_eq(account.address, self.program)
-            {
-                continue;
-            }
-
-            let Some(handle) = handles.get(handle_index) else {
-                return Err(ProgramError::NotEnoughAccountKeys);
-            };
-
-            if account.is_writable {
-                if handle.requires_borrow_check() {
-                    handle.account_view().check_borrow_mut()?;
-                }
-            } else if handle.requires_borrow_check() {
-                handle.account_view().check_borrow()?;
-            }
-
-            handle_index += 1;
-        }
+        crate::program::validate_instruction_accounts(
+            &instruction_accounts,
+            self.program,
+            &handles,
+            self.signer_seeds.is_empty(),
+        )?;
 
         let instruction = InstructionView {
             program_id: self.program,

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -72,9 +72,9 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     }
 
     /// Invoke the CPI with the given instruction data. Collects accounts
-    /// from [`ToCpiAccounts`], appends remaining accounts, and calls
-    /// `invoke_signed_unchecked`.
-    pub fn invoke(&self, data: &[u8]) {
+    /// from [`ToCpiAccounts`], appends remaining accounts, validates borrow
+    /// state, then calls `invoke_signed_unchecked`.
+    pub fn invoke(&self, data: &[u8]) -> ProgramResult {
         let mut instruction_accounts = self.accounts.to_instruction_accounts();
         let mut handles = self.accounts.to_cpi_handles();
 
@@ -86,6 +86,28 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
                 handle.is_signer(),
             ));
             handles.push(*handle);
+        }
+
+        let mut handle_index = 0;
+        for account in &instruction_accounts {
+            if !account.is_writable
+                && !account.is_signer
+                && crate::address_eq(account.address, self.program)
+            {
+                continue;
+            }
+
+            let Some(handle) = handles.get(handle_index) else {
+                return Err(ProgramError::NotEnoughAccountKeys);
+            };
+
+            if account.is_writable {
+                handle.account_view().check_borrow_mut()?;
+            } else {
+                handle.account_view().check_borrow()?;
+            }
+
+            handle_index += 1;
         }
 
         let instruction = InstructionView {
@@ -139,6 +161,8 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
                 &signers,
             );
         }
+
+        Ok(())
     }
 
     /// Invoke a fully built instruction using this context's CPI handles.
@@ -154,13 +178,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
 
         let mut handles = self.accounts.to_cpi_handles();
         handles.extend(self.remaining_accounts.iter().copied());
-        crate::program::validate_handles(&ix, &handles, self.signer_seeds.is_empty())?;
-
-        // SAFETY: `CpiContext` already ties every handle to a Rust borrow of
-        // the caller's typed account. The account metas have been validated
-        // above; use unchecked CPI to preserve the Slab-backed borrow-state
-        // contract during invocation.
-        unsafe { crate::program::invoke_signed_unchecked(&ix, &handles, self.signer_seeds) }
+        crate::program::invoke_signed(&ix, &handles, self.signer_seeds)
     }
 }
 

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -105,7 +105,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
                 if handle.requires_borrow_check() {
                     handle.account_view().check_borrow_mut()?;
                 }
-            } else {
+            } else if handle.requires_borrow_check() {
                 handle.account_view().check_borrow()?;
             }
 
@@ -117,6 +117,8 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
             data,
             accounts: &instruction_accounts,
         };
+
+        let _borrow_guards = crate::enter_cpi(&handles);
 
         // Convert signer seeds to pinocchio Signers.
         // SAFETY: pinocchio::cpi::Seed is repr(C) { *const u8, u64, PhantomData }
@@ -213,6 +215,8 @@ pub fn unchecked_invoke_signed_fixed<'a, const N: usize>(
         data,
         accounts: instruction_accounts,
     };
+
+    let _borrow_guards = crate::enter_cpi(handles);
 
     let mut cpi_accounts = [const { MaybeUninit::<pinocchio::cpi::CpiAccount>::uninit() }; N];
     for (handle, slot) in handles.iter().zip(cpi_accounts.iter_mut()) {

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -102,7 +102,9 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
             };
 
             if account.is_writable {
-                handle.account_view().check_borrow_mut()?;
+                if handle.requires_borrow_check() {
+                    handle.account_view().check_borrow_mut()?;
+                }
             } else {
                 handle.account_view().check_borrow()?;
             }

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -284,9 +284,25 @@ impl<T: Space, const N: usize> Space for [T; N] {
 
 #[doc(hidden)]
 pub mod __private {
+    use crate::CpiHandle;
+    use pinocchio::account::AccountView;
+
     /// Used by `#[derive(InitSpace)]` on enums to pick the largest variant size.
     pub const fn max(a: usize, b: usize) -> usize {
         [a, b][(a < b) as usize]
+    }
+
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn readonly_cpi_handle_for_manual_mut_borrow<'a>(
+        view: &'a AccountView,
+        needs_relax: bool,
+    ) -> CpiHandle<'a> {
+        if needs_relax {
+            CpiHandle::readonly_with_flags(view, false, true)
+        } else {
+            CpiHandle::readonly(view)
+        }
     }
 }
 

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -292,9 +292,8 @@ pub mod __private {
         [a, b][(a < b) as usize]
     }
 
-    #[doc(hidden)]
     #[inline(always)]
-    pub fn readonly_cpi_handle_for_manual_mut_borrow<'a>(
+    pub fn readonly_cpi_handle_for_account_field<'a>(
         view: &'a AccountView,
         needs_relax: bool,
     ) -> CpiHandle<'a> {

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -84,6 +84,7 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
         data: &instruction.data,
     };
     let signers = signers(signer_seeds);
+    let _borrow_guards = crate::enter_cpi(account_handles);
     let cpi_accounts = cpi_accounts(account_handles);
 
     // SAFETY:
@@ -155,7 +156,7 @@ fn validate_handle_borrows(
             if handle.requires_borrow_check() {
                 handle.account_view().check_borrow_mut()?;
             }
-        } else {
+        } else if handle.requires_borrow_check() {
             handle.account_view().check_borrow()?;
         }
 

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -152,7 +152,9 @@ fn validate_handle_borrows(
         };
 
         if meta.is_writable {
-            handle.account_view().check_borrow_mut()?;
+            if handle.requires_borrow_check() {
+                handle.account_view().check_borrow_mut()?;
+            }
         } else {
             handle.account_view().check_borrow()?;
         }

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use {
-    crate::{address_eq, require, CpiHandle},
+    crate::{address_eq, require, Address, CpiHandle},
     alloc::vec::Vec,
     core::{mem::MaybeUninit, slice::from_raw_parts},
     pinocchio::{
@@ -38,8 +38,13 @@ pub fn invoke_signed<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
-    validate_handles(instruction, account_handles, signer_seeds.is_empty())?;
-    validate_handle_borrows(instruction, account_handles)?;
+    let instruction_accounts = instruction_accounts(instruction);
+    validate_instruction_accounts(
+        &instruction_accounts,
+        &instruction.program_id,
+        account_handles,
+        signer_seeds.is_empty(),
+    )?;
 
     // SAFETY: Validation above proves every non-sentinel instruction account
     // has a matching handle, writable metas use writable handles, and
@@ -75,9 +80,9 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
-    let cpi_account_count = required_cpi_account_count(instruction, account_handles.len())?;
-
     let instruction_accounts = instruction_accounts(instruction);
+    let cpi_account_count =
+        required_cpi_account_count(&instruction_accounts, &instruction.program_id, account_handles)?;
     let instruction_view = InstructionView {
         program_id: &instruction.program_id,
         accounts: &instruction_accounts,
@@ -104,55 +109,22 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
     Ok(())
 }
 
-pub(crate) fn validate_handles(
-    instruction: &Instruction,
-    account_handles: &[CpiHandle<'_>],
+pub(crate) fn validate_instruction_accounts<'a>(
+    instruction_accounts: &[InstructionAccount<'a>],
+    program_id: &Address,
+    account_handles: &[CpiHandle<'a>],
     enforce_signers: bool,
 ) -> ProgramResult {
-    let mut handle_index = 0;
+    let bindings =
+        resolve_instruction_account_bindings(instruction_accounts, program_id, account_handles)?;
 
-    for meta in &instruction.accounts {
-        if is_optional_account_sentinel(instruction, meta) {
+    for (account, binding) in instruction_accounts.iter().zip(bindings) {
+        let Some(handle_index) = binding else {
             continue;
-        }
-
-        let Some(handle) = account_handles.get(handle_index) else {
-            return Err(ProgramError::NotEnoughAccountKeys);
         };
-        require!(
-            address_eq(&meta.pubkey, handle.address()),
-            ProgramError::InvalidArgument
-        );
+        let handle = &account_handles[handle_index];
 
-        if meta.is_writable {
-            require!(handle.is_writable(), ProgramError::InvalidArgument);
-        }
-        if enforce_signers && meta.is_signer {
-            require!(handle.is_signer(), ProgramError::MissingRequiredSignature);
-        }
-
-        handle_index += 1;
-    }
-
-    Ok(())
-}
-
-fn validate_handle_borrows(
-    instruction: &Instruction,
-    account_handles: &[CpiHandle<'_>],
-) -> ProgramResult {
-    let mut handle_index = 0;
-
-    for meta in &instruction.accounts {
-        if is_optional_account_sentinel(instruction, meta) {
-            continue;
-        }
-
-        let Some(handle) = account_handles.get(handle_index) else {
-            return Err(ProgramError::NotEnoughAccountKeys);
-        };
-
-        if meta.is_writable {
+        if account.is_writable {
             if handle.requires_borrow_check() {
                 handle.account_view().check_borrow_mut()?;
             }
@@ -160,32 +132,106 @@ fn validate_handle_borrows(
             handle.account_view().check_borrow()?;
         }
 
-        handle_index += 1;
+        if enforce_signers && account.is_signer {
+            require!(handle.is_signer(), ProgramError::MissingRequiredSignature);
+        }
     }
 
     Ok(())
 }
 
-fn required_cpi_account_count(
-    instruction: &Instruction,
-    handle_count: usize,
-) -> Result<usize, ProgramError> {
-    let count = instruction
-        .accounts
-        .iter()
-        .filter(|meta| !is_optional_account_sentinel(instruction, meta))
-        .count();
-
-    require!(handle_count >= count, ProgramError::NotEnoughAccountKeys);
-
-    Ok(count)
+fn is_optional_instruction_account_sentinel_candidate(
+    program_id: &Address,
+    account: &InstructionAccount<'_>,
+) -> bool {
+    !account.is_writable && !account.is_signer && address_eq(account.address, program_id)
 }
 
-fn is_optional_account_sentinel(
-    instruction: &Instruction,
-    meta: &solana_instruction::AccountMeta,
+fn required_cpi_account_count<'a>(
+    instruction_accounts: &[InstructionAccount<'a>],
+    program_id: &Address,
+    account_handles: &[CpiHandle<'a>],
+) -> Result<usize, ProgramError> {
+    Ok(
+        resolve_instruction_account_bindings(instruction_accounts, program_id, account_handles)?
+            .into_iter()
+            .flatten()
+            .count(),
+    )
+}
+
+fn resolve_instruction_account_bindings<'a>(
+    instruction_accounts: &[InstructionAccount<'a>],
+    program_id: &Address,
+    account_handles: &[CpiHandle<'a>],
+) -> Result<Vec<Option<usize>>, ProgramError> {
+    let cols = account_handles.len() + 1;
+    let rows = instruction_accounts.len() + 1;
+    let mut can_match = alloc::vec![false; rows * cols];
+
+    for handle_index in 0..=account_handles.len() {
+        can_match[(rows - 1) * cols + handle_index] = true;
+    }
+
+    for instruction_index in (0..instruction_accounts.len()).rev() {
+        let account = &instruction_accounts[instruction_index];
+        for handle_index in (0..=account_handles.len()).rev() {
+            let can_consume = handle_index < account_handles.len()
+                && instruction_account_matches_handle(account, &account_handles[handle_index])
+                && can_match[(instruction_index + 1) * cols + (handle_index + 1)];
+            let can_skip = is_optional_instruction_account_sentinel_candidate(program_id, account)
+                && can_match[(instruction_index + 1) * cols + handle_index];
+            can_match[instruction_index * cols + handle_index] = can_consume || can_skip;
+        }
+    }
+
+    require!(
+        can_match[0],
+        if account_handles.len() < minimum_required_handle_count(instruction_accounts, program_id) {
+            ProgramError::NotEnoughAccountKeys
+        } else {
+            ProgramError::InvalidArgument
+        }
+    );
+
+    let mut bindings = Vec::with_capacity(instruction_accounts.len());
+    let mut handle_index = 0;
+
+    for (instruction_index, account) in instruction_accounts.iter().enumerate() {
+        let can_consume = handle_index < account_handles.len()
+            && instruction_account_matches_handle(account, &account_handles[handle_index])
+            && can_match[(instruction_index + 1) * cols + (handle_index + 1)];
+        if can_consume {
+            bindings.push(Some(handle_index));
+            handle_index += 1;
+            continue;
+        }
+
+        let can_skip = is_optional_instruction_account_sentinel_candidate(program_id, account)
+            && can_match[(instruction_index + 1) * cols + handle_index];
+        debug_assert!(can_skip, "validated instruction-account matching must reconstruct");
+        bindings.push(None);
+    }
+
+    Ok(bindings)
+}
+
+fn minimum_required_handle_count(
+    instruction_accounts: &[InstructionAccount<'_>],
+    program_id: &Address,
+) -> usize {
+    instruction_accounts
+        .iter()
+        .filter(|account| !is_optional_instruction_account_sentinel_candidate(program_id, account))
+        .count()
+}
+
+fn instruction_account_matches_handle(
+    account: &InstructionAccount<'_>,
+    handle: &CpiHandle<'_>,
 ) -> bool {
-    !meta.is_writable && !meta.is_signer && address_eq(&meta.pubkey, &instruction.program_id)
+    address_eq(account.address, handle.address())
+        && (!account.is_writable || handle.is_writable())
 }
 
 fn instruction_accounts(instruction: &Instruction) -> Vec<InstructionAccount<'_>> {

--- a/lang-v2/src/system_program.rs
+++ b/lang-v2/src/system_program.rs
@@ -54,8 +54,7 @@ fn checked_seed(seed: &str) -> Result<&[u8], ProgramError> {
 #[inline]
 fn invoke<'a, T: ToCpiAccounts<'a>>(ctx: &CpiContext<'a, T>, data: &[u8]) -> ProgramResult {
     check_system_program(ctx.program)?;
-    ctx.invoke(data);
-    Ok(())
+    ctx.invoke(data)
 }
 
 pub fn advance_nonce_account<'a>(ctx: CpiContext<'a, AdvanceNonceAccount<'a>>) -> ProgramResult {

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -233,6 +233,15 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     /// check).
     const MIN_DATA_LEN: usize = 0;
 
+    /// Whether readonly CPI handles borrowed from a mutable wrapper need their
+    /// runtime borrow marker temporarily relaxed during CPI entry.
+    ///
+    /// Wrappers that keep an exclusive marker alive after `load_mut()` (for
+    /// example `Account<T>` / `Slab<H, T>` and `SerializedAccount<T, S>`)
+    /// override this so derive-generated readonly CPI accounts can preserve
+    /// compatibility without reopening writable aliasing.
+    const RELAX_READONLY_CPI_BORROW_FROM_MUT: bool = false;
+
     fn load(view: AccountView) -> core::result::Result<Self, ProgramError>;
 
     /// Load an account for mutable access.

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -11,8 +11,9 @@ use {
 ///
 /// Obtained via [`AnchorAccount::cpi_handle`] (shared borrow) or by erasing a
 /// [`CpiHandleMut`] produced from [`AnchorAccount::cpi_handle_mut`].
-/// Pinocchio's `borrow_state` is never modified — CPI is routed through
-/// `invoke_signed_unchecked` by [`CpiContext::invoke`].
+/// Writable handles participate in raw `AccountView` borrow validation before
+/// CPI by default. Wrappers with their own borrow-state discipline may opt out
+/// for writable CPIs.
 ///
 /// Deliberately does NOT implement `Deref<Target = AccountView>` to
 /// prevent accidental use with pinocchio's checked invoke builders.
@@ -20,6 +21,7 @@ use {
 pub struct CpiHandle<'a> {
     view: &'a AccountView,
     writable: bool,
+    borrow_check: bool,
 }
 
 /// Typed mutable CPI handle for API-facing CPI account structs.
@@ -29,6 +31,7 @@ pub struct CpiHandle<'a> {
 #[derive(Clone, Copy)]
 pub struct CpiHandleMut<'a> {
     view: &'a AccountView,
+    borrow_check: bool,
 }
 
 impl<'a> CpiHandle<'a> {
@@ -37,14 +40,21 @@ impl<'a> CpiHandle<'a> {
         Self {
             view,
             writable: false,
+            borrow_check: true,
         }
     }
 
     #[inline(always)]
     pub fn writable(view: &'a mut AccountView) -> Self {
+        Self::writable_with_borrow_check(view, true)
+    }
+
+    #[inline(always)]
+    pub(crate) fn writable_with_borrow_check(view: &'a AccountView, borrow_check: bool) -> Self {
         Self {
             view,
             writable: true,
+            borrow_check,
         }
     }
 
@@ -78,12 +88,27 @@ impl<'a> CpiHandle<'a> {
     pub(crate) fn account_view(&self) -> &'a AccountView {
         self.view
     }
+
+    #[inline(always)]
+    pub(crate) fn requires_borrow_check(&self) -> bool {
+        self.borrow_check
+    }
 }
 
 impl<'a> CpiHandleMut<'a> {
     #[inline(always)]
     pub fn writable(view: &'a mut AccountView) -> Self {
-        Self { view }
+        Self::writable_with_borrow_check(view, true)
+    }
+
+    #[inline(always)]
+    pub(crate) fn without_borrow_check(view: &'a AccountView) -> Self {
+        Self::writable_with_borrow_check(view, false)
+    }
+
+    #[inline(always)]
+    fn writable_with_borrow_check(view: &'a AccountView, borrow_check: bool) -> Self {
+        Self { view, borrow_check }
     }
 
     /// The account's on-chain address.
@@ -111,6 +136,7 @@ impl<'a> From<CpiHandleMut<'a>> for CpiHandle<'a> {
         Self {
             view: handle.view,
             writable: true,
+            borrow_check: handle.borrow_check,
         }
     }
 }
@@ -202,10 +228,7 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     /// it is alive. The handle's `is_writable` flag is `false`.
     #[inline(always)]
     fn cpi_handle(&self) -> CpiHandle<'_> {
-        CpiHandle {
-            view: self.account(),
-            writable: false,
-        }
+        CpiHandle::readonly(self.account())
     }
 
     /// Obtain a writable CPI handle for this account.
@@ -230,9 +253,10 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
     #[inline(always)]
     fn try_cpi_handle_mut(&mut self) -> Result<CpiHandleMut<'_>, ProgramError> {
         require!(self.account().is_writable(), ProgramError::InvalidArgument);
-        Ok(CpiHandleMut {
-            view: self.account(),
-        })
+        Ok(CpiHandleMut::writable_with_borrow_check(
+            self.account(),
+            true,
+        ))
     }
 }
 

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -3,7 +3,11 @@ use pinocchio::account::{Ref, RefMut};
 use {
     crate::require,
     core::ops::Deref,
-    pinocchio::{account::AccountView, address::Address, instruction::InstructionAccount},
+    pinocchio::{
+        account::{AccountView, NOT_BORROWED},
+        address::Address,
+        instruction::InstructionAccount,
+    },
     solana_program_error::{ProgramError, ProgramResult},
 };
 
@@ -11,9 +15,9 @@ use {
 ///
 /// Obtained via [`AnchorAccount::cpi_handle`] (shared borrow) or by erasing a
 /// [`CpiHandleMut`] produced from [`AnchorAccount::cpi_handle_mut`].
-/// Writable handles participate in raw `AccountView` borrow validation before
-/// CPI by default. Wrappers with their own borrow-state discipline may opt out
-/// for writable CPIs.
+/// Handles participate in raw `AccountView` borrow validation before CPI by
+/// default. Wrappers with their own borrow-state discipline may opt out when
+/// the CPI account meta guarantees the callee cannot mutate the account.
 ///
 /// Deliberately does NOT implement `Deref<Target = AccountView>` to
 /// prevent accidental use with pinocchio's checked invoke builders.
@@ -22,6 +26,7 @@ pub struct CpiHandle<'a> {
     view: &'a AccountView,
     writable: bool,
     borrow_check: bool,
+    relax_readonly_borrow: bool,
 }
 
 /// Typed mutable CPI handle for API-facing CPI account structs.
@@ -34,13 +39,33 @@ pub struct CpiHandleMut<'a> {
     borrow_check: bool,
 }
 
+pub(crate) struct CpiBorrowGuard {
+    borrow_state: *mut u8,
+    restore_to: u8,
+}
+
 impl<'a> CpiHandle<'a> {
     #[inline(always)]
     pub fn readonly(view: &'a AccountView) -> Self {
+        Self::readonly_with_borrow_check(view, true)
+    }
+
+    #[inline(always)]
+    pub(crate) fn readonly_with_borrow_check(view: &'a AccountView, borrow_check: bool) -> Self {
+        Self::readonly_with_flags(view, borrow_check, false)
+    }
+
+    #[inline(always)]
+    pub(crate) fn readonly_with_flags(
+        view: &'a AccountView,
+        borrow_check: bool,
+        relax_readonly_borrow: bool,
+    ) -> Self {
         Self {
             view,
             writable: false,
-            borrow_check: true,
+            borrow_check,
+            relax_readonly_borrow,
         }
     }
 
@@ -55,6 +80,7 @@ impl<'a> CpiHandle<'a> {
             view,
             writable: true,
             borrow_check,
+            relax_readonly_borrow: false,
         }
     }
 
@@ -92,6 +118,25 @@ impl<'a> CpiHandle<'a> {
     #[inline(always)]
     pub(crate) fn requires_borrow_check(&self) -> bool {
         self.borrow_check
+    }
+
+    #[inline(always)]
+    pub(crate) fn enter_cpi(&self) -> Option<CpiBorrowGuard> {
+        if !self.writable && self.relax_readonly_borrow {
+            let borrow_state = self.view.account_ptr().cast_mut().cast::<u8>();
+            // Mutable Slab wrappers pin the runtime borrow state at `0` while
+            // the wrapper is alive. For readonly CPIs that state is too
+            // strong: the callee only needs shared borrows, and readonly metas
+            // prevent writes. Downgrade to a single shared borrow for the CPI
+            // and restore the exclusive marker afterwards.
+            unsafe { *borrow_state = NOT_BORROWED - 1 };
+            Some(CpiBorrowGuard {
+                borrow_state,
+                restore_to: 0,
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -137,8 +182,25 @@ impl<'a> From<CpiHandleMut<'a>> for CpiHandle<'a> {
             view: handle.view,
             writable: true,
             borrow_check: handle.borrow_check,
+            relax_readonly_borrow: false,
         }
     }
+}
+
+impl Drop for CpiBorrowGuard {
+    fn drop(&mut self) {
+        unsafe { *self.borrow_state = self.restore_to };
+    }
+}
+
+pub(crate) fn enter_cpi<'a>(handles: &[CpiHandle<'a>]) -> alloc::vec::Vec<CpiBorrowGuard> {
+    let mut guards = alloc::vec::Vec::new();
+    for handle in handles {
+        if let Some(guard) = handle.enter_cpi() {
+            guards.push(guard);
+        }
+    }
+    guards
 }
 
 /// Converts a CPI accounts struct into instruction metadata and handles.

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -373,6 +373,21 @@ fn cpi_context_invoke_accepts_mutable_slab_handle() {
 }
 
 #[test]
+fn cpi_context_invoke_accepts_readonly_slab_handle_from_mutable_wrapper() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let acct = unsafe { Account::<PodCounter>::load_mut(view) }.unwrap();
+    let accounts = ReadonlyCpi {
+        account: acct.cpi_handle(),
+    };
+
+    CpiContext::new(&program, accounts)
+        .invoke(&[1, 2, 3])
+        .unwrap();
+}
+
+#[test]
 fn invoke_ix_rejects_live_borrow_for_writable_meta() {
     let program = ID;
     let buffer = account_view([1; 32], true);
@@ -409,6 +424,25 @@ fn invoke_ix_accepts_mutable_slab_handle() {
     let ix = Instruction {
         program_id: program,
         accounts: vec![AccountMeta::new(address, false)],
+        data: vec![],
+    };
+
+    CpiContext::new(&program, accounts).invoke_ix(ix).unwrap();
+}
+
+#[test]
+fn invoke_ix_accepts_readonly_slab_handle_from_mutable_wrapper() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let acct = unsafe { Account::<PodCounter>::load_mut(view) }.unwrap();
+    let address = *acct.address();
+    let accounts = ReadonlyCpi {
+        account: acct.cpi_handle(),
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![AccountMeta::new_readonly(address, false)],
         data: vec![],
     };
 

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -2,6 +2,7 @@
 
 use {
     anchor_lang_v2::{
+        accounts::Account,
         prelude::BorshAccount,
         solana_program::{
             instruction::{AccountMeta, Instruction},
@@ -12,6 +13,7 @@ use {
         Address, AnchorAccount, CpiContext, CpiHandle, CpiHandleMut, Discriminator, Owner,
         ToCpiAccounts, ToCpiHandle, ToCpiHandleMut,
     },
+    bytemuck::{Pod, Zeroable},
     solana_program_error::ProgramError,
 };
 
@@ -34,6 +36,20 @@ struct OptionalCpi<'a> {
     optional: Option<CpiHandle<'a>>,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct PodCounter {
+    value: u64,
+}
+
+impl Owner for PodCounter {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for PodCounter {
+    const DISCRIMINATOR: &'static [u8] = &[0x4c, 0xde, 0x7f, 0x28, 0x61, 0x2f, 0x07, 0x73];
+}
+
 #[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
 struct BorshCounter {
     value: u64,
@@ -50,6 +66,27 @@ impl Discriminator for BorshCounter {
 fn account_view(address: [u8; 32], writable: bool) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
     let buffer = AccountBuffer::new();
     buffer.init(address, [9; 32], 8, false, writable, false);
+    buffer
+}
+
+fn slab_account_view(
+    address: [u8; 32],
+    writable: bool,
+    value: u64,
+) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
+    let buffer = AccountBuffer::new();
+    buffer.init(
+        address,
+        PROGRAM_ID,
+        8 + core::mem::size_of::<PodCounter>(),
+        false,
+        writable,
+        false,
+    );
+    let mut data = [0u8; 16];
+    data[..8].copy_from_slice(PodCounter::DISCRIMINATOR);
+    data[8..16].copy_from_slice(&value.to_le_bytes());
+    buffer.write_data(&data);
     buffer
 }
 
@@ -321,6 +358,21 @@ fn cpi_context_invoke_rejects_live_borrow_for_writable_meta() {
 }
 
 #[test]
+fn cpi_context_invoke_accepts_mutable_slab_handle() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe { Account::<PodCounter>::load_mut(view) }.unwrap();
+    let accounts = WritableCpi {
+        account: acct.cpi_handle_mut(),
+    };
+
+    CpiContext::new(&program, accounts)
+        .invoke(&[1, 2, 3])
+        .unwrap();
+}
+
+#[test]
 fn invoke_ix_rejects_live_borrow_for_writable_meta() {
     let program = ID;
     let buffer = account_view([1; 32], true);
@@ -342,6 +394,25 @@ fn invoke_ix_rejects_live_borrow_for_writable_meta() {
         .unwrap_err();
 
     assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+#[test]
+fn invoke_ix_accepts_mutable_slab_handle() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe { Account::<PodCounter>::load_mut(view) }.unwrap();
+    let address = *acct.address();
+    let accounts = WritableCpi {
+        account: acct.cpi_handle_mut(),
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![AccountMeta::new(address, false)],
+        data: vec![],
+    };
+
+    CpiContext::new(&program, accounts).invoke_ix(ix).unwrap();
 }
 
 #[test]

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -2,21 +2,30 @@
 
 use {
     anchor_lang_v2::{
+        prelude::BorshAccount,
         solana_program::{
             instruction::{AccountMeta, Instruction},
             program,
         },
         testing::{AccountBuffer, MIN_ACCOUNT_BUF},
-        Address, CpiContext, CpiHandle, ToCpiAccounts, ToCpiHandle, ToCpiHandleMut,
+        wincode::{SchemaRead, SchemaWrite},
+        Address, AnchorAccount, CpiContext, CpiHandle, CpiHandleMut, Discriminator, Owner,
+        ToCpiAccounts, ToCpiHandle, ToCpiHandleMut,
     },
     solana_program_error::ProgramError,
 };
 
 const ID: Address = Address::new_from_array([7; 32]);
+const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
 #[derive(ToCpiAccounts)]
 struct ReadonlyCpi<'a> {
     account: CpiHandle<'a>,
+}
+
+#[derive(ToCpiAccounts)]
+struct WritableCpi<'a> {
+    account: CpiHandleMut<'a>,
 }
 
 #[derive(ToCpiAccounts)]
@@ -25,9 +34,33 @@ struct OptionalCpi<'a> {
     optional: Option<CpiHandle<'a>>,
 }
 
+#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+struct BorshCounter {
+    value: u64,
+}
+
+impl Owner for BorshCounter {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for BorshCounter {
+    const DISCRIMINATOR: &'static [u8] = &[0xff, 0xb0, 0x04, 0xf5, 0xbc, 0xfd, 0x7c, 0x19];
+}
+
 fn account_view(address: [u8; 32], writable: bool) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
     let buffer = AccountBuffer::new();
     buffer.init(address, [9; 32], 8, false, writable, false);
+    buffer
+}
+
+fn borsh_account_view(address: [u8; 32], writable: bool, value: u64) -> AccountBuffer<256> {
+    let buffer = AccountBuffer::new();
+    buffer.init(address, PROGRAM_ID, 16, false, writable, false);
+    let mut data = [0u8; 16];
+    data[..8].copy_from_slice(BorshCounter::DISCRIMINATOR);
+    data[8..16].copy_from_slice(&value.to_le_bytes());
+    buffer.write_data(&data);
+    buffer.set_lamports(1_000_000_000);
     buffer
 }
 
@@ -267,6 +300,94 @@ fn checked_invoke_rejects_live_borrow_for_writable_meta() {
     let err = program::invoke(&ix, &handles).unwrap_err();
 
     assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+#[test]
+fn cpi_context_invoke_rejects_live_borrow_for_writable_meta() {
+    let program = ID;
+    let buffer = account_view([1; 32], true);
+    let mut view = unsafe { buffer.view() };
+    let borrow_view = view;
+    let _borrow = borrow_view.try_borrow().unwrap();
+    let accounts = WritableCpi {
+        account: view.to_cpi_handle_mut(),
+    };
+
+    let err = CpiContext::new(&program, accounts)
+        .invoke(&[1, 2, 3])
+        .unwrap_err();
+
+    assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+#[test]
+fn invoke_ix_rejects_live_borrow_for_writable_meta() {
+    let program = ID;
+    let buffer = account_view([1; 32], true);
+    let mut view = unsafe { buffer.view() };
+    let address = *view.address();
+    let borrow_view = view;
+    let _borrow = borrow_view.try_borrow().unwrap();
+    let accounts = WritableCpi {
+        account: view.to_cpi_handle_mut(),
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![AccountMeta::new(address, false)],
+        data: vec![],
+    };
+
+    let err = CpiContext::new(&program, accounts)
+        .invoke_ix(ix)
+        .unwrap_err();
+
+    assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+#[test]
+fn cpi_context_invoke_accepts_mutable_borsh_handle() {
+    let program = ID;
+    let buffer = borsh_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe { BorshAccount::<BorshCounter>::load_mut(view) }.unwrap();
+
+    {
+        let accounts = WritableCpi {
+            account: acct.cpi_handle_mut(),
+        };
+        CpiContext::new(&program, accounts)
+            .invoke(&[1, 2, 3])
+            .unwrap();
+    }
+
+    acct.reacquire_borrow_mut().unwrap();
+    acct.value = 11;
+    assert_eq!(acct.value, 11);
+}
+
+#[test]
+fn invoke_ix_accepts_mutable_borsh_handle() {
+    let program = ID;
+    let buffer = borsh_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe { BorshAccount::<BorshCounter>::load_mut(view) }.unwrap();
+    let address = *acct.address();
+
+    {
+        let accounts = WritableCpi {
+            account: acct.cpi_handle_mut(),
+        };
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![AccountMeta::new(address, false)],
+            data: vec![],
+        };
+        CpiContext::new(&program, accounts).invoke_ix(ix).unwrap();
+    }
+
+    acct.reacquire_borrow_mut().unwrap();
+    acct.value = 11;
+    assert_eq!(acct.value, 11);
 }
 
 #[test]

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -36,6 +36,13 @@ struct OptionalCpi<'a> {
     optional: Option<CpiHandle<'a>>,
 }
 
+#[derive(ToCpiAccounts)]
+struct ThreeReadonlyCpi<'a> {
+    first: CpiHandle<'a>,
+    second: CpiHandle<'a>,
+    third: CpiHandle<'a>,
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct PodCounter {
@@ -181,6 +188,32 @@ fn checked_invoke_accepts_optional_none_program_id_sentinel() {
 }
 
 #[test]
+fn checked_invoke_accepts_real_program_id_account_before_later_accounts() {
+    let first_buffer = account_view([1; 32], false);
+    let middle_buffer = account_view([7; 32], false);
+    let third_buffer = account_view([2; 32], false);
+    let first = unsafe { first_buffer.view() };
+    let middle = unsafe { middle_buffer.view() };
+    let third = unsafe { third_buffer.view() };
+    let ix = Instruction {
+        program_id: ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*first.address(), false),
+            AccountMeta::new_readonly(*middle.address(), false),
+            AccountMeta::new_readonly(*third.address(), false),
+        ],
+        data: vec![],
+    };
+    let handles = [
+        first.to_cpi_handle(),
+        middle.to_cpi_handle(),
+        third.to_cpi_handle(),
+    ];
+
+    program::invoke(&ix, &handles).unwrap();
+}
+
+#[test]
 fn checked_invoke_rejects_address_mismatch() {
     let buffer = account_view([1; 32], false);
     let view = unsafe { buffer.view() };
@@ -298,6 +331,24 @@ fn invoke_ix_accepts_optional_none_program_id_sentinel() {
     };
 
     CpiContext::new(&program, accounts).invoke_ix(ix).unwrap();
+}
+
+#[test]
+fn cpi_context_invoke_accepts_real_program_id_account_before_later_accounts() {
+    let program = ID;
+    let first_buffer = account_view([1; 32], false);
+    let middle_buffer = account_view([7; 32], false);
+    let third_buffer = account_view([2; 32], false);
+    let first = unsafe { first_buffer.view() };
+    let middle = unsafe { middle_buffer.view() };
+    let third = unsafe { third_buffer.view() };
+    let accounts = ThreeReadonlyCpi {
+        first: first.to_cpi_handle(),
+        second: middle.to_cpi_handle(),
+        third: third.to_cpi_handle(),
+    };
+
+    CpiContext::new(&program, accounts).invoke(&[]).unwrap();
 }
 
 #[test]

--- a/spl-v2/src/associated_token.rs
+++ b/spl-v2/src/associated_token.rs
@@ -69,8 +69,7 @@ pub fn create<'a>(ctx: CpiContext<'a, Create<'a>>) -> Result<(), ProgramError> {
         );
     }
     crate::token_shared::validate_token_interface_program(ctx.accounts.token_program.address())?;
-    ctx.invoke(&[0]);
-    Ok(())
+    ctx.invoke(&[0])
 }
 
 pub fn create_idempotent<'a>(
@@ -91,6 +90,5 @@ pub fn create_idempotent<'a>(
         );
     }
     crate::token_shared::validate_token_interface_program(ctx.accounts.token_program.address())?;
-    ctx.invoke(&[1]);
-    Ok(())
+    ctx.invoke(&[1])
 }

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -32,7 +32,7 @@ pub mod caller {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::set_data(cpi_ctx, value);
+        callee::cpi::set_data(cpi_ctx, value)?;
         Ok(())
     }
 
@@ -44,7 +44,7 @@ pub mod caller {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::noop(cpi_ctx);
+        callee::cpi::noop(cpi_ctx)?;
         Ok(())
     }
 
@@ -57,7 +57,7 @@ pub mod caller {
             ctx.accounts.callee_program.address(),
             callee::cpi::accounts::Empty::new(),
         );
-        callee::cpi::empty(cpi_ctx);
+        callee::cpi::empty(cpi_ctx)?;
         Ok(())
     }
 
@@ -72,7 +72,7 @@ pub mod caller {
             spectator: ctx.accounts.spectator.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
-        callee::cpi::touch(cpi_ctx, delta);
+        callee::cpi::touch(cpi_ctx, delta)?;
         Ok(())
     }
 }

--- a/tests-v2/programs/declare-program/cpi/src/lib.rs
+++ b/tests-v2/programs/declare-program/cpi/src/lib.rs
@@ -18,7 +18,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.external_program.address(), cpi_accounts);
-        external_cpi::cpi::set_value(cpi_ctx, value);
+        external_cpi::cpi::set_value(cpi_ctx, value)?;
         Ok(())
     }
 
@@ -32,7 +32,7 @@ pub mod declare_program {
             payer: ctx.accounts.payer.cpi_handle_mut(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.external_program.address(), cpi_accounts);
-        external_cpi::cpi::composite(cpi_ctx, count);
+        external_cpi::cpi::composite(cpi_ctx, count)?;
         Ok(())
     }
 
@@ -54,7 +54,7 @@ pub mod declare_program {
                 tag,
                 owner: *ctx.accounts.authority.address(),
             },
-        );
+        )?;
         Ok(())
     }
 
@@ -65,7 +65,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.alt_program.address(), cpi_accounts);
-        alt_cpi::cpi::bump(cpi_ctx, delta);
+        alt_cpi::cpi::bump(cpi_ctx, delta)?;
         Ok(())
     }
 
@@ -81,7 +81,7 @@ pub mod declare_program {
             authority: ctx.accounts.authority.cpi_handle(),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.hash_program.address(), cpi_accounts);
-        hash_cpi::cpi::apply(cpi_ctx, delta, flag, marker);
+        hash_cpi::cpi::apply(cpi_ctx, delta, flag, marker)?;
         Ok(())
     }
 }

--- a/tests-v2/programs/declare-program/optional/src/lib.rs
+++ b/tests-v2/programs/declare-program/optional/src/lib.rs
@@ -20,7 +20,7 @@ pub mod declare_program_optional {
                 .map(|account| account.cpi_handle()),
         };
         let cpi_ctx = CpiContext::new(ctx.accounts.optional_program.address(), cpi_accounts);
-        optional_callee::cpi::record(cpi_ctx, value);
+        optional_callee::cpi::record(cpi_ctx, value)?;
         Ok(())
     }
 }


### PR DESCRIPTION
#### Finding
v2 CPI helpers used the unchecked invoke path without validating live writable borrows first. That let callers forward wrappers like `BorshAccount` / `SerializedAccount` while `load_mut()` still held a mutable borrow. If the callee mutated the account, the caller could later serialize stale wrapper state during `exit()`, clobbering the callee’s update.

#### Fix
This PR makes `CpiContext::invoke` / `invoke_ix` validate writable CPI borrows before unchecked invocation and updates generated v2 CPI wrappers to propagate failures. Slab-backed mutable accounts explicitly opt out, preserving their existing safe borrow model. As a result, live `load_mut()` CPI patterns now fail with `AccountBorrowFailed` unless released first.