### PR TITLE
fix(v2): distinct v1-aligned error codes for has_one/address/close

### DIFF
--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -336,9 +336,13 @@ impl From<ErrorCode> for solana_program_error::ProgramError {
                 solana_program_error::ProgramError::MissingRequiredSignature
             }
             ErrorCode::ConstraintSeeds => solana_program_error::ProgramError::InvalidSeeds,
-            ErrorCode::ConstraintHasOne => solana_program_error::ProgramError::InvalidAccountData,
-            ErrorCode::ConstraintAddress => solana_program_error::ProgramError::InvalidAccountData,
-            ErrorCode::ConstraintClose => solana_program_error::ProgramError::InvalidAccountData,
+            // Distinct v1-aligned codes rather than a shared builtin:
+            // grouping these under `InvalidAccountData` made a failed
+            // `has_one`/`address`/`close` indistinguishable from each other
+            // and from discriminator/deserialization failures (#4849).
+            ErrorCode::ConstraintHasOne => solana_program_error::ProgramError::Custom(2001),
+            ErrorCode::ConstraintAddress => solana_program_error::ProgramError::Custom(2012),
+            ErrorCode::ConstraintClose => solana_program_error::ProgramError::Custom(2011),
             ErrorCode::ConstraintOwner => solana_program_error::ProgramError::IllegalOwner,
             ErrorCode::ConstraintRaw => solana_program_error::ProgramError::Custom(2003),
             ErrorCode::ConstraintExecutable => solana_program_error::ProgramError::Custom(2007),

--- a/lang-v2/tests/error_code_collisions.rs
+++ b/lang-v2/tests/error_code_collisions.rs
@@ -6,10 +6,15 @@
 //! can't tell which constraint failed.
 //!
 //! Note: multiple variants mapping to the same *built-in*
-//! `ProgramError` (e.g., `ConstraintHasOne`, `ConstraintAddress`,
-//! `ConstraintClose` all → `InvalidAccountData`) is acceptable — those
-//! are semantic groupings. The invariant is specifically "no two
-//! variants share a `Custom(u32)` code".
+//! `ProgramError` is acceptable only when the variants mean the same
+//! thing to a caller (e.g., `InstructionDidNotDeserialize` and
+//! `InstructionFallbackNotFound` both → `InvalidInstructionData`:
+//! either way the instruction data was wrong). Account-relation
+//! constraints (`has_one`, `address`, `close`) instead get distinct
+//! v1-aligned `Custom` codes — sharing `InvalidAccountData` made
+//! their failures indistinguishable from each other and from
+//! discriminator/deserialization errors (#4849). The invariant is
+//! specifically "no two variants share a `Custom(u32)` code".
 //!
 //! Exhaustiveness: the helper below uses an `#[allow(dead_code)]`
 //! match on a fresh `ErrorCode` parameter with explicit arms for
@@ -115,7 +120,7 @@ fn no_two_variants_share_a_custom_code() {
     }
     // Snapshot — adding a new Custom variant forces a review of this number.
     assert_eq!(
-        custom_count, 12,
+        custom_count, 15,
         "Number of Custom error codes changed; update this snapshot after review"
     );
 }
@@ -183,23 +188,6 @@ fn builtin_groupings_are_stable() {
         IncorrectProgramId,
     );
 
