### PR TITLE
fix(lang-v2): invoke_ix silently drops remaining_accounts from the actual CPI

### DIFF
--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use {
     crate::{address_eq, require, CpiHandle, ToCpiAccounts},
-    alloc::vec::Vec,
+    alloc::{collections::BTreeSet, vec::Vec},
     core::mem::MaybeUninit,
     pinocchio::{
         address::Address,
@@ -176,14 +176,21 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
 
         let mut handles = self.accounts.to_cpi_handles();
 
-        for handle in &self.remaining_accounts {
-            let meta = if handle.is_writable() {
-                AccountMeta::new(*handle.address(), handle.is_signer())
-            } else {
-                AccountMeta::new_readonly(*handle.address(), handle.is_signer())
-            };
-            ix.accounts.push(meta);
-            handles.push(*handle);
+        if !self.remaining_accounts.is_empty() {
+            // Ignore duplicates by tracking seen addresses in a `BTreeSet`.
+            let mut seen: BTreeSet<Address> = ix.accounts.iter().map(|meta| meta.pubkey).collect();
+
+            for handle in &self.remaining_accounts {
+                if seen.insert(*handle.address()) {
+                    let meta = if handle.is_writable() {
+                        AccountMeta::new(*handle.address(), handle.is_signer())
+                    } else {
+                        AccountMeta::new_readonly(*handle.address(), handle.is_signer())
+                    };
+                    ix.accounts.push(meta);
+                }
+                handles.push(*handle);
+            }
         }
 
         let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -8,7 +8,7 @@ use {
         address::Address,
         instruction::{InstructionAccount, InstructionView},
     },
-    solana_instruction::Instruction,
+    solana_instruction::{AccountMeta, Instruction},
     solana_program_error::{ProgramError, ProgramResult},
 };
 
@@ -161,20 +161,30 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     /// Invoke a fully built instruction using this context's CPI handles.
     ///
     /// The instruction's program id must match this context's program. Account
-    /// metas are taken from the instruction, while account handles are collected
-    /// from [`ToCpiAccounts`] and `remaining_accounts`.
+    /// metas for the fixed [`ToCpiAccounts`] fields are taken from the
+    /// instruction as supplied; `remaining_accounts` are appended to both the
+    /// instruction's metas and the CPI handles, so the two stay in sync.
     ///
     /// Optional `None` sentinel slots must appear in the same positions as in
     /// [`ToCpiAccounts::to_instruction_accounts`]; only those indices may omit
     /// handles for readonly program-id metas.
-    pub fn invoke_ix(&self, ix: Instruction) -> ProgramResult {
+    pub fn invoke_ix(&self, mut ix: Instruction) -> ProgramResult {
         require!(
             address_eq(self.program, &ix.program_id),
             ProgramError::IncorrectProgramId
         );
 
         let mut handles = self.accounts.to_cpi_handles();
-        handles.extend(self.remaining_accounts.iter().copied());
+
+        for handle in &self.remaining_accounts {
+            let meta = if handle.is_writable() {
+                AccountMeta::new(*handle.address(), handle.is_signer())
+            } else {
+                AccountMeta::new_readonly(*handle.address(), handle.is_signer())
+            };
+            ix.accounts.push(meta);
+            handles.push(*handle);
+        }
 
         let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();
         require!(

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use {
     crate::{address_eq, require, CpiHandle, ToCpiAccounts},
-    alloc::{collections::BTreeSet, vec::Vec},
+    alloc::vec::Vec,
     core::mem::MaybeUninit,
     pinocchio::{
         address::Address,
@@ -162,8 +162,11 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     ///
     /// The instruction's program id must match this context's program. Account
     /// metas for the fixed [`ToCpiAccounts`] fields are taken from the
-    /// instruction as supplied; `remaining_accounts` are appended to both the
-    /// instruction's metas and the CPI handles, so the two stay in sync.
+    /// instruction as supplied. Any metas the instruction carries beyond that
+    /// prefix are treated as builder-supplied metas for the leading
+    /// `remaining_accounts`, in order. `metas` are appended only for the
+    /// remaining handles the instruction does not already cover, so metas and
+    /// handles stay paired one-to-one.
     ///
     /// Optional `None` sentinel slots must appear in the same positions as in
     /// [`ToCpiAccounts::to_instruction_accounts`]; only those indices may omit
@@ -176,28 +179,28 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
 
         let mut handles = self.accounts.to_cpi_handles();
 
-        if !self.remaining_accounts.is_empty() {
-            // Ignore duplicates by tracking seen addresses in a `BTreeSet`.
-            let mut seen: BTreeSet<Address> = ix.accounts.iter().map(|meta| meta.pubkey).collect();
-
-            for handle in &self.remaining_accounts {
-                if seen.insert(*handle.address()) {
-                    let meta = if handle.is_writable() {
-                        AccountMeta::new(*handle.address(), handle.is_signer())
-                    } else {
-                        AccountMeta::new_readonly(*handle.address(), handle.is_signer())
-                    };
-                    ix.accounts.push(meta);
-                }
-                handles.push(*handle);
-            }
-        }
-
         let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();
         require!(
             optional_sentinel_flags.len() <= ix.accounts.len(),
             ProgramError::InvalidArgument
         );
+
+        // Metas past the fixed prefix already cover the leading remaining
+        // accounts, in order. Append only the rest, keeping metas and handles
+        // paired one-to-one.
+        let prebuilt_remaining_metas = ix.accounts.len() - optional_sentinel_flags.len();
+        require!(
+            prebuilt_remaining_metas <= self.remaining_accounts.len(),
+            ProgramError::NotEnoughAccountKeys
+        );
+        for handle in &self.remaining_accounts[prebuilt_remaining_metas..] {
+            ix.accounts.push(if handle.is_writable() {
+                AccountMeta::new(*handle.address(), handle.is_signer())
+            } else {
+                AccountMeta::new_readonly(*handle.address(), handle.is_signer())
+            });
+        }
+        handles.extend(self.remaining_accounts.iter().copied());
         // Trailing metas (e.g. remaining accounts already baked into `ix`) are
         // never treated as optional sentinels from this accounts struct.
         optional_sentinel_flags.resize(ix.accounts.len(), false);

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -564,6 +564,60 @@ fn invoke_ix_rejects_live_borrow_for_writable_meta() {
     assert_eq!(err, ProgramError::AccountBorrowFailed);
 }
 
+
+#[test]
+fn invoke_ix_validates_remaining_account_borrow_state() {
+    let program = ID;
+    let buffer = account_view([1; 32], true);
+    let view = unsafe { buffer.view() };
+    let accounts = ReadonlyCpi {
+        account: view.to_cpi_handle(),
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![AccountMeta::new_readonly(*view.address(), false)],
+        data: vec![],
+    };
+
+    let remaining_buffer = account_view([2; 32], true);
+    let mut remaining_view = unsafe { remaining_buffer.view() };
+    let borrow_view = remaining_view;
+    let _borrow = borrow_view.try_borrow().unwrap();
+    let remaining_handle = CpiHandle::writable(&mut remaining_view);
+
+    let err = CpiContext::new(&program, accounts)
+        .with_remaining_accounts(vec![remaining_handle])
+        .invoke_ix(ix)
+        .unwrap_err();
+
+    assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+
+#[test]
+fn invoke_ix_accepts_remaining_accounts_alongside_fixed_accounts() {
+    let program = ID;
+    let buffer = account_view([1; 32], true);
+    let view = unsafe { buffer.view() };
+    let accounts = ReadonlyCpi {
+        account: view.to_cpi_handle(),
+    };
+    let ix = Instruction {
+        program_id: program,
+        accounts: vec![AccountMeta::new_readonly(*view.address(), false)],
+        data: vec![],
+    };
+
+    let remaining_buffer = account_view([2; 32], true);
+    let remaining_view = unsafe { remaining_buffer.view() };
+    let remaining_handle = remaining_view.to_cpi_handle();
+
+    CpiContext::new(&program, accounts)
+        .with_remaining_accounts(vec![remaining_handle])
+        .invoke_ix(ix)
+        .unwrap();
+}
+
 #[test]
 fn invoke_ix_accepts_mutable_slab_handle() {
     let program = ID;


### PR DESCRIPTION
`CpiContext::invoke_ix` appended `remaining_accounts` only to its handle, never extending `ix.accounts`. The lower-level invoker derives the forwarded CPI-account count solely from those metas, so any handle with no matching meta exactly what `remaining_accounts` becomes when `ix` comes from an external builder (e.g. `spl_token_2022::instruction::
transfer_checked`) is silently dropped before it reaches the callee.

Affects every SPL Token-2022 wrapper relying on `with_remaining_accounts`.

## Fix
`invoke_ix` now pushes a matching `AccountMeta` for each remaining-account handle alongside the handle itself, keeping metas and handles in sync.

Fixes HackHack audit finding 23