### PR TITLE
fix(lang-v2): reserve generated instruction argument names

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -819,6 +819,13 @@ fn parse_instruction_attrs(attrs: &[syn::Attribute]) -> syn::Result<Vec<(Ident, 
         attr.parse_args_with(|input: syn::parse::ParseStream| {
             while !input.is_empty() {
                 let name: Ident = input.parse()?;
+                if name.to_string().starts_with("__") {
+                    return Err(syn::Error::new(
+                        name.span(),
+                        "instruction argument names beginning with `__` are reserved for \
+                         generated code",
+                    ));
+                }
                 input.parse::<syn::Token![:]>()?;
                 let ty: Type = input.parse()?;
                 result.push((name, ty));

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -394,6 +394,30 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn instruction_args_reject_generated_name_namespace() {
+    compile_fail_case(
+        "reserved_instruction_arg",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+#[instruction(__base_offset: usize)]
+pub struct Bad {
+    #[account(mut)]
+    pub data: Option<UncheckedAccount>,
+}
+"#,
+        &[
+            "instruction argument names beginning with `__` are reserved for generated code",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",


### PR DESCRIPTION
User-controlled instruction argument names could collide with generated `__` identifiers and shadow derive internals.

- Reject `#[instruction]` names in the generated `__` namespace.
- Prevent user arguments from shadowing internals such as `__base_offset`.
- Add a targeted macro diagnostic regression.

Fixes hackhack audit finding 96