### PR TITLE
ci: bind build-cli dry_run/matrix values via env before shell

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -72,17 +72,20 @@ jobs:
         shell: bash
         env:
           DIST: ${{ inputs.dist }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$DRY_RUN" == "true" ]]; then
             version="dry-run"
           else
             version=$(echo $GITHUB_REF_NAME | cut -dv -f2)
           fi
           ext=""
-          [[ "${{ matrix.os }}" == windows-latest ]] && ext=".exe"
+          [[ "$MATRIX_OS" == windows-latest ]] && ext=".exe"
 
           mkdir "$DIST"
-          mv "target/${{ matrix.target }}/release/anchor$ext" "$DIST/anchor-$version-${{ matrix.target }}$ext"
+          mv "target/${MATRIX_TARGET}/release/anchor$ext" "$DIST/anchor-$version-${MATRIX_TARGET}$ext"
 
           echo "version=$version" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Bind `inputs.dry_run` plus `matrix.os` / `matrix.target` through `env:` before the Prepare shell step in `build-cli.yaml`.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Dry-run build still sets version to `dry-run`
- [ ] Release build still derives version from tag ref and uploads per-target artifact names


Made with [Cursor](https://cursor.com)