### PR TITLE
feat(lang-v2): removing lifetime from Interface program account wrapper

### DIFF
--- a/lang-v2/src/accounts/interface.rs
+++ b/lang-v2/src/accounts/interface.rs
@@ -6,12 +6,12 @@ use {
 };
 
 /// Program account wrapper that accepts any address declared by `T::ids()`.
-pub struct Interface<'info, T: Ids> {
+pub struct Interface<T: Ids> {
     view: AccountView,
-    _phantom: PhantomData<&'info T>,
+    _phantom: PhantomData<T>,
 }
 
-impl<T: Ids> Interface<'_, T> {
+impl<T: Ids> Interface<T> {
     /// Returns the account's address.
     #[inline(always)]
     pub fn address(&self) -> &Address {
@@ -19,7 +19,7 @@ impl<T: Ids> Interface<'_, T> {
     }
 }
 
-impl<T: Ids> AnchorAccount for Interface<'_, T> {
+impl<T: Ids> AnchorAccount for Interface<T> {
     type Data = AccountView;
 
     #[inline(always)]
@@ -44,7 +44,7 @@ impl<T: Ids> AnchorAccount for Interface<'_, T> {
     }
 }
 
-impl<T: Ids> Deref for Interface<'_, T> {
+impl<T: Ids> Deref for Interface<T> {
     type Target = AccountView;
 
     #[inline(always)]
@@ -53,28 +53,28 @@ impl<T: Ids> Deref for Interface<'_, T> {
     }
 }
 
-impl<T: Ids> AsRef<AccountView> for Interface<'_, T> {
+impl<T: Ids> AsRef<AccountView> for Interface<T> {
     #[inline(always)]
     fn as_ref(&self) -> &AccountView {
         &self.view
     }
 }
 
-impl<T: Ids> AsRef<Address> for Interface<'_, T> {
+impl<T: Ids> AsRef<Address> for Interface<T> {
     #[inline(always)]
     fn as_ref(&self) -> &Address {
         self.view.address()
     }
 }
 
-impl<T: Ids> crate::ToCpiHandle for Interface<'_, T> {
+impl<T: Ids> crate::ToCpiHandle for Interface<T> {
     #[inline(always)]
     fn to_cpi_handle(&self) -> crate::CpiHandle<'_> {
         crate::AnchorAccount::cpi_handle(self)
     }
 }
 
-impl<T: Ids> crate::ToCpiHandleMut for Interface<'_, T> {
+impl<T: Ids> crate::ToCpiHandleMut for Interface<T> {
     #[inline(always)]
     fn try_to_cpi_handle_mut(
         &mut self,
@@ -84,4 +84,4 @@ impl<T: Ids> crate::ToCpiHandleMut for Interface<'_, T> {
 }
 
 #[doc(hidden)]
-impl<T: Ids> crate::IdlAccountType for Interface<'_, T> {}
+impl<T: Ids> crate::IdlAccountType for Interface<T> {}

--- a/tests-v2/programs/token-interface/src/lib.rs
+++ b/tests-v2/programs/token-interface/src/lib.rs
@@ -99,7 +99,7 @@ pub mod token_interface_test {
 
 #[derive(Accounts)]
 pub struct CheckTokenProgram {
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
 }
 
 #[derive(Accounts)]
@@ -107,7 +107,7 @@ pub struct InitInterfaceMint {
     #[account(mut)]
     pub payer: Signer,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,
@@ -124,7 +124,7 @@ pub struct InitInterfaceMintPda {
     #[account(mut)]
     pub payer: Signer,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,
@@ -144,7 +144,7 @@ pub struct InitInterfaceTokenAccount {
     pub payer: Signer,
     pub mint: InterfaceAccount<Mint>,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,
@@ -162,7 +162,7 @@ pub struct InitInterfaceTokenAccountPda {
     pub payer: Signer,
     pub mint: InterfaceAccount<Mint>,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,
@@ -184,7 +184,7 @@ pub struct InitInterfaceTokenAccountPda {
 pub struct CheckInterfaceTokenConstraints {
     pub mint: InterfaceAccount<Mint>,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         token::mint = mint,
         token::authority = authority,
@@ -196,7 +196,7 @@ pub struct CheckInterfaceTokenConstraints {
 #[derive(Accounts)]
 pub struct CheckInterfaceMintConstraints {
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         mint::decimals = 6,
         mint::authority = authority,
@@ -212,7 +212,7 @@ pub struct MintToInterfaceAccount {
     #[account(mut, token::mint = mint, token::token_program = token_program)]
     pub to: InterfaceAccount<TokenAccount>,
     pub authority: Signer,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
 }
 
 #[derive(Accounts)]
@@ -220,7 +220,7 @@ pub struct InitInterfaceMintDecimals9 {
     #[account(mut)]
     pub payer: Signer,
     pub authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,
@@ -238,7 +238,7 @@ pub struct InitInterfaceMintWithFreezeAuthority {
     pub payer: Signer,
     pub authority: UncheckedAccount,
     pub freeze_authority: UncheckedAccount,
-    pub token_program: Interface<'static, TokenInterface>,
+    pub token_program: Interface<TokenInterface>,
     #[account(
         init,
         payer = payer,


### PR DESCRIPTION
## Summary

Removed lifetime parameter from anchor-v2 `Interface<>` program account wrapper to match other account wrapper types.