### PR TITLE
feat(lang-v2): Reject tuple and unit structs for `#[account]`

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2207,6 +2207,16 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into()
         }
     };
+    // Tuple (`struct Foo(u64)`) and unit (`struct Foo;`) structs are rejected outright
+    if !matches!(fields, Fields::Named(_)) {
+        return syn::Error::new(
+            name.span(),
+            "`#[account]` only supports structs with named fields (tuple and unit structs are \
+             not supported)",
+        )
+        .to_compile_error()
+        .into();
+    }
     if is_borsh {
         if let Err(err) = reject_float_fields("`#[account(borsh)]`", fields) {
             return err.to_compile_error().into();

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1533,3 +1533,49 @@ pub struct Bad {
         &["optional account fields cannot be used as PDA seeds"],
     );
 }
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn account_rejects_tuple_and_unit_structs() {
+    compile_fail_case(
+        "account_tuple_struct_rejected",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct TupleData(pub u64, pub u32);
+"#,
+        &["`#[account]` only supports structs with named fields"],
+    );
+
+    compile_fail_case(
+        "account_unit_struct_rejected",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct UnitData;
+"#,
+        &["`#[account]` only supports structs with named fields"],
+    );
+
+    compile_fail_case(
+        "account_borsh_tuple_struct_rejected",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account(borsh)]
+pub struct BorshTupleData(pub u64, pub u32);
+"#,
+        &["`#[account]` only supports structs with named fields"],
+    );
+}


### PR DESCRIPTION
Reject tuple and unit #[account] structs immediately after the existing struct-only check. Return a targeted compile error instead of letting the Pod/padding/IDL logic silently no-op or surfacing the unrelated syntax error.

Add compile-fail coverage for tuple structs, unit structs, and borsh tuple structs. This is a compile-time-only check no runtime behavior changes.

Fixes hackhack audit finding 3