### PR TITLE
fix(lang-v2): reject InitSpace with wincode tag_encoding

### DIFF
--- a/lang-v2/derive/src/init_space.rs
+++ b/lang-v2/derive/src/init_space.rs
@@ -18,6 +18,41 @@ use {
 
 pub fn expand(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
+    match crate::find_unsupported_wincode_attr(&input.attrs) {
+        Ok(Some((crate::UnsupportedWincodeAttrKind::TagEncoding, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(tag_encoding = ...)]` because \
+                 InitSpace assumes borsh's 1-byte enum discriminant; remove the override or \
+                 compute the account size manually",
+            )
+            .to_compile_error()
+            .into();
+        }
+        Ok(Some((crate::UnsupportedWincodeAttrKind::Skip, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(skip)]` because wincode \
+                 overrides change the serialized layout; remove the override or compute the \
+                 account size manually",
+            )
+            .to_compile_error()
+            .into();
+        }
+        Ok(Some((crate::UnsupportedWincodeAttrKind::With, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` because custom \
+                 wincode codecs can change the serialized layout; remove the override or \
+                 compute the account size manually",
+            )
+            .to_compile_error()
+            .into();
+        }
+        Ok(None) => {}
+        Err(err) => return err.to_compile_error().into(),
+    }
+
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let name = input.ident;
 
@@ -91,6 +126,15 @@ fn field_len_tokens(field: Field) -> TokenStream2 {
                 span,
                 "#[derive(InitSpace)] does not support `#[wincode(with = ...)]` fields because \
                  custom wincode codecs can change the serialized layout; remove the override or \
+                 compute the account size manually",
+            )
+            .to_compile_error();
+        }
+        Ok(Some((crate::UnsupportedWincodeAttrKind::TagEncoding, span))) => {
+            return syn::Error::new(
+                span,
+                "#[derive(InitSpace)] does not support `#[wincode(tag_encoding = ...)]` because \
+                 InitSpace assumes borsh's 1-byte enum discriminant; remove the override or \
                  compute the account size manually",
             )
             .to_compile_error();

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -67,6 +67,8 @@ struct AccountMetaAttrs {
 pub(crate) enum UnsupportedWincodeAttrKind {
     Skip,
     With,
+    /// Enum-level override of discriminant width (e.g. `u32` instead of borsh's `u8`).
+    TagEncoding,
 }
 
 pub(crate) fn find_unsupported_wincode_attr(
@@ -103,6 +105,12 @@ pub(crate) fn find_unsupported_wincode_attr(
                     let _ = value.parse::<Expr>()?;
                 }
                 unsupported = Some((UnsupportedWincodeAttrKind::With, span));
+            } else if meta.path.is_ident("tag_encoding") {
+                if meta.input.peek(syn::Token![=]) {
+                    let value = meta.value()?;
+                    let _ = value.parse::<Expr>()?;
+                }
+                unsupported = Some((UnsupportedWincodeAttrKind::TagEncoding, span));
             }
             Ok(())
         });
@@ -4483,6 +4491,14 @@ fn unsupported_wincode_idl_attr_error(
                 "{surface} does not support `#[wincode(with = ...)]` fields because custom \
                  wincode codecs can change the serialized wire layout; remove the override or \
                  exclude this type from generated IDL"
+            ),
+        )),
+        Ok(Some((UnsupportedWincodeAttrKind::TagEncoding, span))) => Some(syn::Error::new(
+            span,
+            format!(
+                "{surface} does not support `#[wincode(tag_encoding = ...)]` because generated \
+                 IDL assumes borsh's 1-byte enum discriminant; remove the override or exclude \
+                 this type from generated IDL"
             ),
         )),
         Ok(None) => None,

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -272,6 +272,24 @@ mod shim {
             "custom wincode codecs can change the serialized layout",
         ],
     );
+
+    compile_fail_case(
+        "init_space_wincode_tag_encoding",
+        r#"
+use anchor_lang_v2::InitSpace;
+
+#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[wincode(tag_encoding = "u32")]
+pub enum Bad {
+    A([u8; 32]),
+    B(u8),
+}
+"#,
+        &[
+            "#[derive(InitSpace)] does not support `#[wincode(tag_encoding = ...)]`",
+            "1-byte enum discriminant",
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes finding AI # 70
InitSpace always sizes enums with a 1-byte discriminant. Reject `#[wincode(tag_encoding = ...)]` so wider tags cannot silently understate account space, matching the field-override reject pattern from #4790.