### PR TITLE
Fix typos in doc comments

### DIFF
--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -160,7 +160,7 @@ impl<'a, T: Id> TryFrom<&'a AccountInfo<'a>> for Program<'a, T> {
     }
 }
 
-/// `Progam<'info>` with no type parameter (or `Program<'info, ()>`) is a special shorthand for
+/// `Program<'info>` with no type parameter (or `Program<'info, ()>`) is a special shorthand for
 /// 'any program account'.
 impl<'a> TryFrom<&'a AccountInfo<'a>> for Program<'a, ()> {
     type Error = Error;

--- a/lang/src/bpf_writer.rs
+++ b/lang/src/bpf_writer.rs
@@ -26,7 +26,7 @@ impl Write for BpfWriter<&mut [u8]> {
         };
 
         let amt = cmp::min(remaining_inner.len(), buf.len());
-        // SAFETY: `amt` is guarenteed by the above line to be in bounds for both slices
+        // SAFETY: `amt` is guaranteed by the above line to be in bounds for both slices
         unsafe {
             sol_memcpy(remaining_inner, buf, amt);
         }


### PR DESCRIPTION
Fixes two spelling typos in doc comments. No code change.

- `guarenteed` should be `guaranteed` (lang/src/bpf_writer.rs)
- `Progam` should be `Program` (lang/src/accounts/program.rs)
