### PR TITLE
fix(lang-v2): include generics in InitSpace enum impl

### DIFF
--- a/lang-v2/derive/src/init_space.rs
+++ b/lang-v2/derive/src/init_space.rs
@@ -91,7 +91,7 @@ pub fn expand(item: TokenStream) -> TokenStream {
 
             quote! {
                 #[automatically_derived]
-                impl anchor_lang::Space for #name {
+                impl #impl_generics anchor_lang::Space for #name #ty_generics #where_clause {
                     const INIT_SPACE: usize = 1 + #max;
                 }
             }

--- a/lang-v2/tests/init_space.rs
+++ b/lang-v2/tests/init_space.rs
@@ -141,6 +141,21 @@ fn enum_picks_largest_variant_plus_discriminator() {
 }
 
 #[derive(InitSpace)]
+enum GenericVariant<T: Space> {
+    Empty,
+    One(T),
+    Two(u64, T),
+}
+
+#[test]
+fn generic_enum_emits_space_impl_with_type_params() {
+    // 1 (disc) + max(0, 8, 8+8) = 17 when T = u64
+    assert_eq!(GenericVariant::<u64>::INIT_SPACE, 1 + 16);
+    // 1 + max(0, 32, 8+32) = 41 when T = Address
+    assert_eq!(GenericVariant::<Address>::INIT_SPACE, 1 + 40);
+}
+
+#[derive(InitSpace)]
 struct Unit;
 
 #[test]


### PR DESCRIPTION
Fixes Finding AI # 71
`#[derive(InitSpace)]` must emit` impl Space for …` with `INIT_SPACE`. For non-generic enums that already works. For generic enums the emit is incomplete (`impl Space for Foo` instead of `impl<T> Space for Foo<T>`), so rustc rejects it.
