### PR TITLE
feat(lang-v2) size SerializedAccount from T::DISCRIMINATOR.len()

### DIFF
--- a/lang-v2/src/accounts/serialized_account.rs
+++ b/lang-v2/src/accounts/serialized_account.rs
@@ -12,10 +12,6 @@ use {
     solana_program_memory::sol_memset,
 };
 
-/// Discriminator length in bytes. All `#[account]` types use an 8-byte
-/// discriminator; serialized accounts prefix their data with it.
-pub(crate) const DISC_LEN: usize = 8;
-
 /// Pluggable codec for [`SerializedAccount`].
 ///
 /// Implementors are zero-sized tag types (e.g. [`super::BorshSerializer`])
@@ -68,15 +64,16 @@ enum SerializedAccountBorrow {
     Released,
 }
 
-// Forward `Space::INIT_SPACE` from the inner type and add 8 for the
-// discriminator. Lets `#[account(init)]` default to the correct size
-// when `space` is omitted.
+// Forward `Space::INIT_SPACE` from the inner type and add the type's
+// discriminator width. Lets `#[account(init)]` default to the correct
+// size when `space` is omitted — including `declare_program!` / imported
+// accounts whose discs are not eight bytes.
 impl<T, S> crate::Space for SerializedAccount<T, S>
 where
     T: Owner + Discriminator + crate::Space,
     S: AnchorAccountSerialize<T>,
 {
-    const INIT_SPACE: usize = 8 + T::INIT_SPACE;
+    const INIT_SPACE: usize = T::DISCRIMINATOR.len() + T::INIT_SPACE;
 }
 
 impl<T, S> SerializedAccount<T, S>
@@ -106,14 +103,20 @@ where
         Ok(())
     }
 
