### PR TITLE
spl-v2: support multisig token authorities

### DIFF
--- a/spl-v2/src/token.rs
+++ b/spl-v2/src/token.rs
@@ -375,6 +375,9 @@ pub fn set_authority<'a>(
 /// letting callers avoid manually building `CpiContext` for simple Token CPIs.
 /// Pass `&[]` for transaction signers, or PDA signer seeds for program-signed
 /// authorities on methods that support PDA signing.
+///
+/// SPL multisig authorities use the corresponding free function and attach
+/// member signer handles with `CpiContext::with_remaining_accounts`.
 pub trait TokenCpiExt {
     fn mint_to<'a, M, T, A>(
         &'a self,

--- a/spl-v2/src/token_2022.rs
+++ b/spl-v2/src/token_2022.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use {
+    crate::token_shared::multisig_signer_addresses,
     alloc::{string::String, vec::Vec},
     anchor_lang_v2::{require_eq, CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
@@ -171,12 +172,13 @@ pub fn reallocate<'a>(
     ctx: CpiContext<'a, Reallocate<'a>>,
     extension_types: &[ExtensionType],
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::reallocate(
         ctx.program,
         ctx.accounts.account.address(),
         ctx.accounts.payer.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         extension_types,
     )?;
     ctx.invoke_ix(ix)
@@ -185,12 +187,13 @@ pub fn reallocate<'a>(
 pub fn withdraw_excess_lamports<'a>(
     ctx: CpiContext<'a, WithdrawExcessLamports<'a>>,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::withdraw_excess_lamports(
         ctx.program,
         ctx.accounts.source.address(),
         ctx.accounts.destination.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }

--- a/spl-v2/src/token_2022_extensions/default_account_state.rs
+++ b/spl-v2/src/token_2022_extensions/default_account_state.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     solana_program_error::ProgramError,
 };
@@ -38,12 +38,13 @@ pub fn default_account_state_update<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix =
         spl_token_2022::extension::default_account_state::instruction::update_default_account_state(
             &program,
             ctx.accounts.mint.address(),
             ctx.accounts.freeze_authority.address(),
-            &[],
+            &signer_addresses,
             state,
         )?;
     ctx.invoke_ix(ix)

--- a/spl-v2/src/token_2022_extensions/group_member_pointer.rs
+++ b/spl-v2/src/token_2022_extensions/group_member_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -38,11 +38,12 @@ pub fn group_member_pointer_update<'a>(
     member_address: Option<&Address>,
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::group_member_pointer::instruction::update(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         member_address.copied(),
     )?;
     ctx.invoke_ix(ix)

--- a/spl-v2/src/token_2022_extensions/group_pointer.rs
+++ b/spl-v2/src/token_2022_extensions/group_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_instruction::Instruction,
@@ -39,10 +39,12 @@ pub fn group_pointer_update<'a>(
     group_address: Option<&Address>,
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = group_pointer_update_ix(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
+        &signer_addresses,
         group_address,
     )?;
     ctx.invoke_ix(ix)
@@ -52,13 +54,14 @@ fn group_pointer_update_ix(
     program: &Address,
     mint: &Address,
     authority: &Address,
+    signer_addresses: &[&Address],
     group_address: Option<&Address>,
 ) -> Result<Instruction, ProgramError> {
     spl_token_2022::extension::group_pointer::instruction::update(
         program,
         mint,
         authority,
-        &[],
+        signer_addresses,
         group_address.copied(),
     )
 }
@@ -91,7 +94,7 @@ mod tests {
         let authority = Address::new_from_array([2; 32]);
         let group = Address::new_from_array([3; 32]);
 
-        let ix = group_pointer_update_ix(&program, &mint, &authority, Some(&group))
+        let ix = group_pointer_update_ix(&program, &mint, &authority, &[], Some(&group))
             .expect("group pointer update ix should build");
         assert_eq!(ix.accounts.len(), 2);
         assert!(ix.accounts[0].is_writable);

--- a/spl-v2/src/token_2022_extensions/interest_bearing_mint.rs
+++ b/spl-v2/src/token_2022_extensions/interest_bearing_mint.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -40,11 +40,12 @@ pub fn interest_bearing_mint_update_rate<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::interest_bearing_mint::instruction::update_rate(
         &program,
         ctx.accounts.mint.address(),
         ctx.accounts.rate_authority.address(),
-        &[],
+        &signer_addresses,
         rate,
     )?;
     ctx.invoke_ix(ix)

--- a/spl-v2/src/token_2022_extensions/memo_transfer.rs
+++ b/spl-v2/src/token_2022_extensions/memo_transfer.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     solana_program_error::ProgramError,
 };
@@ -17,11 +17,12 @@ pub fn memo_transfer_initialize<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::memo_transfer::instruction::enable_required_transfer_memos(
         &program,
         ctx.accounts.account.address(),
         ctx.accounts.owner.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
@@ -31,12 +32,13 @@ pub fn memo_transfer_disable<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix =
         spl_token_2022::extension::memo_transfer::instruction::disable_required_transfer_memos(
             &program,
             ctx.accounts.account.address(),
             ctx.accounts.owner.address(),
-            &[],
+            &signer_addresses,
         )?;
     ctx.invoke_ix(ix)
 }

--- a/spl-v2/src/token_2022_extensions/metadata_pointer.rs
+++ b/spl-v2/src/token_2022_extensions/metadata_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -40,11 +40,12 @@ pub fn metadata_pointer_update<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::metadata_pointer::instruction::update(
         &program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         metadata_address.copied(),
     )?;
     ctx.invoke_ix(ix)

--- a/spl-v2/src/token_2022_extensions/pausable.rs
+++ b/spl-v2/src/token_2022_extensions/pausable.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -33,22 +33,24 @@ pub fn pausable_initialize<'a>(
 
 pub fn pausable_pause<'a>(ctx: CpiContext<'a, PausableToggle<'a>>) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::pausable::instruction::pause(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
 
 pub fn pausable_resume<'a>(ctx: CpiContext<'a, PausableToggle<'a>>) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::pausable::instruction::resume(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }

--- a/spl-v2/src/token_2022_extensions/transfer_fee.rs
+++ b/spl-v2/src/token_2022_extensions/transfer_fee.rs
@@ -1,6 +1,6 @@
 use {
     super::common::{pubkey_refs, validate_token_2022_program},
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     alloc::vec::Vec,
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
@@ -79,11 +79,12 @@ pub fn transfer_fee_set<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::transfer_fee::instruction::set_transfer_fee(
         &program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         transfer_fee_basis_points,
         maximum_fee,
     )?;
@@ -98,13 +99,14 @@ pub fn transfer_checked_with_fee<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::transfer_fee::instruction::transfer_checked_with_fee(
         &program,
         ctx.accounts.source.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.destination.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
         decimals,
         fee,
@@ -136,13 +138,14 @@ pub fn withdraw_withheld_tokens_from_mint<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix =
         spl_token_2022::extension::transfer_fee::instruction::withdraw_withheld_tokens_from_mint(
             &program,
             ctx.accounts.mint.address(),
             ctx.accounts.destination.address(),
             ctx.accounts.authority.address(),
-            &[],
+            &signer_addresses,
         )?;
     ctx.invoke_ix(ix)
 }
@@ -153,6 +156,7 @@ pub fn withdraw_withheld_tokens_from_accounts<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let source_pubkeys: Vec<Pubkey> = sources.iter().map(|source| *source.address()).collect();
     let source_refs = pubkey_refs(&source_pubkeys);
     let ix =
@@ -161,11 +165,11 @@ pub fn withdraw_withheld_tokens_from_accounts<'a>(
             ctx.accounts.mint.address(),
             ctx.accounts.destination.address(),
             ctx.accounts.authority.address(),
-            &[],
+            &signer_addresses,
             &source_refs,
         )?;
-    let mut remaining_accounts: Vec<CpiHandle<'a>> = sources.into_iter().map(Into::into).collect();
-    remaining_accounts.extend(ctx.remaining_accounts.iter().copied());
+    let mut remaining_accounts = ctx.remaining_accounts.clone();
+    remaining_accounts.extend(sources.into_iter().map(CpiHandle::from));
     ctx.with_remaining_accounts(remaining_accounts)
         .invoke_ix(ix)
 }

--- a/spl-v2/src/token_2022_extensions/transfer_hook.rs
+++ b/spl-v2/src/token_2022_extensions/transfer_hook.rs
@@ -1,6 +1,6 @@
 use {
     super::common::validate_token_2022_program,
-    crate::token_2022::spl_token_2022,
+    crate::{token_2022::spl_token_2022, token_shared::multisig_signer_addresses},
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -40,11 +40,12 @@ pub fn transfer_hook_update<'a>(
 ) -> Result<(), ProgramError> {
     validate_token_2022_program(ctx.program)?;
     let program = *ctx.program;
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::extension::transfer_hook::instruction::update(
         &program,
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         transfer_hook_program_id.copied(),
     )?;
     ctx.invoke_ix(ix)

--- a/spl-v2/src/token_shared.rs
+++ b/spl-v2/src/token_shared.rs
@@ -1,15 +1,27 @@
 //! Shared base token CPI helpers used by `token` and `token_2022`.
+//!
+//! Authority-bearing helpers support both single authorities and SPL
+//! multisigs. For a multisig, pass the member signer handles in canonical
+//! order through [`CpiContext::with_remaining_accounts`].
 
 extern crate alloc;
 
 #[cfg(feature = "guardrails")]
 use anchor_lang_v2::{require, Id};
 use {
+    alloc::vec::Vec,
     anchor_lang_v2::{CpiContext, CpiHandle, CpiHandleMut, ToCpiAccounts},
     pinocchio::address::Address,
     solana_program_error::ProgramError,
     spl_token_2022_interface as spl_token_2022,
 };
+
+/// SPL Token encodes a multisig authority by marking the authority account
+/// non-signer and appending each member signer to the instruction. Token CPI
+/// callers provide those member handles through `remaining_accounts`.
+pub(crate) fn multisig_signer_addresses<'a>(accounts: &[CpiHandle<'a>]) -> Vec<&'a Address> {
+    accounts.iter().map(CpiHandle::address).collect()
+}
 
 #[cfg(feature = "guardrails")]
 #[inline]