-    // Grouped under InvalidAccountData
-    check(
-        "ConstraintHasOne",
-        ErrorCode::ConstraintHasOne.into(),
-        InvalidAccountData,
-    );
-    check(
-        "ConstraintAddress",
-        ErrorCode::ConstraintAddress.into(),
-        InvalidAccountData,
-    );
-    check(
-        "ConstraintClose",
-        ErrorCode::ConstraintClose.into(),
-        InvalidAccountData,
-    );
-
     // Grouped under InvalidInstructionData
     check(
         "InstructionDidNotDeserialize",
@@ -211,4 +199,57 @@ fn builtin_groupings_are_stable() {
         ErrorCode::InstructionFallbackNotFound.into(),
         InvalidInstructionData,
     );
+}
+
+#[test]
+fn custom_codes_match_v1_numbering() {
+    // Every `Custom` code must equal the discriminant of the same-named
+    // variant in v1's `ErrorCode` (lang/src/error.rs), so clients and
+    // explorers that already decode v1 codes read v2 errors correctly.
+    // Snapshot test — a mismatch here is a breaking API change.
+    let expected: Vec<(&'static str, ErrorCode, u32)> = vec![
+        ("ConstraintMut", ErrorCode::ConstraintMut, 2000),
+        ("ConstraintHasOne", ErrorCode::ConstraintHasOne, 2001),
+        ("ConstraintRaw", ErrorCode::ConstraintRaw, 2003),
+        (
+            "ConstraintExecutable",
+            ErrorCode::ConstraintExecutable,
+            2007,
+        ),
+        ("ConstraintClose", ErrorCode::ConstraintClose, 2011),
+        ("ConstraintAddress", ErrorCode::ConstraintAddress, 2012),
+        ("ConstraintZero", ErrorCode::ConstraintZero, 2013),
+        (
+            "ConstraintDuplicateMutableAccount",
+            ErrorCode::ConstraintDuplicateMutableAccount,
+            2040,
+        ),
+        ("RequireViolated", ErrorCode::RequireViolated, 2500),
+        ("RequireEqViolated", ErrorCode::RequireEqViolated, 2501),
+        ("RequireNeqViolated", ErrorCode::RequireNeqViolated, 2502),
+        (
+            "RequireKeysEqViolated",
+            ErrorCode::RequireKeysEqViolated,
+            2503,
+        ),
+        (
+            "RequireKeysNeqViolated",
+            ErrorCode::RequireKeysNeqViolated,
+            2504,
+        ),
+        ("RequireGtViolated", ErrorCode::RequireGtViolated, 2505),
+        ("RequireGteViolated", ErrorCode::RequireGteViolated, 2506),
+    ];
+    // Keep this list in sync with the Custom-code count snapshot above.
+    assert_eq!(expected.len(), 15);
+    for (label, code, expected_code) in expected {
+        let err: ProgramError = code.into();
+        assert_eq!(
+            err,
+            ProgramError::Custom(expected_code),
+            "ErrorCode::{} should map to Custom({}) to match v1 numbering",
+            label,
+            expected_code
+        );
+    }
 }

--- a/tests-v2/tests/constraints.rs
+++ b/tests-v2/tests/constraints.rs
@@ -201,8 +201,8 @@ fn address_mismatch_rejected() {
         vec![AccountMeta::new_readonly(wrong, false)],
         &[],
     );
-    // Default `ConstraintAddress` maps to `ProgramError::InvalidAccountData`.
-    assert_err_contains(&result, "InvalidAccountData");
+    // Default `ConstraintAddress` maps to `Custom(2012)`, v1's code.
+    assert_err_contains(&result, "Custom(2012)");
 }
 
 // ---- 2. address = expr @ MyErr --------------------------------------------
@@ -268,8 +268,8 @@ fn has_one_mismatch_rejected() {
         ],
         &[],
     );
-    // Default `ConstraintHasOne` -> `ProgramError::InvalidAccountData`.
-    assert_err_contains(&result, "InvalidAccountData");
+    // Default `ConstraintHasOne` -> `Custom(2001)`, v1's code.
+    assert_err_contains(&result, "Custom(2001)");
 }
 
 // ---- 4. has_one = field @ MyErr -------------------------------------------
@@ -330,8 +330,8 @@ fn address_field_path_mismatch_rejected() {
         ],
         &[],
     );
-    // Default `ConstraintAddress` -> `ProgramError::InvalidAccountData`.
-    assert_err_contains(&result, "InvalidAccountData");
+    // Default `ConstraintAddress` -> `Custom(2012)`, v1's code.
+    assert_err_contains(&result, "Custom(2012)");
 }
 
 // ---- 5. owner = expr -------------------------------------------------------
