### PR TITLE
fix(lang-v2): forward ForeignOwnerInit through Box<T>

### DIFF
--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -1,7 +1,9 @@
 extern crate alloc;
 
 use {
-    crate::{AccountConstraint, AccountInitialize, AnchorAccount, Discriminator, Space},
+    crate::{
+        AccountConstraint, AccountInitialize, AnchorAccount, Discriminator, ForeignOwnerInit, Space,
+    },
     alloc::boxed::Box,
     pinocchio::{account::AccountView, address::Address},
     solana_program_error::ProgramError,
@@ -97,7 +99,8 @@ impl<T: crate::IdlAccountType> crate::IdlAccountType for Box<T> {
 // ---------------------------------------------------------------------------
 // Forward the init-time trait surface so `Box<Account<T>>` and
 // `Box<BorshAccount<T>>` work with `#[account(init, …)]`, `#[account(zeroed)]`,
-// `space = …` omitted, and namespaced constraints (`token::mint = …`, etc.).
+// `space = …` omitted, namespaced constraints (`token::mint = …`, etc.), and
+// `Box<UncheckedAccount>` with `owner = …` (`ForeignOwnerInit`).
 //
 // The derive reaches for these traits via UFCS on the field type — e.g.
 // `<Box<Account<T>> as AccountInitialize>::create_and_initialize(…)` — so
@@ -128,6 +131,10 @@ impl<T: AccountInitialize> AccountInitialize for Box<T> {
         .map(Box::new)
     }
 }
+
+/// Forward the foreign-owner init marker so `Box<UncheckedAccount>` works with
+/// `#[account(init, owner = …)]` the same way bare `UncheckedAccount` does.
+impl<T: ForeignOwnerInit> ForeignOwnerInit for Box<T> {}
 
 impl<T: Space> Space for Box<T> {
     const INIT_SPACE: usize = T::INIT_SPACE;

--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -132,8 +132,6 @@ impl<T: AccountInitialize> AccountInitialize for Box<T> {
     }
 }
 
-/// Forward the foreign-owner init marker so `Box<UncheckedAccount>` works with
-/// `#[account(init, owner = …)]` the same way bare `UncheckedAccount` does.
 impl<T: ForeignOwnerInit> ForeignOwnerInit for Box<T> {}
 
 impl<T: Space> Space for Box<T> {

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1533,3 +1533,39 @@ pub struct Bad {
         &["optional account fields cannot be used as PDA seeds"],
     );
 }
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn boxed_unchecked_account_accepts_init_owner_override() {
+    // Finding #86: Box forwards AccountInitialize but omitted ForeignOwnerInit,
+    // so Box<UncheckedAccount> + owner = … failed the derive's marker assertion
+    // even though bare UncheckedAccount is the sanctioned escape hatch.
+    compile_pass_case(
+        "init_owner_override_boxed_unchecked_account",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+pub const OTHER_PROGRAM: Address =
+    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
+
+#[derive(Accounts)]
+pub struct Ok {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 0,
+        owner = OTHER_PROGRAM,
+    )]
+    pub data: Box<UncheckedAccount>,
+    pub system_program: Program<System>,
+}
+"#,
+    );
+}

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -1533,39 +1533,3 @@ pub struct Bad {
         &["optional account fields cannot be used as PDA seeds"],
     );
 }
-
-#[test]
-#[cfg_attr(
-    miri,
-    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
-)]
-fn boxed_unchecked_account_accepts_init_owner_override() {
-    // Finding #86: Box forwards AccountInitialize but omitted ForeignOwnerInit,
-    // so Box<UncheckedAccount> + owner = … failed the derive's marker assertion
-    // even though bare UncheckedAccount is the sanctioned escape hatch.
-    compile_pass_case(
-        "init_owner_override_boxed_unchecked_account",
-        r#"
-use anchor_lang_v2::prelude::*;
-
-declare_id!("11111111111111111111111111111111");
-
-pub const OTHER_PROGRAM: Address =
-    Address::from_str_const("Gue5TpR6sstSyGhSvmVeH2TeKqBYYqmXpRCacB9jAk8u");
-
-#[derive(Accounts)]
-pub struct Ok {
-    #[account(mut)]
-    pub payer: Signer,
-    #[account(
-        init,
-        payer = payer,
-        space = 0,
-        owner = OTHER_PROGRAM,
-    )]
-    pub data: Box<UncheckedAccount>,
-    pub system_program: Program<System>,
-}
-"#,
-    );
-}


### PR DESCRIPTION
Problem - AI # 86
#[account(init, owner = …)] requires ForeignOwnerInit on the field type. Only UncheckedAccount implements that marker. Box<T> already forwarded AccountInitialize (and related init traits) for UFCS, but not ForeignOwnerInit, so swapping a valid UncheckedAccount field to Box<UncheckedAccount> broke compilation.