@@ -58,7 +70,7 @@ pub struct InitializeMint2<'a> {
 /// Token / Token-2022 transfer instruction — accounts list:
 ///   0. `[writable]` from
 ///   1. `[writable]` to
-///   2. `[signer]` authority (owner/delegate)
+///   2. `[signer]` authority, or `[]` multisig authority followed by member signers
 #[derive(ToCpiAccounts)]
 pub struct Transfer<'a> {
     pub from: CpiHandleMut<'a>,
@@ -72,7 +84,7 @@ pub struct Transfer<'a> {
 ///   0. `[writable]` from
 ///   1. `[]` mint
 ///   2. `[writable]` to
-///   3. `[signer]` authority
+///   3. `[signer]` authority, or `[]` multisig authority followed by member signers
 #[derive(ToCpiAccounts)]
 pub struct TransferChecked<'a> {
     pub from: CpiHandleMut<'a>,
@@ -231,13 +243,14 @@ pub fn initialize_mint2<'a>(
 }
 
 pub fn transfer<'a>(ctx: CpiContext<'a, Transfer<'a>>, amount: u64) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     #[allow(deprecated)]
     let ix = spl_token_2022::instruction::transfer(
         ctx.program,
         ctx.accounts.from.address(),
         ctx.accounts.to.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
     )?;
     ctx.invoke_ix(ix)
