### PR TITLE
fix(lang-v2): reject chained account closes

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -962,6 +962,28 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         Err(err) => return err.to_compile_error(),
     };
 
+    for field in &field_summaries {
+        let Some(close_target) = field.attrs.close.as_ref() else {
+            continue;
+        };
+        let Some(target) = field_summaries
+            .iter()
+            .find(|candidate| candidate.name == *close_target)
+        else {
+            continue;
+        };
+        if target.attrs.close.is_some() {
+            return syn::Error::new(
+                close_target.span(),
+                format!(
+                    "close target `{close_target}` is also scheduled to close; close chains can \
+                     revive an account that was already closed"
+                ),
+            )
+            .to_compile_error();
+        }
+    }
+
     let fields: Vec<parse::AccountField> = match named_fields
         .named
         .iter()

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -418,6 +418,41 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn close_target_cannot_also_be_closed() {
+    compile_fail_case(
+        "close_chain",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account(borsh)]
+pub struct Data {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut, close = receiver)]
+    pub first: BorshAccount<Data>,
+    #[account(mut, close = first)]
+    pub second: BorshAccount<Data>,
+    #[account(mut)]
+    pub receiver: SystemAccount,
+}
+"#,
+        &[
+            "close target `first` is also scheduled to close",
+            "close chains can revive an account that was already closed",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",


### PR DESCRIPTION
A close target could itself be scheduled for closure, making exit order refund lamports into an already-closed account.

- Reject close targets that are themselves scheduled to close.
- Prevent source-ordered exits from refunding an already-closed account.
- Add a targeted derive diagnostic regression.

Fixes hackhack audit finding 82