### PR TITLE
fix(lang-v2): scope realloc payer alias check

### DIFF
--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -628,11 +628,7 @@ pub fn realloc_account(
 ) -> Result<(), ProgramError> {
     use pinocchio::Resize;
 
-    require!(
-        !pinocchio::address::address_eq(payer.address(), account.address()),
-        ProgramError::InvalidArgument
-    );
-
+    let payer_is_account = pinocchio::address::address_eq(payer.address(), account.address());
     let old_space = account.data_len();
     let new_rent_minimum = rent_exempt_lamports(new_space)?;
     let current_lamports = account.lamports();
@@ -640,6 +636,7 @@ pub fn realloc_account(
     if new_space > old_space {
         let deficit = new_rent_minimum.saturating_sub(current_lamports);
         if deficit > 0 {
+            require!(!payer_is_account, ProgramError::InvalidArgument);
             transfer_lamports_unchecked(payer, &*account as &AccountView, deficit)?;
         }
     } else if new_space < old_space {
@@ -656,7 +653,7 @@ pub fn realloc_account(
             // When the payer aliases the resized account, the refund is a
             // no-op transfer. Skip the lamport writes so we do not overwrite
             // the first write with the second and accidentally burn lamports.
-            if payer.address() != account.address() {
+            if !payer_is_account {
                 let mut payer_mut = *payer;
                 // `checked_add` rather than `+`: overflow-checks is disabled in
                 // release builds, and this arithmetic is on user-supplied account

--- a/lang-v2/tests/realloc_payer_target_check.rs
+++ b/lang-v2/tests/realloc_payer_target_check.rs
@@ -1,14 +1,18 @@
 use {
-    anchor_lang_v2::{cpi::realloc_account, testing::AccountBuffer},
+    anchor_lang_v2::{
+        cpi::{realloc_account, rent_exempt_lamports},
+        testing::AccountBuffer,
+    },
     solana_program_error::ProgramError,
 };
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
 #[test]
-fn realloc_rejects_payer_equal_target_before_resize() {
+fn realloc_rejects_underfunded_growth_with_target_as_payer() {
     let buf = AccountBuffer::<256>::new();
     buf.init([0xAB; 32], PROGRAM_ID, 24, false, true, false);
+    buf.set_lamports(rent_exempt_lamports(24).unwrap());
 
     let mut account = unsafe { buf.view() };
     let payer = account;
@@ -21,4 +25,21 @@ fn realloc_rejects_payer_equal_target_before_resize() {
     assert_eq!(err, ProgramError::InvalidArgument);
     assert_eq!(account.data_len(), old_space);
     assert_eq!(account.lamports(), old_lamports);
+}
+
+#[test]
+fn realloc_allows_funded_growth_with_target_as_payer() {
+    let buf = AccountBuffer::<256>::new();
+    buf.init([0xAB; 32], PROGRAM_ID, 24, false, true, false);
+    let new_space = 64;
+    let funded_lamports = rent_exempt_lamports(new_space).unwrap();
+    buf.set_lamports(funded_lamports);
+
+    let mut account = unsafe { buf.view() };
+    let payer = account;
+
+    realloc_account(&mut account, new_space, &payer, false).unwrap();
+
+    assert_eq!(account.data_len(), new_space);
+    assert_eq!(account.lamports(), funded_lamports);
 }


### PR DESCRIPTION
Restrict payer/target alias rejection to underfunded growth, where a self-transfer would be required. This restores self-payer shrink behavior while retaining the growth protection from #4692.

Tests: `cargo test --tests -p anchor-lang-v2 --features testing --offline`