@@ -579,7 +579,7 @@ fn close_self_close_rejected() {
     );
     let rendered = format!("{:?}", result.as_ref().err().expect("should fail").err);
     assert!(
-        rendered.contains("Custom(2040)") || rendered.contains("InvalidAccountData"),
+        rendered.contains("Custom(2040)") || rendered.contains("Custom(2011)"),
         "expected dup-mut or ConstraintClose rejection, got: {rendered}",
     );
 }
@@ -859,7 +859,7 @@ fn address_into_from_byte_array_mismatch_rejected() {
         vec![AccountMeta::new_readonly(Pubkey::new_unique(), false)],
         &[],
     );
-    assert_err_contains(&result, "InvalidAccountData");
+    assert_err_contains(&result, "Custom(2012)");
 }
 
 #[test]
@@ -885,7 +885,7 @@ fn address_into_from_ref_mismatch_rejected() {
         vec![AccountMeta::new_readonly(Pubkey::new_unique(), false)],
         &[],
     );
-    assert_err_contains(&result, "InvalidAccountData");
+    assert_err_contains(&result, "Custom(2012)");
 }
 
 // ---- 16. Multiple constraints on a single field --------------------------

--- a/tests-v2/tests/ix_macro.rs
+++ b/tests-v2/tests/ix_macro.rs
@@ -135,8 +135,5 @@ fn instruction_arg_address_constraint_rejects_wrong_account() {
     )
     .expect_err("address constraint should reject mismatched marker")
     .to_string();
-    assert!(
-        err.contains("InvalidAccountData"),
-        "unexpected error: {err}"
-    );
+    assert!(err.contains("Custom(2012)"), "unexpected error: {err}");
 }


### PR DESCRIPTION
Fixes #4849

A failed `address`, `has_one`, or self-`close` constraint all surfaced as the same bare `ProgramError::InvalidAccountData` — which is also what discriminator mismatches and failed deserialization return. So "invalid account data for instruction" in a tx log could mean four different things, and since the generated checks don't log anything, there was nothing else to go on while debugging.

The `From<ErrorCode>` impl already maps the other constraint errors to v1-aligned `Custom` codes (`mut`=2000, `constraint`=2003, `executable`=2007, `zero`=2013, dup-mut=2040), so this extends that convention to the three that were collapsed into a builtin:

- `ConstraintHasOne` → `Custom(2001)`
- `ConstraintClose` → `Custom(2011)`
- `ConstraintAddress` → `Custom(2012)`

These are the exact numbers v1 programs return today, so explorers and client tooling that already decode anchor error codes pick these up as-is. Zero runtime or binary-size cost — same match-arm shape. And `InvalidAccountData` goes back to meaning what it says: the account's *data* didn't validate (wrong discriminator / failed deser), not "some relation between accounts is wrong".

## Changes

- `lang-v2/src/lib.rs` — the three mappings, with a comment so nobody regroups them later
- `lang-v2/tests/error_code_collisions.rs` — new `custom_codes_match_v1_numbering` snapshot pinning all 15 `Custom` codes to v1's numbering; updated the `custom_count` snapshot (12 → 15) and dropped the three from the builtin-grouping check. That test's own message says to update it after review — this PR is that review.
- `tests-v2/tests/constraints.rs` + `tests-v2/tests/ix_macro.rs` — the litesvm tests now assert the specific codes (`Custom(2012)` etc.) instead of `InvalidAccountData`, so a regression back to the ambiguous mapping fails loudly.

## Notes

- Breaking for anything matching on `InvalidAccountData` from these three constraints, but the old grouping was the bug.
- Left `InstructionDidNotDeserialize`/`InstructionFallbackNotFound` sharing `InvalidInstructionData` — both genuinely mean the instruction data was wrong, and you always know which ix you sent.
- This deliberately doesn't bring back v1's rich `AnchorError` (account name, left/right values, source location) — that costs binary size and CUs in no_std, and it's a bigger design call. Distinct codes fix the ambiguity for free; richer errors could layer on top later if wanted.
- Ran `anchor-lang-v2` unit tests plus the `constraints`, `ix_macro`, `accounts`, `optional_accounts`, `dispatch_remaining`, and `client_builders` litesvm suites locally — all green.