@@ -248,13 +261,14 @@ pub fn transfer_checked<'a>(
     amount: u64,
     decimals: u8,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::transfer_checked(
         ctx.program,
         ctx.accounts.from.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.to.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
         decimals,
     )?;
@@ -262,12 +276,13 @@ pub fn transfer_checked<'a>(
 }
 
 pub fn mint_to<'a>(ctx: CpiContext<'a, MintTo<'a>>, amount: u64) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::mint_to(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.to.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
     )?;
     ctx.invoke_ix(ix)
@@ -278,12 +293,13 @@ pub fn mint_to_checked<'a>(
     amount: u64,
     decimals: u8,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::mint_to_checked(
         ctx.program,
         ctx.accounts.mint.address(),
         ctx.accounts.to.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
         decimals,
     )?;
@@ -291,12 +307,13 @@ pub fn mint_to_checked<'a>(
 }
 
 pub fn burn<'a>(ctx: CpiContext<'a, Burn<'a>>, amount: u64) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::burn(
         ctx.program,
         ctx.accounts.from.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
     )?;
     ctx.invoke_ix(ix)
@@ -307,12 +324,13 @@ pub fn burn_checked<'a>(
     amount: u64,
     decimals: u8,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::burn_checked(
         ctx.program,
         ctx.accounts.from.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
         decimals,
     )?;
@@ -320,12 +338,13 @@ pub fn burn_checked<'a>(
 }
 
 pub fn approve<'a>(ctx: CpiContext<'a, Approve<'a>>, amount: u64) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::approve(
         ctx.program,
         ctx.accounts.to.address(),
         ctx.accounts.delegate.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
     )?;
     ctx.invoke_ix(ix)
@@ -336,13 +355,14 @@ pub fn approve_checked<'a>(
     amount: u64,
     decimals: u8,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::approve_checked(
         ctx.program,
         ctx.accounts.to.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.delegate.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
         amount,
         decimals,
     )?;
