### PR TITLE
fix(lang-v2): reject floats on borsh-compatible surfaces

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1942,6 +1942,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into()
         }
     };
+    if is_borsh {
+        if let Err(err) = reject_float_fields("`#[account(borsh)]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     use sha2::Digest;
     let hash = sha2::Sha256::digest(format!("account:{name_str}").as_bytes());
     let disc_bytes = &hash[..8];
@@ -2257,6 +2262,9 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     // `"bytemuck"` tag here would lie in the IDL for non-Pod types.
     let (idl_type_def, field_dep_walkers, idl_validation_tokens) = match &input.data {
         Data::Struct(data) => {
+            if let Err(err) = reject_float_fields("`#[derive(IdlType)]`", &data.fields) {
+                return err.to_compile_error().into();
+            }
             (
                 idl::build_struct_type_def_emission(
                     &name_str,
@@ -2269,6 +2277,11 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
             )
         }
         Data::Enum(data) => {
+            for variant in &data.variants {
+                if let Err(err) = reject_float_fields("`#[derive(IdlType)]`", &variant.fields) {
+                    return err.to_compile_error().into();
+                }
+            }
             (
                 idl::build_enum_type_def_emission(
                     &name_str,
@@ -4297,6 +4310,60 @@ fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Ty
     }
 }
 
+fn type_contains_float(ty: &Type) -> bool {
+    fn path_arguments_contain_float(arguments: &syn::PathArguments) -> bool {
+        let syn::PathArguments::AngleBracketed(arguments) = arguments else {
+            return false;
+        };
+        arguments.args.iter().any(|argument| match argument {
+            syn::GenericArgument::Type(ty) => type_contains_float(ty),
+            syn::GenericArgument::AssocType(binding) => type_contains_float(&binding.ty),
+            _ => false,
+        })
+    }
+
+    match ty {
+        Type::Path(path) => path.path.segments.iter().any(|segment| {
+            matches!(segment.ident.to_string().as_str(), "f32" | "f64")
+                || path_arguments_contain_float(&segment.arguments)
+        }),
+        Type::Array(array) => type_contains_float(&array.elem),
+        Type::Slice(slice) => type_contains_float(&slice.elem),
+        Type::Reference(reference) => type_contains_float(&reference.elem),
+        Type::Ptr(pointer) => type_contains_float(&pointer.elem),
+        Type::Tuple(tuple) => tuple.elems.iter().any(type_contains_float),
+        Type::Paren(paren) => type_contains_float(&paren.elem),
+        Type::Group(group) => type_contains_float(&group.elem),
+        Type::BareFn(function) => {
+            function
+                .inputs
+                .iter()
+                .any(|argument| type_contains_float(&argument.ty))
+                || matches!(
+                    &function.output,
+                    syn::ReturnType::Type(_, ty) if type_contains_float(ty)
+                )
+        }
+        _ => false,
+    }
+}
+
+fn reject_float_fields(surface: &str, fields: &Fields) -> syn::Result<()> {
+    for field in fields {
+        if type_contains_float(&field.ty) {
+            return Err(syn::Error::new(
+                field.ty.span(),
+                format!(
+                    "`f32` and `f64` are not supported on {surface} because its \
+                     Borsh-compatible decoder would accept NaN; use an integer or fixed-point \
+                     representation"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn process_handler(
     handler: &syn::ItemFn,
     mod_name: &Ident,
@@ -4310,6 +4377,16 @@ fn process_handler(
         Ok(return_ty) => return_ty,
         Err(err) => return HandlerCodegen::error(handler, err),
     };
+    if let Some(return_ty) = return_type.as_ref().filter(|ty| type_contains_float(ty)) {
+        return HandlerCodegen::error(
+            handler,
+            syn::Error::new(
+                return_ty.span(),
+                "`f32` and `f64` return values are not supported because the Borsh-compatible \
+                 encoder would accept NaN; use an integer or fixed-point representation",
+            ),
+        );
+    }
     let return_ty = return_type
         .as_ref()
         .map(|return_ty| quote! { #return_ty })
@@ -4377,6 +4454,17 @@ fn process_handler(
             None
         })
         .collect();
+    if let Some((_, ty)) = extra_args.iter().find(|(_, ty)| type_contains_float(ty)) {
+        return HandlerCodegen::error(
+            handler,
+            syn::Error::new(
+                ty.span(),
+                "`f32` and `f64` instruction arguments are not supported because the \
+                 Borsh-compatible decoder would accept NaN; use an integer or fixed-point \
+                 representation",
+            ),
+        );
+    }
 
     let extra_arg_names: Vec<_> = extra_args.iter().map(|(n, _)| *n).collect();
     let (extra_arg_types, has_ref_args) = args_meta(&extra_args);
@@ -5272,6 +5360,11 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into()
         }
     };
+    if matches!(mode, EventMode::Wincode) {
+        if let Err(err) = reject_float_fields("`#[event]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     use sha2::Digest;
     let hash = sha2::Sha256::digest(format!("event:{name_str}").as_bytes());
     let disc_bytes = &hash[..8];

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2167,6 +2167,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into()
         }
     };
+    if is_borsh {
+        if let Err(err) = reject_float_fields("`#[account(borsh)]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     use sha2::Digest;
     let hash = sha2::Sha256::digest(format!("account:{name_str}").as_bytes());
     let disc_bytes = &hash[..8];
@@ -2512,28 +2517,43 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
     // `"bytemuck"` tag here would lie in the IDL for non-Pod types.
     let empty_disc: [u8; 0] = [];
     let (idl_type_def, field_dep_walkers, idl_validation_tokens) = match &input.data {
-        Data::Struct(data) => (
-            idl::build_struct_type_def_emission(
-                &name_str,
-                &docs,
-                &data.fields,
-                idl::TypeKind::Borsh,
-                &input.generics,
-            ),
-            cfg_field_dep_walkers(&data.fields),
-            wincode_idl_override_tokens_for_fields("`#[derive(IdlType)]`", &data.fields),
-        ),
-        Data::Enum(data) => (
-            idl::build_enum_type_def_emission(
-                &name_str,
-                &docs,
-                &data.variants,
-                idl::TypeKind::Borsh,
-                &input.generics,
-            ),
-            cfg_variant_dep_walkers(&data.variants),
-            wincode_idl_override_tokens_for_variants("`#[derive(IdlType)]`", &data.variants),
-        ),
+        Data::Struct(data) => {
+            if let Err(err) = reject_float_fields("`#[derive(IdlType)]`", &data.fields) {
+                return err.to_compile_error().into();
+            }
+            (
+                idl::build_struct_type_def_emission(
+                    &name_str,
+                    &docs,
+                    &data.fields,
+                    idl::TypeKind::Borsh,
+                    &input.generics,
+                ),
+                cfg_field_dep_walkers(&data.fields),
+                wincode_idl_override_tokens_for_fields("`#[derive(IdlType)]`", &data.fields),
+            )
+        }
+        Data::Enum(data) => {
+            for variant in &data.variants {
+                if let Err(err) = reject_float_fields("`#[derive(IdlType)]`", &variant.fields) {
+                    return err.to_compile_error().into();
+                }
+            }
+            (
+                idl::build_enum_type_def_emission(
+                    &name_str,
+                    &docs,
+                    &data.variants,
+                    idl::TypeKind::Borsh,
+                    &input.generics,
+                ),
+                cfg_variant_dep_walkers(&data.variants),
+                wincode_idl_override_tokens_for_variants(
+                    "`#[derive(IdlType)]`",
+                    &data.variants,
+                ),
+            )
+        }
         Data::Union(_) => {
             return syn::Error::new(
                 name.span(),
@@ -4766,6 +4786,60 @@ fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Ty
     }
 }
 
+fn type_contains_float(ty: &Type) -> bool {
+    fn path_arguments_contain_float(arguments: &syn::PathArguments) -> bool {
+        let syn::PathArguments::AngleBracketed(arguments) = arguments else {
+            return false;
+        };
+        arguments.args.iter().any(|argument| match argument {
+            syn::GenericArgument::Type(ty) => type_contains_float(ty),
+            syn::GenericArgument::AssocType(binding) => type_contains_float(&binding.ty),
+            _ => false,
+        })
+    }
+
+    match ty {
+        Type::Path(path) => path.path.segments.iter().any(|segment| {
+            matches!(segment.ident.to_string().as_str(), "f32" | "f64")
+                || path_arguments_contain_float(&segment.arguments)
+        }),
+        Type::Array(array) => type_contains_float(&array.elem),
+        Type::Slice(slice) => type_contains_float(&slice.elem),
+        Type::Reference(reference) => type_contains_float(&reference.elem),
+        Type::Ptr(pointer) => type_contains_float(&pointer.elem),
+        Type::Tuple(tuple) => tuple.elems.iter().any(type_contains_float),
+        Type::Paren(paren) => type_contains_float(&paren.elem),
+        Type::Group(group) => type_contains_float(&group.elem),
+        Type::BareFn(function) => {
+            function
+                .inputs
+                .iter()
+                .any(|argument| type_contains_float(&argument.ty))
+                || matches!(
+                    &function.output,
+                    syn::ReturnType::Type(_, ty) if type_contains_float(ty)
+                )
+        }
+        _ => false,
+    }
+}
+
+fn reject_float_fields(surface: &str, fields: &Fields) -> syn::Result<()> {
+    for field in fields {
+        if type_contains_float(&field.ty) {
+            return Err(syn::Error::new(
+                field.ty.span(),
+                format!(
+                    "`f32` and `f64` are not supported on {surface} because its \
+                     Borsh-compatible decoder would accept NaN; use an integer or fixed-point \
+                     representation"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn process_handler(
     handler: &syn::ItemFn,
     mod_name: &Ident,
@@ -4779,6 +4853,16 @@ fn process_handler(
         Ok(return_ty) => return_ty,
         Err(err) => return HandlerCodegen::error(handler, err),
     };
+    if let Some(return_ty) = return_type.as_ref().filter(|ty| type_contains_float(ty)) {
+        return HandlerCodegen::error(
+            handler,
+            syn::Error::new(
+                return_ty.span(),
+                "`f32` and `f64` return values are not supported because the Borsh-compatible \
+                 encoder would accept NaN; use an integer or fixed-point representation",
+            ),
+        );
+    }
     let return_ty = return_type
         .as_ref()
         .map(|return_ty| quote! { #return_ty })
@@ -4855,6 +4939,17 @@ fn process_handler(
             None
         })
         .collect();
+    if let Some((_, ty)) = extra_args.iter().find(|(_, ty)| type_contains_float(ty)) {
+        return HandlerCodegen::error(
+            handler,
+            syn::Error::new(
+                ty.span(),
+                "`f32` and `f64` instruction arguments are not supported because the \
+                 Borsh-compatible decoder would accept NaN; use an integer or fixed-point \
+                 representation",
+            ),
+        );
+    }
 
     let extra_arg_names: Vec<_> = extra_args.iter().map(|(n, _)| *n).collect();
     let (extra_arg_types, has_ref_args) = args_meta(&extra_args);
@@ -5747,6 +5842,11 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into()
         }
     };
+    if matches!(mode, EventMode::Wincode) {
+        if let Err(err) = reject_float_fields("`#[event]`", fields) {
+            return err.to_compile_error().into();
+        }
+    }
     use sha2::Digest;
     let hash = sha2::Sha256::digest(format!("event:{name_str}").as_bytes());
     let disc_bytes = &hash[..8];

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -102,8 +102,9 @@ pub use wincode;
 /// - **`HashMap` / `HashSet`**: borsh sorts entries by key, wincode preserves
 ///   insertion order. Use `BTreeMap` / `BTreeSet` or `Vec<(K, V)>` if you
 ///   need canonical ordering.
-/// - **`f32` / `f64` NaN**: borsh rejects NaN on deserialize, wincode
-///   accepts it. v2 won't surface an error for a NaN-bearing account.
+/// - **`f32` / `f64`**: wincode accepts NaN while borsh rejects it, so Anchor
+///   macros reject floats on Borsh-compatible instruction, account, event, and
+///   IDL type surfaces. Use an integer or fixed-point representation instead.
 ///
 /// Programs that don't use these types are unaffected.
 ///

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -418,6 +418,89 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn floats_are_rejected_on_borsh_compatible_surfaces() {
+    compile_fail_case(
+        "float_instruction_arg",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod float_instruction_arg {
+    use super::*;
+
+    pub fn set(_ctx: &mut Context<Noop>, value: f64) -> Result<()> {
+        let _ = value;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Noop {}
+"#,
+        &[
+            "`f32` and `f64` instruction arguments are not supported",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_borsh_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account(borsh)]
+pub struct Price {
+    pub value: Option<f32>,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[account(borsh)]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_event",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[event]
+pub struct PriceChanged {
+    pub value: f64,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[event]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_idl_type",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+#[derive(IdlType)]
+pub struct Price {
+    pub value: Vec<f64>,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[derive(IdlType)]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -576,6 +576,89 @@ pub struct Outer {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn floats_are_rejected_on_borsh_compatible_surfaces() {
+    compile_fail_case(
+        "float_instruction_arg",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod float_instruction_arg {
+    use super::*;
+
+    pub fn set(_ctx: &mut Context<Noop>, value: f64) -> Result<()> {
+        let _ = value;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Noop {}
+"#,
+        &[
+            "`f32` and `f64` instruction arguments are not supported",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_borsh_account",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account(borsh)]
+pub struct Price {
+    pub value: Option<f32>,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[account(borsh)]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_event",
+        r#"
+use anchor_lang::prelude::*;
+
+#[event]
+pub struct PriceChanged {
+    pub value: f64,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[event]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+
+    compile_fail_case(
+        "float_idl_type",
+        r#"
+use anchor_lang::prelude::*;
+
+#[derive(IdlType)]
+pub struct Price {
+    pub value: Vec<f64>,
+}
+"#,
+        &[
+            "`f32` and `f64` are not supported on `#[derive(IdlType)]`",
+            "use an integer or fixed-point representation",
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",

--- a/tests-v2/programs/declare-program/types/idls/weird_types.json
+++ b/tests-v2/programs/declare-program/types/idls/weird_types.json
@@ -13,14 +13,6 @@
       "accounts": [],
       "args": [
         {
-          "name": "float32",
-          "type": "f32"
-        },
-        {
-          "name": "float64",
-          "type": "f64"
-        },
-        {
           "name": "unit",
           "type": {
             "defined": {

--- a/tests-v2/src/declare-program/types.rs
+++ b/tests-v2/src/declare-program/types.rs
@@ -42,8 +42,6 @@ fn declared_weird_types_compile_and_serialize() {
     assert!(documented_type_def.contains("\"repr\":{\"kind\":\"c\"}"));
 
     let data = weird_types::instruction::UseWeirdTypes {
-        float32: 1.5,
-        float64: -2.25,
         unit: weird_types::UnitMarker,
         empty: weird_types::EmptyNamed {},
         tuple: weird_types::PairTuple(7, true),

--- a/tests-v2/src/declare-program/types.rs
+++ b/tests-v2/src/declare-program/types.rs
@@ -46,8 +46,6 @@ fn declared_weird_types_compile_and_serialize() {
     assert!(documented_type_def.contains("\"repr\":{\"kind\":\"c\"}"));
 
     let data = weird_types::instruction::UseWeirdTypes {
-        float32: 1.5,
-        float64: -2.25,
         unit: weird_types::UnitMarker,
         empty: weird_types::EmptyNamed {},
         tuple: weird_types::PairTuple(7, true),


### PR DESCRIPTION
Borsh-compatible surfaces accepted floating-point values, including NaN encodings without stable equality semantics.

- Reject `f32` and `f64` on Borsh-compatible instruction, account, event, return, and IDL type surfaces.
- Traverse container and tuple types so nested float syntax is rejected too.
- Recommend integer or fixed-point representations until the shared decoder can reject NaN itself.
- Leave bytemuck-only layouts unchanged.

Fixes hackhack audit finding 47