### PR TITLE
fix(lang-v2): no-op Slab::refund when recipient aliases self

### DIFF
--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -416,7 +416,9 @@ where
     }
 
     /// Move excess lamports (current - min_lamports) from the account to
-    /// `recipient`. No-op if the account is already at the rent floor.
+    /// `recipient`. No-op if the account is already at the rent floor, or if
+    /// `recipient` aliases this account's lamport slot (a self-transfer would
+    /// otherwise credit then overwrite and burn the excess).
     ///
     /// Direct lamport arithmetic, no CPI — callers must only use this for
     /// accounts whose owner permits in-program lamport mutation.
@@ -425,6 +427,11 @@ where
         let required = self.min_lamports()?;
         let current = self.view.lamports();
         if current <= required {
+            return Ok(());
+        }
+        // When the recipient aliases this account, credit-then-debit would
+        // overwrite the first write and burn `excess`. Skip both writes.
+        if pinocchio::address::address_eq(recipient.address(), self.view.address()) {
             return Ok(());
         }
         let excess = current - required;

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -634,6 +634,30 @@ fn refund_is_noop_when_account_is_at_rent_floor() {
 }
 
 #[test]
+fn refund_with_self_recipient_is_noop() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);
+
+    let required = expected_min_lamports(ITEMS_OFFSET + 4 * ITEM_SIZE).unwrap();
+    let original = required + 500;
+    buf.set_lamports(original);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    // `AccountView` is `Copy`, so a program can pass an alias of the slab as
+    // the refund recipient. That must not burn the excess via credit-then-
+    // overwrite on the shared lamport slot.
+    let mut self_recipient = unsafe { buf.view() };
+
+    slab.refund(&mut self_recipient).unwrap();
+
+    assert_eq!(
+        slab.view().lamports(),
+        original,
+        "self-recipient refund must preserve the original balance",
+    );
+}
+
+#[test]
 #[should_panic(expected = "Tried to mutate `Slab<H, T>` through a read-only load")]
 fn top_up_panics_when_loaded_read_only() {
     let mut buf = setup_ledger(/*capacity*/ 4, /*len*/ 1);


### PR DESCRIPTION
#### Finding AI # 76

`Slab::refund` credits excess lamports to the recipient, then sets the source account to its rent minimum. `AccountView` is `Copy`, so a program can pass a second view of the same account as recipient. Both writes hit the same lamport slot: the credit is overwritten by required, burning the excess and unbalancing lamports (usually causing rollback).

#### Fix 

Before moving lamports, detect when recipient aliases the slab account (`address_eq`) and return early as a no-op — same approach as shrink refunds in `cpi::realloc_account`. Added `refund_with_self_recipient_is_noop` to lock in the behavior.