### PR TITLE
fix(lang-v2): align Slab empty/full/pop with post-shrink effective_len

### DIFF
--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -169,6 +169,12 @@ where
     H: Pod + Zeroable + SlabSchema,
 {
     fn drop(&mut self) {
+        if self.is_mutable {
+            // If the account was externally shrunk while this wrapper was
+            // retained, persist a repaired tail length before we release the
+            // exclusive borrow so a later reload still validates.
+            self.repair_stale_len_after_external_shrink();
+        }
         let borrow_state = unsafe { &mut (*self.view.account_ptr().cast_mut()).borrow_state };
         if self.is_mutable {
             *borrow_state = NOT_BORROWED;
@@ -246,6 +252,30 @@ where
                 "Slab tail alignment exceeds Solana's 8-byte account data alignment",
             );
         };
+    }
+
+    /// Clamp a retained tail's stored `len` down to current capacity after an
+    /// external shrink. No-op for header-only slabs, read-only loads, or when
+    /// the shrink removed the `len` field entirely.
+    #[inline(always)]
+    fn repair_stale_len_after_external_shrink(&mut self) {
+        if !self.is_mutable || !Self::HAS_TAIL || self.view.data_len() < Self::LEN_OFFSET + 4 {
+            return;
+        }
+
+        let capacity = capacity_for(
+            self.view.data_len(),
+            Self::ITEMS_OFFSET,
+            core::mem::size_of::<T>(),
+        );
+        let bytes = unsafe { self.view.borrow_unchecked_mut() };
+        let mut len_bytes = [0u8; 4];
+        len_bytes.copy_from_slice(&bytes[Self::LEN_OFFSET..Self::LEN_OFFSET + 4]);
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        if len > capacity {
+            bytes[Self::LEN_OFFSET..Self::LEN_OFFSET + 4]
+                .copy_from_slice(&(capacity as u32).to_le_bytes());
+        }
     }
 
     /// Returns the account's address. Always safe regardless of borrow state.

--- a/lang-v2/src/accounts/slab.rs
+++ b/lang-v2/src/accounts/slab.rs
@@ -580,14 +580,23 @@ where
         self.len().min(self.capacity())
     }
 
+    /// Whether the live tail has no readable items.
+    ///
+    /// Uses [`effective_len`](Self::effective_len) so a retained slab whose
+    /// account was externally shrunk below the stored `len` still reports
+    /// empty when every live slot is gone (including zero-capacity shrinks).
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.effective_len() == 0
     }
 
+    /// Whether the live tail cannot accept another push without growing.
+    ///
+    /// Uses [`effective_len`](Self::effective_len) so a post-shrink state with
+    /// raw `len > capacity` reports full rather than neither-empty-nor-full.
     #[inline(always)]
     pub fn is_full(&self) -> bool {
-        self.len() == self.capacity()
+        self.effective_len() == self.capacity()
     }
 
     /// View the tail region as an immutable slice. Uses `effective_len` so
@@ -684,9 +693,17 @@ where
     /// `effective_len` so a post-shrink Slab (raw len > capacity) doesn't
     /// read past the live data buffer; the write-back also clamps the
     /// stored len to a value `<= capacity`.
+    ///
+    /// When an external shrink left `capacity == 0` but a nonzero stored
+    /// `len`, this still clears the stale length before returning `None`
+    /// so a later `load` does not reject `len > capacity`.
     pub fn pop(&mut self) -> Option<T> {
         let len = self.effective_len();
         if len == 0 {
+            // Repair a zero-capacity post-shrink that retained a stale len.
+            if self.len() != 0 {
+                self.write_len(0);
+            }
             return None;
         }
         let new_len = len - 1;

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -402,6 +402,28 @@ fn pop_after_external_shrink_uses_effective_len() {
 }
 
 #[test]
+fn drop_repairs_stale_len_after_external_shrink_without_tail_mutation() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
+
+    let view = unsafe { buf.view() };
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab.capacity(), 4);
+
+    // External resize: capacity drops to 1 while the slab stays in scope.
+    buf.set_data_len((ITEMS_OFFSET + ITEM_SIZE) as u64);
+    assert_eq!(slab.capacity(), 1);
+
+    // Dropping without any tail mutation should still persist a repaired
+    // len so future loads do not reject `len > capacity`.
+    drop(slab);
+
+    let reloaded = CounterLedger::load(view).unwrap();
+    assert_eq!(reloaded.capacity(), 1);
+    assert_eq!(reloaded.len(), 1);
+}
+
+#[test]
 fn predicates_use_effective_len_after_external_shrink() {
     let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
 

--- a/lang-v2/tests/slab_resize_reproducers.rs
+++ b/lang-v2/tests/slab_resize_reproducers.rs
@@ -401,6 +401,52 @@ fn pop_after_external_shrink_uses_effective_len() {
     assert_eq!(slab.len(), 0);
 }
 
+#[test]
+fn predicates_use_effective_len_after_external_shrink() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
+
+    let view = unsafe { buf.view() };
+    let slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+
+    // Shrink below stored len while the wrapper is retained.
+    buf.set_data_len((ITEMS_OFFSET + ITEM_SIZE) as u64);
+    assert_eq!(slab.len(), 3);
+    assert_eq!(slab.capacity(), 1);
+
+    // Pre-fix: is_empty/is_full used raw len and reported neither empty nor
+    // full. Post-fix they track the live tail (min(len, capacity) == 1).
+    assert!(!slab.is_empty());
+    assert!(slab.is_full());
+}
+
+#[test]
+fn pop_repairs_stale_len_when_capacity_is_zero() {
+    let buf = setup_ledger(/*capacity*/ 4, /*len*/ 3);
+
+    let view = unsafe { buf.view() };
+    let mut slab = unsafe { CounterLedger::load_mut(view) }.unwrap();
+
+    // Shrink to the structural minimum: zero item capacity, but the stored
+    // len field is still present and still holds 3.
+    buf.set_data_len(ITEMS_OFFSET as u64);
+    assert_eq!(slab.capacity(), 0);
+    assert_eq!(slab.len(), 3);
+    assert!(slab.is_empty());
+    assert!(slab.is_full());
+
+    // Pre-fix: pop returned None without write_len, leaving len=3 so a
+    // later load rejected len > capacity. Post-fix: repair first.
+    assert_eq!(slab.pop(), None);
+    assert_eq!(slab.len(), 0);
+
+    // Drop the retained wrapper and reload — validation must succeed.
+    drop(slab);
+    let view = unsafe { buf.view() };
+    let reloaded = unsafe { CounterLedger::load_mut(view) }.unwrap();
+    assert!(reloaded.is_empty());
+    assert_eq!(reloaded.len(), 0);
+}
+
 // -- Regression: swap_remove respects effective_len after shrink ------
 
 #[test]


### PR DESCRIPTION
#### Fixes finding AI # 50
After an external shrink, `is_empty/is_full` ignored `effective_len`, and zero-capacity pop left a stale nonzero len unrepaired. Now this pr drive those predicates off `effective_len`, and have pop clamp stored len to 0 when the live tail is empty.