### PR TITLE
fix(lang-v2): disambiguate CPI optional program-id sentinels via ToCp…

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -356,6 +356,21 @@ fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
         },
     });
 
+    let flag_steps = cpi_fields.iter().map(|(ident, kind, _)| match kind {
+        CpiFieldKind::Phantom => quote! {},
+        CpiFieldKind::Nested => quote! {
+            __flags.extend(
+                anchor_lang_v2::ToCpiAccounts::optional_account_sentinel_flags(&self.#ident),
+            );
+        },
+        CpiFieldKind::Readonly | CpiFieldKind::Writable => quote! {
+            __flags.push(false);
+        },
+        CpiFieldKind::OptionalReadonly | CpiFieldKind::OptionalWritable => quote! {
+            __flags.push(self.#ident.is_none());
+        },
+    });
+
     quote! {
         impl #impl_generics anchor_lang_v2::ToCpiAccounts<#cpi_lifetime>
             for #name #ty_generics #where_clause
@@ -376,6 +391,12 @@ fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
                 let mut __handles = anchor_lang_v2::__alloc::vec::Vec::new();
                 #(#handle_steps)*
                 __handles
+            }
+
+            fn optional_account_sentinel_flags(&self) -> anchor_lang_v2::__alloc::vec::Vec<bool> {
+                let mut __flags = anchor_lang_v2::__alloc::vec::Vec::new();
+                #(#flag_steps)*
+                __flags
             }
         }
     }
@@ -6123,6 +6144,14 @@ pub fn emit_cpi(input: TokenStream) -> TokenStream {
                     let mut __handles = anchor_lang_v2::__alloc::vec::Vec::with_capacity(1);
                     __handles.push(self.event_authority);
                     __handles
+                }
+
+                fn optional_account_sentinel_flags(
+                    &self,
+                ) -> anchor_lang_v2::__alloc::vec::Vec<bool> {
+                    let mut __flags = anchor_lang_v2::__alloc::vec::Vec::with_capacity(1);
+                    __flags.push(false);
+                    __flags
                 }
             }
 

--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -77,6 +77,7 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     pub fn invoke(&self, data: &[u8]) -> ProgramResult {
         let mut instruction_accounts = self.accounts.to_instruction_accounts();
         let mut handles = self.accounts.to_cpi_handles();
+        let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();
 
         // Append remaining accounts using the handle's flags.
         for handle in &self.remaining_accounts {
@@ -86,12 +87,14 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
                 handle.is_signer(),
             ));
             handles.push(*handle);
+            optional_sentinel_flags.push(false);
         }
 
         crate::program::validate_instruction_accounts(
             &instruction_accounts,
             self.program,
             &handles,
+            &optional_sentinel_flags,
             self.signer_seeds.is_empty(),
         )?;
 
@@ -121,7 +124,9 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
             })
             .collect();
 
-        // Build CpiAccounts and invoke.
+        // Build CpiAccounts and invoke. Account count matches handles (optional
+        // None sentinels have metas but no handles); pinocchio skips program-id
+        // placeholder metas that lack a paired CpiAccount.
         let n = handles.len();
         let mut cpi_accounts: Vec<core::mem::MaybeUninit<pinocchio::cpi::CpiAccount>> =
             Vec::with_capacity(n);
@@ -157,6 +162,10 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
     /// The instruction's program id must match this context's program. Account
     /// metas are taken from the instruction, while account handles are collected
     /// from [`ToCpiAccounts`] and `remaining_accounts`.
+    ///
+    /// Optional `None` sentinel slots must appear in the same positions as in
+    /// [`ToCpiAccounts::to_instruction_accounts`]; only those indices may omit
+    /// handles for readonly program-id metas.
     pub fn invoke_ix(&self, ix: Instruction) -> ProgramResult {
         require!(
             address_eq(self.program, &ix.program_id),
@@ -165,7 +174,22 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
 
         let mut handles = self.accounts.to_cpi_handles();
         handles.extend(self.remaining_accounts.iter().copied());
-        crate::program::invoke_signed(&ix, &handles, self.signer_seeds)
+
+        let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();
+        require!(
+            optional_sentinel_flags.len() <= ix.accounts.len(),
+            ProgramError::InvalidArgument
+        );
+        // Trailing metas (e.g. remaining accounts already baked into `ix`) are
+        // never treated as optional sentinels from this accounts struct.
+        optional_sentinel_flags.resize(ix.accounts.len(), false);
+
+        crate::program::invoke_signed_with_optional_sentinels(
+            &ix,
+            &handles,
+            self.signer_seeds,
+            &optional_sentinel_flags,
+        )
     }
 }
 

