### PR TITLE
fix(lang-v2): guard close against non-writable destinations

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -910,6 +910,33 @@ fn validate_init_constraint_refs(
 
     Ok(())
 }
+
+/// `close = dest` must name a sibling account field marked `mut`, matching the
+/// init-payer mutability check.
+fn validate_close_destination(
+    attrs: &AccountAttrs,
+    field_summaries: &[FieldSummary],
+) -> syn::Result<()> {
+    let Some(ref destination) = attrs.close else {
+        return Ok(());
+    };
+
+    match field_summaries
+        .iter()
+        .find(|summary| summary.name == *destination)
+    {
+        Some(dest) if dest.attrs.is_mut => Ok(()),
+        Some(_) => Err(syn::Error::new(
+            destination.span(),
+            "the destination specified for a close constraint must be mutable",
+        )),
+        None => Err(syn::Error::new(
+            destination.span(),
+            "the destination specified for a close constraint does not exist",
+        )),
+    }
+}
+
 fn field_offset_expr(
     field_offsets: &[(String, TokenStream2)],
     ident: &Ident,
@@ -2227,6 +2254,7 @@ pub fn parse_field(
             "mut must be provided when using close",
         ));
     }
+    validate_close_destination(&attrs, field_summaries)?;
     let option_inner = extract_option_inner(field_ty);
     let associated_token = parse_associated_token_init(&attrs, field_names)?;
     let init_if_needed_reuse_validation = if attrs.is_init_if_needed {
@@ -3377,6 +3405,53 @@ mod tests {
         let parsed_attrs = parse_account_attrs(&attrs).unwrap();
         assert!(!parsed_attrs.is_mut);
         assert_eq!(parsed_attrs.close.unwrap().to_string(), "receiver");
+    }
+
+    #[test]
+    fn close_destination_must_be_mutable() {
+        use syn::parse::Parser;
+
+        let closed: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(mut, close = receiver)]
+                pub data: Account<Data>
+            })
+            .unwrap();
+        let receiver: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                pub receiver: SystemAccount
+            })
+            .unwrap();
+        let summaries = vec![
+            FieldSummary {
+                name: syn::parse_quote!(data),
+                ty: syn::parse_quote!(Account<Data>),
+                attrs: parse_account_attrs(&closed.attrs).unwrap(),
+            },
+            FieldSummary {
+                name: syn::parse_quote!(receiver),
+                ty: syn::parse_quote!(SystemAccount),
+                attrs: parse_account_attrs(&receiver.attrs).unwrap(),
+            },
+        ];
+        let closed_attrs = parse_account_attrs(&closed.attrs).unwrap();
+        let err = match parse_field(
+            &closed,
+            &closed_attrs,
+            &["data".into(), "receiver".into()],
+            &[],
+            quote::quote!(0usize),
+            &[],
+            &summaries,
+        ) {
+            Ok(_) => panic!("non-mut close destination must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("the destination specified for a close constraint must be mutable"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -330,6 +330,12 @@ where
     S: AnchorAccountSerialize<T>,
 {
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
+        // Guardrail: catches "forgot `#[account(mut)]`" on the close
+        // destination early with a clear error.
+        #[cfg(feature = "guardrails")]
+        if !destination.is_writable() {
+            return Err(super::slab::cold_not_writable());
+        }
         self.assert_mutable_loaded();
         let mut self_view = self.view;
         let dest_lamports = destination

--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -336,6 +336,12 @@ where
         if !destination.is_writable() {
             return Err(super::slab::cold_not_writable());
         }
+        // Guardrail: self-close would credit the lamports and then zero them on
+        // the same account, burning them.
+        #[cfg(feature = "guardrails")]
+        if pinocchio::address::address_eq(destination.address(), self.view.address()) {
+            return Err(super::slab::cold_self_close());
+        }
         self.assert_mutable_loaded();
         let mut self_view = self.view;
         let dest_lamports = destination

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -854,6 +854,12 @@ where
 {
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
         self.assert_mutable();
+        // Guardrail: catches "forgot `#[account(mut)]`" on the close
+        // destination early with a clear error. 
+        #[cfg(feature = "guardrails")]
+        if !destination.is_writable() {
+            return Err(cold_not_writable());
+        }
         let mut self_view = self.view;
         let dest_lamports = destination
             .lamports()

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -31,16 +31,22 @@ pub(super) fn cold_owner_error(view: &AccountView) -> ProgramError {
 /// Whether the runtime account header reflects a completed close.
 #[inline(always)]
 pub(super) fn is_closed(view: &AccountView) -> bool {
-    view.lamports() == 0
-        && view.data_len() == 0
-        && view.owned_by(&crate::programs::System::id())
+    view.lamports() == 0 && view.data_len() == 0 && view.owned_by(&crate::programs::System::id())
 }
 
-/// Error for read-only account passed to `load_mut`.
+/// Error for read-only account passed to `load_mut`, and for a non-writable
+/// `close` destination.
 #[cfg(feature = "guardrails")]
 #[inline(always)]
 pub(super) fn cold_not_writable() -> ProgramError {
     crate::ErrorCode::ConstraintMut.into()
+}
+
+/// Error for a `close` destination that aliases the account being closed.
+#[cfg(feature = "guardrails")]
+#[inline(always)]
+pub(super) fn cold_self_close() -> ProgramError {
+    crate::ErrorCode::ConstraintClose.into()
 }
 
 /// Capacity from live `data_len` / `items_offset` / `item_size`. Returns 0
@@ -834,11 +840,7 @@ where
 
     #[inline(always)]
     fn cpi_handle(&self) -> crate::CpiHandle<'_> {
-        crate::CpiHandle::readonly_with_flags(
-            self.account(),
-            !self.is_mutable,
-            self.is_mutable,
-        )
+        crate::CpiHandle::readonly_with_flags(self.account(), !self.is_mutable, self.is_mutable)
     }
 
     #[inline(always)]
@@ -855,10 +857,16 @@ where
     fn close(&mut self, mut destination: AccountView) -> pinocchio::ProgramResult {
         self.assert_mutable();
         // Guardrail: catches "forgot `#[account(mut)]`" on the close
-        // destination early with a clear error. 
+        // destination early with a clear error.
         #[cfg(feature = "guardrails")]
         if !destination.is_writable() {
             return Err(cold_not_writable());
+        }
+        // Guardrail: self-close would credit the lamports and then zero them on
+        // the same account, burning them.
+        #[cfg(feature = "guardrails")]
+        if pinocchio::address::address_eq(destination.address(), self.view.address()) {
+            return Err(cold_self_close());
         }
         let mut self_view = self.view;
         let dest_lamports = destination

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -144,7 +144,6 @@ fn close_zeros_the_48_byte_header() {
     );
 }
 
-
 #[test]
 fn close_rejects_non_writable_destination() {
     let mut buf = AccountBuffer::<256>::new();
@@ -448,6 +447,57 @@ fn slab_close_scrubs_discriminator_to_closed_sentinel() {
         &data[..8],
         &[u8::MAX; 8][..],
         "Slab::close must scrub the discriminator to the closed sentinel"
+    );
+}
+
+#[test]
+fn close_rejects_self_as_destination() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_vault_buf(&mut buf);
+
+    let view = unsafe { buf.view() };
+    // Same account handed in as the close destination.
+    let self_as_dest = unsafe { buf.view() };
+    let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
+
+    let err = vault.close(self_as_dest).unwrap_err();
+
+    assert_eq!(err, ErrorCode::ConstraintClose.into());
+
+    // Without the guard, close credits the balance to self and then zeroes it,
+    // burning the lamports. Nothing should have moved.
+    let raw = unsafe { &*(buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        raw.lamports, 1_000_000_000,
+        "rejected self-close must not burn the account's lamports"
+    );
+    assert_ne!(
+        raw.data_len, 0,
+        "rejected self-close must not close the account"
+    );
+}
+
+#[test]
+fn slab_close_rejects_self_as_destination() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf);
+
+    let view = unsafe { buf.view() };
+    let self_as_dest = unsafe { buf.view() };
+    let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
+
+    let err = counter.close(self_as_dest).unwrap_err();
+
+    assert_eq!(err, ErrorCode::ConstraintClose.into());
+
+    let raw = unsafe { &*(buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        raw.lamports, 1_000_000_000,
+        "rejected self-close must not burn the account's lamports"
+    );
+    assert_ne!(
+        raw.data_len, 0,
+        "rejected self-close must not close the account"
     );
 }
 

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -51,7 +51,7 @@ use {
         prelude::BorshAccount,
         testing::AccountBuffer,
         AccountClose, AccountRealloc, AnchorAccount, AnchorDeserialize, AnchorSerialize,
-        Discriminator, Owner,
+        Discriminator, ErrorCode, Owner,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::{account::RuntimeAccount, address::Address},
@@ -141,6 +141,37 @@ fn close_zeros_the_48_byte_header() {
         dest_raw.lamports,
         100 + 1_000_000_000,
         "destination should have received all self lamports"
+    );
+}
+
+
+#[test]
+fn close_rejects_non_writable_destination() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_vault_buf(&mut buf);
+
+    let dest_buf = AccountBuffer::<256>::new();
+    dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, false, false);
+    dest_buf.set_lamports(100);
+
+    let view = unsafe { buf.view() };
+    let dest_view = unsafe { dest_buf.view() };
+    let mut vault = unsafe { BorshAccount::<Vault>::load_mut(view) }.unwrap();
+
+    let err = vault.close(dest_view).unwrap_err();
+
+    assert_eq!(err, ErrorCode::ConstraintMut.into());
+
+    // Nothing should have moved: the account being closed is untouched.
+    let raw = unsafe { &*(buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        raw.lamports, 1_000_000_000,
+        "rejected close must not drain the account being closed"
+    );
+    let dest_raw = unsafe { &*(dest_buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        dest_raw.lamports, 100,
+        "rejected close must not credit the non-writable destination"
     );
 }
 
@@ -417,6 +448,35 @@ fn slab_close_scrubs_discriminator_to_closed_sentinel() {
         &data[..8],
         &[u8::MAX; 8][..],
         "Slab::close must scrub the discriminator to the closed sentinel"
+    );
+}
+
+#[test]
+fn slab_close_rejects_non_writable_destination() {
+    let mut buf = AccountBuffer::<256>::new();
+    setup_counter_buf(&mut buf);
+
+    let dest_buf = AccountBuffer::<256>::new();
+    dest_buf.init([0xDD; 32], PROGRAM_ID, 0, false, false, false);
+    dest_buf.set_lamports(100);
+
+    let view = unsafe { buf.view() };
+    let dest_view = unsafe { dest_buf.view() };
+    let mut counter = unsafe { Slab::<CounterHeader>::load_mut(view) }.unwrap();
+
+    let err = counter.close(dest_view).unwrap_err();
+
+    assert_eq!(err, ErrorCode::ConstraintMut.into());
+
+    let raw = unsafe { &*(buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        raw.lamports, 1_000_000_000,
+        "rejected close must not drain the account being closed"
+    );
+    let dest_raw = unsafe { &*(dest_buf.raw() as *const RuntimeAccount) };
+    assert_eq!(
+        dest_raw.lamports, 100,
+        "rejected close must not credit the non-writable destination"
     );
 }
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1902,7 +1902,7 @@ fn close_destination_must_be_mutable() {
     CompileCase::new(
         "close_destination_must_be_mutable",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1898,6 +1898,42 @@ pub struct Close {
 }
 
 #[test]
+fn close_destination_must_be_mutable() {
+    CompileCase::new(
+        "close_destination_must_be_mutable",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data {
+    pub value: u64,
+}
+
+#[program]
+pub mod close_destination_must_be_mutable {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn close(ctx: &mut Context<Close>) -> Result<()> {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close {
+    #[account(mut, close = receiver)]
+    pub data: Account<Data>,
+    pub receiver: SystemAccount,
+}
+"#,
+    )
+    .expect_fail(&["the destination specified for a close constraint must be mutable"]);
+}
+
+#[test]
 fn account_attrs_on_nested_field_do_not_compile() {
     CompileCase::new(
         "account_attrs_on_nested_field",


### PR DESCRIPTION
`Slab::close`/`SerializedAccount::close` now reject a non-writable `close` destination with `ConstraintMut`, gated behind `guardrails`.

Fixes HackHack audit finding 25