### PR TITLE
fix(lang-v2): apply account updates after access control

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1881,8 +1881,13 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 #(#loads)*
                 #(#deferred_loads)*
                 #(#constraints)*
-                #(#updates)*
                 Ok((Self { #(#field_names),* }, __bumps, #ix_args_return))
+            }
+
+            #[inline(always)]
+            fn update_accounts(&mut self) -> anchor_lang_v2::Result<()> {
+                #(#updates)*
+                Ok(())
             }
 
             //
@@ -4297,6 +4302,46 @@ fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Ty
     }
 }
 
+/// Prepare an executable handler for the framework's post-authorization
+/// update phase.
+///
+/// The update is inserted as the first handler statement. Any
+/// `#[access_control(...)]` attribute remains on the handler and expands by
+/// prepending its checks, so authorization runs before this update without
+/// duplicating the attribute macro's behavior here.
+fn prepare_executable_handler(handler: &syn::ItemFn) -> syn::Result<syn::ItemFn> {
+    let mut handler = handler.clone();
+    handler.attrs.retain(|attr| {
+        !matches!(
+            &attr.meta,
+            syn::Meta::NameValue(nv) if nv.path.is_ident("discrim")
+        )
+    });
+
+    let Some(FnArg::Typed(ctx_arg)) = handler.sig.inputs.first() else {
+        return Err(syn::Error::new(
+            handler.sig.ident.span(),
+            "handler must have a `ctx: &mut Context<T>` parameter",
+        ));
+    };
+    let Pat::Ident(ctx_pat) = &*ctx_arg.pat else {
+        return Err(syn::Error::new(
+            ctx_arg.pat.span(),
+            "handler context parameter must be an identifier",
+        ));
+    };
+    let ctx = &ctx_pat.ident;
+
+    handler.block.stmts.insert(
+        0,
+        syn::parse_quote! {
+            anchor_lang_v2::TryAccounts::update_accounts(&mut #ctx.accounts)?;
+        },
+    );
+
+    Ok(handler)
+}
+
 fn process_handler(
     handler: &syn::ItemFn,
     mod_name: &Ident,
@@ -4916,22 +4961,32 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
         }
     };
 
-    // Strip #[discrim = N] attributes from handler outputs so rustc
-    // doesn't complain about an unknown attribute.
-    let handlers: Vec<_> = handlers
+    // Executable handlers receive their generated account updates here.
+    // `#[access_control]` remains on the function and expands by prepending its
+    // checks, producing validation -> access control -> update -> handler.
+    // Interface-only modules only need their dispatch-only `#[discrim]` marker
+    // stripped.
+    let handlers: Vec<_> = match handlers
         .iter()
         .map(|func| {
-            let mut func = (*func).clone();
-            func.attrs.retain(|attr| {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    !nv.path.is_ident("discrim")
-                } else {
-                    true
-                }
-            });
-            func
+            if config.mode == ProgramMode::Executable {
+                prepare_executable_handler(func)
+            } else {
+                let mut func = (*func).clone();
+                func.attrs.retain(|attr| {
+                    !matches!(
+                        &attr.meta,
+                        syn::Meta::NameValue(nv) if nv.path.is_ident("discrim")
+                    )
+                });
+                Ok(func)
+            }
         })
