### PR TITLE
fix(lang-v2): cap flattened Accounts HEADER_SIZE at 255

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -974,6 +974,9 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .collect();
 
     if named_fields.named.len() > 255 {
+        // Syntactic top-level field cap. Flattened Nested account counts are
+        // separately bounded by the HEADER_SIZE assert emitted on the
+        // TryAccounts impl (duplicate-tracking / u8 offset domain is 256 bits).
         return syn::Error::new(name.span(), "`Accounts` derive supports at most 255 fields")
             .to_compile_error();
     }
@@ -1974,6 +1977,14 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 Ok(())
             }
         }
+
+        // Flattened declared-account count must fit the 256-bit duplicate
+        // bitvec and u8 field-offset domain. Top-level field count alone is
+        // not enough: Nested<Inner> expands to Inner::HEADER_SIZE slots.
+        const _: () = assert!(
+            <#name as anchor_lang_v2::TryAccounts>::HEADER_SIZE <= 255,
+            "`Accounts` flattened HEADER_SIZE must be <= 255 (duplicate-tracking domain)"
+        );
 
         #[cfg(feature = "idl-build")]
         #[doc(hidden)]

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -134,6 +134,41 @@ pub struct Bad {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn nested_accounts_flattened_header_size_must_fit_u8_domain() {
+    // Top-level field count is only 2, but Nested expands to 128+128 = 256
+    // slots — past the 256-bit duplicate / u8 offset domain.
+    let chunk_fields: String = (0..128)
+        .map(|i| format!("    pub a{i}: UncheckedAccount,\n"))
+        .collect();
+    let source = format!(
+        r#"
+use anchor_lang_v2::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(Accounts)]
+pub struct Chunk {{
+{chunk_fields}}}
+
+#[derive(Accounts)]
+pub struct Outer {{
+    pub left: Nested<Chunk>,
+    pub right: Nested<Chunk>,
+}}
+"#
+    );
+    compile_fail_case(
+        "nested_header_size_overflow",
+        &source,
+        &["HEADER_SIZE must be <= 255"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn invalid_account_arguments_are_targeted() {
     compile_fail_case(
         "invalid_account_argument",


### PR DESCRIPTION
#### Fixes finding AI # 32
Nested Accounts could flatten past 255 slots while only the top-level field count was capped, leaving mute-mask/offset math out of domain. So the fix applies here and now compile-time assert that flattened `HEADER_SIZE` fits the `256`-bit duplicate-tracking domain.