### PR TITLE
fix(lang-v2): reject optional account fields used as PDA seeds

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1157,6 +1157,42 @@ fn address_v1_relation_source(
     field_names.contains(&sibling).then_some(sibling)
 }
 
+/// Returns an error when any seed in `seeds` is a bare identifier that names
+/// an `Option<_>`-typed sibling field. Optional accounts carry no `.address()`
+/// method, so the generated `<sibling>.address()` call would not compile;
+/// surfacing a clear diagnostic here beats a type-error inside the generated
+/// expansion.
+fn reject_optional_sibling_seeds(
+    seeds: &[&Expr],
+    field_summaries: &[FieldSummary],
+) -> syn::Result<()> {
+    for seed in seeds {
+        let Expr::Path(ep) = seed else { continue };
+        if ep.qself.is_some()
+            || ep.path.leading_colon.is_some()
+            || ep.path.segments.len() != 1
+        {
+            continue;
+        }
+        let seg = &ep.path.segments[0];
+        if !seg.arguments.is_empty() {
+            continue;
+        }
+        let ident = &seg.ident;
+        if field_summaries
+            .iter()
+            .any(|s| s.name == *ident && extract_option_inner(&s.ty).is_some())
+        {
+            return Err(syn::Error::new(
+                ident.span(),
+                "optional account fields cannot be used as PDA seeds; \
+                 use a non-optional account for seed derivation",
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Rewrite a single seed expression so that a bare field-name identifier
 /// (like `wallet` in `seeds = [b"vault", wallet]`) is replaced with the
 /// explicit address accessor `wallet.address()`.
@@ -1368,6 +1404,7 @@ fn emit_payer_signer_seeds_binding(
     let bump_field = &payer_field.name;
     if let Expr::Array(arr) = seeds_expr {
         let seed_elems: Vec<&Expr> = arr.elems.iter().collect();
+        reject_optional_sibling_seeds(&seed_elems, field_summaries)?;
         let (seed_bindings, seed_refs) = materialize_seed_refs(&seed_elems, field_names);
         let seed_count = seed_refs.len();
         if let Some(Some(ref bump_expr)) = payer_field.attrs.bump {
@@ -1539,6 +1576,7 @@ fn emit_init_body(
         };
         if let Expr::Array(arr) = seeds_expr {
             let seed_elems: Vec<&Expr> = arr.elems.iter().collect();
+            reject_optional_sibling_seeds(&seed_elems, field_summaries)?;
             emit_seeds_check(
                 &seed_elems,
                 field_names,
@@ -2242,6 +2280,7 @@ pub fn parse_field(
             if let Expr::Array(arr) = seeds_expr {
                 // Array-literal seeds: `seeds = [b"vault", user.address().as_ref()]`
                 let seed_elems: Vec<&Expr> = arr.elems.iter().collect();
+                reject_optional_sibling_seeds(&seed_elems, field_summaries)?;
                 let seed_constraint = if let Some(Some(ref bump_expr)) = attrs.bump {
                     let bump_assign = if is_optional {
                         quote! { Some(__bump_val) }

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -977,3 +977,59 @@ pub struct Bad {{
         "Box<BorshAccount<Data>>",
     );
 }
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn optional_sibling_seed_is_rejected() {
+    // An optional sibling used as a bare PDA seed generates `sibling.address()`
+    // in the on-chain validation path; `Option<T>` has no `.address()` method,
+    // so the expansion never compiles. The derive should surface a clear
+    // diagnostic at attribute-parse time instead of a confusing type error
+    // inside the generated code.
+    compile_fail_case(
+        "optional_sibling_seed_non_init",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data { pub val: u64 }
+
+#[derive(Accounts)]
+pub struct Bad {
+    // `authority` is optional — using it bare as a seed is forbidden.
+    pub authority: Option<UncheckedAccount>,
+    #[account(seeds = [authority], bump)]
+    pub pda: Account<Data>,
+}
+"#,
+        &["optional account fields cannot be used as PDA seeds"],
+    );
+
+    compile_fail_case(
+        "optional_sibling_seed_init",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[account]
+pub struct Data { pub val: u64 }
+
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Option<UncheckedAccount>,
+    #[account(init, payer = payer, space = 8 + 8, seeds = [authority], bump)]
+    pub pda: Account<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+        &["optional account fields cannot be used as PDA seeds"],
+    );
+}


### PR DESCRIPTION
Anchor v2's `#[derive(Accounts)]` silently generates `sibling.address()` when a bare optional field is used as a PDA seed. Since `Option<T>` has no `.address()` method, the program fails to compile with a confusing type error inside the macro expansion rather than a useful diagnostic.

This PR adds a guard that detects optional sibling seeds before any code is emitted and surfaces a clear `syn::Error` at the ident's span.

- Covered by two compile-fail regression tests (non-init and init paths).

Fixes HackHack Audit finding 7