### PR TITLE
lang-v2: preserve instruction argument names

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -737,6 +737,13 @@ struct ArgsDeser {
     arg_types: Vec<Type>,
 }
 
+fn instruction_arg_name_hash(name: &Ident) -> u128 {
+    use sha2::Digest;
+
+    let digest = sha2::Sha256::digest(name.to_string().as_bytes());
+    u128::from_le_bytes(digest[..16].try_into().unwrap())
+}
+
 /// Compute lifetime-rewritten argument types plus a flag indicating whether
 /// any argument carries an instruction-data borrow.
 fn args_meta(args: &[(&Ident, &Type)]) -> (Vec<Type>, bool) {
@@ -1227,15 +1234,31 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .collect();
 
     let (ix_deser, ix_args_assoc, ix_args_return) = if ix_args.is_empty() {
-        (quote! {}, quote! { type IxArgs<'ix> = (); }, quote! { () })
+        (
+            quote! {},
+            quote! {
+                type IxArgs<'ix> = ();
+                type IxArgSchema<'ix> = ();
+            },
+            quote! { () },
+        )
     } else {
         let pairs: Vec<(&Ident, &Type)> = ix_args.iter().map(|(n, t)| (n, t)).collect();
         let ix_args_deser = emit_args_deser(&pairs, "__IxArgs", false);
         let ix_arg_types = ix_args_deser.arg_types;
         let ix_arg_names: Vec<&Ident> = ix_args.iter().map(|(n, _)| n).collect();
+        let ix_arg_name_hashes: Vec<u128> = ix_arg_names
+            .iter()
+            .map(|name| instruction_arg_name_hash(name))
+            .collect();
         (
             ix_args_deser.deser,
-            quote! { type IxArgs<'ix> = (#(#ix_arg_types,)*); },
+            quote! {
+                type IxArgs<'ix> = (#(#ix_arg_types,)*);
+                type IxArgSchema<'ix> = (
+                    #(anchor_lang_v2::InstructionArg<#ix_arg_types, #ix_arg_name_hashes>,)*
+                );
+            },
             quote! { (#(#ix_arg_names,)*) },
         )
     };
@@ -4462,6 +4485,15 @@ fn process_handler(
         }
     } else {
         let tuple_ty = quote! { (#(#extra_arg_types,)*) };
+        let extra_arg_name_hashes: Vec<u128> = extra_arg_names
+            .iter()
+            .map(|name| instruction_arg_name_hash(name))
+            .collect();
+        let arg_schema_ty = quote! {
+            (
+                #(anchor_lang_v2::InstructionArg<#extra_arg_types, #extra_arg_name_hashes>,)*
+            )
+        };
         let args_deser = emit_args_deser(&extra_args, "__Args", false);
         let deser_args = args_deser.deser;
         quote! {
@@ -4494,6 +4526,16 @@ fn process_handler(
                         Ok(self)
                     }
                 }
+
+                trait __AnchorIxArgSchema {}
+                impl __AnchorIxArgSchema for () {}
+                impl __AnchorIxArgSchema for #arg_schema_ty {}
+
+                #[inline(always)]
+                fn __anchor_assert_ix_arg_schema<T: __AnchorIxArgSchema>() {}
+                __anchor_assert_ix_arg_schema::<
+                    <#accounts_path as anchor_lang_v2::TryAccounts>::IxArgSchema<'a>
+                >();
 
                 match anchor_lang_v2::run_handler::<#accounts_path, #return_ty>(
                     __program_id,

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -8,6 +8,14 @@ use {
     solana_program_error::ProgramError,
 };
 
+/// Type-level identity for an instruction argument.
+///
+/// Generated code uses `NAME_HASH` together with `T` to ensure an Accounts
+/// constraint and its handler agree on both the semantic name and type of
+/// every instruction argument.
+#[doc(hidden)]
+pub struct InstructionArg<T, const NAME_HASH: u128>(core::marker::PhantomData<T>);
+
 /// Trait that `#[derive(Accounts)]` implements on account structs.
 ///
 /// `try_accounts` receives a pre-walked `&[AccountView]` slice (from a
@@ -44,6 +52,12 @@ pub trait TryAccounts: Bumps + Sized {
     /// Parsed instruction args carried alongside validated accounts.
     /// Accounts structs without `#[instruction(...)]` use `()`.
     type IxArgs<'ix>;
+
+    /// Type-level instruction argument names and types. Generated handler
+    /// dispatch accepts either `()` (no constraint arguments) or the exact
+    /// handler schema.
+    #[doc(hidden)]
+    type IxArgSchema<'ix>;
 
     /// `base_offset` is the index of the first view in the global bitvec.
     /// Top-level callers pass 0; `Nested<T>` passes its field's offset so

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -183,7 +183,7 @@ pub use {
         find_program_address, verify_program_address,
     },
     cursor::{mut_mask_or_shifted, mut_mask_set_bit, AccountBitvec, AccountCursor},
-    dispatch::{run_handler, TryAccounts},
+    dispatch::{run_handler, InstructionArg, TryAccounts},
     event::{sol_log_data, Event},
     hash::sha256,
     loader::AccountLoader,

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -394,6 +394,74 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn instruction_arg_names_must_match_handler_order() {
+    compile_fail_case(
+        "instruction_arg_name_mismatch",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod instruction_arg_name_mismatch {
+    use super::*;
+
+    pub fn ix(
+        _ctx: &mut Context<Bad>,
+        max_amount: u64,
+        requested_amount: u64,
+    ) -> Result<()> {
+        let _ = (max_amount, requested_amount);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(requested_amount: u64, max_amount: u64)]
+pub struct Bad {
+    #[account(constraint = requested_amount <= max_amount)]
+    pub data: UncheckedAccount,
+}
+"#,
+        &["__AnchorIxArgSchema", "is not implemented"],
+    );
+
+    compile_pass_case(
+        "instruction_arg_names_match",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod instruction_arg_names_match {
+    use super::*;
+
+    pub fn ix(
+        _ctx: &mut Context<Good>,
+        max_amount: u64,
+        requested_amount: u64,
+    ) -> Result<()> {
+        let _ = (max_amount, requested_amount);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(max_amount: u64, requested_amount: u64)]
+pub struct Good {
+    #[account(constraint = requested_amount <= max_amount)]
+    pub data: UncheckedAccount,
+}
+"#,
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",

--- a/tests-v2/programs/seeds/src/lib.rs
+++ b/tests-v2/programs/seeds/src/lib.rs
@@ -106,24 +106,27 @@ pub mod seeds {
     #[discrim = 11]
     pub fn init_wrapped_arg_seed(
         _ctx: &mut Context<InitWrappedArgSeed>,
-        _next_oracle_id: u64,
+        next_oracle_id: u64,
     ) -> Result<()> {
+        let _ = next_oracle_id;
         Ok(())
     }
 
     #[discrim = 12]
     pub fn check_literal_untrusted_bump(
         _ctx: &mut Context<CheckLiteralUntrustedBump>,
-        _untrusted_bump: u8,
+        untrusted_bump: u8,
     ) -> Result<()> {
+        let _ = untrusted_bump;
         Ok(())
     }
 
     #[discrim = 13]
     pub fn check_fn_seeds_untrusted_bump(
         _ctx: &mut Context<CheckFnSeedsUntrustedBump>,
-        _untrusted_bump: u8,
+        untrusted_bump: u8,
     ) -> Result<()> {
+        let _ = untrusted_bump;
         Ok(())
     }
 }


### PR DESCRIPTION
Same-typed instruction arguments could be reordered or renamed between a handler and `#[instruction(...)]`, causing constraints to consume the wrong value.

- Encode each instruction argument name and type into a generated type-level schema.
- Require handler dispatch to match that schema exactly when `#[instruction(...)]` is present.
- Preserve the existing no-annotation fallback that deserializes handler arguments directly.
- Add compile-fail coverage for swapped same-typed arguments and a matching control.

The name identity uses a 128-bit SHA-256 prefix generated at compile time and has no runtime cost.

Fixes hackhack audit finding 94