### PR TITLE
lang-v2: gate Slab writes by program ownership

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1815,7 +1815,12 @@ pub fn parse_field(
                 if #existed {
                     // SAFETY: the bitvec duplicate-account check below ensures
                     // no other mutable reference to this account's data exists.
-                    unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
+                    unsafe {
+                        <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                            __target,
+                            __program_id,
+                        )?
+                    }
                 } else {
                     // Create branch: run `AccountConstraint::init` for every
                     // runtime-only constraint AFTER the account's typed
@@ -1832,6 +1837,9 @@ pub fn parse_field(
         quote! {
             let mut #field_name: #field_ty = {
                 let __target = __views[#offset_expr];
+                if !__target.owned_by(__program_id) {
+                    return Err(anchor_lang_v2::Error::IllegalOwner);
+                }
                 let __disc = <#field_ty as anchor_lang_v2::Discriminator>::DISCRIMINATOR;
                 {
                     let __data = __target.try_borrow()?;
@@ -1846,14 +1854,24 @@ pub fn parse_field(
                 }
                 // SAFETY: the bitvec duplicate-account check below ensures
                 // no other mutable reference to this account's data exists.
-                unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__target)? }
+                unsafe {
+                    <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                        __target,
+                        __program_id,
+                    )?
+                }
             };
         }
     } else if attrs.is_mut {
         quote! {
             // SAFETY: the bitvec duplicate-account check below ensures no
             // other mutable reference to this account's data exists.
-            let mut #field_name = unsafe { <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut(__views[#offset_expr])? };
+            let mut #field_name = unsafe {
+                <#field_ty as anchor_lang_v2::AnchorAccount>::load_mut_for_program(
+                    __views[#offset_expr],
+                    __program_id,
+                )?
+            };
         }
     } else {
         quote! {

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -26,6 +26,17 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
 
     /// # Safety
     ///
+    /// See [`AnchorAccount::load_mut_for_program`] — caller must ensure no
+    /// other live `&mut` to the same account data exists.
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        program_id: &Address,
+    ) -> Result<Self, ProgramError> {
+        T::load_mut_for_program(view, program_id).map(Box::new)
+    }
+
+    /// # Safety
+    ///
     /// See [`AnchorAccount::load_mut_after_init`] — caller must ensure no
     /// other live `&mut` to the same account data exists.
     unsafe fn load_mut_after_init(view: AccountView) -> Result<Self, ProgramError> {

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -779,6 +779,21 @@ where
         Ok(slab)
     }
 
+    #[inline(always)]
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        program_id: &Address,
+    ) -> Result<Self, ProgramError> {
+        if !view.is_writable() {
+            return Err(crate::ErrorCode::ConstraintMut.into());
+        }
+        if view.owned_by(program_id) {
+            Self::load_mut(view)
+        } else {
+            Self::load(view)
+        }
+    }
+
     /// Fast-path `load_mut` after `create_and_initialize`. Skips
     /// `H::validate` and `validate_tail` (all tautologies post-init).
     ///

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -168,6 +168,24 @@ pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {
         Self::load(view)
     }
 