-        .collect();
+        .collect::<syn::Result<Vec<_>>>()
+    {
+        Ok(handlers) => handlers,
+        Err(err) => return err.to_compile_error(),
+    };
 
     let interface_account_reexports = if config.mode == ProgramMode::Interface {
         quote! { pub use super::*; }
@@ -5836,6 +5891,11 @@ pub fn event_cpi(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// Executes the given access control method before running the decorated
 /// instruction handler. Any method in scope of the attribute can be invoked
 /// with any arguments from the associated instruction handler.
+///
+/// Within an executable `#[program]` module, generated account `update(...)`
+/// hooks run after these checks succeed and before the first user-written
+/// handler statement. This ensures access control reads the validated,
+/// pre-update account state.
 ///
 /// # Example
 ///

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1568,6 +1568,9 @@ pub fn parse_field(
                 )?;
             let #field_name = anchor_lang_v2::Nested(__nested_inner);
         };
+        let updates = vec![quote! {
+            self.#field_name.0.update_accounts()?;
+        }];
         let exit = Some(quote! {
             self.#field_name.0.exit_accounts()?;
         });
@@ -1577,7 +1580,7 @@ pub fn parse_field(
             load,
             deferred_load: None,
             constraints: vec![],
-            updates: vec![],
+            updates,
             exit,
             has_bump: false,
             is_optional: false,
@@ -2151,8 +2154,8 @@ pub fn parse_field(
     // The `init` dispatch is embedded inline into the init body by
     // `wrap_init_body_with_constraints` above so the hook only fires on
     // actual creation. `check` emits into the validation phase here;
-    // `update` is deferred into a later post-validation phase so sibling
-    // field constraints still observe the pre-update state.
+    // `update` is deferred until after handler-level access control so both
+    // account constraints and authorization observe the pre-update state.
     //
     // Field refs thread through `AsRef::as_ref` so the call-site's
     // `V` is inferred from the `AccountConstraint::Value` associated
@@ -2168,6 +2171,48 @@ pub fn parse_field(
         // specific marker module.
         let ns = syn::Ident::new(&nc.namespace, proc_macro2::Span::call_site());
         let key = syn::Ident::new(&nc.key, proc_macro2::Span::call_site());
+        if nc.is_update {
+            let value = &nc.value;
+            let expected = if let Some(value_field) =
+                expr_as_field_ident(value).filter(|ident| field_names.contains(&ident.to_string()))
+            {
+                if nc.namespace == "mint" || nc.namespace == "token" {
+                    quote! {
+                        anchor_lang_v2::AccountAddress::account_address(&self.#value_field)
+                    }
+                } else {
+                    quote! { AsRef::as_ref(&self.#value_field) }
+                }
+            } else if let Some(ix_arg) =
+                expr_as_field_ident(value).filter(|ident| ix_arg_names.contains(&ident.to_string()))
+            {
+                return Err(syn::Error::new(
+                    ix_arg.span(),
+                    "instruction arguments are not supported in `update(...)` because deferred \
+                     updates do not retain instruction arguments; store the value in an account \
+                     or update it in the handler",
+                ));
+            } else {
+                quote! { &#value }
+            };
+            if is_optional {
+                updates.push(quote! {
+                    if let Some(__inner) = self.#field_name.as_mut() {
+                        <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
+                            __inner, #expected,
+                        )?;
+                    }
+                });
+            } else {
+                updates.push(quote! {
+                    <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
+                        &mut self.#field_name, #expected,
+                    )?;
+                });
+            }
+            continue;
+        }
+
         let value = &nc.value;
         let expected = if nc.is_field_ref && (nc.namespace == "mint" || nc.namespace == "token") {
             quote! { anchor_lang_v2::AccountAddress::account_address(&#value) }
@@ -2176,22 +2221,6 @@ pub fn parse_field(
         } else {
             quote! { &#value }
         };
-
-        if nc.is_update {
-            let update_target = if is_optional {
-                quote! { #field_name }
-            } else {
-                quote! { &mut #field_name }
-            };
-            // `update(...)` — fires regardless of init state, but only after
-            // all account validations have completed.
-            updates.push(quote! {
-                <#ns::#key as anchor_lang_v2::AccountConstraint<_>>::update(
-                    #update_target, #expected,
-                )?;
-            });
-            continue;
-        }
 
         // `check` fires for:
         //   - non-init fields,
@@ -2344,17 +2373,6 @@ pub fn parse_field(
                             let _ = &#field_name;
                             #c
                         }
-                    }
-                }
-            })
-            .collect();
-        let updates = updates
-            .into_iter()
-            .map(|u| {
-                quote! {
-                    if let Some(ref mut #field_name) = #field_name {
-                        let _ = &#field_name;
-                        #u
                     }
                 }
             })

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -57,6 +57,17 @@ pub trait TryAccounts: Bumps + Sized {
         ix_data: &'ix [u8],
     ) -> Result<(Self, Self::Bumps, Self::IxArgs<'ix>), ProgramError>;
 
+    /// Apply generated `update(...)` hooks after handler-level
+    /// `#[access_control]` checks and before the user-written handler body.
+    ///
+    /// The `#[program]` macro inserts this phase into each executable handler.
+    /// Keeping it separate from `try_accounts` ensures authorization observes
+    /// the validated, pre-update account state.
+    #[inline(always)]
+    fn update_accounts(&mut self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+
     fn exit_accounts(&mut self) -> Result<(), ProgramError>;
 }
 

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -572,7 +572,7 @@ pub trait ForeignOwnerInit: AccountInitialize {}
 /// | `init, ns::key = v`                                | `init`                |
 /// | `init_if_needed, ns::key = v` (creating)           | `init`, then `check`  |
 /// | `init_if_needed, ns::key = v` (already exists)     | `check`               |
-/// | `update(ns::key = v)`                              | `update` (post-validation) |
+/// | `update(ns::key = v)`                              | `update` (after access control, before handler body) |
 /// | Any of the above                                    | `exit` (exit phase)  |
 ///
 /// There is deliberately **no blanket `impl<T: AccountConstraint<A>>
@@ -643,8 +643,11 @@ pub trait AccountConstraint<A> {
     /// inside an `update(...)` wrapper, e.g.
     /// `#[account(update(my_ns::field = value))]`. Intended for
     /// constraints that set / rewrite on-chain state rather than
-    /// validating it. Runs after `try_accounts` has finished all
-    /// account validations, but before the instruction handler.
+    /// validating it. Runs after `try_accounts` has finished all account
+    /// validations and after handler-level `#[access_control]` checks, but
+    /// before the user-written handler body. Consequently, access control
+    /// observes the original validated state while the handler body observes
+    /// the updated state.
     #[inline(always)]
     fn update(_account: &mut A, _value: &Self::Value) -> core::result::Result<(), ProgramError> {
         Ok(())

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -418,6 +418,31 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn update_hooks_reject_instruction_argument_values() {
+    compile_fail_case(
+        "update_instruction_arg",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(Accounts)]
+#[instruction(value: u64)]
+pub struct Bad {
+    #[account(update(custom::value = value))]
+    pub data: UncheckedAccount,
+}
+"#,
+        &[
+            "instruction arguments are not supported in `update(...)` because deferred updates do \
+             not retain instruction arguments",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",

--- a/tests-v2/programs/custom-constraints/src/lib.rs
+++ b/tests-v2/programs/custom-constraints/src/lib.rs
@@ -30,9 +30,30 @@ pub mod custom_constraints {
         Ok(())
     }
 
-    /// `update(counter_ns::set_value = 42)` on a `mut` field.
-    /// `SetValueConstraint::update` writes `counter.value = 42`.
-    pub fn handle_update(_ctx: &mut Context<HandleUpdate>) -> Result<()> {
+    /// Access control observes the initialized value (`5`), then
+    /// `update(counter_ns::set_value = 42)` runs before this body.
+    #[access_control(require_counter_before_update(ctx))]
+    pub fn handle_update(ctx: &mut Context<HandleUpdate>) -> Result<()> {
+        require!(ctx.accounts.counter.value == 42, WErr::BadValue);
+        Ok(())
+    }
+
+    /// Initialize the authority record used by the update/access-control
+    /// regression. The payer is the initial authorized signer.
+    pub fn handle_authority_init(ctx: &mut Context<HandleAuthorityInit>) -> Result<()> {
+        ctx.accounts.counter.value = address_tag(ctx.accounts.payer.address());
+        Ok(())
+    }
+
+    /// Rotate the stored authority. Access control must compare `actor`
+    /// against the original stored authority before the generated update
+    /// writes `next_authority`; the body must then observe the new authority.
+    #[access_control(require_current_authority(ctx))]
+    pub fn handle_authority_update(ctx: &mut Context<HandleAuthorityUpdate>) -> Result<()> {
+        require!(
+            ctx.accounts.counter.value == address_tag(ctx.accounts.next_authority.address()),
+            WErr::BadValue
+        );
         Ok(())
     }
 
@@ -100,6 +121,26 @@ pub mod custom_constraints {
     }
 }
 
+fn address_tag(address: &Address) -> u64 {
+    let bytes = address.as_array();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
+}
+
+fn require_counter_before_update(ctx: &Context<HandleUpdate>) -> Result<()> {
+    require!(ctx.accounts.counter.value == 5, WErr::Unauthorized);
+    Ok(())
+}
+
+fn require_current_authority(ctx: &Context<HandleAuthorityUpdate>) -> Result<()> {
+    require!(
+        ctx.accounts.counter.value == address_tag(ctx.accounts.actor.address()),
+        WErr::Unauthorized
+    );
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Account data type — a plain Borsh-serialised counter.
 // ---------------------------------------------------------------------------
@@ -116,8 +157,8 @@ pub struct Counter {
 
 pub mod counter_ns {
     use {
-        super::Counter,
-        anchor_lang_v2::{accounts::BorshAccount, AccountConstraint},
+        super::{address_tag, Counter},
+        anchor_lang_v2::{accounts::BorshAccount, AccountConstraint, AccountView},
         solana_program_error::ProgramError,
     };
 
@@ -158,6 +199,23 @@ pub mod counter_ns {
 
         fn update(account: &mut BorshAccount<Counter>, value: &u64) -> Result<(), ProgramError> {
             account.value = *value;
+            Ok(())
+        }
+    }
+
+    /// `counter_ns::set_authority = account` — stores a compact identity tag
+    /// for the supplied account. Used to prove access control runs before an
+    /// attacker-controlled authority update.
+    pub struct SetAuthorityConstraint;
+
+    impl AccountConstraint<BorshAccount<Counter>> for SetAuthorityConstraint {
+        type Value = AccountView;
+
+        fn update(
+            account: &mut BorshAccount<Counter>,
+            value: &AccountView,
+        ) -> Result<(), ProgramError> {
+            account.value = address_tag(value.address());
             Ok(())
         }
     }
@@ -216,6 +274,34 @@ pub struct HandleUpdate {
         update(counter_ns::set_value = 42u64),
     )]
     pub counter: BorshAccount<Counter>,
+}
+
+#[derive(Accounts)]
+pub struct HandleAuthorityInit {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + 8,
+        seeds = [b"authority-counter"],
+        bump,
+    )]
+    pub counter: BorshAccount<Counter>,
+    pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct HandleAuthorityUpdate {
+    #[account(
+        mut,
+        seeds = [b"authority-counter"],
+        bump,
+        update(counter_ns::set_authority = next_authority),
+    )]
+    pub counter: BorshAccount<Counter>,
+    pub actor: Signer,
+    pub next_authority: UncheckedAccount,
 }
 
 #[derive(Accounts)]
@@ -346,4 +432,6 @@ pub struct HandleUpdateAfterLaterValidation {
 pub enum WErr {
     #[msg("bad value")]
     BadValue,
+    #[msg("unauthorized")]
+    Unauthorized,
 }

--- a/tests-v2/tests/custom_constraints.rs
+++ b/tests-v2/tests/custom_constraints.rs
@@ -1,11 +1,9 @@
 //! Integration tests for user-defined `AccountConstraint` impls.
 //!
-//! The `custom-constraints` test program defines four constraint markers
-//! in `counter_ns`, each overriding exactly one of the four trait methods
-//! (`init`, `check`, `update`, `exit`). These tests drive each handler
-//! and inspect the persisted `Counter.value` to prove that the derive
-//! routed each call to the correct method at the correct lifecycle
-//! phase.
+//! The `custom-constraints` test program defines constraint markers covering
+//! all four trait methods (`init`, `check`, `update`, `exit`). These tests
+//! inspect persisted state to prove both method routing and lifecycle order,
+//! including the security boundary between `#[access_control]` and `update`.
 
 use {
     anchor_lang_v2::{solana_program::instruction::AccountMeta, InstructionData},
@@ -24,6 +22,10 @@ fn program_id() -> Pubkey {
 
 fn counter_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"counter"], &program_id()).0
+}
+
+fn authority_counter_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"authority-counter"], &program_id()).0
 }
 
 fn boxed_counter_pda() -> Pubkey {
@@ -83,6 +85,24 @@ fn init_counter(svm: &mut LiteSVM, payer: &Keypair) {
     ];
     send_instruction(svm, program_id(), data, metas, payer, &[])
         .expect("handle_init should succeed");
+}
+
+fn init_authority_counter(svm: &mut LiteSVM, payer: &Keypair) {
+    let data = custom_constraints::instruction::HandleAuthorityInit {}.data();
+    let metas = vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(authority_counter_pda(), false),
+        AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
+    ];
+    send_instruction(svm, program_id(), data, metas, payer, &[])
+        .expect("handle_authority_init should succeed");
+}
+
+fn address_tag(address: &Pubkey) -> u64 {
+    let bytes = address.as_array();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
 }
 
 fn init_boxed_counter(svm: &mut LiteSVM, payer: &Keypair) {
@@ -226,8 +246,57 @@ fn update_hook_writes_new_value() {
     send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
         .expect("handle_update should succeed");
 
-    // `SetValueConstraint::update` overwrote the value.
+    // Access control saw `5`; the handler body and persisted account saw `42`.
     assert_eq!(read_counter_value(&svm, &counter_pda()), 42);
+}
+
+#[test]
+fn update_hook_cannot_self_authorize_protected_handler() {
+    let (mut svm, payer) = setup();
+    init_authority_counter(&mut svm, &payer);
+
+    let attacker = keypair_for("custom-constraints-attacker");
+    svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+
+    assert_eq!(
+        read_counter_value(&svm, &authority_counter_pda()),
+        address_tag(&payer.pubkey()),
+    );
+
+    // The attacker asks the update hook to install its own identity. If the
+    // hook ran before access control, the comparison would become
+    // attacker == attacker and this protected instruction would succeed.
+    let data = custom_constraints::instruction::HandleAuthorityUpdate {}.data();
+    let metas = vec![
+        AccountMeta::new(authority_counter_pda(), false),
+        AccountMeta::new_readonly(attacker.pubkey(), true),
+        AccountMeta::new_readonly(attacker.pubkey(), false),
+    ];
+    let result = send_instruction(&mut svm, program_id(), data, metas, &payer, &[&attacker]);
+    assert!(
+        result.is_err(),
+        "attacker-controlled update must not run before access control",
+    );
+    assert_eq!(
+        read_counter_value(&svm, &authority_counter_pda()),
+        address_tag(&payer.pubkey()),
+        "failed access control must leave the original authority intact",
+    );
+
+    // The current authority can rotate successfully. Access control observes
+    // the payer, then the update runs, and the handler body observes attacker.
+    let data = custom_constraints::instruction::HandleAuthorityUpdate {}.data();
+    let metas = vec![
+        AccountMeta::new(authority_counter_pda(), false),
+        AccountMeta::new_readonly(payer.pubkey(), true),
+        AccountMeta::new_readonly(attacker.pubkey(), false),
+    ];
+    send_instruction(&mut svm, program_id(), data, metas, &payer, &[])
+        .expect("current authority should be able to rotate authority");
+    assert_eq!(
+        read_counter_value(&svm, &authority_counter_pda()),
+        address_tag(&attacker.pubkey()),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Generated account `update(...)` hooks could mutate authority data before handler-level `#[access_control]`, allowing a requested authority change to authorize itself.

- Run account validation first, then `#[access_control]`, generated updates, and user handler code.
- Preserve pre-handler update semantics while ensuring authorization sees the original validated state.
- Forward deferred updates through nested account structs.
- Reject instruction-argument update values until they can be retained without a second deserialization.
- Cover both attacker self-authorization rejection and legitimate authority rotation.

Fixes hackhack audit finding 67