--- a/lang-v2/src/program.rs
+++ b/lang-v2/src/program.rs
@@ -27,8 +27,25 @@ pub fn get_return_data() -> Option<(crate::Address, Vec<u8>)> {
 /// Unlike the legacy `AccountInfo` API, callers pass [`CpiHandle`]s obtained
 /// from `cpi_handle()` / `cpi_handle_mut()`, so CPI account lifetimes remain
 /// tied to Rust borrows of the caller's typed accounts.
+///
+/// Optional program-id sentinel metas from `Option::None` CPI slots are not
+/// inferred from address alone — use
+/// [`invoke_with_optional_sentinels`] / [`invoke_signed_with_optional_sentinels`]
+/// (or [`crate::CpiContext`]) so required readonly program-id accounts still
+/// require matching handles.
 pub fn invoke<'a>(instruction: &Instruction, account_handles: &[CpiHandle<'a>]) -> ProgramResult {
     invoke_signed(instruction, account_handles, &[])
+}
+
+/// Like [`invoke`], but marks instruction-account indices that are intentional
+/// optional `None` program-id sentinels (parallel to
+/// [`crate::ToCpiAccounts::optional_account_sentinel_flags`]).
+pub fn invoke_with_optional_sentinels<'a>(
+    instruction: &Instruction,
+    account_handles: &[CpiHandle<'a>],
+    optional_sentinel_flags: &[bool],
+) -> ProgramResult {
+    invoke_signed_with_optional_sentinels(instruction, account_handles, &[], optional_sentinel_flags)
 }
 
 /// Invoke a cross-program instruction with PDA signer seeds using Anchor v2
