### PR TITLE
fix(lang-v2): preserve writes across transient zero balances

### DIFF
--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -320,8 +320,10 @@ where
     }
 
     fn exit(&mut self) -> pinocchio::ProgramResult {
-        // Skip serialization if account was closed (lamports == 0, reassigned to system program).
-        if self.view.lamports() == 0 {
+        // Skip serialization only after close() has cleared the account header.
+        // A zero lamport balance can be transient when a later exit refunds this
+        // account, so lamports alone do not prove that write-back is unnecessary.
+        if super::slab::is_closed(&self.view) {
             return Ok(());
         }
         // Belt-and-braces: the derive's `realloc` constraint does

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -28,6 +28,14 @@ pub(super) fn cold_owner_error(view: &AccountView) -> ProgramError {
     }
 }
 
+/// Whether the runtime account header reflects a completed close.
+#[inline(always)]
+pub(super) fn is_closed(view: &AccountView) -> bool {
+    view.lamports() == 0
+        && view.data_len() == 0
+        && view.owned_by(&crate::programs::System::id())
+}
+
 /// Error for read-only account passed to `load_mut`.
 #[cfg(feature = "guardrails")]
 #[inline(always)]

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -8,7 +8,8 @@
 //!    the buffer, picking up any CPI-induced changes. A CPI that
 //!    reassigned the account or swapped its disc is rejected.
 //! 3. `exit` serializes `self.data` through the held mutable guard.
-//!    On a closed account (lamports == 0) it is a no-op.
+//!    On an account whose runtime header reflects a completed close it
+//!    is a no-op.
 //! 4. `exit`'s stale-size detection fires when an external resize
 //!    happened without the user going through release / reacquire.
 //!    It does not fire on content-only out-of-band mutation (same
@@ -353,13 +354,10 @@ fn reacquire_rejects_when_owner_changes_during_release() {
     );
 }
 
-// -- 4. Exit on a closed account is a no-op --------------------------
-//
-// The first line of exit checks `view.lamports() == 0` and bails.
-// This prevents serializing back to a closed/about-to-close account.
+// -- 4. Exit distinguishes a transient zero balance from close -------
 
 #[test]
-fn exit_on_zero_lamport_account_is_noop() {
+fn exit_on_transient_zero_lamport_account_serializes() {
     let mut buf = AccountBuffer::<256>::new();
     setup_counter_buf(&mut buf, 42);
 
@@ -369,19 +367,41 @@ fn exit_on_zero_lamport_account_is_noop() {
     // Modify self.data.
     acct.value = 999;
 
-    // Simulate close: set lamports to 0 (bypassing normal close path
-    // for test purposes).
+    // A later account exit can refund this account, so zero lamports
+    // without the close header transition is not a completed close.
     buf.set_lamports(0);
 
-    // exit should be a no-op — closed account's data should not be
-    // serialized over.
+    acct.exit().unwrap();
+
+    let bytes = read_data_bytes(&buf, 8, 8);
+    assert_eq!(
+        u64::from_le_bytes(bytes.try_into().unwrap()),
+        999,
+        "a transient zero balance must not suppress write-back"
+    );
+}
+
+#[test]
+fn exit_on_closed_account_is_noop() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf, 42);
+
+    let view = unsafe { buf.view() };
+    let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
+    acct.value = 999;
+
+    // pinocchio's close() clears these runtime header fields.
+    buf.set_lamports(0);
+    buf.set_data_len(0);
+    buf.set_owner([0; 32]);
+
     acct.exit().unwrap();
 
     let bytes = read_data_bytes(&buf, 8, 8);
     assert_eq!(
         u64::from_le_bytes(bytes.try_into().unwrap()),
         42,
-        "exit on zero-lamport account must not write back — correct"
+        "a completed close must suppress write-back"
     );
 }
 

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -269,10 +269,10 @@ fn le_codec_reacquire_rejects_owner_change() {
     assert_eq!(err, ProgramError::IllegalOwner);
 }
 
-// -- 1.10 exit on zero-lamport account is a no-op ------------------------
+// -- 1.10 exit on transient zero-lamport account serializes --------------
 
 #[test]
-fn le_codec_exit_on_closed_account_is_noop() {
+fn le_codec_exit_on_transient_zero_lamport_account_serializes() {
     let mut buf = AccountBuffer::<256>::new();
     setup_stats_buf(&mut buf, 1, 0xAABB_CCDD);
 
@@ -282,9 +282,10 @@ fn le_codec_exit_on_closed_account_is_noop() {
     buf.set_lamports(0);
     acct.exit().unwrap();
 
-    // The buffer still reflects the original count, not 555.
+    // Zero lamports alone do not prove the account was closed. Persist the
+    // update unless the closed-account discriminator is also present.
     let bytes = read_data_bytes(&buf, 8, 4);
-    assert_eq!(u32::from_le_bytes(bytes.try_into().unwrap()), 1);
+    assert_eq!(u32::from_le_bytes(bytes.try_into().unwrap()), 555);
 }
 
 // =========================================================================


### PR DESCRIPTION
`exit` treated any zero-lamport account as closed, so transient zero balances could silently discard modified serialized state.

- Distinguish a completed close from a transient zero-lamport balance.
- Serialize modified Borsh state when a later exit may refund the account.
- Keep completed closes as write-back no-ops.

Fixes hackhack audit finding 83