+    #[inline(always)]
+    const fn disc_len() -> usize {
+        T::DISCRIMINATOR.len()
+    }
+
     fn serialize_mutable_borrow(
         data: &T,
         borrow: &mut SerializedAccountBorrow,
         serialized_len: &mut usize,
     ) -> Result<(), ProgramError> {
         if let SerializedAccountBorrow::Mutable { ref mut guard } = borrow {
-            let payload_len = guard.len() - DISC_LEN;
-            let mut payload = &mut guard[DISC_LEN..];
+            let disc_len = Self::disc_len();
+            let payload_len = guard.len() - disc_len;
+            let mut payload = &mut guard[disc_len..];
             S::serialize(data, &mut payload)?;
 
             let new_serialized_len = payload_len - payload.len();
@@ -146,15 +149,16 @@ where
         require!(self.view.owned_by(&T::OWNER), ProgramError::IllegalOwner);
         let mut view_mut = self.view;
         let data_ref = view_mut.try_borrow_mut()?;
-        if data_ref.len() < DISC_LEN {
+        let disc_len = Self::disc_len();
+        if data_ref.len() < disc_len {
             return Err(ProgramError::AccountDataTooSmall);
         }
         require_eq!(
-            &data_ref[..DISC_LEN],
+            &data_ref[..disc_len],
             T::DISCRIMINATOR,
             ProgramError::InvalidAccountData
         );
-        let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[DISC_LEN..])?;
+        let (data, serialized_len) = Self::deserialize_payload_with_len(&data_ref[disc_len..])?;
         self.data = data;
         self.serialized_len = serialized_len;
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
@@ -179,9 +183,9 @@ where
         // A resize that left the buffer shorter than the discriminator
         // means the on-chain `T` discriminator was just truncated. Reject
         // here so the realloc gets rolled back rather than leaving the
-        // account permanently un-loadable (and panicking exit() at
-        // `guard[DISC_LEN..]`).
-        if data_ref.len() < DISC_LEN {
+        // account permanently un-loadable (and panicking exit() at the
+        // post-discriminator payload slice).
+        if data_ref.len() < Self::disc_len() {
             return Err(ProgramError::AccountDataTooSmall);
         }
         let guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
@@ -204,15 +208,16 @@ where
             view.owned_by(&T::OWNER),
             super::slab::cold_owner_error(&view)
         );
-        if data.len() < DISC_LEN {
+        let disc_len = Self::disc_len();
+        if data.len() < disc_len {
             return Err(ProgramError::AccountDataTooSmall);
         }
         require_eq!(
-            &data[..DISC_LEN],
+            &data[..disc_len],
             T::DISCRIMINATOR,
             ProgramError::InvalidAccountData
         );
-        Self::deserialize_payload_with_len(&data[DISC_LEN..])
+        Self::deserialize_payload_with_len(&data[disc_len..])
     }
 }
 
@@ -223,7 +228,7 @@ where
 {
     type Data = T;
     const RELAX_READONLY_CPI_BORROW_FROM_MUT: bool = true;
-    const MIN_DATA_LEN: usize = 8;
+    const MIN_DATA_LEN: usize = T::DISCRIMINATOR.len();
 
     fn load(view: AccountView) -> Result<Self, ProgramError> {
         let data_ref = view.try_borrow()?;
@@ -324,7 +329,7 @@ where
         // and close), this is a no-op.
         self.borrow = SerializedAccountBorrow::Released;
 
-        // Defense-in-depth: write a closed-account sentinel ([u8::MAX; 8])
+        // Defense-in-depth: write a closed-account sentinel (`u8::MAX`)
         // over the discriminator before pinocchio's close() zeros the
         // 48-byte header (lamports + data_len + owner). pinocchio's
         // close does not zero the data region — verified by the
@@ -341,8 +346,11 @@ where
         // other live borrow on this account; the view's data is valid
         // until pinocchio's `close()` reassigns ownership below.
         let data = unsafe { self_view.borrow_unchecked_mut() };
-        if data.len() >= 8 {
-            data[..8].copy_from_slice(&[u8::MAX; 8]);
+        let disc_len = Self::disc_len();
+        if disc_len > 0 && data.len() >= disc_len {
+            // `sol_memset` matches the rest of this module's scrubbing
+            // style and works for any discriminator width.
+            unsafe { sol_memset(&mut data[..disc_len], u8::MAX, disc_len) };
         }
 
         self_view.close()?;
@@ -501,9 +509,11 @@ where
         signer_seeds: Option<&[&[u8]]>,
         payer_signer_seeds: Option<&[&[u8]]>,
     ) -> Result<Self, ProgramError> {
-        let disc: &[u8; 8] = T::DISCRIMINATOR
-            .try_into()
-            .map_err(|_| ProgramError::InvalidAccountData)?;
+        let disc = T::DISCRIMINATOR;
+        let disc_len = disc.len();
+        if space < disc_len {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
         crate::create_account_with_signers(
             payer,
             account,
@@ -515,11 +525,11 @@ where
         let mut view_mut = *account;
         let data_ref = view_mut.try_borrow_mut()?;
         let mut guard: RefMut<'static, [u8]> = unsafe { core::mem::transmute(data_ref) };
-        match guard.first_chunk_mut::<DISC_LEN>() {
-            Some(dst) => *dst = *disc,
-            None => return Err(ProgramError::AccountDataTooSmall),
+        if guard.len() < disc_len {
+            return Err(ProgramError::AccountDataTooSmall);
         }
-        let (data, serialized_len) = Self::deserialize_payload_with_len(&guard[DISC_LEN..])?;
+        guard[..disc_len].copy_from_slice(disc);
+        let (data, serialized_len) = Self::deserialize_payload_with_len(&guard[disc_len..])?;
         Ok(Self {
             view: *account,
             data,

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -605,11 +605,11 @@ fn codec_round_trip_advances_cursor() {
 // -- 8. realloc-shrink below discriminator is rejected ----------------
 //
 // `realloc_account` does not (and cannot, given Slab over external
-// header-only types) enforce that `new_space >= DISC_LEN`. The
-// BorshAccount-shaped reacquire path must reject it: leaving the buffer
-// shorter than the 8-byte discriminator truncates `T::DISCRIMINATOR`
-// on chain, bricks the account, and panics exit()'s `guard[DISC_LEN..]`
-// slice index. The Solana runtime rolls back the rejected transaction.
+// header-only types) enforce that `new_space >= T::DISCRIMINATOR.len()`.
+// The BorshAccount-shaped reacquire path must reject it: leaving the
+// buffer shorter than the discriminator truncates `T::DISCRIMINATOR`
+// on chain, bricks the account, and panics exit()'s post-discriminator
+// payload slice. The Solana runtime rolls back the rejected transaction.
 
 #[test]
 fn reacquire_guard_only_rejects_buffer_shorter_than_discriminator() {
@@ -619,21 +619,21 @@ fn reacquire_guard_only_rejects_buffer_shorter_than_discriminator() {
     let view = unsafe { buf.view() };
     let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
 
-    // Simulate `realloc_account(new_space = 4)`: shrink below DISC_LEN.
+    // Simulate `realloc_account(new_space = 4)`: shrink below the disc.
     acct.release_borrow().unwrap();
     buf.set_data_len(4);
 
     let err = acct.reacquire_guard_only().expect_err(
-        "reacquire_guard_only must reject a post-resize buffer shorter than DISC_LEN — otherwise \
-         the discriminator is truncated on-chain and exit()'s guard[DISC_LEN..] panics",
+        "reacquire_guard_only must reject a post-resize buffer shorter than the discriminator — \
+         otherwise the discriminator is truncated on-chain and exit()'s payload slice panics",
     );
     assert!(matches!(err, ProgramError::AccountDataTooSmall));
 }
 
-// Exit path: an out-of-band shrink below DISC_LEN triggers the stale-
-// detection branch in `exit()`, which calls `reacquire_guard_only`. The
-// added check propagates the error rather than panicking on the
-// subsequent `guard[DISC_LEN..]` slice.
+// Exit path: an out-of-band shrink below the discriminator triggers the
+// stale-detection branch in `exit()`, which calls `reacquire_guard_only`.
+// The added check propagates the error rather than panicking on the
+// subsequent post-discriminator payload slice.
 
 #[test]
 fn exit_rejects_external_shrink_below_discriminator() {
@@ -644,11 +644,11 @@ fn exit_rejects_external_shrink_below_discriminator() {
     let mut acct = unsafe { BorshAccount::<Counter>::load_mut(view) }.unwrap();
     acct.value = 100;
 
-    // Simulate an external resize to 4 bytes (below DISC_LEN = 8).
+    // Simulate an external resize to 4 bytes (below an 8-byte disc).
     buf.set_data_len(4);
 
     let err = acct
         .exit()
-        .expect_err("exit must surface the under-DISC_LEN buffer as an error, not panic");
+        .expect_err("exit must surface the undersized buffer as an error, not panic");
     assert!(matches!(err, ProgramError::AccountDataTooSmall));
 }

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -256,13 +256,13 @@ fn load_after_close_rejects_with_data_too_small() {
     }
 
     // Even though data bytes retain the disc, the framework rejects
-    // because `data_len = 0` (< DISC_LEN=8 → AccountDataTooSmall).
+    // because `data_len = 0` (< discriminator length → AccountDataTooSmall).
     let view = unsafe { buf.view() };
     let result = BorshAccount::<Vault>::load(view);
     assert!(
         result.is_err(),
         "BorshAccount::load must reject a closed account (owner is [0;32] != program_id, AND \
-         data_len=0 < DISC_LEN)"
+         data_len=0 < discriminator length)"
     );
 }
 

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -422,3 +422,194 @@ fn wincode_codec_release_reacquire_picks_up_cpi_write() {
     assert_eq!(acct.balance, 12_345);
     assert_eq!(acct.nonce, 99);
 }
+
+// =========================================================================
+// Variable-length discriminators (Finding #103)
+//
+// `Discriminator` is a byte slice and `declare_program!` / imported accounts
+// may use non-8-byte discs. SerializedAccount must size/load/serialize from
+// `T::DISCRIMINATOR.len()`, not a hardcoded 8.
+// =========================================================================
+
+#[derive(Default, Clone, PartialEq, Debug)]
+struct Compact {
+    value: u32,
+}
+
+const COMPACT_DISC: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+
+impl Owner for Compact {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for Compact {
+    const DISCRIMINATOR: &'static [u8] = &COMPACT_DISC;
+}
+
+impl AnchorAccountSerialize<Compact> for LeCodec {
+    fn serialize(value: &Compact, buf: &mut &mut [u8]) -> Result<(), ProgramError> {
+        if buf.len() < 4 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let tmp = core::mem::take(buf);
+        let (payload, rest) = tmp.split_at_mut(4);
+        payload.copy_from_slice(&value.value.to_le_bytes());
+        *buf = rest;
+        Ok(())
+    }
+
+    fn deserialize(buf: &mut &[u8]) -> Result<Compact, ProgramError> {
+        if buf.len() < 4 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let (payload, rest) = buf.split_at(4);
+        *buf = rest;
+        Ok(Compact {
+            value: u32::from_le_bytes(payload.try_into().unwrap()),
+        })
+    }
+}
+
+type CompactAccount = SerializedAccount<Compact, LeCodec>;
+
+fn setup_compact_buf(buf: &mut AccountBuffer<256>, value: u32) {
+    let data_len = COMPACT_DISC.len() + 4;
+    buf.init([0xAA; 32], PROGRAM_ID, data_len, false, true, false);
+    let mut data = [0u8; 8];
+    data[..4].copy_from_slice(&COMPACT_DISC);
+    data[4..8].copy_from_slice(&value.to_le_bytes());
+    buf.write_data(&data);
+    buf.set_lamports(1_000_000_000);
+}
+
+#[derive(Default, Clone, PartialEq, Debug)]
+struct Wide {
+    value: u32,
+}
+
+const WIDE_DISC: [u8; 16] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+];
+
+impl Owner for Wide {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+
+impl Discriminator for Wide {
+    const DISCRIMINATOR: &'static [u8] = &WIDE_DISC;
+}
+
+impl AnchorAccountSerialize<Wide> for LeCodec {
+    fn serialize(value: &Wide, buf: &mut &mut [u8]) -> Result<(), ProgramError> {
+        if buf.len() < 4 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let tmp = core::mem::take(buf);
+        let (payload, rest) = tmp.split_at_mut(4);
+        payload.copy_from_slice(&value.value.to_le_bytes());
+        *buf = rest;
+        Ok(())
+    }
+
+    fn deserialize(buf: &mut &[u8]) -> Result<Wide, ProgramError> {
+        if buf.len() < 4 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let (payload, rest) = buf.split_at(4);
+        *buf = rest;
+        Ok(Wide {
+            value: u32::from_le_bytes(payload.try_into().unwrap()),
+        })
+    }
+}
+
+type WideAccount = SerializedAccount<Wide, LeCodec>;
+
+fn setup_wide_buf(buf: &mut AccountBuffer<256>, value: u32) {
+    let data_len = WIDE_DISC.len() + 4;
+    buf.init([0xAA; 32], PROGRAM_ID, data_len, false, true, false);
+    let mut data = [0u8; 20];
+    data[..16].copy_from_slice(&WIDE_DISC);
+    data[16..20].copy_from_slice(&value.to_le_bytes());
+    buf.write_data(&data);
+    buf.set_lamports(1_000_000_000);
+}
+
+#[test]
+fn four_byte_discriminator_load_and_exit_round_trip() {
+    assert_eq!(
+        <CompactAccount as AnchorAccount>::MIN_DATA_LEN,
+        COMPACT_DISC.len()
+    );
+
+    let mut buf = AccountBuffer::<256>::new();
+    setup_compact_buf(&mut buf, 7);
+
+    {
+        let view = unsafe { buf.view() };
+        let mut acct = unsafe { CompactAccount::load_mut(view) }.unwrap();
+        assert_eq!(acct.value, 7);
+        acct.value = 99;
+        acct.exit().unwrap();
+    }
+
+    assert_eq!(read_data_bytes(&buf, 0, 4), COMPACT_DISC);
+    let payload = read_data_bytes(&buf, 4, 4);
+    assert_eq!(u32::from_le_bytes(payload.try_into().unwrap()), 99);
+}
+
+#[test]
+fn sixteen_byte_discriminator_load_and_exit_round_trip() {
+    assert_eq!(
+        <WideAccount as AnchorAccount>::MIN_DATA_LEN,
+        WIDE_DISC.len()
+    );
+
+    let mut buf = AccountBuffer::<256>::new();
+    setup_wide_buf(&mut buf, 11);
+
+    {
+        let view = unsafe { buf.view() };
+        let mut acct = unsafe { WideAccount::load_mut(view) }.unwrap();
+        assert_eq!(acct.value, 11);
+        acct.value = 55;
+        acct.exit().unwrap();
+    }
+
+    assert_eq!(read_data_bytes(&buf, 0, 16), WIDE_DISC);
+    let payload = read_data_bytes(&buf, 16, 4);
+    assert_eq!(u32::from_le_bytes(payload.try_into().unwrap()), 55);
+}
+
+#[test]
+fn four_byte_discriminator_rejects_buffer_shorter_than_disc() {
+    let mut buf = AccountBuffer::<256>::new();
+    // Eight-byte buffer would have passed the old hardcoded DISC_LEN=8 floor
+    // for a four-byte disc type, but still be short of a real 8-byte payload
+    // layout. A three-byte buffer is unambiguously below Compact's disc.
+    buf.init([0xAA; 32], PROGRAM_ID, 3, false, true, false);
+    buf.write_data(&[0xde, 0xad, 0xbe]);
+    buf.set_lamports(1_000_000_000);
+
+    let view = unsafe { buf.view() };
+    let err = CompactAccount::load(view).err();
+    assert_eq!(err, Some(ProgramError::AccountDataTooSmall));
+}
+
+#[test]
+fn sixteen_byte_discriminator_rejects_classic_eight_byte_prefix() {
+    // Pre-fix SerializedAccount would slice only eight bytes and compare
+    // them to a sixteen-byte DISCRIMINATOR (length mismatch → reject). Post-
+    // fix it still rejects an eight-byte buffer as too small for a 16-byte
+    // disc — the important case is that a correctly laid-out 16+payload
+    // account loads (covered above).
+    let mut buf = AccountBuffer::<256>::new();
+    buf.init([0xAA; 32], PROGRAM_ID, 8, false, true, false);
+    buf.write_data(&WIDE_DISC[..8]);
+    buf.set_lamports(1_000_000_000);
+
+    let view = unsafe { buf.view() };
+    let err = WideAccount::load(view).err();
+    assert_eq!(err, Some(ProgramError::AccountDataTooSmall));
+}
+


### PR DESCRIPTION
Fixes AI # 103
Hardcoded 8-byte disc boundaries rejected valid non-8-byte BorshAccount integrations (e.g. declare_program! imports); align load/init/space with variable-length Discriminator like SlabSchema.