### PR TITLE
fix(lang-v2): allow empty seeds arrays in PDA bump codegen

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -1690,7 +1690,7 @@ fn emit_seeds_check(
                             #(#seed_bindings)*
                             let __bump_seed = [#bump_const];
                             let __seeds: Option<&[&[u8]]> =
-                                Some(&[#(#seed_refs),* , __bump_seed.as_ref()]);
+                                Some(&[#(#seed_refs,)* __bump_seed.as_ref()]);
                         }
                     } else {
                         // Wrap non-init in a block so the consts are
@@ -1737,7 +1737,7 @@ fn emit_seeds_check(
             #find
             let __bump_seed = [__bump];
             let __seeds: Option<&[&[u8]]> =
-                Some(&[#(#seed_refs),* , __bump_seed.as_ref()]);
+                Some(&[#(#seed_refs,)* __bump_seed.as_ref()]);
         }
     } else {
         find
@@ -1798,14 +1798,14 @@ fn emit_payer_signer_seeds_binding(
                 }
                 let __payer_bump: u8 = #bump_expr;
                 anchor_lang::verify_program_address(
-                    &[#(#seed_refs),* , &[__payer_bump]],
+                    &[#(#seed_refs,)* &[__payer_bump]],
                     __program_id,
                     __payer.address(),
                 )?;
                 #bump_cache = __payer_bump;
                 let __payer_bump_seed = [__payer_bump];
                 let __payer_signer_seeds: Option<&[&[u8]]> =
-                    Some(&[#(#seed_refs),* , __payer_bump_seed.as_ref()]);
+                    Some(&[#(#seed_refs,)* __payer_bump_seed.as_ref()]);
             });
         }
 
@@ -1821,7 +1821,7 @@ fn emit_payer_signer_seeds_binding(
             #bump_cache = __payer_bump;
             let __payer_bump_seed = [__payer_bump];
             let __payer_signer_seeds: Option<&[&[u8]]> =
-                Some(&[#(#seed_refs),* , __payer_bump_seed.as_ref()]);
+                Some(&[#(#seed_refs,)* __payer_bump_seed.as_ref()]);
         });
     }
 
@@ -2732,7 +2732,7 @@ pub fn parse_field(
                             #(#seed_bindings)*
                             let __bump_val: u8 = #bump_expr;
                             anchor_lang::verify_program_address(
-                                &[#(#seed_refs),* , &[__bump_val]],
+                                &[#(#seed_refs,)* &[__bump_val]],
                                 #pda_program,
                                 #field_name.account().address(),
                             )?;
@@ -3368,6 +3368,16 @@ mod tests {
             err.to_string().contains("`seeds` requires `bump`"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn empty_seed_array_with_bump_is_accepted() {
+        let attrs: Vec<Attribute> = vec![syn::parse_quote!(
+            #[account(seeds = [], bump = 255)]
+        )];
+        let parsed = parse_account_attrs(&attrs).expect("empty seeds with bump must parse");
+        assert!(parsed.seeds.is_some());
+        assert!(matches!(parsed.bump, Some(Some(_))));
     }
 
     #[test]

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -783,6 +783,58 @@ pub struct Good {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn empty_seeds_array_with_bump_compiles() {
+    // Pre-fix: `#(#seed_refs),* , bump` left a leading comma when
+    // `seeds = []`, producing invalid Rust. Post-fix: bump-only arrays.
+    compile_pass_case(
+        "empty_seeds_with_bump",
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(anchor_lang_v2::wincode::SchemaRead, anchor_lang_v2::wincode::SchemaWrite)]
+pub struct Data {
+    pub value: u64,
+}
+
+impl Owner for Data {
+    const OWNER: Address = crate::ID;
+}
+
+impl Discriminator for Data {
+    const DISCRIMINATOR: &'static [u8] = &[0x65, 0x6d, 0x70, 0x74, 0x79, 0x73, 0x65, 0x64];
+}
+
+#[derive(Accounts)]
+pub struct VerifyEmptySeeds {
+    #[account(seeds = [], bump = 255)]
+    pub pda: BorshAccount<Data>,
+}
+
+#[derive(Accounts)]
+pub struct InitEmptySeeds {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + core::mem::size_of::<Data>(),
+        seeds = [],
+        bump
+    )]
+    pub pda: BorshAccount<Data>,
+    pub system_program: Program<System>,
+}
+"#,
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn init_opaque_seed_expressions_keep_bump_bytes_alive() {
     compile_pass_case(
         "init_opaque_seed_expr",

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -789,11 +789,11 @@ fn empty_seeds_array_with_bump_compiles() {
     compile_pass_case(
         "empty_seeds_with_bump",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
-#[derive(anchor_lang_v2::wincode::SchemaRead, anchor_lang_v2::wincode::SchemaWrite)]
+#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
 pub struct Data {
     pub value: u64,
 }


### PR DESCRIPTION
#### Fixes finding AI # 34
`seeds = []` with bump generated `&[ , bump…]` and failed to compile. Now this fixes and emit `#(#seed_refs,)*` bump so empty seeds produce a valid bump-only seed list.