### PR TITLE
Fix/v2 seedless init if needed signer

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -115,6 +115,10 @@ name = "init_if_needed_space_check"
 required-features = ["testing"]
 
 [[test]]
+name = "init_if_needed_signer_check"
+required-features = ["testing"]
+
+[[test]]
 name = "lamports"
 required-features = ["testing"]
 

--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -953,10 +953,12 @@ pub struct AccountField {
     // IDL metadata
     pub idl_writable: bool,
     /// True when this is a fresh-keypair init site (attrs: `init` or
-    /// `init_if_needed` without `seeds`). The caller must sign the tx with
-    /// the new account's keypair, so it surfaces as `signer: true` in the
-    /// IDL. Orthogonal to the `Signer` field type — those contribute via
-    /// `<Ty as IdlAccountType>::__IDL_IS_SIGNER` at runtime.
+    /// `init_if_needed` without `seeds`) or an explicit `signer` constraint.
+    /// The caller must sign the tx with the account's keypair. Used for:
+    ///   - IDL / client / CPI metadata (`signer: true`)
+    ///   - the runtime `ConstraintSigner` check emitted by the derive
+    /// Orthogonal to the `Signer` field type — those contribute via
+    /// `<Ty as IdlAccountType>::__IDL_IS_SIGNER` / `AnchorAccount::IS_SIGNER`.
     pub idl_init_signer: bool,
     /// `has_one = target` targets declared on this field's attrs. Relations
     /// emission walks every field and looks for has_one chains targeting
@@ -1777,9 +1779,16 @@ pub fn parse_field(
 
     let option_inner = extract_option_inner(field_ty);
     let is_optional = option_inner.is_some();
-    // Explicit signer constraint or fresh-keypair init (no seeds) — caller
-    // signs the tx. Distinct from `Signer`-type fields, which the IDL picks
-    // up through `IdlAccountType::__IDL_IS_SIGNER` at runtime.
+    // Explicit signer constraint or fresh-keypair init / init_if_needed
+    // (no seeds, not an ATA). The flag drives both IDL/CPI `signer: true`
+    // metadata and the runtime `ConstraintSigner` check below. Distinct
+    // from `Signer`-type fields, which the IDL picks up through
+    // `IdlAccountType::__IDL_IS_SIGNER` / `AnchorAccount::IS_SIGNER`.
+    //
+    // Runtime enforcement matters most for seedless `init_if_needed`: the
+    // exist branch calls `load_mut` without a System Program create CPI,
+    // so without this check an unsigned victim account could reach
+    // `close = …` exit and have its lamports drained.
     let idl_init_signer = attrs.is_signer
         || ((attrs.is_init || attrs.is_init_if_needed)
             && attrs.seeds.is_none()
@@ -2208,8 +2217,10 @@ pub fn parse_field(
     // the default (UncheckedAccount, SystemAccount, Program, Sysvar) get
     // it via the trait default.
 
-    // signer check
-    if attrs.is_signer {
+    // signer check — covers explicit `signer` and seedless init /
+    // init_if_needed (see `idl_init_signer`). PDA / ATA init paths leave
+    // the flag false so they are not required to be transaction signers.
+    if idl_init_signer {
         constraints.push(quote! {
             if !#field_name.account().is_signer() {
                 return Err(anchor_lang_v2::ErrorCode::ConstraintSigner.into());
@@ -2897,6 +2908,141 @@ mod tests {
             err.to_string()
                 .contains("`#[account(...)]` attributes are not supported on `Nested<T>` fields"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn seedless_init_if_needed_emits_runtime_signer_check() {
+        // Regression: seedless init_if_needed previously only set
+        // `idl_init_signer` for client/CPI metadata. The exist branch
+        // loaded via `load_mut` with no System Program create CPI, so an
+        // unsigned victim account could reach `close = …` and be drained.
+        // The derive must emit ConstraintSigner for that surface.
+        use syn::parse::Parser;
+
+        let payer_field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(mut)]
+                pub payer: Signer
+            })
+            .unwrap();
+        let data_field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(init_if_needed, payer = payer, space = 8, close = payer)]
+                pub data: Account<Data>
+            })
+            .unwrap();
+
+        let payer_attrs = parse_account_attrs(&payer_field.attrs).unwrap();
+        let data_attrs = parse_account_attrs(&data_field.attrs).unwrap();
+        let summaries = vec![
+            FieldSummary {
+                name: syn::parse_quote!(payer),
+                ty: payer_field.ty.clone(),
+                attrs: payer_attrs,
+            },
+            FieldSummary {
+                name: syn::parse_quote!(data),
+                ty: data_field.ty.clone(),
+                attrs: data_attrs,
+            },
+        ];
+        let field_names = vec!["payer".to_string(), "data".to_string()];
+        let field_offsets = vec![
+            ("payer".to_string(), quote::quote!(0usize)),
+            ("data".to_string(), quote::quote!(1usize)),
+        ];
+
+        let parsed = parse_field(
+            &data_field,
+            &field_names,
+            &field_offsets,
+            quote::quote!(1usize),
+            &[],
+            &summaries,
+        )
+        .unwrap();
+
+        assert!(
+            parsed.idl_init_signer,
+            "seedless init_if_needed must still advertise signer in IDL metadata"
+        );
+        let joined = parsed
+            .constraints
+            .iter()
+            .map(|t| t.to_string())
+            .collect::<String>();
+        assert!(
+            joined.contains("ConstraintSigner"),
+            "seedless init_if_needed must emit a runtime ConstraintSigner check, got: {joined}"
+        );
+        assert!(
+            joined.contains("is_signer"),
+            "expected is_signer() guard in generated constraints, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn seeded_init_if_needed_does_not_emit_runtime_signer_check() {
+        // Control: PDA init_if_needed accounts cannot sign. Runtime must
+        // not require is_signer(); authorization comes from seeds/bump.
+        use syn::parse::Parser;
+
+        let payer_field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(mut)]
+                pub payer: Signer
+            })
+            .unwrap();
+        let data_field: syn::Field = syn::Field::parse_named
+            .parse2(quote::quote! {
+                #[account(init_if_needed, payer = payer, space = 8, seeds = [b"vault"], bump)]
+                pub data: Account<Data>
+            })
+            .unwrap();
+
+        let payer_attrs = parse_account_attrs(&payer_field.attrs).unwrap();
+        let data_attrs = parse_account_attrs(&data_field.attrs).unwrap();
+        let summaries = vec![
+            FieldSummary {
+                name: syn::parse_quote!(payer),
+                ty: payer_field.ty.clone(),
+                attrs: payer_attrs,
+            },
+            FieldSummary {
+                name: syn::parse_quote!(data),
+                ty: data_field.ty.clone(),
+                attrs: data_attrs,
+            },
+        ];
+        let field_names = vec!["payer".to_string(), "data".to_string()];
+        let field_offsets = vec![
+            ("payer".to_string(), quote::quote!(0usize)),
+            ("data".to_string(), quote::quote!(1usize)),
+        ];
+
+        let parsed = parse_field(
+            &data_field,
+            &field_names,
+            &field_offsets,
+            quote::quote!(1usize),
+            &[],
+            &summaries,
+        )
+        .unwrap();
+
+        assert!(
+            !parsed.idl_init_signer,
+            "PDA init_if_needed must not advertise signer metadata"
+        );
+        let joined = parsed
+            .constraints
+            .iter()
+            .map(|t| t.to_string())
+            .collect::<String>();
+        assert!(
+            !joined.contains("ConstraintSigner"),
+            "PDA init_if_needed must not emit ConstraintSigner, got: {joined}"
         );
     }
 

--- a/lang-v2/tests/init_if_needed_signer_check.rs
+++ b/lang-v2/tests/init_if_needed_signer_check.rs
@@ -1,0 +1,202 @@
+//! Runtime regression for seedless `init_if_needed` signer enforcement.
+//!
+//! Seedless `init_if_needed` advertises `signer: true` in IDL/CPI metadata.
+//! The exist branch never hits System Program `create_account`, so the
+//! derive must also emit a runtime `ConstraintSigner` check — otherwise an
+//! unsigned victim account can reach `close = …` exit and be drained.
+//!
+//! Run:
+//! `cargo test -p anchor-lang-v2 --features testing --test init_if_needed_signer_check`
+
+use {
+    anchor_lang_v2::{
+        accounts::{Account, Program, SystemAccount},
+        programs::System,
+        testing::AccountBuffer,
+        Accounts, AnchorAccount, Discriminator, ErrorCode, Id, InitSpace, Owner, Space,
+        TryAccounts,
+    },
+    bytemuck::{Pod, Zeroable},
+    pinocchio::address::Address,
+    solana_program_error::ProgramError,
+};
+
+anchor_lang_v2::declare_id!("11111111111111111111111111111111");
+
+const PROGRAM_ID: [u8; 32] = [0x42; 32];
+const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, InitSpace)]
+struct Vault {
+    value: u64,
+}
+
+impl Owner for Vault {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for Vault {
+    // sha256("account:Vault")[..8]
+    const DISCRIMINATOR: &'static [u8] = &[0xd3, 0x08, 0xe8, 0x2b, 0x02, 0x98, 0x75, 0x77];
+}
+
+const VAULT_SPACE: usize = 8 + Vault::INIT_SPACE;
+const VAULT_LAMPORTS: u64 = 1_000_000;
+const RECEIVER_LAMPORTS: u64 = 25;
+
+/// Seedless `init_if_needed` + `close` — the vulnerable surface before the
+/// fix. Compile smoke + runtime coverage below.
+#[allow(dead_code)]
+#[derive(Accounts)]
+struct SeedlessInitIfNeededClose {
+    #[account(mut)]
+    payer: SystemAccount,
+    #[account(
+        init_if_needed,
+        payer = payer,
+        space = VAULT_SPACE,
+        close = receiver
+    )]
+    vault: Account<Vault>,
+    #[account(mut)]
+    receiver: SystemAccount,
+    system_program: Program<System>,
+}
+
+/// Control: PDA `init_if_needed` must not require a transaction signature.
+#[allow(dead_code)]
+#[derive(Accounts)]
+struct SeededInitIfNeeded {
+    #[account(init_if_needed, payer = payer, space = VAULT_SPACE, seeds = [b"vault"], bump)]
+    vault: Account<Vault>,
+    #[account(mut)]
+    payer: SystemAccount,
+    system_program: Program<System>,
+}
+
+fn setup_existing_vault(buf: &AccountBuffer<256>, address: [u8; 32], is_signer: bool) {
+    buf.init(
+        address,
+        PROGRAM_ID,
+        VAULT_SPACE,
+        is_signer,
+        /*writable*/ true,
+        false,
+    );
+    let mut data = [0u8; VAULT_SPACE];
+    data[..8].copy_from_slice(Vault::DISCRIMINATOR);
+    data[8..16].copy_from_slice(&7u64.to_le_bytes());
+    buf.write_data(&data);
+    buf.set_lamports(VAULT_LAMPORTS);
+}
+
+fn setup_system_account(buf: &AccountBuffer<128>, address: [u8; 32], lamports: u64) {
+    buf.init(
+        address,
+        SYSTEM_PROGRAM_ID,
+        0,
+        /*signer*/ true,
+        /*writable*/ true,
+        false,
+    );
+    buf.set_lamports(lamports);
+}
+
+fn setup_system_program(buf: &AccountBuffer<128>) {
+    buf.init(
+        SYSTEM_PROGRAM_ID,
+        SYSTEM_PROGRAM_ID,
+        0,
+        false,
+        false,
+        /*executable*/ true,
+    );
+}
+
+fn try_seedless(
+    payer: &AccountBuffer<128>,
+    vault: &AccountBuffer<256>,
+    receiver: &AccountBuffer<128>,
+    system_program: &AccountBuffer<128>,
+) -> Result<SeedlessInitIfNeededClose, ProgramError> {
+    let program_id = Address::new_from_array(PROGRAM_ID);
+    let views = [
+        unsafe { payer.view() },
+        unsafe { vault.view() },
+        unsafe { receiver.view() },
+        unsafe { system_program.view() },
+    ];
+    SeedlessInitIfNeededClose::try_accounts(&program_id, &views, None, 0, &[])
+        .map(|(accounts, _bumps, _)| accounts)
+}
+
+#[test]
+fn seedless_and_seeded_init_if_needed_derive_smoke() {
+    assert_eq!(VAULT_SPACE, 16);
+    assert_eq!(SeedlessInitIfNeededClose::HEADER_SIZE, 4);
+    assert_eq!(SeededInitIfNeeded::HEADER_SIZE, 3);
+}
+
+#[test]
+fn seedless_init_if_needed_exist_rejects_unsigned_account_before_close() {
+    // Attack shape from finding #79: existing program-owned vault is
+    // writable but not a signer; attacker signs only as payer and names an
+    // attacker-controlled close recipient.
+    let payer = AccountBuffer::<128>::new();
+    setup_system_account(&payer, [0x11; 32], 50);
+
+    let vault = AccountBuffer::<256>::new();
+    setup_existing_vault(&vault, [0xAA; 32], /*is_signer*/ false);
+
+    let receiver = AccountBuffer::<128>::new();
+    setup_system_account(&receiver, [0xCC; 32], RECEIVER_LAMPORTS);
+
+    let system_program = AccountBuffer::<128>::new();
+    setup_system_program(&system_program);
+
+    let err = match try_seedless(&payer, &vault, &receiver, &system_program) {
+        Ok(_) => panic!("unsigned existing vault must be rejected before close"),
+        Err(err) => err,
+    };
+    assert_eq!(err, ErrorCode::ConstraintSigner.into());
+
+    // No close happened — balances unchanged.
+    assert_eq!(unsafe { vault.view() }.lamports(), VAULT_LAMPORTS);
+    assert_eq!(unsafe { receiver.view() }.lamports(), RECEIVER_LAMPORTS);
+}
+
+#[test]
+fn seedless_init_if_needed_exist_allows_signed_account_and_close_transfers() {
+    let payer = AccountBuffer::<128>::new();
+    setup_system_account(&payer, [0x11; 32], 50);
+
+    let vault = AccountBuffer::<256>::new();
+    setup_existing_vault(&vault, [0xAA; 32], /*is_signer*/ true);
+
+    let receiver = AccountBuffer::<128>::new();
+    setup_system_account(&receiver, [0xCC; 32], RECEIVER_LAMPORTS);
+
+    let system_program = AccountBuffer::<128>::new();
+    setup_system_program(&system_program);
+
+    let mut accounts = match try_seedless(&payer, &vault, &receiver, &system_program) {
+        Ok(accounts) => accounts,
+        Err(err) => panic!("signed vault must load, got: {err:?}"),
+    };
+
+    if let Err(err) = accounts.exit_accounts(&[]) {
+        panic!("close exit must succeed, got: {err:?}");
+    }
+
+    assert_eq!(
+        unsafe { vault.view() }.lamports(),
+        0,
+        "closed vault must have zero lamports"
+    );
+    assert_eq!(
+        unsafe { receiver.view() }.lamports(),
+        RECEIVER_LAMPORTS + VAULT_LAMPORTS,
+        "receiver must receive the closed vault's lamports"
+    );
+}

