### PR TITLE
lang-v2: reject nested instruction arguments

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1115,10 +1115,15 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .collect();
     let bump_cache_locals: Vec<proc_macro2::TokenStream> = fields
         .iter()
-        .filter(|f| f.has_bump)
+        .filter(|f| f.has_bump || parse::extract_nested_inner_type(&f.ty).is_some())
         .map(|f| {
             let bump_cache = parse::bump_cache_ident(&f.name);
-            if f.is_optional {
+            if let Some(inner_ty) = parse::extract_nested_inner_type(&f.ty) {
+                quote! {
+                    let mut #bump_cache: <#inner_ty as anchor_lang_v2::Bumps>::Bumps =
+                        ::core::default::Default::default();
+                }
+            } else if f.is_optional {
                 quote! {
                     let mut #bump_cache: ::core::option::Option<u8> = ::core::default::Default::default();
                 }
@@ -7054,6 +7059,12 @@ mod tests {
                 "let (__nested_inner , __anchor_bump_cache_inner , _) = < Inner as anchor_lang_v2 :: TryAccounts > :: validate_accounts"
             ),
             "expected nested validate_accounts call to keep the returned bumps value: {generated}"
+        );
+        assert!(
+            generated.contains(
+                "let mut __anchor_bump_cache_inner : < Inner as anchor_lang_v2 :: Bumps > :: Bumps = :: core :: default :: Default :: default() ;"
+            ),
+            "expected nested bump cache local declaration: {generated}"
         );
         assert!(
             generated

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2324,6 +2324,10 @@ pub fn parse_field(
         let inner_ty = extract_nested_inner_type(field_ty)
             .expect("is_nested_type was true but extract_nested_inner_type returned None");
         let nested_bumps = bump_cache_ident(field_name);
+        let assert_no_nested_ix_args = Ident::new(
+            &format!("__anchor_assert_no_nested_ix_args_{field_name}"),
+            field_name.span(),
+        );
         // Nested<Inner> — delegate to Inner::validate_accounts, which advances
         // the shared cursor by Inner::HEADER_SIZE without firing inner
         // update-hooks yet. The outer walk_n covers only direct
@@ -2340,7 +2344,7 @@ pub fn parse_field(
         // nested struct. A future optimization could pre-shift the bitvec
         // or use a wrapper that offsets transparently.
         let load = quote! {
-            let (__nested_inner, #nested_bumps, _) =
+            let (__nested_inner, #nested_bumps, __nested_ix_args) =
                 <#inner_ty as anchor_lang_v2::TryAccounts>::validate_accounts(
                     __program_id,
                     &__views[#offset_expr .. #offset_expr + <#inner_ty as anchor_lang_v2::TryAccounts>::HEADER_SIZE],
@@ -2348,6 +2352,13 @@ pub fn parse_field(
                     __base_offset + #offset_expr,
                     __ix_data,
                 )?;
+            // A nested Accounts type currently has no way to return its
+            // parsed arguments to handler dispatch. Reject such schemas at
+            // compile time instead of validating one interpretation of the
+            // bytes and letting the handler consume another.
+            #[inline(always)]
+            fn #assert_no_nested_ix_args(_: ()) {}
+            #assert_no_nested_ix_args(__nested_ix_args);
             let #field_name = anchor_lang_v2::Nested(__nested_inner);
         };
         let exit = Some(quote! {

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -507,6 +507,45 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn nested_accounts_reject_instruction_arguments() {
+    compile_fail_case(
+        "nested_instruction_args",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod nested_instruction_args {
+    use super::*;
+
+    pub fn ix(_ctx: &mut Context<Outer>, amount: u64) -> Result<()> {
+        let _ = amount;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(amount: u8)]
+pub struct Inner {
+    #[account(constraint = amount == 0)]
+    pub data: UncheckedAccount,
+}
+
+#[derive(Accounts)]
+pub struct Outer {
+    pub inner: Nested<Inner>,
+}
+"#,
+        &["expected `()`, found `(u8,)`"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",


### PR DESCRIPTION
Nested account validation could deserialize the same instruction bytes under a second, incompatible argument schema.

- Stop discarding instruction arguments returned by nested Accounts validation.
- Reject nested Accounts types with `#[instruction(...)]` at compile time, before two schemas can reinterpret the same bytes.
- Keep ordinary nested Accounts behavior unchanged.
- Add a compile-fail regression for the `u8` constraint / `u64` handler case.

This deliberately chooses a small safe restriction for the draft. Supporting nested instruction arguments later should propagate their typed schema into top-level handler dispatch rather than deserialize twice.

Fixes hackhack audit finding 95