### PR TITLE
fix: on events reject failed txs

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -101,7 +101,6 @@ use {
         },
         filter::Memcmp,
         request::RpcError,
-        response::{Response as RpcResponse, RpcLogsResponse},
     },
     solana_signature::Signature,
     std::{
@@ -364,6 +363,10 @@ impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
             })?;
 
             while let Some(logs) = notifications.next().await {
+                if logs.value.err.is_some() {
+                    continue;
+                }
+
                 let signature: Signature = logs.value.signature.parse().map_err(|e| {
                     ClientError::LogParseError(format!(
                         "Invalid signature '{}': {e}",
@@ -374,7 +377,7 @@ impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
                     signature,
                     slot: logs.context.slot,
                 };
-                let events = parse_logs_response(logs, &program_id_str)?;
+                let events = parse_logs(&logs.value.logs, &program_id_str)?;
                 for e in events {
                     f(&ctx, e);
                 }
@@ -451,7 +454,7 @@ pub fn handle_system_log(this_program_str: &str, log: &str) -> (Option<String>, 
         if invoke_match.get(1).unwrap().as_str() == this_program_str {
             return (Some(this_program_str.to_string()), false);
 
-            // `Invoke [1]` instructions are pushed to the stack in `parse_logs_response`,
+            // `Invoke [1]` instructions are pushed to the stack in `parse_logs`,
             // so this ensures we only push CPIs to the stack at this stage
         } else if invoke_match.get(2).unwrap().as_str() != "1" {
             return (Some("cpi".to_string()), false); // Any string will do.
@@ -875,11 +878,11 @@ impl<C: Deref<Target = impl Signer> + Clone, S: AsSigner> RequestBuilder<'_, C, 
     }
 }
 
-fn parse_logs_response<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
-    logs: RpcResponse<RpcLogsResponse>,
+fn parse_logs<T: anchor_lang::Event + anchor_lang::AnchorDeserialize>(
+    logs: &[String],
     program_id_str: &str,
 ) -> Result<Vec<T>, ClientError> {
-    let mut logs = &logs.value.logs[..];
+    let mut logs = logs;
     let mut events: Vec<T> = Vec::new();
     if !logs.is_empty() {
         if let Ok(mut execution) = Execution::new(&mut logs) {
@@ -945,7 +948,6 @@ mod tests {
     use {
         anchor_lang::{prelude::*, Event},
         futures::{SinkExt, StreamExt},
-        solana_rpc_client_api::response::RpcResponseContext,
         std::sync::atomic::{AtomicU64, Ordering},
         tokio_tungstenite::tungstenite::Message,
     };
@@ -982,8 +984,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_logs_response() -> Result<()> {
-        // Mock logs received within an `RpcResponse`. These are based on a Jupiter transaction.
+    fn test_parse_logs() -> Result<()> {
+        // These logs are based on a Jupiter transaction.
         let logs = vec![
             "Program VeryCoolProgram invoke [1]", // Outer instruction #1 starts
             "Program log: Instruction: VeryCoolEvent",
@@ -1075,31 +1077,96 @@ mod tests {
             "Program ComputeBudget111111111111111111111111111111 success",
         ];
 
-        // Converting to Vec<String> as expected in `RpcLogsResponse`
+        // Convert to the owned strings received from RPC.
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();
 
         let program_id_str = "VeryCoolProgram";
 
         // No events returned here. Just ensuring that the function doesn't panic
         // due an incorrectly emptied stack.
-        parse_logs_response::<MockEvent>(
-            RpcResponse {
-                context: RpcResponseContext::new(0),
-                value: RpcLogsResponse {
-                    signature: "".to_string(),
-                    err: None,
-                    logs: logs.to_vec(),
-                },
-            },
-            program_id_str,
-        )
-        .unwrap();
+        parse_logs::<MockEvent>(&logs, program_id_str).unwrap();
 
         Ok(())
     }
 
     #[test]
-    fn test_parse_logs_response_fake_pop() -> Result<()> {
+    fn failed_transaction_events_are_not_emitted() {
+        use {
+            anchor_lang::__private::base64,
+            base64::{engine::general_purpose::STANDARD, Engine},
+            std::{sync::mpsc, time::Duration},
+        };
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (addr_tx, addr_rx) = mpsc::channel();
+        let program_id = Pubkey::new_unique();
+        let program_id_str = program_id.to_string();
+        let event_log = format!("Program data: {}", STANDARD.encode(MockEvent {}.data()));
+        let failed_signature = Signature::default();
+        let successful_signature = Signature::from([1u8; 64]);
+
+        rt.spawn(async move {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            addr_tx.send(listener.local_addr().unwrap()).unwrap();
+
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            ws.next().await.unwrap().unwrap();
+            ws.send(Message::Text(
+                r#"{"jsonrpc":"2.0","result":0,"id":1}"#.into(),
+            ))
+            .await
+            .unwrap();
+
+            let failed_notification = format!(
+                r#"{{"jsonrpc":"2.0","method":"logsNotification","params":{{"result":{{"context":{{"slot":1}},"value":{{"signature":"{failed_signature}","err":"AccountNotFound","logs":["Program {program_id_str} invoke [1]","{event_log}","Program {program_id_str} failed: custom program error: 0x1"]}}}},"subscription":0}}}}"#
+            );
+            ws.send(Message::Text(failed_notification.into()))
+                .await
+                .unwrap();
+
+            let successful_notification = format!(
+                r#"{{"jsonrpc":"2.0","method":"logsNotification","params":{{"result":{{"context":{{"slot":2}},"value":{{"signature":"{successful_signature}","err":null,"logs":["Program {program_id_str} invoke [1]","{event_log}","Program {program_id_str} success"]}}}},"subscription":0}}}}"#
+            );
+            ws.send(Message::Text(successful_notification.into()))
+                .await
+                .unwrap();
+
+            // Keep the websocket alive until the client or test runtime closes it.
+            ws.next().await;
+        });
+
+        let addr = addr_rx.recv().unwrap();
+        let ws_url = format!("ws://{addr}");
+        let client = super::Client::new(
+            super::Cluster::Custom(ws_url.clone(), ws_url),
+            std::sync::Arc::new(solana_keypair::Keypair::new()),
+        );
+        let program = client.program(program_id).unwrap();
+        let (event_tx, event_rx) = mpsc::channel();
+        let (handle, _unsubscribe_rx) = rt
+            .block_on(program.on_internal(move |ctx, _event: MockEvent| {
+                event_tx.send(ctx.signature).unwrap();
+            }))
+            .unwrap();
+
+        let emitted_signature = event_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "event subscription ended without an event ({e}): {:?}",
+                    rt.block_on(handle)
+                )
+            });
+        assert_eq!(emitted_signature, successful_signature);
+        assert!(event_rx.recv_timeout(Duration::from_millis(100)).is_err());
+    }
+
+    #[test]
+    fn test_parse_logs_fake_pop() -> Result<()> {
         let logs = [
             "Program fake111111111111111111111111111111111111112 invoke [1]",
             "Program log: i logged success",
@@ -1109,25 +1176,14 @@ mod tests {
             "Program fake111111111111111111111111111111111111112 success",
         ];
 
-        // Converting to Vec<String> as expected in `RpcLogsResponse`
+        // Convert to the owned strings received from RPC.
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();
 
         let program_id_str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 
         // No events returned here. Just ensuring that the function doesn't panic
         // due an incorrectly emptied stack.
-        parse_logs_response::<MockEvent>(
-            RpcResponse {
-                context: RpcResponseContext::new(0),
-                value: RpcLogsResponse {
-                    signature: "".to_string(),
-                    err: None,
-                    logs: logs.to_vec(),
-                },
-            },
-            program_id_str,
-        )
-        .unwrap();
+        parse_logs::<MockEvent>(&logs, program_id_str).unwrap();
 
         Ok(())
     }
@@ -1138,7 +1194,7 @@ mod tests {
     /// strict `^Program <pubkey> invoke [N]$` regex, panicking on
     /// `.captures(...).unwrap()` whenever it appeared right after a CPI pop.
     #[test]
-    fn test_parse_logs_response_log_line_ends_with_invoke_1() -> Result<()> {
+    fn test_parse_logs_log_line_ends_with_invoke_1() -> Result<()> {
         let logs = [
             "Program VeryCoolProgram invoke [1]",
             "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
@@ -1150,18 +1206,7 @@ mod tests {
         ];
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();
 
-        parse_logs_response::<MockEvent>(
-            RpcResponse {
-                context: RpcResponseContext::new(0),
-                value: RpcLogsResponse {
-                    signature: "".to_string(),
-                    err: None,
-                    logs,
-                },
-            },
-            "VeryCoolProgram",
-        )
-        .unwrap();
+        parse_logs::<MockEvent>(&logs, "VeryCoolProgram").unwrap();
 
         Ok(())
     }
@@ -1219,23 +1264,12 @@ mod tests {
             "Program 11111111111111111111111111111111 success",
         ];
 
-        // Converting to Vec<String> as expected in `RpcLogsResponse`
+        // Convert to the owned strings received from RPC.
         let logs: Vec<String> = logs.iter().map(|&l| l.to_string()).collect();
 
         let program_id_str = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P";
 
-        let events = parse_logs_response::<MockEvent>(
-            RpcResponse {
-                context: RpcResponseContext::new(0),
-                value: RpcLogsResponse {
-                    signature: "".to_string(),
-                    err: None,
-                    logs: logs.to_vec(),
-                },
-            },
-            program_id_str,
-        )
-        .unwrap();
+        let events = parse_logs::<MockEvent>(&logs, program_id_str).unwrap();
 
         assert_eq!(events.len(), 1);
 


### PR DESCRIPTION
## Summary

It does not make sense to listen behind for events of txs that failed and that succeeded without any knowledge about potential failure, i don't see a use case for listening to failed events at all.

