### PR TITLE
fix(lang-v2): enforce PodVec MAX fits u16 length prefix

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2360,9 +2360,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .iter()
                 .filter_map(|field| {
                     let field_name = field.ident.as_ref()?.to_string();
-                    let msg = diagnose_non_pod_field(&field.ty, &field_name, &name_str).or_else(
-                        || diagnose_oversized_pod_vec(&field.ty, &field_name, &name_str),
-                    )?;
+                    let msg = diagnose_non_pod_field(&field.ty, &field_name, &name_str)?;
                     let cfg_attrs = cfg_attrs(&field.attrs);
                     let span = field.ty.span();
                     Some(quote::quote_spanned!(span=>
@@ -2401,9 +2399,11 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .map(|field| {
                     let ty = &field.ty;
                     let cfg_attrs = cfg_attrs(&field.attrs);
+                    let capacity_check = pod_vec_capacity_check(ty);
                     quote! {
                         #(#cfg_attrs)*
                         {
+                            #capacity_check
                             __size += core::mem::size_of::<#ty>();
                         }
                     }
@@ -2681,42 +2681,17 @@ fn diagnose_non_pod_field(ty: &Type, field_name: &str, struct_name: &str) -> Opt
     }
 }
 
-/// Reject `PodVec<T, MAX>` account fields whose `MAX` exceeds the `PodU16`
-/// length prefix (`u16::MAX`). The inherent `_MAX_FITS_U16` assert only fires
-/// once a method monomorphizes it; catching the literal here fails at
-/// `#[account]` expansion before the type is accepted as a zero-copy field.
-fn diagnose_oversized_pod_vec(ty: &Type, field_name: &str, struct_name: &str) -> Option<String> {
+/// Force the capacity invariant while evaluating the account's layout const,
+/// even if no `PodVec` methods are used. Rust resolves and evaluates `MAX`,
+/// including named constants and const expressions that the macro cannot
+/// evaluate from syntax alone.
+fn pod_vec_capacity_check(ty: &Type) -> Option<TokenStream2> {
     let Type::Path(tp) = ty else { return None };
     let seg = tp.path.segments.last()?;
     if seg.ident != "PodVec" {
         return None;
     }
-    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
-        return None;
-    };
-    for arg in &args.args {
-        let syn::GenericArgument::Const(expr) = arg else {
-            continue;
-        };
-        let syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Int(n),
-            ..
-        }) = expr
-        else {
-            continue;
-        };
-        let Ok(val) = n.base10_parse::<u128>() else {
-            continue;
-        };
-        if val > u16::MAX as u128 {
-            return Some(format!(
-                "field `{field_name}` on `#[account] struct {struct_name}` uses `PodVec<_, \
-                 {val}>`, but PodVec's length prefix is a u16 (max 65535). Reduce MAX to <= \
-                 65535, or use a larger length-prefix wrapper."
-            ));
-        }
-    }
-    None
+    Some(quote::quote_spanned!(ty.span()=> let _ = <#ty>::CAPACITY;))
 }
 
 // ---------------------------------------------------------------------------

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2360,7 +2360,9 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .iter()
                 .filter_map(|field| {
                     let field_name = field.ident.as_ref()?.to_string();
-                    let msg = diagnose_non_pod_field(&field.ty, &field_name, &name_str)?;
+                    let msg = diagnose_non_pod_field(&field.ty, &field_name, &name_str).or_else(
+                        || diagnose_oversized_pod_vec(&field.ty, &field_name, &name_str),
+                    )?;
                     let cfg_attrs = cfg_attrs(&field.attrs);
                     let span = field.ty.span();
                     Some(quote::quote_spanned!(span=>
@@ -2677,6 +2679,44 @@ fn diagnose_non_pod_field(ty: &Type, field_name: &str, struct_name: &str) -> Opt
         )),
         _ => None,
     }
+}
+
+/// Reject `PodVec<T, MAX>` account fields whose `MAX` exceeds the `PodU16`
+/// length prefix (`u16::MAX`). The inherent `_MAX_FITS_U16` assert only fires
+/// once a method monomorphizes it; catching the literal here fails at
+/// `#[account]` expansion before the type is accepted as a zero-copy field.
+fn diagnose_oversized_pod_vec(ty: &Type, field_name: &str, struct_name: &str) -> Option<String> {
+    let Type::Path(tp) = ty else { return None };
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "PodVec" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    for arg in &args.args {
+        let syn::GenericArgument::Const(expr) = arg else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(n),
+            ..
+        }) = expr
+        else {
+            continue;
+        };
+        let Ok(val) = n.base10_parse::<u128>() else {
+            continue;
+        };
+        if val > u16::MAX as u128 {
+            return Some(format!(
+                "field `{field_name}` on `#[account] struct {struct_name}` uses `PodVec<_, \
+                 {val}>`, but PodVec's length prefix is a u16 (max 65535). Reduce MAX to <= \
+                 65535, or use a larger length-prefix wrapper."
+            ));
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------

--- a/lang-v2/src/pod.rs
+++ b/lang-v2/src/pod.rs
@@ -611,38 +611,50 @@ impl<T: bytemuck::Pod, const MAX: usize> PodVec<T, MAX> {
     // Compile-time check: MAX must fit in the u16 length prefix. Without
     // this guard, `try_push` / `pop` / `truncate` / `set_from_slice` /
     // `try_extend_from_slice` silently truncate `usize → u16` and corrupt
-    // `len` when the in-memory vec exceeds u16::MAX items. Catch at
-    // monomorphization so `PodVec<T, N>` with `N > 65_535` fails to compile.
+    // `len` when the in-memory vec exceeds u16::MAX items. Exposed as
+    // `CAPACITY` and forced from `Default` / `len` / `write_len` so
+    // declaration, sizing, and read-only use fail at monomorphization —
+    // not only on the first mutation.
     const _MAX_FITS_U16: () = assert!(
         MAX <= u16::MAX as usize,
         "PodVec<T, MAX>: MAX must be <= 65_535 (u16::MAX). Use a larger length-prefix wrapper for \
          capacities beyond this."
     );
 
+    /// Maximum element capacity. Evaluating this associated const forces the
+    /// `MAX <= u16::MAX` check at monomorphization time.
+    pub const CAPACITY: usize = {
+        #[allow(clippy::let_unit_value)]
+        let _ = Self::_MAX_FITS_U16;
+        MAX
+    };
+
     // --- Length / capacity ---
 
     /// Returns the number of populated elements.
     #[inline(always)]
     pub fn len(&self) -> usize {
+        let _ = Self::CAPACITY;
         self.len.get() as usize
     }
 
     /// Returns `true` if no elements are populated.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
+        let _ = Self::CAPACITY;
         self.len.is_zero()
     }
 
     /// Returns `true` if the vector is at capacity.
     #[inline(always)]
     pub fn is_full(&self) -> bool {
-        self.len() == MAX
+        self.len() == Self::CAPACITY
     }
 
     /// Returns the maximum capacity.
     #[inline(always)]
     pub const fn capacity(&self) -> usize {
-        MAX
+        Self::CAPACITY
     }
 
     // --- Validation (for `PodVec`s cast from attacker-controlled bytes) ---
@@ -657,6 +669,7 @@ impl<T: bytemuck::Pod, const MAX: usize> PodVec<T, MAX> {
     /// [`validate`]: Self::validate
     #[inline(always)]
     pub fn is_valid_len(&self) -> bool {
+        let _ = Self::CAPACITY;
         self.len() <= MAX
     }
 
@@ -811,12 +824,10 @@ impl<T: bytemuck::Pod, const MAX: usize> PodVec<T, MAX> {
 
     /// Centralised `len` write: every length-mutating method funnels
     /// through here so `Self::_MAX_FITS_U16` is forced at monomorphization
-    /// time. Without this, a `PodVec<T, 70_000>` could compile and silently
-    /// truncate its prefix through any direct `self.len = ...` write.
+    /// time (alongside `Default` / `capacity` / `len`).
     #[inline(always)]
     fn write_len(&mut self, new_len: usize) {
-        #[allow(clippy::let_unit_value)]
-        let _ = Self::_MAX_FITS_U16;
+        let _ = Self::CAPACITY;
         self.len = PodU16::from(new_len as u16);
     }
 
@@ -966,6 +977,7 @@ impl<'a, T: bytemuck::Pod, const MAX: usize> IntoIterator for &'a mut PodVec<T, 
 
 impl<T: bytemuck::Pod, const MAX: usize> Default for PodVec<T, MAX> {
     fn default() -> Self {
+        let _ = Self::CAPACITY;
         // Safety: PodVec is Pod, so all-zeros is a valid representation.
         unsafe { core::mem::zeroed() }
     }

--- a/lang-v2/tests/pod_vec_validation.rs
+++ b/lang-v2/tests/pod_vec_validation.rs
@@ -10,9 +10,9 @@
 //! (instead of relying on a transaction-aborting panic) use the
 //! `try_*` variants exercised here.
 //!
-//! Paired with `pod_vec_max_overflow`'s compile-time `MAX > u16::MAX`
-//! guard, this closes the remaining runtime-validation gap documented
-//! in the PodVec API comments.
+//! Paired with the compile-time `MAX > u16::MAX` guard (`PodVec::CAPACITY` /
+//! `Default` / `#[account]` field diagnostics), this closes the remaining
+//! runtime-validation gap documented in the PodVec API comments.
 
 use anchor_lang::pod::{CapacityError, PodU64, PodVec};
 

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -2142,7 +2142,7 @@ fn podvec_oversized_max_account_field_does_not_compile() {
 use anchor_lang::prelude::*;
 use anchor_lang::pod::{PodU8, PodVec};
 
-declare_id!("PodVecMax1111111111111111111111111111111111");
+declare_id!("11111111111111111111111111111111");
 
 #[account]
 pub struct Oversized {
@@ -2150,7 +2150,67 @@ pub struct Oversized {
 }
 "#,
     )
-    .expect_fail(&["PodVec's length prefix is a u16"]);
+    .expect_fail(&["MAX must be <= 65_535"]);
+}
+
+#[test]
+fn podvec_oversized_max_const_account_field_does_not_compile() {
+    let source = r#"
+use anchor_lang::prelude::*;
+use anchor_lang::pod::{PodU64, PodVec};
+
+declare_id!("11111111111111111111111111111111");
+
+pub const MAX_VALIDATORS: usize = 70000;
+
+pub struct Limits;
+impl Limits {
+    pub const MAX: usize = MAX_VALIDATORS;
+}
+
+#[account]
+#[repr(C)]
+pub struct ValidatorRegistry {
+    pub count: PodU64,
+    pub validators: PodVec<PodU64, CAPACITY_EXPR>,
+}
+"#;
+
+    for (name, capacity) in [
+        ("podvec_account_named_const", "MAX_VALIDATORS"),
+        ("podvec_account_const_expr", "{ u16::MAX as usize + 1 }"),
+        ("podvec_account_associated_const", "{ Limits::MAX }"),
+    ] {
+        CompileCase::new(name, &source.replace("CAPACITY_EXPR", capacity))
+            .expect_fail(&["MAX must be <= 65_535"]);
+    }
+}
+
+#[test]
+fn podvec_max_u16_const_account_field_compiles() {
+    CompileCase::new(
+        "podvec_max_u16_const_account_field",
+        r#"
+use anchor_lang::prelude::*;
+use anchor_lang::pod::{PodU64, PodVec};
+
+declare_id!("11111111111111111111111111111111");
+
+pub const MAX_VALIDATORS: usize = u16::MAX as usize;
+
+#[account]
+pub struct ValidatorRegistry {
+    pub count: PodU64,
+    pub validators: PodVec<PodU64, MAX_VALIDATORS>,
+    pub empty: anchor_lang::pod::PodVec<PodU64, 0>,
+    #[cfg(any())]
+    pub disabled: PodVec<PodU64, { u16::MAX as usize + 1 }>,
+    #[cfg(any())]
+    pub also_disabled: PodVec<PodU64, UNKNOWN_CAPACITY>,
+}
+"#,
+    )
+    .expect_pass();
 }
 
 #[test]

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -2103,6 +2103,57 @@ const _: usize = Slab::<GoodHeader, ()>::space_for(0);
 }
 
 #[test]
+fn podvec_oversized_max_default_does_not_compile() {
+    CompileCase::new(
+        "podvec_oversized_max_default",
+        r#"
+use anchor_lang::pod::{PodU8, PodVec};
+
+// Public item so the lib target monomorphizes Default (private fns may be skipped).
+pub fn force_default() {
+    let _ = PodVec::<PodU8, 70000>::default();
+}
+"#,
+    )
+    .build()
+    .expect_fail(&["MAX must be <= 65_535"]);
+}
+
+#[test]
+fn podvec_oversized_max_capacity_does_not_compile() {
+    CompileCase::new(
+        "podvec_oversized_max_capacity",
+        r#"
+use anchor_lang::pod::{PodU8, PodVec};
+
+// Evaluating CAPACITY forces the MAX <= u16::MAX assert.
+const _: usize = PodVec::<PodU8, 70000>::CAPACITY;
+"#,
+    )
+    .build()
+    .expect_fail(&["MAX must be <= 65_535"]);
+}
+
+#[test]
+fn podvec_oversized_max_account_field_does_not_compile() {
+    CompileCase::new(
+        "podvec_oversized_max_account_field",
+        r#"
+use anchor_lang::prelude::*;
+use anchor_lang::pod::{PodU8, PodVec};
+
+declare_id!("PodVecMax1111111111111111111111111111111111");
+
+#[account]
+pub struct Oversized {
+    pub items: PodVec<PodU8, 70000>,
+}
+"#,
+    )
+    .expect_fail(&["PodVec's length prefix is a u16"]);
+}
+
+#[test]
 fn realloc_on_unchecked_account_does_not_compile() {
     CompileCase::new(
         "realloc_on_unchecked_account",


### PR DESCRIPTION
#### Fixes finding AI # 43: 
`PodVec` stored len as `u16` but accepted any `MAX`, so oversized vectors could be declared and advertise capacity until a mutation forced the assert. Now, it force the bound via CAPACITY/Default/reads and reject oversized `PodVec` fields in `#[account]`.