### PR TITLE
fix(lang-v2): both handle types now have into_readonly()

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -339,7 +339,7 @@ fn impl_to_cpi_accounts(input: &DeriveInput) -> TokenStream2 {
             __handles.extend(anchor_lang_v2::ToCpiAccounts::to_cpi_handles(&self.#ident));
         },
         CpiFieldKind::Readonly => quote! {
-            __handles.push(self.#ident);
+            __handles.push(self.#ident.into_readonly());
         },
         CpiFieldKind::Writable => quote! {
             __handles.push(self.#ident.into());

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -106,6 +106,15 @@ impl<'a> CpiHandle<'a> {
         self.view.is_signer()
     }
 
+    /// Erase to a readonly CPI handle.
+    ///
+    /// Used by `#[account_meta(duplicate_readonly)]` so a `CpiHandle` or
+    /// `CpiHandleMut` field can emit a second readonly meta/handle pair.
+    #[inline(always)]
+    pub fn into_readonly(self) -> CpiHandle<'a> {
+        Self::readonly_with_flags(self.view, self.borrow_check, self.relax_readonly_borrow)
+    }
+
     /// Access the underlying `AccountView` for CPI account construction.
     ///
     /// Restricted to the crate so external code cannot extract the view
@@ -172,6 +181,15 @@ impl<'a> CpiHandleMut<'a> {
     #[inline(always)]
     pub fn is_signer(&self) -> bool {
         self.view.is_signer()
+    }
+
+    /// Erase to a readonly [`CpiHandle`].
+    ///
+    /// Used by `#[account_meta(duplicate_readonly)]` so a writable field can
+    /// still emit a second readonly meta/handle pair.
+    #[inline(always)]
+    pub fn into_readonly(self) -> CpiHandle<'a> {
+        CpiHandle::readonly_with_borrow_check(self.view, self.borrow_check)
     }
 }
 

--- a/lang-v2/tests/to_cpi_accounts_derive.rs
+++ b/lang-v2/tests/to_cpi_accounts_derive.rs
@@ -19,6 +19,14 @@ struct EmptyCpi<'a> {
 }
 
 #[derive(ToCpiAccounts)]
+struct DuplicateReadonlyCpi<'a> {
+    #[account_meta(duplicate_readonly)]
+    readonly: CpiHandle<'a>,
+    #[account_meta(duplicate_readonly)]
+    writable: CpiHandleMut<'a>,
+}
+
+#[derive(ToCpiAccounts)]
 struct ManualCpi<'a> {
     readonly: CpiHandle<'a>,
     writable: CpiHandleMut<'a>,
@@ -122,4 +130,38 @@ fn derive_to_cpi_accounts_accepts_phantom_only_empty_structs() {
 
     assert!(accounts.to_instruction_accounts().is_empty());
     assert!(accounts.to_cpi_handles().is_empty());
+}
+
+#[test]
+fn derive_to_cpi_accounts_duplicate_readonly_erases_handle_mut() {
+    let readonly_buffer = account([1; 32], false, false);
+    let writable_buffer = account([2; 32], false, true);
+    let readonly_view = unsafe { readonly_buffer.view() };
+    let mut writable_view = unsafe { writable_buffer.view() };
+
+    let accounts = DuplicateReadonlyCpi {
+        readonly: readonly_view.to_cpi_handle(),
+        writable: writable_view.to_cpi_handle_mut(),
+    };
+
+    let metas = accounts.to_instruction_accounts();
+    assert_eq!(metas.len(), 4);
+    assert_eq!(*metas[0].address, Address::new_from_array([1; 32]));
+    assert!(!metas[0].is_writable);
+    assert_eq!(*metas[1].address, Address::new_from_array([1; 32]));
+    assert!(!metas[1].is_writable);
+    assert_eq!(*metas[2].address, Address::new_from_array([2; 32]));
+    assert!(!metas[2].is_writable);
+    assert_eq!(*metas[3].address, Address::new_from_array([2; 32]));
+    assert!(metas[3].is_writable);
+
+    let handles = accounts.to_cpi_handles();
+    assert_eq!(handles.len(), 4);
+    assert!(!handles[0].is_writable());
+    assert!(!handles[1].is_writable());
+    assert!(!handles[2].is_writable());
+    assert!(handles[3].is_writable());
+    assert_eq!(*handles[0].address(), Address::new_from_array([1; 32]));
+    assert_eq!(*handles[2].address(), Address::new_from_array([2; 32]));
+    assert_eq!(*handles[3].address(), Address::new_from_array([2; 32]));
 }


### PR DESCRIPTION
Fixes finding AI # 21:
`duplicate_readonly` on `CpiHandleMut` still emits a raw push into `Vec<CpiHandle>`, this pr fixes now that both handle types now have `into_readonly()` and the `Readonly` arm uses it. Duplicate metas stay `readonly`; the original `CpiHandleMut` still erases with `.into()`