### PR TITLE
refactor(PDA handling): prevent auto-derivation for explicit bumps

### DIFF
--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -364,6 +364,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-derive-accounts-v2"
+version = "2.0.0"
+dependencies = [
+ "anchor-lang-idl",
+ "bs58",
+ "curve25519-dalek",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-address 2.6.0",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "anchor-derive-serde"
 version = "2.0.0-rc.1"
 dependencies = [
@@ -465,6 +480,48 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "anchor-lang-idl"
+version = "0.1.2"
+dependencies = [
+ "anchor-lang-idl-spec",
+ "anyhow",
+ "heck",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "anchor-lang-idl-spec"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
+name = "anchor-lang-v2"
+version = "2.0.0"
+dependencies = [
+ "anchor-derive-accounts-v2",
+ "bytemuck",
+ "pinocchio",
+ "pinocchio-system",
+ "sha2 0.10.9",
+ "solana-address 2.6.0",
+ "solana-define-syscall 5.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-sha256-hasher",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]

--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -364,21 +364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-derive-accounts-v2"
-version = "2.0.0"
-dependencies = [
- "anchor-lang-idl",
- "bs58",
- "curve25519-dalek",
- "proc-macro2",
- "quote",
- "serde_json",
- "sha2 0.10.9",
- "solana-address 2.6.0",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "anchor-derive-serde"
 version = "2.0.0-rc.1"
 dependencies = [
@@ -480,48 +465,6 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "anchor-lang-idl"
-version = "0.1.2"
-dependencies = [
- "anchor-lang-idl-spec",
- "anyhow",
- "heck",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "anchor-lang-idl-spec"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "serde",
-]
-
-[[package]]
-name = "anchor-lang-v2"
-version = "2.0.0"
-dependencies = [
- "anchor-derive-accounts-v2",
- "bytemuck",
- "pinocchio",
- "pinocchio-system",
- "sha2 0.10.9",
- "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-program-memory",
- "solana-sha256-hasher",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "wincode",
 ]
 
 [[package]]
@@ -805,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -815,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -907,16 +850,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.6"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -977,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -988,15 +930,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1047,7 +989,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1074,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1238,18 +1180,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1533,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -1602,7 +1544,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1675,12 +1617,13 @@ checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1738,7 +1681,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1872,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -1946,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2020,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2149,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -2370,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "managed"
@@ -2403,6 +2346,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2774,7 +2727,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2896,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3151,7 +3104,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3416,7 +3369,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "serde_with",
@@ -4241,7 +4194,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "percentage",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "solana-account",
  "solana-account-info",
@@ -4378,7 +4331,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rustc-demangle",
  "thiserror 2.0.20",
  "winapi",
@@ -4396,7 +4349,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rustc-demangle",
  "thiserror 2.0.20",
  "winapi",
@@ -4698,7 +4651,7 @@ version = "3.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b78cd0bfb102d4197ce8c590f800a119ba0d358369ca57b0f66e94d1317fd0e"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -5072,7 +5025,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5107,7 +5060,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5167,7 +5120,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "sha3",
@@ -5231,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5283,7 +5236,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5804,6 +5757,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/bench/programs/multisig/anchor-v2/tests/multisig.rs
+++ b/bench/programs/multisig/anchor-v2/tests/multisig.rs
@@ -99,6 +99,7 @@ fn test_set_label() {
     let mut label = [0u8; 32];
     label[..label_bytes.len()].copy_from_slice(label_bytes);
 
+    let (config, _) = config_address(&creator.pubkey());
     let ix = Instruction::new_with_bytes(
         multisig_v2::id(),
         &instruction::SetLabel {
@@ -106,7 +107,7 @@ fn test_set_label() {
             label,
         }
         .data(),
-        multisig_v2::accounts::SetLabelResolved { creator: creator.pubkey() }
+        multisig_v2::accounts::SetLabelResolved { creator: creator.pubkey(), config }
             .to_account_metas(None),
     );
     let res = send(&mut svm, ix, &[&creator]).expect("set_label");
@@ -138,6 +139,7 @@ fn test_execute_transfer() {
 
     // Execute transfer
     let mut metas = multisig_v2::accounts::ExecuteTransferResolved {
+        config,
         creator: creator.pubkey(),
         recipient: recipient.pubkey(),
     }

--- a/bench/src/programs/multisig.rs
+++ b/bench/src/programs/multisig.rs
@@ -230,6 +230,7 @@ pub mod anchor_v2 {
         ctx.airdrop(&creator.pubkey(), 1_000_000_000)?;
         setup_multisig_v2(ctx, &creator, &[&signer_one, &signer_two], 2)?;
 
+        let (config, _) = config_address(&creator.pubkey());
         let label_bytes = b"bench-multisig";
         let mut label = [0u8; 32];
         label[..label_bytes.len()].copy_from_slice(label_bytes);
@@ -239,8 +240,11 @@ pub mod anchor_v2 {
                 label,
             }
             .data(),
-            multisig_v2::accounts::SetLabelResolved { creator: creator.pubkey() }
-                .to_account_metas(None),
+            multisig_v2::accounts::SetLabelResolved {
+                creator: creator.pubkey(),
+                config,
+            }
+            .to_account_metas(None),
         )
         .with_signer(creator))
     }
@@ -266,6 +270,7 @@ pub mod anchor_v2 {
         )?;
 
         let mut metas = multisig_v2::accounts::ExecuteTransferResolved {
+            config,
             creator: creator.pubkey(),
             recipient: recipient.pubkey(),
         }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1537,6 +1537,11 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
             let attrs = parse::parse_account_attrs(&raw_field.attrs)
                 .expect("parse_field already validated account attributes");
             if let Some(ref seeds_expr) = attrs.seeds {
+                // `bump = <expr>` is verified on-chain; client auto-derive
+                // would use the canonical bump and can mismatch.
+                if matches!(attrs.bump, Some(Some(_))) {
+                    return (f, FieldKind::Required);
+                }
                 // Client-side PDA derivation only works when we can
                 // inspect individual seed expressions — requires the
                 // array-bracket form `seeds = [...]`. Expression-form
@@ -1767,6 +1772,10 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
             )
             .expect("parse_field already validated account attributes");
             let seeds_expr = attrs.seeds.as_ref()?;
+            // Don't emit a canonical-bump helper for `bump = <expr>`.
+            if matches!(attrs.bump, Some(Some(_))) {
+                return None;
+            }
             // Expression-form seeds (e.g. `seeds = Counter::seeds()`) don't
             // support client-side PDA helpers — skip.
             let seed_arr = match seeds_expr {

--- a/tests-v2/tests/seeds.rs
+++ b/tests-v2/tests/seeds.rs
@@ -5,7 +5,10 @@
 //! bare-bump (runtime find) and explicit stored-bump variants.
 
 use {
-    anchor_lang::solana_program::instruction::{AccountMeta, Instruction},
+    anchor_lang::{
+        solana_program::instruction::{AccountMeta, Instruction},
+        ToAccountMetas,
+    },
     litesvm::{types::TransactionResult, LiteSVM},
     sha2::{Digest, Sha256},
     solana_account::Account,
@@ -54,6 +57,21 @@ fn find_on_curve_bump() -> (Pubkey, u8) {
         }
     }
     panic!("expected at least one on-curve bump");
+}
+
+fn non_canonical_data_pda() -> (Pubkey, u8) {
+    let (canonical, canonical_bump) = Pubkey::find_program_address(&[b"data"], &program_id());
+    for bump in (0..=u8::MAX).rev() {
+        if bump == canonical_bump {
+            continue;
+        }
+        let bump_seed = [bump];
+        if let Ok(address) = Pubkey::create_program_address(&[b"data", &bump_seed], &program_id()) {
+            assert_ne!(address, canonical);
+            return (address, bump);
+        }
+    }
+    panic!("expected at least one non-canonical off-curve bump");
 }
 
 fn setup() -> (LiteSVM, Keypair) {
@@ -398,6 +416,33 @@ fn literal_untrusted_bump_rejects_on_curve_address() {
         result.is_err(),
         "on-curve address derived from explicit bump must be rejected",
     );
+}
+
+// `bump = <expr>` must not auto-derive via find_program_address on Resolved.
+#[test]
+fn resolved_builder_requires_address_for_explicit_bump() {
+    let (mut svm, payer) = setup();
+    let (pda, bump) = non_canonical_data_pda();
+    assert_ne!(pda, data_pda(), "fixture must differ from the canonical PDA");
+
+    // Compiles only if `data` is Required (not Pda-auto-derived).
+    let metas = seeds::accounts::CheckLiteralUntrustedBumpResolved {
+        payer: payer.pubkey(),
+        data: pda,
+    }
+    .to_account_metas(None);
+    assert_eq!(metas[1].pubkey, pda);
+
+    set_system_account(&mut svm, pda, 1_000_000, 0);
+    send_instruction(
+        &mut svm,
+        program_id(),
+        vec![12, bump],
+        metas,
+        &payer,
+        &[],
+    )
+    .expect("non-canonical explicit-bump PDA accepted when address is supplied");
 }
 
 #[test]


### PR DESCRIPTION
Stop client Resolved builders and `find_*_address` helpers from auto-deriving PDAs with `find_program_address` when the account uses `bump = <expr>`. Those paths always used the canonical bump and ignored the pinned bump, so non-canonical cases emitted the wrong address. Callers must supply the address instead.

Fixes HackHack Audit finding 5