### PR TITLE
Ensure AVM nightly artifacts match manifest provenance

### DIFF
--- a/.github/workflows/nightly-attested-binaries.yaml
+++ b/.github/workflows/nightly-attested-binaries.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1

--- a/avm/src/attestation.rs
+++ b/avm/src/attestation.rs
@@ -19,6 +19,7 @@ const GITHUB_ACTIONS_ISSUER: &str = "https://token.actions.githubusercontent.com
 const SLSA_PROVENANCE_V1: &str = "https://slsa.dev/provenance/v1";
 const RELEASE_WORKFLOW: &str = ".github/workflows/build-cli.yaml";
 const NIGHTLY_WORKFLOW: &str = ".github/workflows/nightly-attested-binaries.yaml";
+const NIGHTLY_GIT_REF: &str = "refs/heads/master";
 const FIRST_ATTESTED_RELEASE: Version = Version::new(1, 1, 0);
 
 #[derive(Deserialize)]
@@ -36,11 +37,11 @@ pub(crate) fn verify_release(path: &Path, version: &Version) -> Result<()> {
         eprintln!("Anchor v{version} does not have signed releases, skipping checks");
         return Ok(());
     }
-    verify(path, &release_identity(version))
+    verify(path, &release_identity(version), None)
 }
 
-pub(crate) fn verify_nightly(path: &Path) -> Result<()> {
-    verify(path, &nightly_identity())
+pub(crate) fn verify_nightly(path: &Path, source_commit: &str, subject: &str) -> Result<()> {
+    verify(path, &nightly_identity(), Some((source_commit, subject)))
 }
 
 fn release_identity(version: &Version) -> String {
@@ -53,14 +54,22 @@ fn release_has_attestation(version: &Version) -> bool {
 }
 
 fn nightly_identity() -> String {
-    workflow_identity(NIGHTLY_WORKFLOW, "refs/heads/master")
+    workflow_identity(NIGHTLY_WORKFLOW, NIGHTLY_GIT_REF)
 }
 
 fn workflow_identity(workflow: &str, git_ref: &str) -> String {
     format!("https://github.com/{GITHUB_REPOSITORY}/{workflow}@{git_ref}")
 }
 
-fn verify(path: &Path, expected_identity: &str) -> Result<()> {
+fn nightly_source_uri() -> String {
+    format!("git+https://github.com/{GITHUB_REPOSITORY}@{NIGHTLY_GIT_REF}")
+}
+
+fn verify(
+    path: &Path,
+    expected_identity: &str,
+    expected_nightly: Option<(&str, &str)>,
+) -> Result<()> {
     let digest = sha256_file(path)?;
     let attestations = fetch_attestations(digest).with_context(|| {
         format!(
@@ -68,7 +77,7 @@ fn verify(path: &Path, expected_identity: &str) -> Result<()> {
             path.display()
         )
     })?;
-    verify_attestations(&attestations, digest, expected_identity)
+    verify_attestations(&attestations, digest, expected_identity, expected_nightly)
 }
 
 fn fetch_attestations(digest: Sha256Hash) -> Result<Vec<GitHubAttestation>> {
@@ -109,6 +118,7 @@ fn verify_attestations(
     attestations: &[GitHubAttestation],
     digest: Sha256Hash,
     expected_identity: &str,
+    expected_nightly: Option<(&str, &str)>,
 ) -> Result<()> {
     if attestations.is_empty() {
         bail!(
@@ -130,10 +140,13 @@ fn verify_attestations(
             let json = serde_json::to_string(&attestation.bundle)
                 .context("Serializing Sigstore bundle")?;
             let bundle = Bundle::from_json(&json).context("Parsing Sigstore bundle")?;
-            require_slsa_provenance(&bundle)?;
+            let statement = require_slsa_provenance(&bundle)?;
             verifier
                 .verify(digest, &bundle, &policy)
                 .context("Verifying Sigstore bundle")?;
+            if let Some(expected) = expected_nightly {
+                require_nightly_provenance(&statement, digest, expected)?;
+            }
             Ok(())
         })();
 
@@ -154,7 +167,7 @@ fn verify_attestations(
     )
 }
 
-fn require_slsa_provenance(bundle: &Bundle) -> Result<()> {
+fn require_slsa_provenance(bundle: &Bundle) -> Result<Statement> {
     let SignatureContent::DsseEnvelope(envelope) = &bundle.content else {
         bail!("Build provenance attestation is not a DSSE envelope");
     };
@@ -173,6 +186,47 @@ fn require_slsa_provenance(bundle: &Bundle) -> Result<()> {
             statement.predicate_type
         );
     }
+    Ok(statement)
+}
+
+fn require_nightly_provenance(
+    statement: &Statement,
+    digest: Sha256Hash,
+    expected: (&str, &str),
+) -> Result<()> {
+    let (source_commit, expected_subject) = expected;
+    let source_matches = statement
+        .predicate
+        .pointer("/buildDefinition/resolvedDependencies")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|dependency| {
+            dependency.get("uri").and_then(Value::as_str) == Some(nightly_source_uri().as_str())
+                && dependency
+                    .pointer("/digest/gitCommit")
+                    .and_then(Value::as_str)
+                    == Some(source_commit)
+        });
+    if !source_matches {
+        bail!(
+            "Build provenance source commit does not match `{}`",
+            source_commit
+        );
+    }
+
+    let digest = digest.to_hex();
+    let subject_matches = statement.subject.iter().any(|subject| {
+        subject.name == expected_subject
+            && subject.digest.sha256.as_deref() == Some(digest.as_str())
+    });
+    if !subject_matches {
+        bail!(
+            "Build provenance subject does not match `{}` with digest `sha256:{digest}`",
+            expected_subject
+        );
+    }
+
     Ok(())
 }
 
@@ -234,15 +288,66 @@ mod tests {
         .unwrap();
         let attestations = fetch_attestations(digest).unwrap();
 
-        verify_attestations(&attestations, digest, &nightly_identity()).unwrap();
+        verify_attestations(&attestations, digest, &nightly_identity(), None).unwrap();
 
         let wrong_digest = Sha256Hash::from_bytes([0; 32]);
-        assert!(verify_attestations(&attestations, wrong_digest, &nightly_identity()).is_err());
+        assert!(
+            verify_attestations(&attestations, wrong_digest, &nightly_identity(), None).is_err()
+        );
         assert!(verify_attestations(
             &attestations,
             digest,
-            &release_identity(&Version::new(1, 1, 2))
+            &release_identity(&Version::new(1, 1, 2)),
+            None,
         )
         .is_err());
+    }
+
+    #[test]
+    fn nightly_provenance_must_match_source_commit_and_subject() {
+        let digest = Sha256Hash::from_bytes([7; 32]);
+        let digest_hex = digest.to_hex();
+        let statement = serde_json::from_value::<Statement>(serde_json::json!({
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{
+                "name": "anchor-nightly-20260803-abcdef0-aarch64-apple-darwin.tar.gz",
+                "digest": { "sha256": digest_hex }
+            }],
+            "predicateType": SLSA_PROVENANCE_V1,
+            "predicate": {
+                "buildDefinition": {
+                    "resolvedDependencies": [{
+                        "uri": nightly_source_uri(),
+                        "digest": { "gitCommit": "abcdef0123456789" }
+                    }]
+                }
+            }
+        }))
+        .unwrap();
+        let expected = (
+            "abcdef0123456789",
+            "anchor-nightly-20260803-abcdef0-aarch64-apple-darwin.tar.gz",
+        );
+
+        require_nightly_provenance(&statement, digest, expected).unwrap();
+
+        assert!(
+            require_nightly_provenance(&statement, digest, ("0000000000000000", expected.1))
+                .is_err()
+        );
+        assert!(require_nightly_provenance(
+            &statement,
+            digest,
+            (
+                expected.0,
+                "anchor-nightly-20260802-0000000-aarch64-apple-darwin.tar.gz"
+            )
+        )
+        .is_err());
+
+        assert!(
+            require_nightly_provenance(&statement, Sha256Hash::from_bytes([8; 32]), expected)
+                .is_err()
+        );
     }
 }

--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -908,6 +908,7 @@ fn nightly_enabled() -> bool {
 #[derive(Debug, Deserialize)]
 struct NightlyManifest {
     version: String,
+    git_sha: String,
     artifacts: Vec<NightlyArtifact>,
 }
 
@@ -1055,10 +1056,41 @@ fn install_nightly_manifest(manifest: &NightlyManifest, skip_attestation: bool) 
     if needs_download {
         if skip_attestation {
             warn_attestation_skipped();
+        } else {
+            validate_nightly_commit(manifest)?;
         }
-        install_nightly_artifact(&anchor, &nightly_anchor_binary_path(), skip_attestation)?;
-        install_nightly_artifact(&avm, &nightly_avm_binary_path(), skip_attestation)?;
+        install_nightly_artifact(
+            manifest,
+            &anchor,
+            &nightly_anchor_binary_path(),
+            skip_attestation,
+        )?;
+        install_nightly_artifact(manifest, &avm, &nightly_avm_binary_path(), skip_attestation)?;
     }
+    Ok(())
+}
+
+fn validate_nightly_commit(manifest: &NightlyManifest) -> Result<()> {
+    let source_commit = &manifest.git_sha;
+    if source_commit.len() != 40 || !source_commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("Nightly manifest `git_sha` must be a full 40-character hexadecimal commit");
+    }
+
+    let version_commit = manifest
+        .version
+        .rsplit_once('-')
+        .map(|(_, commit)| commit)
+        .filter(|commit| {
+            (7..=40).contains(&commit.len()) && commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+        .context("Nightly manifest version is missing a valid commit suffix")?;
+    if !source_commit.starts_with(version_commit) {
+        bail!(
+            "Nightly manifest version commit suffix `{version_commit}` does not match `git_sha` \
+             `{source_commit}`"
+        );
+    }
+
     Ok(())
 }
 
@@ -1081,6 +1113,7 @@ fn nightly_artifact(
 }
 
 fn install_nightly_artifact(
+    manifest: &NightlyManifest,
     artifact: &NightlyArtifact,
     destination: &Path,
     skip_attestation: bool,
@@ -1099,7 +1132,7 @@ fn install_nightly_artifact(
 
     let result = (|| -> Result<()> {
         let archive_path = staging.join(archive_name);
-        download_nightly_artifact(artifact, &archive_path, skip_attestation)?;
+        download_nightly_artifact(manifest, artifact, &archive_path, skip_attestation)?;
         extract_tar_gz(&archive_path, &staging)?;
         let extracted = extracted_nightly_binary(&staging, &artifact.tool)?;
         install_binary_atomic(&extracted, destination)?;
@@ -1120,6 +1153,7 @@ fn nightly_archive_name(file: &str) -> Result<&Path> {
 }
 
 fn download_nightly_artifact(
+    manifest: &NightlyManifest,
     artifact: &NightlyArtifact,
     dest: &Path,
     skip_attestation: bool,
@@ -1144,7 +1178,11 @@ fn download_nightly_artifact(
     }
     fs::write(dest, bytes.as_ref()).with_context(|| format!("Writing {}", dest.display()))?;
     if !skip_attestation {
-        attestation::verify_nightly(dest).with_context(|| {
+        let subject = format!(
+            "{}-{}-{}.tar.gz",
+            artifact.tool, manifest.version, artifact.target
+        );
+        attestation::verify_nightly(dest, &manifest.git_sha, &subject).with_context(|| {
             format!(
                 "Downloaded nightly artifact `{url}` failed build provenance verification. \
                  Refusing to install it."
@@ -1536,6 +1574,7 @@ mod tests {
     fn test_nightly_artifact_selects_tool_and_target() {
         let manifest = NightlyManifest {
             version: "nightly-20260522-f693b0f".to_string(),
+            git_sha: "f693b0f823fccaf947914956ff4b460eab9e366e".to_string(),
             artifacts: vec![
                 NightlyArtifact {
                     tool: "anchor".to_string(),
@@ -1566,6 +1605,7 @@ mod tests {
     fn test_nightly_artifact_errors_for_missing_target() {
         let manifest = NightlyManifest {
             version: "nightly-20260522-f693b0f".to_string(),
+            git_sha: "f693b0f823fccaf947914956ff4b460eab9e366e".to_string(),
             artifacts: vec![],
         };
 
@@ -1573,6 +1613,31 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("does not include `anchor` for target `x86_64-unknown-linux-gnu`"));
+    }
+
+    #[test]
+    fn test_nightly_manifest_binds_version_suffix_to_full_commit() {
+        let source_commit = "f693b0f823fccaf947914956ff4b460eab9e366e";
+        let mut manifest = NightlyManifest {
+            version: "nightly-20260522-f693b0f".to_string(),
+            git_sha: source_commit.to_string(),
+            artifacts: vec![],
+        };
+
+        validate_nightly_commit(&manifest).unwrap();
+
+        manifest.version = "nightly-20260522-0000000".to_string();
+        assert!(validate_nightly_commit(&manifest)
+            .unwrap_err()
+            .to_string()
+            .contains("does not match `git_sha`"));
+
+        manifest.version = "nightly-20260522-f693b0f".to_string();
+        manifest.git_sha = "f693b0f".to_string();
+        assert!(validate_nightly_commit(&manifest)
+            .unwrap_err()
+            .to_string()
+            .contains("full 40-character hexadecimal commit"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Ensure a verified AVM nightly archive matches the commit and artifact identity selected by the nightly manifest.

Closes #4877.

## Changes

- require the manifest's full `git_sha` to match its nightly version suffix;
- require the attested Anchor source commit to equal that `git_sha`;
- require the downloaded digest to belong to the expected `<tool>-<version>-<target>.tar.gz` subject; and
- build nightlies from the triggering commit and restrict publication to `master`.

Unsigned or modified archives remain rejected by the existing checksum and Sigstore verification.

## Validation

- `cargo test -p avm --locked`: 122 passed
- `cargo clippy -p avm --all-targets --locked -- -D warnings`
- `cargo fmt -p avm -- --check`
