### PR TITLE
lang-v2: gate Borsh writes by program ownership

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1815,7 +1815,12 @@ pub fn parse_field(
                 if #existed {
                     // SAFETY: the bitvec duplicate-account check below ensures
                     // no other mutable reference to this account's data exists.
-                    unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
+                    unsafe {
+                        <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                            __target,
+                            __program_id,
+                        )?
+                    }
                 } else {
                     // Create branch: run `AccountConstraint::init` for every
                     // runtime-only constraint AFTER the account's typed
@@ -1832,6 +1837,9 @@ pub fn parse_field(
         quote! {
             let mut #field_name: #field_ty = {
                 let __target = __views[#offset_expr];
+                if !__target.owned_by(__program_id) {
+                    return Err(anchor_lang_v2::Error::IllegalOwner);
+                }
                 let __disc = <#field_ty as anchor_lang_v2::Discriminator>::DISCRIMINATOR;
                 {
                     let __data = __target.try_borrow()?;
@@ -1846,14 +1854,24 @@ pub fn parse_field(
                 }
                 // SAFETY: the bitvec duplicate-account check below ensures
                 // no other mutable reference to this account's data exists.
-                unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
+                unsafe {
+                    <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                        __target,
+                        __program_id,
+                    )?
+                }
             };
         }
     } else if attrs.is_mut {
         quote! {
             // SAFETY: the bitvec duplicate-account check below ensures no
             // other mutable reference to this account's data exists.
-            let mut #field_name = unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__views[#offset_expr])? };
+            let mut #field_name = unsafe {
+                <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                    __views[#offset_expr],
+                    __program_id,
+                )?
+            };
         }
     } else {
         quote! {

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -26,6 +26,17 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
 
     /// # Safety
     ///
+    /// See [`AnchorAccount::load_mut_for_program`] — caller must ensure no
+    /// other live `&mut` to the same account data exists.
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        program_id: &Address,
+    ) -> Result<Self, ProgramError> {
+        T::load_mut_for_program(view, program_id).map(Box::new)
+    }
+
+    /// # Safety
+    ///
     /// See [`AnchorAccount::load_mut_after_init`] — caller must ensure no
     /// other live `&mut` to the same account data exists.
     unsafe fn load_mut_after_init(view: AccountView) -> Result<Self, ProgramError> {

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -59,6 +59,7 @@ where
     data: T,
     borrow: SerializedAccountBorrow,
     serialized_len: usize,
+    write_authorized: bool,
     _serializer: PhantomData<S>,
 }
 
@@ -139,6 +140,7 @@ where
     /// Returns `IllegalOwner` / `AccountDataTooSmall` /
     /// `InvalidAccountData` if the account no longer validates as `T`.
     pub fn reacquire_borrow_mut(&mut self) -> Result<(), ProgramError> {
+        require!(self.write_authorized, ProgramError::IllegalOwner);
         // Re-run the load-time invariants. A CPI in the release window
         // could have mutated owner, discriminator, or payload in any
         // combination — without re-checking, we'd accept an account that
@@ -174,6 +176,7 @@ where
     /// For post-CPI use (where CPI may have mutated owner, disc, or
     /// payload), use [`reacquire_borrow_mut`] instead.
     pub fn reacquire_guard_only(&mut self) -> Result<(), ProgramError> {
+        require!(self.write_authorized, ProgramError::IllegalOwner);
         let mut view_mut = self.view;
         let data_ref = view_mut.try_borrow_mut()?;
         // A resize that left the buffer shorter than the discriminator
@@ -236,6 +239,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Immutable { _guard: guard },
             serialized_len,
+            write_authorized: false,
             _serializer: PhantomData,
         })
     }
@@ -264,8 +268,23 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
+            write_authorized: true,
             _serializer: PhantomData,
         })
+    }
+
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        program_id: &Address,
+    ) -> Result<Self, ProgramError> {
+        if !view.is_writable() {
+            return Err(crate::ErrorCode::ConstraintMut.into());
+        }
+        if view.owned_by(program_id) {
+            Self::load_mut(view)
+        } else {
+            Self::load(view)
+        }
     }
 
     fn account(&self) -> &AccountView {
@@ -280,6 +299,7 @@ where
     }
 
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
+        require!(self.write_authorized, ProgramError::IllegalOwner);
         let mut self_view = self.view;
         let dest_lamports = destination
             .lamports()