@@ -38,18 +55,36 @@ pub fn invoke_signed<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
+    invoke_signed_with_optional_sentinels(instruction, account_handles, signer_seeds, &[])
+}
+
+/// Like [`invoke_signed`], with an explicit optional-sentinel mask.
+pub fn invoke_signed_with_optional_sentinels<'a, 'seeds>(
+    instruction: &Instruction,
+    account_handles: &[CpiHandle<'a>],
+    signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
+    optional_sentinel_flags: &[bool],
+) -> ProgramResult {
     let instruction_accounts = instruction_accounts(instruction);
     validate_instruction_accounts(
         &instruction_accounts,
         &instruction.program_id,
         account_handles,
+        optional_sentinel_flags,
         signer_seeds.is_empty(),
     )?;
 
     // SAFETY: Validation above proves every non-sentinel instruction account
     // has a matching handle, writable metas use writable handles, and
     // AccountView borrow state permits the CPI.
-    unsafe { invoke_signed_unchecked(instruction, account_handles, signer_seeds) }
+    unsafe {
+        invoke_signed_unchecked_with_optional_sentinels(
+            instruction,
+            account_handles,
+            signer_seeds,
+            optional_sentinel_flags,
+        )
+    }
 }
 
 /// Invoke a cross-program instruction without borrow validation.
@@ -80,9 +115,27 @@ pub unsafe fn invoke_signed_unchecked<'a, 'seeds>(
     account_handles: &[CpiHandle<'a>],
     signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
 ) -> ProgramResult {
+    unsafe { invoke_signed_unchecked_with_optional_sentinels(instruction, account_handles, signer_seeds, &[]) }
+}
+
+/// Like [`invoke_signed_unchecked`], with an explicit optional-sentinel mask.
+///
+/// # Safety
+///
+/// Same as [`invoke_signed_unchecked`].
+pub unsafe fn invoke_signed_unchecked_with_optional_sentinels<'a, 'seeds>(
+    instruction: &Instruction,
+    account_handles: &[CpiHandle<'a>],
+    signer_seeds: &'seeds [&'seeds [&'seeds [u8]]],
+    optional_sentinel_flags: &[bool],
+) -> ProgramResult {
     let instruction_accounts = instruction_accounts(instruction);
-    let cpi_account_count =
-        required_cpi_account_count(&instruction_accounts, &instruction.program_id, account_handles)?;
+    let cpi_account_count = required_cpi_account_count(
+        &instruction_accounts,
+        &instruction.program_id,
+        account_handles,
+        optional_sentinel_flags,
+    )?;
     let instruction_view = InstructionView {
         program_id: &instruction.program_id,
         accounts: &instruction_accounts,
@@ -113,10 +166,15 @@ pub(crate) fn validate_instruction_accounts<'a>(
     instruction_accounts: &[InstructionAccount<'a>],
     program_id: &Address,
     account_handles: &[CpiHandle<'a>],
+    optional_sentinel_flags: &[bool],
     enforce_signers: bool,
 ) -> ProgramResult {
-    let bindings =
-        resolve_instruction_account_bindings(instruction_accounts, program_id, account_handles)?;
+    let bindings = resolve_instruction_account_bindings(
+        instruction_accounts,
+        program_id,
+        account_handles,
+        optional_sentinel_flags,
+    )?;
 
     for (account, binding) in instruction_accounts.iter().zip(bindings) {
         let Some(handle_index) = binding else {
@@ -147,23 +205,41 @@ fn is_optional_instruction_account_sentinel_candidate(
     !account.is_writable && !account.is_signer && address_eq(account.address, program_id)
 }
 
+fn is_skippable_optional_sentinel(
+    program_id: &Address,
+    account: &InstructionAccount<'_>,
+    optional_sentinel_flags: &[bool],
+    instruction_index: usize,
+) -> bool {
+    optional_sentinel_flags
+        .get(instruction_index)
+        .copied()
+        .unwrap_or(false)
+        && is_optional_instruction_account_sentinel_candidate(program_id, account)
+}
+
 fn required_cpi_account_count<'a>(
     instruction_accounts: &[InstructionAccount<'a>],
     program_id: &Address,
     account_handles: &[CpiHandle<'a>],
+    optional_sentinel_flags: &[bool],
 ) -> Result<usize, ProgramError> {
-    Ok(
-        resolve_instruction_account_bindings(instruction_accounts, program_id, account_handles)?
-            .into_iter()
-            .flatten()
-            .count(),
-    )
+    Ok(resolve_instruction_account_bindings(
+        instruction_accounts,
+        program_id,
+        account_handles,
+        optional_sentinel_flags,
+    )?
+    .into_iter()
+    .flatten()
+    .count())
 }
 
 fn resolve_instruction_account_bindings<'a>(
     instruction_accounts: &[InstructionAccount<'a>],
     program_id: &Address,
     account_handles: &[CpiHandle<'a>],
+    optional_sentinel_flags: &[bool],
 ) -> Result<Vec<Option<usize>>, ProgramError> {
     let cols = account_handles.len() + 1;
     let rows = instruction_accounts.len() + 1;
@@ -179,15 +255,25 @@ fn resolve_instruction_account_bindings<'a>(
             let can_consume = handle_index < account_handles.len()
                 && instruction_account_matches_handle(account, &account_handles[handle_index])
                 && can_match[(instruction_index + 1) * cols + (handle_index + 1)];
-            let can_skip = is_optional_instruction_account_sentinel_candidate(program_id, account)
-                && can_match[(instruction_index + 1) * cols + handle_index];
+            let can_skip = is_skippable_optional_sentinel(
+                program_id,
+                account,
+                optional_sentinel_flags,
+                instruction_index,
+            ) && can_match[(instruction_index + 1) * cols + handle_index];
             can_match[instruction_index * cols + handle_index] = can_consume || can_skip;
         }
     }
 
     require!(
         can_match[0],
-        if account_handles.len() < minimum_required_handle_count(instruction_accounts, program_id) {
+        if account_handles.len()
+            < minimum_required_handle_count(
+                instruction_accounts,
+                program_id,
+                optional_sentinel_flags
+            )
+        {
             ProgramError::NotEnoughAccountKeys
         } else {
             ProgramError::InvalidArgument
@@ -198,6 +284,19 @@ fn resolve_instruction_account_bindings<'a>(
     let mut handle_index = 0;
 
     for (instruction_index, account) in instruction_accounts.iter().enumerate() {
+        // Prefer skipping intentional Option::None sentinels so a later
+        // required program-id account can still consume a matching handle.
+        let can_skip = is_skippable_optional_sentinel(
+            program_id,
+            account,
+            optional_sentinel_flags,
+            instruction_index,
+        ) && can_match[(instruction_index + 1) * cols + handle_index];
+        if can_skip {
+            bindings.push(None);
+            continue;
+        }
+
         let can_consume = handle_index < account_handles.len()
             && instruction_account_matches_handle(account, &account_handles[handle_index])
             && can_match[(instruction_index + 1) * cols + (handle_index + 1)];
@@ -207,9 +306,10 @@ fn resolve_instruction_account_bindings<'a>(
             continue;
         }
 
-        let can_skip = is_optional_instruction_account_sentinel_candidate(program_id, account)
-            && can_match[(instruction_index + 1) * cols + handle_index];
-        debug_assert!(can_skip, "validated instruction-account matching must reconstruct");
+        debug_assert!(
+            false,
+            "validated instruction-account matching must reconstruct"
+        );
         bindings.push(None);
     }
 
@@ -219,10 +319,14 @@ fn resolve_instruction_account_bindings<'a>(
 fn minimum_required_handle_count(
     instruction_accounts: &[InstructionAccount<'_>],
     program_id: &Address,
+    optional_sentinel_flags: &[bool],
 ) -> usize {
     instruction_accounts
         .iter()
-        .filter(|account| !is_optional_instruction_account_sentinel_candidate(program_id, account))
+        .enumerate()
+        .filter(|(index, account)| {
+            !is_skippable_optional_sentinel(program_id, account, optional_sentinel_flags, *index)
+        })
         .count()
 }
 

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -214,6 +214,14 @@ pub trait ToCpiAccounts<'a> {
 
     /// Collect all CPI handles for the invocation.
     fn to_cpi_handles(&self) -> alloc::vec::Vec<CpiHandle<'a>>;
+
+    /// Parallel to [`to_instruction_accounts`]: `true` at each index where an
+    /// optional field was `None` and a program-id sentinel meta was emitted.
+    ///
+    /// The CPI invoker may skip a matching handle only for these indices.
+    /// Required accounts whose address equals the callee program id must be
+    /// `false` here so they still require a handle.
+    fn optional_account_sentinel_flags(&self) -> alloc::vec::Vec<bool>;
 }
 
 pub trait AnchorAccount: Deref<Target = Self::Data> + Sized {

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -184,7 +184,67 @@ fn checked_invoke_accepts_optional_none_program_id_sentinel() {
     };
     let handles = [view.to_cpi_handle()];
 
+    // Index 1 is an intentional Option::None sentinel — not a required account.
+    program::invoke_with_optional_sentinels(&ix, &handles, &[false, true]).unwrap();
+}
+
+#[test]
+fn checked_invoke_rejects_required_program_id_account_without_handle() {
+    // Pre-fix: any readonly non-signer meta at the callee program id was
+    // treated as an optional None sentinel, so a required program-id account
+    // could be skipped when its handle was omitted.
+    let other = account_view([1; 32], false);
+    let other_view = unsafe { other.view() };
+    let ix = Instruction {
+        program_id: ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*other_view.address(), false),
+            AccountMeta::new_readonly(ID, false),
+        ],
+        data: vec![],
+    };
+    let handles = [other_view.to_cpi_handle()];
+
+    let err = program::invoke(&ix, &handles).unwrap_err();
+    assert_eq!(err, ProgramError::NotEnoughAccountKeys);
+}
+
+#[test]
+fn checked_invoke_accepts_required_program_id_account_with_handle() {
+    let other = account_view([1; 32], false);
+    let program_account = account_view([7; 32], false);
+    let other_view = unsafe { other.view() };
+    let program_view = unsafe { program_account.view() };
+    let ix = Instruction {
+        program_id: ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*other_view.address(), false),
+            AccountMeta::new_readonly(ID, false),
+        ],
+        data: vec![],
+    };
+    let handles = [other_view.to_cpi_handle(), program_view.to_cpi_handle()];
+
     program::invoke(&ix, &handles).unwrap();
+}
+
+#[test]
+fn checked_invoke_optional_none_before_required_program_id_uses_mask() {
+    // Optional None sentinel then a required program-id account. The handle
+    // must bind to the required slot, not be stolen by the sentinel.
+    let program_account = account_view([7; 32], false);
+    let program_view = unsafe { program_account.view() };
+    let ix = Instruction {
+        program_id: ID,
+        accounts: vec![
+            AccountMeta::new_readonly(ID, false),
+            AccountMeta::new_readonly(ID, false),
+        ],
+        data: vec![],
+    };
+    let handles = [program_view.to_cpi_handle()];
+
+    program::invoke_with_optional_sentinels(&ix, &handles, &[true, false]).unwrap();
 }
 
 #[test]

--- a/lang-v2/tests/to_cpi_accounts_derive.rs
+++ b/lang-v2/tests/to_cpi_accounts_derive.rs
@@ -112,6 +112,9 @@ fn derive_to_cpi_accounts_emits_metas_and_erased_handles() {
     assert!(handles[4].is_writable());
     assert!(!handles[5].is_writable());
     assert!(handles[6].is_writable());
+
+    let flags = accounts.optional_account_sentinel_flags();
+    assert_eq!(flags, vec![false, false, false, false, false, false, false, true]);
 }
 
 #[test]
@@ -122,4 +125,5 @@ fn derive_to_cpi_accounts_accepts_phantom_only_empty_structs() {
 
     assert!(accounts.to_instruction_accounts().is_empty());
     assert!(accounts.to_cpi_handles().is_empty());
+    assert!(accounts.optional_account_sentinel_flags().is_empty());
 }


### PR DESCRIPTION
Fixes finding AI # 22
CPI treated any readonly `program-id` meta as an optional None sentinel, so required `program-id` accounts could be skipped. Skip now only when `ToCpiAccounts` flags the slot.