### PR TITLE
fix(lang-v2): handle zero-byte CPI returns in Return::get

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -5410,17 +5410,33 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
                 >,
             {
                 pub fn get(&self) -> T {
-                    let __return_data =
-                        anchor_lang::pinocchio::cpi::get_return_data().unwrap();
-                    assert!(
-                        anchor_lang::address_eq(__return_data.program_id(), &self.program),
-                        "return data program id mismatch"
-                    );
-                    anchor_lang::wincode::config::deserialize(
-                        __return_data.as_slice(),
-                        anchor_lang::BORSH_CONFIG,
-                    )
-                        .unwrap()
+                    // Solana / Pinocchio report a zero-length return buffer as
+                    // `None` (`sol_get_return_data` size == 0). Empty structs
+                    // and other ZST returns serialize to zero bytes, so treat
+                    // missing return data as an empty slice. Non-empty `T`
+                    // still fails to deserialize from `[]`. When bytes are
+                    // present, keep the program-id authenticity check.
+                    match anchor_lang::pinocchio::cpi::get_return_data() {
+                        Some(__return_data) => {
+                            assert!(
+                                anchor_lang::address_eq(
+                                    __return_data.program_id(),
+                                    &self.program,
+                                ),
+                                "return data program id mismatch"
+                            );
+                            anchor_lang::wincode::config::deserialize(
+                                __return_data.as_slice(),
+                                anchor_lang::BORSH_CONFIG,
+                            )
+                            .unwrap()
+                        }
+                        None => anchor_lang::wincode::config::deserialize(
+                            &[][..],
+                            anchor_lang::BORSH_CONFIG,
+                        )
+                        .unwrap(),
+                    }
                 }
             }
 

--- a/tests-v2/programs/callee/src/lib.rs
+++ b/tests-v2/programs/callee/src/lib.rs
@@ -44,7 +44,18 @@ pub mod callee {
         ctx.accounts.data.value = ctx.accounts.data.value.saturating_add(delta);
         Ok(())
     }
+
+    /// Zero-byte return type — Finding #81: empty structs serialize to `[]`,
+    /// which the runtime exposes as `None` from `get_return_data`. CPI
+    /// callers must still be able to `Return<Ack>::get()`.
+    pub fn acknowledge(_ctx: &mut Context<Empty>) -> Result<Ack> {
+        Ok(Ack {})
+    }
 }
+
+/// Empty return payload with a valid zero-byte wincode schema.
+#[derive(Clone, Copy, wincode::SchemaRead, wincode::SchemaWrite)]
+pub struct Ack {}
 
 #[derive(Accounts)]
 pub struct Initialize {

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -75,6 +75,18 @@ pub mod caller {
         callee::cpi::touch(cpi_ctx, delta)?;
         Ok(())
     }
+
+    /// CPIs into `acknowledge` and reads the zero-byte `Ack` return via
+    /// `Return::get` — must not panic when the runtime reports empty
+    /// return data as `None`.
+    pub fn proxy_acknowledge(ctx: &mut Context<ProxyEmpty>) -> Result<()> {
+        let cpi_ctx = CpiContext::new(
+            ctx.accounts.callee_program.address(),
+            callee::cpi::accounts::Empty::new(),
+        );
+        let _ack = callee::cpi::acknowledge(cpi_ctx)?.get();
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]

--- a/tests-v2/tests/cpi.rs
+++ b/tests-v2/tests/cpi.rs
@@ -85,6 +85,19 @@ fn test_cpi_empty_accounts() {
         .expect("caller::proxy_empty should succeed");
 }
 
+/// Finding #81: empty-struct returns serialize to zero bytes; the runtime
+/// exposes that as `get_return_data() == None`. `Return::get` must treat
+/// `None` as an empty slice so CPI callers don't panic.
+#[test]
+fn test_cpi_empty_struct_return() {
+    let (mut svm, payer) = setup();
+
+    let proxy = caller::instruction::ProxyAcknowledge {}.data();
+    let proxy_metas = vec![AccountMeta::new_readonly(callee_id(), false)];
+    send_instruction(&mut svm, caller_id(), proxy, proxy_metas, &payer, &[])
+        .expect("caller::proxy_acknowledge should succeed reading Ack via Return::get");
+}
+
 #[test]
 fn test_direct_set_data() {
     let (mut svm, payer) = setup();


### PR DESCRIPTION
AI Finding # 81
The `#[program]` macro treats only syntactic () as `no return.` Any other `Result<T>` (including empty `struct Ack {}`) sets return data. Those types encode to 0 bytes, and the runtime reports that as `None` from `get_return_data`. Generated `Return<T>::get()` did `unwrap()`, so a valid CPI that returned an empty struct panicked. `Tx` rolls back — no fund loss. So Fixing this with `Return::get`: `Some` → keep program-id check + deserialize; `None` → deserialize from &[] (ZST ok; non-empty T still fails)