--- a/lang-v2/tests/init_if_needed_space_check.rs
+++ b/lang-v2/tests/init_if_needed_space_check.rs
@@ -1,7 +1,8 @@
 //! Smoke test for `init_if_needed` with an explicit `space = ...` account.
 //!
-//! The behavioral regression is covered end-to-end in `tests-v2`; this file
-//! just keeps a focused derive example in `lang-v2`.
+//! Runtime signer enforcement for seedless `init_if_needed` (+ `close`) lives
+//! in `init_if_needed_signer_check.rs`. End-to-end LiteSVM coverage is in
+//! `tests-v2`.
 
 use {
     anchor_lang_v2::{
@@ -41,6 +42,20 @@ struct InitIfNeededVault {
     vault: Account<Vault>,
     #[account(mut)]
     payer: SystemAccount,
+    system_program: Program<System>,
+}
+
+/// Compile smoke for the seedless surface (signer enforced at runtime in
+/// `init_if_needed_signer_check.rs`).
+#[allow(dead_code)]
+#[derive(Accounts)]
+struct InitIfNeededSeedlessClose {
+    #[account(mut)]
+    payer: SystemAccount,
+    #[account(init_if_needed, payer = payer, space = VAULT_SPACE, close = receiver)]
+    vault: Account<Vault>,
+    #[account(mut)]
+    receiver: SystemAccount,
     system_program: Program<System>,
 }
 


### PR DESCRIPTION
#### Finding (HackHack Audit 79)
Seedless `init_if_needed` set `idl_init_signer` for IDL/CPI metadata (signer: true) but the derive only emitted a runtime `ConstraintSigner` check for explicit `#[account(signer)]`.

On the existing-account branch the account is loaded with `load_mut` (no System Program create CPI). Combined with `close = recipient`, an attacker can pass a victim’s writable non-signer account and drain its lamports on exit.

#### Fix
Gate the runtime signer check on `idl_init_signer` instead of `attrs.is_signer` only:
- seedless `init` / `init_if_needed` → `require is_signer()`
- PDA / ATA init paths unchanged (flag stays false)
- explicit signer still covered