### PR TITLE
chore: bump crucible-fuzz-cli to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4958f4ea2b8611aed7ed087c7d6856cd46398b2c4f0c9bd1a3a85eabd7bef3a"
+checksum = "3fd18509ebe29e733b43042adc8aec09d89bdfb5ab01ad1d2a0ef3d62691295a"
 dependencies = [
  "anyhow",
  "clap 4.6.1",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,7 @@ cargo_metadata = "0.23.1"
 cargo_toml.workspace = true
 chrono = "0.4.19"
 clap = { version = "4.5.17", features = ["derive"] }
-crucible-fuzz-cli = "0.2.0"
+crucible-fuzz-cli = "0.2.1"
 clap_complete = "4.5.26"
 console = "0.15"
 dirs = "4.0"


### PR DESCRIPTION
## What

Bumps `crucible-fuzz-cli` from 0.2.0 to 0.2.1, and tightens the manifest requirement from `"0.2.0"` to `"0.2.1"`.

## Why

crucible-fuzz-cli 0.2.0 generates harness Cargo.tomls with unpinned `{ git, branch = "main" }` crucible deps. 0.2.1 pins them to the crates.io release matching the CLI's own version instead. See asymmetric-research/crucible#17.

The manifest requirement is tightened, not left as `"0.2.0"`, because 0.2.0 is specifically the broken version — a bare `"0.2.0"` requirement is `^0.2.0` = `>=0.2.0, <0.3.0`, which still permits resolving back to 0.2.0 under a lockfile-less or `-Z minimal-versions` build. `"0.2.1"` (`>=0.2.1, <0.3.0`) excludes it structurally.

## Diff

Minimal: `cli/Cargo.toml` requirement bump + matching `Cargo.lock` entry. No other packages touched.

## Verification

Built `anchor-cli` from this branch and ran `anchor fuzz init test_program` against a scratch dir. Generated `fuzz/test_program/Cargo.toml`:
```
crucible-fuzzer = "0.2.1"
crucible-test-context = "0.2.1"
crucible-idl-gen = "0.2.1"
```
Confirms the fix takes effect end-to-end, not just at the lockfile level.

## Test plan

- [x] `cargo build -p anchor-cli --bin anchor` succeeds
- [x] `anchor fuzz init <program>` generates a harness pinned to crucible 0.2.1
- [ ] CI