### PR TITLE
ci: consolidate cargo dependency caches

### DIFF
--- a/.github/actions/setup-ts/action.yaml
+++ b/.github/actions/setup-ts/action.yaml
@@ -13,13 +13,6 @@ runs:
         path: |
           ./ts/node_modules/
         key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/yarn.lock') }}
-    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-      name: Cache Typescript Dist
-      id: cache-typescript-dist
-      with:
-        path: |
-          ./ts/dist/
-        key: solana-${{ runner.os }}-v0000-${{ env.NODE_VERSION }}-${{ hashFiles('./ts/**/*.ts') }}
     - run: cd ts/packages/borsh && yarn --frozen-lockfile && yarn build && yarn link && cd ../../../
       shell: bash
     - run: cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build && yarn link && cd ../../../

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -10,3 +10,18 @@ runs:
       shell: bash
     - run: git submodule update --init --recursive --depth 1
       shell: bash
+    - name: Set up sccache
+      if: ${{ env.CACHE == 'true' }}
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      with:
+        version: v0.16.0
+    - name: Enable sccache for Rust
+      if: ${{ env.CACHE == 'true' }}
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+          echo "SCCACHE_GHA_RW_MODE=READ_ONLY" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -126,46 +126,6 @@ jobs:
       - uses: ./.github/actions/setup-ts/
       - uses: ./.github/actions/setup-surfpool/
 
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: basic-0 cache
-        id: cache-basic-0
-        with:
-          path: ./examples/tutorial/basic-0/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-0/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: basic-1 cache
-        id: cache-basic-1
-        with:
-          path: ./examples/tutorial/basic-1/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-1/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: basic-2 cache
-        id: cache-basic-2
-        with:
-          path: ./examples/tutorial/basic-2/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-2/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: basic-3 cache
-        id: cache-basic-3
-        with:
-          path: ./examples/tutorial/basic-3/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-3/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: basic-4 cache
-        id: cache-basic-4
-        with:
-          path: ./examples/tutorial/basic-4/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('./examples/tutorial/basic-4/**/Cargo.toml') }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
       - run: cd examples/tutorial && yarn workspaces run test
       - uses: ./.github/actions/git-diff/
 
@@ -246,13 +206,6 @@ jobs:
         with:
           name: composite.so
           path: tests/composite/target/deploy/
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: Cache client/example target
-        id: cache-test-target
-        with:
-          path: client/example/target
-          key: cargo-${{ runner.os }}-client/example-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
       - run: cd client/example && ./run-test.sh
@@ -285,14 +238,6 @@ jobs:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: Cache tests/bpf-upgradeable-state target
-        id: cache-test-target
-        with:
-          path: tests/bpf-upgradeable-state/target
-          key: cargo-${{ runner.os }}-tests/bpf-upgradeable-state-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: surfpool start --ci --offline &
         name: start surfpool
@@ -559,14 +504,6 @@ jobs:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
-        if: ${{ env.CACHE != 'false' }}
-        name: Cache ${{ matrix.node.path }} target
-        id: cache-test-target
-        with:
-          path: ${{ matrix.node.path }}/target
-          key: cargo-${{ runner.os }}-${{ matrix.node.path }}-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: ${{ matrix.node.cmd }}
         name: ${{ matrix.node.path }} program test

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -32,11 +32,9 @@ env:
   ANCHOR_BINARY_NAME: ${{ inputs.anchor_binary_name }}
   SURFPOOL_CLI_VERSION: ${{ inputs.surfpool_cli_version }}
   CARGO_CACHE_PATH: |
-    ~/.cargo/bin/
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/
     ~/.cargo/git/db/
-    ./target/
 
 jobs:
   test-core:
@@ -57,7 +55,7 @@ jobs:
         id: cache-cargo-build
         with:
           path: ${{ env.CARGO_CACHE_PATH }}
-          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
       - run: cargo build
       - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt && cargo +nightly fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
@@ -93,7 +91,7 @@ jobs:
         id: cache-anchor
         with:
           path: ${{ env.CARGO_CACHE_PATH }}
-          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
       - run: cargo install --path cli anchor-cli --locked --force --debug --features idl-localnet-testing
         if: env.CARGO_PROFILE == 'debug'
@@ -280,7 +278,7 @@ jobs:
         id: cache-anchor
         with:
           path: ${{ env.CARGO_CACHE_PATH }}
-          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -382,7 +380,7 @@ jobs:
         id: cache-anchor
         with:
           path: ${{ env.CARGO_CACHE_PATH }}
-          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -554,7 +552,7 @@ jobs:
         id: cache-anchor
         with:
           path: ${{ env.CARGO_CACHE_PATH }}
-          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
Attempt at https://github.com/otter-sec/anchor/issues/4903. Target caching is a bad idea in the long run and hopefully making use of sccache should give us better results.