@@ -353,6 +373,7 @@ where
         payer: AccountView,
         zero: bool,
     ) -> pinocchio::ProgramResult {
+        require!(self.write_authorized, ProgramError::IllegalOwner);
         let mut view = *self.account();
         if new_space != view.data_len() {
             self.release_borrow()?;
@@ -516,6 +537,7 @@ where
             data,
             borrow: SerializedAccountBorrow::Mutable { guard },
             serialized_len,
+            write_authorized: true,
             _serializer: PhantomData,
         })
     }

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -168,6 +168,24 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
         Self::load(view)
     }
 
+    /// Load an account for mutable access by the currently executing program.
+    ///
+    /// The default preserves the behavior of wrappers without locally
+    /// mutable data. Data-carrying wrappers override this to distinguish
+    /// transaction writability (which is sufficient for CPI forwarding)
+    /// from authority to mutate the account's data in the current program.
+    ///
+    /// # Safety
+    ///
+    /// Same aliasing requirements as [`load_mut`].
+    #[inline(always)]
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        _program_id: &Address,
+    ) -> core::result::Result<Self, ProgramError> {
+        Self::load_mut(view)
+    }
+
     /// Like [`load_mut`], but called right after
     /// `AccountInitialize::create_and_initialize`. Owner, discriminator,
     /// and min-length checks are tautologies on this path, so data-carrying

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -20,7 +20,7 @@ use {
         prelude::BorshAccount,
         testing::AccountBuffer,
         wincode::{SchemaRead, SchemaWrite},
-        AnchorAccount, Discriminator, Owner,
+        AnchorAccount, Discriminator, Owner, ToCpiHandleMut,
     },
     pinocchio::{account::RuntimeAccount, address::Address},
     solana_program_error::ProgramError,
@@ -189,6 +189,53 @@ fn release_borrow_serializes_mutably_loaded_foreign_owned_account() {
 
     let bytes = read_data_bytes(&buf, 8, 8);
     assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 999);
+}
+
+#[test]
+fn program_scoped_mutable_load_keeps_foreign_accounts_read_only() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_foreign_counter_buf(&mut buf, 42);
+
+    let view = unsafe { buf.view() };
+    let mut acct = unsafe {
+        BorshAccount::<ForeignCounter>::load_mut_for_program(
+            view,
+            &Address::new_from_array(PROGRAM_ID),
+        )
+    }
+    .unwrap();
+
+    assert_eq!(acct.value, 42);
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| acct.value = 999)).is_err(),
+        "foreign-owned typed data must not be locally mutable"
+    );
+    assert!(
+        acct.try_to_cpi_handle_mut().is_ok(),
+        "transaction writability must remain available for CPI forwarding"
+    );
+    assert_eq!(u64::from_le_bytes(read_data_bytes(&buf, 8, 8).try_into().unwrap()), 42);
+}
+
+#[test]
+fn program_scoped_mutable_load_allows_owned_accounts() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf, 42);
+
+    {
+        let view = unsafe { buf.view() };
+        let mut acct = unsafe {
+            BorshAccount::<Counter>::load_mut_for_program(
+                view,
+                &Address::new_from_array(PROGRAM_ID),
+            )
+        }
+        .unwrap();
+        acct.value = 999;
+        acct.exit().unwrap();
+    }
+
+    assert_eq!(u64::from_le_bytes(read_data_bytes(&buf, 8, 8).try_into().unwrap()), 999);
 }
 
 // -- 2. Stale detection: content-only change is NOT detected ---------


### PR DESCRIPTION
A foreign-owned writable Borsh account could receive mutable typed access even though only its owning program may modify its data.

- Separate transaction writability from local typed write authority.
- Load foreign-owned writable Borsh accounts read-only while retaining writable CPI forwarding.
- Prevent close, realloc, and mutable reacquisition through a read-only wrapper.
- Add owned and foreign-owned regression coverage.

This draft shares the `load_mut_for_program` trait hook with the separate Slab fix for finding 46; one should be rebased on the other before merge.

Fixes hackhack audit finding 88