+    /// Load an account for mutable access by the currently executing program.
+    ///
+    /// The default preserves the behavior of wrappers without locally
+    /// mutable data. Data-carrying wrappers override this to distinguish
+    /// transaction writability (which is sufficient for CPI forwarding)
+    /// from authority to mutate the account's data in the current program.
+    ///
+    /// # Safety
+    ///
+    /// Same aliasing requirements as [`load_mut`].
+    #[inline(always)]
+    unsafe fn load_mut_for_program(
+        view: AccountView,
+        _program_id: &Address,
+    ) -> core::result::Result<Self, ProgramError> {
+        Self::load_mut(view)
+    }
+
     /// Like [`load_mut`], but called right after
     /// `AccountInitialize::create_and_initialize`. Owner, discriminator,
     /// and min-length checks are tautologies on this path, so data-carrying

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -22,7 +22,8 @@ use {
         programs::{System, Token},
         testing::AccountBuffer,
         wincode::{SchemaRead, SchemaWrite},
-        Accounts, AnchorAccount, Discriminator, ErrorCode, Ids, Owner, TryAccounts,
+        Accounts, AnchorAccount, Discriminator, ErrorCode, Ids, Owner, ToCpiHandleMut,
+        TryAccounts,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::address::Address,
@@ -30,6 +31,7 @@ use {
 };
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
+const FOREIGN_PROGRAM_ID: [u8; 32] = [0x24; 32];
 const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
 
 struct TestInterface;
@@ -68,6 +70,20 @@ impl Owner for PodCounter {
 impl Discriminator for PodCounter {
     // sha256("account:PodCounter")[..8]
     const DISCRIMINATOR: &'static [u8] = &[0x4c, 0xde, 0x7f, 0x28, 0x61, 0x2f, 0x07, 0x73];
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct ForeignPodCounter {
+    value: u64,
+}
+
+impl Owner for ForeignPodCounter {
+    const OWNER: Address = Address::new_from_array(FOREIGN_PROGRAM_ID);
+}
+
+impl Discriminator for ForeignPodCounter {
+    const DISCRIMINATOR: &'static [u8] = &[0xa4, 0x95, 0x5a, 0x12, 0xb3, 0x8e, 0x74, 0x31];
 }
 
 #[repr(C)]
@@ -131,6 +147,21 @@ fn setup_pod_counter_buf(
     buf.init([0x45; 32], owner, 16, false, writable, false);
     let mut data = [0u8; 16];
     data[..8].copy_from_slice(PodCounter::DISCRIMINATOR);
+    data[8..16].copy_from_slice(&value.to_le_bytes());
+    buf.write_data(&data);
+}
+
+fn setup_foreign_pod_counter_buf(buf: &mut AccountBuffer<128>, value: u64) {
+    buf.init(
+        [0x48; 32],
+        FOREIGN_PROGRAM_ID,
+        16,
+        false,
+        true,
+        false,
+    );
+    let mut data = [0u8; 16];
+    data[..8].copy_from_slice(ForeignPodCounter::DISCRIMINATOR);
     data[8..16].copy_from_slice(&value.to_le_bytes());
     buf.write_data(&data);
 }
@@ -506,6 +537,58 @@ fn account_deref_mut_panics_when_loaded_read_only() {
     let view = unsafe { buf.view() };
     let mut acct = Account::<PodCounter>::load(view).unwrap();
     acct.value = 18;
+}
+
+#[test]
+fn program_scoped_slab_load_keeps_foreign_accounts_read_only() {
+    let mut buf = AccountBuffer::<128>::new();
+    setup_foreign_pod_counter_buf(&mut buf, 17);
+
+    let view = unsafe { buf.view() };
+    let mut acct = unsafe {
+        Account::<ForeignPodCounter>::load_mut_for_program(
+            view,
+            &Address::new_from_array(PROGRAM_ID),
+        )
+    }
+    .unwrap();
+
+    assert_eq!(acct.value, 17);
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| acct.value = 18)).is_err(),
+        "foreign-owned typed data must not be locally mutable"
+    );
+    assert!(
+        acct.try_to_cpi_handle_mut().is_ok(),
+        "transaction writability must remain available for CPI forwarding"
+    );
+    assert_eq!(
+        u64::from_le_bytes(buf.read_data()[8..16].try_into().unwrap()),
+        17
+    );
+}
+
+#[test]
+fn program_scoped_slab_load_allows_owned_accounts() {
+    let mut buf = AccountBuffer::<128>::new();
+    setup_pod_counter_buf(&mut buf, PROGRAM_ID, true, 17);
+
+    {
+        let view = unsafe { buf.view() };
+        let mut acct = unsafe {
+            Account::<PodCounter>::load_mut_for_program(
+                view,
+                &Address::new_from_array(PROGRAM_ID),
+            )
+        }
+        .unwrap();
+        acct.value = 18;
+    }
+
+    assert_eq!(
+        u64::from_le_bytes(buf.read_data()[8..16].try_into().unwrap()),
+        18
+    );
 }
 
 // -- BorshAccount<T> ---------------------------------------------------

--- a/tests-v2/tests/derives.rs
+++ b/tests-v2/tests/derives.rs
@@ -338,7 +338,7 @@ fn emit_bytemuck_event_copies_repr_c_bytes() {
     do_bump(&mut svm, &payer, counter, 99, 0);
 
     // snapshot (discrim=5) emits a bytemuck-mode event.
-    let metas = vec![AccountMeta::new_readonly(counter, false)];
+    let metas = vec![AccountMeta::new(counter, false)];
     let meta = send_instruction(&mut svm, program_id(), vec![5], metas, &payer, &[])
         .expect("snapshot should succeed");
 


### PR DESCRIPTION
A foreign-owned writable Slab account could receive mutable typed access even though only its owning program may modify its data.

- Separate transaction writability from local typed write authority.
- Load foreign-owned writable Slab accounts read-only while retaining writable CPI forwarding.
- Keep current-program-owned Slab accounts mutable.
- Reject foreign-owned `zeroed` writes before stamping the discriminator.
- Add owned and foreign-owned regression coverage.

This draft shares the `load_mut_for_program` trait hook with the separate Borsh fix for finding 88; one should be rebased on the other before merge.

Fixes hackhack audit finding 46