@@ -350,11 +370,12 @@ pub fn approve_checked<'a>(
 }
 
 pub fn revoke<'a>(ctx: CpiContext<'a, Revoke<'a>>) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::revoke(
         ctx.program,
         ctx.accounts.source.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
@@ -364,46 +385,50 @@ pub fn set_authority<'a>(
     authority_type: spl_token_2022::instruction::AuthorityType,
     new_authority: Option<&Address>,
 ) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::set_authority(
         ctx.program,
         ctx.accounts.account_or_mint.address(),
         new_authority,
         authority_type,
         ctx.accounts.current_authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
 
 pub fn close_account<'a>(ctx: CpiContext<'a, CloseAccount<'a>>) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::close_account(
         ctx.program,
         ctx.accounts.account.address(),
         ctx.accounts.destination.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
 
 pub fn freeze_account<'a>(ctx: CpiContext<'a, FreezeAccount<'a>>) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::freeze_account(
         ctx.program,
         ctx.accounts.account.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
 
 pub fn thaw_account<'a>(ctx: CpiContext<'a, ThawAccount<'a>>) -> Result<(), ProgramError> {
+    let signer_addresses = multisig_signer_addresses(&ctx.remaining_accounts);
     let ix = spl_token_2022::instruction::thaw_account(
         ctx.program,
         ctx.accounts.account.address(),
         ctx.accounts.mint.address(),
         ctx.accounts.authority.address(),
-        &[],
+        &signer_addresses,
     )?;
     ctx.invoke_ix(ix)
 }
@@ -411,4 +436,56 @@ pub fn thaw_account<'a>(ctx: CpiContext<'a, ThawAccount<'a>>) -> Result<(), Prog
 pub fn sync_native<'a>(ctx: CpiContext<'a, SyncNative<'a>>) -> Result<(), ProgramError> {
     let ix = spl_token_2022::instruction::sync_native(ctx.program, ctx.accounts.account.address())?;
     ctx.invoke_ix(ix)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        anchor_lang_v2::{
+            programs::Token,
+            testing::{AccountBuffer, MIN_ACCOUNT_BUF},
+            Id,
+        },
+    };
+
+    fn signer(address: [u8; 32]) -> AccountBuffer<{ MIN_ACCOUNT_BUF + 8 }> {
+        let buffer = AccountBuffer::new();
+        buffer.init(address, [9; 32], 8, true, false, false);
+        buffer
+    }
+
+    #[test]
+    fn remaining_signers_encode_canonical_multisig_layout() {
+        let member_one = signer([4; 32]);
+        let member_two = signer([5; 32]);
+        let member_one_view = unsafe { member_one.view() };
+        let member_two_view = unsafe { member_two.view() };
+        let handles = [
+            CpiHandle::readonly(&member_one_view),
+            CpiHandle::readonly(&member_two_view),
+        ];
+        let signer_addresses = multisig_signer_addresses(&handles);
+
+        #[allow(deprecated)]
+        let ix = spl_token_2022::instruction::transfer(
+            &Token::id(),
+            &Address::new_from_array([1; 32]),
+            &Address::new_from_array([2; 32]),
+            &Address::new_from_array([3; 32]),
+            &signer_addresses,
+            7,
+        )
+        .unwrap();
+
+        assert_eq!(ix.accounts.len(), 5);
+        assert!(
+            !ix.accounts[2].is_signer,
+            "multisig account is not a signer"
+        );
+        assert!(ix.accounts[3].is_signer);
+        assert!(ix.accounts[4].is_signer);
+        assert_eq!(ix.accounts[3].pubkey.as_ref(), [4; 32].as_slice());
+        assert_eq!(ix.accounts[4].pubkey.as_ref(), [5; 32].as_slice());
+    }
 }


### PR DESCRIPTION
SPL v2 CPI helpers omitted multisig member signer accounts, so valid Token and Token-2022 multisig authority calls could not be constructed.

- Treat `CpiContext::remaining_accounts` as the ordered SPL multisig member-signers for authority-bearing Token and Token-2022 helpers.
- Pass those addresses to every shared and extension instruction builder that previously hard-coded an empty signer list.
- Preserve the existing single-authority and PDA-authority behavior when the list is empty.
- Keep dynamic transfer-fee source handles after multisig signer handles so instruction metas and CPI handles stay aligned.
- Document the free-function path for multisig callers and add canonical meta-layout coverage.

Example:
```rust
let cpi = CpiContext::new(token_program.address(), accounts)
    .with_remaining_accounts(vec![member_one.cpi_handle(), member_two.cpi_handle()]);
token::transfer(cpi, 7)?;
```

Fixes hackhack audit finding 59