### PR TITLE
fix(lang-v2): reject zero-sized Pod Slab tails

### DIFF
--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -44,9 +44,9 @@ pub(super) fn cold_not_writable() -> ProgramError {
 }
 
 /// Capacity from live `data_len` / `items_offset` / `item_size`. Returns 0
-/// when `data_len < items_offset` to guard against underflow if an external
-/// `realloc_account` shrinks the buffer while a `Slab` is retained. Caller
-/// must ensure `item_size > 0` (`Slab` skips this for ZST items).
+/// when `data_len < items_offset` (external shrink below the tail region) or
+/// when `item_size == 0` (Pod ZST tails are rejected by the tail API; this
+/// guard keeps the helper panic-free if called incorrectly).
 ///
 /// Factored out of `Slab::capacity` as a free `const fn` so the Kani proofs
 /// below (`capacity_never_underflows`, `capacity_fits_within_data_len_item_*`,
@@ -54,7 +54,7 @@ pub(super) fn cold_not_writable() -> ProgramError {
 /// `Slab`'s generic plumbing.
 #[inline(always)]
 const fn capacity_for(data_len: usize, items_offset: usize, item_size: usize) -> usize {
-    if data_len < items_offset {
+    if item_size == 0 || data_len < items_offset {
         0
     } else {
         (data_len - items_offset) / item_size
@@ -442,6 +442,8 @@ where
 // ===========================================================================
 // Tail-only impl block — `T: Pod` bound excludes `HeaderOnly`, so these
 // methods are "method not found" compile errors on `Account<H>`.
+// Zero-sized `Pod` types (e.g. `()`) are also rejected: layout treats them as
+// tail-less (`HAS_TAIL = false`) but the capacity math divides by item size.
 // ===========================================================================
 
 impl<H, T> Slab<H, T>
@@ -449,6 +451,14 @@ where
     H: Pod + Zeroable + SlabSchema,
     T: Pod,
 {
+    // Evaluated when any method from this impl is monomorphized.
+    #[allow(dead_code)]
+    const _NONZERO_TAIL: () = assert!(
+        core::mem::size_of::<T>() > 0,
+        "Slab tail item type must be non-zero-sized; use Account<H> / Slab<H, HeaderOnly> \
+         for header-only accounts",
+    );
+
     // -----------------------------------------------------------------------
     // Safe byte-slice accessors — bounds checks + bytemuck alignment checks
     // trade a small cost for zero unsafe in the tail-mutation path.
@@ -519,6 +529,7 @@ where
     /// user-supplied capacities so arithmetic failures become program errors.
     #[inline(always)]
     pub const fn try_space_for(capacity: u32) -> Result<usize, ProgramError> {
+        let _ = Self::_NONZERO_TAIL;
         let item_bytes = match (capacity as usize).checked_mul(core::mem::size_of::<T>()) {
             Some(value) => value,
             None => return Err(ProgramError::ArithmeticOverflow),
@@ -544,6 +555,7 @@ where
     /// account below the Slab's structural minimum).
     #[inline(always)]
     pub fn capacity(&self) -> usize {
+        let _ = Self::_NONZERO_TAIL;
         capacity_for(
             self.view.data_len(),
             Self::ITEMS_OFFSET,
@@ -981,6 +993,7 @@ where
 
     #[inline(always)]
     fn index(&self, index: usize) -> &T {
+        let _ = Self::_NONZERO_TAIL;
         &self.as_slice()[index]
     }
 }
@@ -992,6 +1005,7 @@ where
 {
     #[inline(always)]
     fn index_mut(&mut self, index: usize) -> &mut T {
+        let _ = Self::_NONZERO_TAIL;
         &mut self.as_mut_slice()[index]
     }
 }
@@ -1186,6 +1200,12 @@ mod tests {
         assert_eq!(acct.value, 99);
     }
 
+    #[test]
+    fn capacity_for_zero_item_size_returns_zero() {
+        assert_eq!(capacity_for(0, 0, 0), 0);
+        assert_eq!(capacity_for(128, 32, 0), 0);
+        assert_eq!(capacity_for(10, 32, 0), 0);
+    }
 }
 
 // Kani proofs for the `capacity_for` helper, which backs `Slab::capacity`
@@ -1204,13 +1224,13 @@ mod kani_proofs {
     const OFFSET_MAX: usize = 1024;
     const ITEM_SIZE_MAX: usize = 1024;
 
-    // `capacity_for` never panics or wraps for any valid input.
+    // `capacity_for` never panics or wraps for any input, including
+    // `item_size == 0` (returns 0).
     #[kani::proof]
     fn capacity_never_underflows() {
         let data_len: usize = kani::any();
         let items_offset: usize = kani::any();
         let item_size: usize = kani::any();
-        kani::assume(item_size > 0);
         kani::assume(data_len <= DATA_LEN_MAX);
         kani::assume(items_offset <= OFFSET_MAX);
         kani::assume(item_size <= ITEM_SIZE_MAX);

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -1753,6 +1753,46 @@ pub unsafe fn load_bad(view: AccountView) {
 }
 
 #[test]
+fn slab_zero_sized_pod_tail_does_not_compile() {
+    CompileCase::new(
+        "slab_zero_sized_pod_tail",
+        r#"
+use anchor_lang_v2::{
+    accounts::{Slab, SlabSchema},
+    prelude::*,
+};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GoodHeader {
+    value: u64,
+}
+
+unsafe impl anchor_lang_v2::bytemuck::Zeroable for GoodHeader {}
+unsafe impl anchor_lang_v2::bytemuck::Pod for GoodHeader {}
+
+impl SlabSchema for GoodHeader {
+    const DATA_OFFSET: usize = 0;
+    const MIN_DATA_LEN: usize = 8;
+
+    fn validate(
+        _view: &AccountView,
+        _data: &[u8],
+    ) -> core::result::Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+// `()` is Pod + ZST. Layout treats it as tail-less, but the tail API would
+// divide by zero in capacity — must fail at compile time.
+const _: usize = Slab::<GoodHeader, ()>::space_for(0);
+"#,
+    )
+    .build()
+    .expect_fail(&["Slab tail item type must be non-zero-sized"]);
+}
+
+#[test]
 fn realloc_on_unchecked_account_does_not_compile() {
     CompileCase::new(
         "realloc_on_unchecked_account",


### PR DESCRIPTION
Fixes Finding AI # 58

#4796 only hardened missing-len after shrink (`read_len` → `None` / `len() == 0`). `capacity_for` still assumes `item_size` > `0` and does not guard zero. Now Pod tail API asserts `size_of::<T>() > 0` (referenced from `try_space_for` / `capacity` / `indexing`) — `Slab<H, ()>` fails with a clear message; use `Account<H>` / `HeaderOnly` instead. Also `capacity_for` returns `0` when `item_size` == `0` (no divide-by-zero).