### PR TITLE
fix(lang-v2): keep optional Program/PDA on *Resolved as Option

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -1407,8 +1407,10 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
     // --- Client-side struct for off-chain usage (tests, CPI, SDK) ---
     //
     // The struct only contains fields the user must provide (Signer, raw
-    // accounts, etc.). Derivable fields (Program<T>, PDAs) are computed
-    // inside `to_account_metas()` so the user never has to fill them.
+    // accounts, optional Program/PDA presence, etc.). Non-optional derivable
+    // fields (Program<T>, PDAs) are computed inside `to_account_metas()` so
+    // the user never has to fill them. Optional Program/PDA stay on the
+    // struct as `Option<Address>` so `None` can emit the program-id sentinel.
     let client_mod_name = syn::Ident::new(
         &format!("__client_accounts_{}", name.to_string().to_lowercase()),
         name.span(),
@@ -1435,6 +1437,15 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 None => &f.ty,
             };
             let ty_name = parse::field_ty_str(base_ty);
+
+            // Optional Program<T> / seed PDAs must stay caller-provided on the
+            // *Resolved builder so `None` can emit the program-id sentinel.
+            // Auto-deriving them as `Some(address)` made that sentinel arm
+            // unreachable while the full (non-Resolved) builder could still
+            // represent absence.
+            if f.is_optional {
+                return (f, FieldKind::Required);
+            }
 
             if ty_name == "Program" {
                 if let Type::Path(tp) = base_ty {
@@ -1613,42 +1624,20 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         .filter_map(|&i| {
             let (f, kind) = &field_kinds[i];
             let ident = &f.name;
-            // When the field is `Option<Program<T>>` / `Option<...seeds...>`,
-            // the downstream `client_meta_entries` match expects the local
-            // binding to be `Option<Address>`, not a bare `Address`. Wrap
-            // the derived value in `Some(...)` in that case so the match
-            // arms type-check.
+            // Non-optional Program/PDA locals are bare Address values.
+            // Optional accounts never reach FieldKind::Program/Pda — they stay
+            // FieldKind::Required so callers can pass None for the sentinel.
             match kind {
-                FieldKind::Program(expr) => {
-                    let init = if f.is_optional {
-                        quote! { Some(#expr) }
-                    } else {
-                        quote! { #expr }
-                    };
-                    Some(quote! { let #ident = #init; })
-                }
+                FieldKind::Program(expr) => Some(quote! { let #ident = #expr; }),
                 FieldKind::Pda {
                     seed_exprs,
                     program_ref,
                     ..
-                } => {
-                    if f.is_optional {
-                        Some(quote! {
-                            let #ident = {
-                                let (__addr, _) = anchor_lang_v2::find_program_address(
-                                    &[#(#seed_exprs),*], #program_ref,
-                                );
-                                Some(__addr)
-                            };
-                        })
-                    } else {
-                        Some(quote! {
-                            let (#ident, _) = anchor_lang_v2::find_program_address(
-                                &[#(#seed_exprs),*], #program_ref,
-                            );
-                        })
-                    }
-                }
+                } => Some(quote! {
+                    let (#ident, _) = anchor_lang_v2::find_program_address(
+                        &[#(#seed_exprs),*], #program_ref,
+                    );
+                }),
                 _ => None,
             }
         })

--- a/tests-v2/programs/client-builders/src/lib.rs
+++ b/tests-v2/programs/client-builders/src/lib.rs
@@ -80,6 +80,13 @@ pub mod client_builders {
         Ok(())
     }
 
+    #[discrim = 8]
+    pub fn optional_derivable_builder_case(
+        _ctx: &mut Context<OptionalDerivableBuilderCase>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     #[discrim = 5]
     pub fn check_external_pda(_ctx: &mut Context<CheckExternalPda>) -> Result<()> {
         Ok(())
@@ -129,6 +136,13 @@ pub struct OptionalBuilderCase {
     #[account(mut)]
     pub user_state: Option<Account<UserState>>,
     pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct OptionalDerivableBuilderCase {
+    pub system_program: Option<Program<System>>,
+    #[account(seeds = [b"optional_pda"], bump)]
+    pub optional_pda: Option<UncheckedAccount>,
 }
 
 #[derive(Accounts)]

--- a/tests-v2/tests/client_builders.rs
+++ b/tests-v2/tests/client_builders.rs
@@ -250,6 +250,37 @@ fn optional_none_builder_uses_program_id_sentinel() {
 }
 
 #[test]
+fn optional_derivable_none_resolved_uses_program_id_sentinel() {
+    // Pre-fix: optional Program/PDA were auto-derived as Some(address) on
+    // *Resolved, so None → program-id sentinel was unreachable.
+    let accounts = accounts::OptionalDerivableBuilderCaseResolved {
+        system_program: None,
+        optional_pda: None,
+    };
+    let metas = accounts.to_account_metas(None);
+    assert_eq!(metas.len(), 2);
+    assert_eq!(metas[0].pubkey, program_id());
+    assert!(!metas[0].is_writable);
+    assert!(!metas[0].is_signer);
+    assert_eq!(metas[1].pubkey, program_id());
+    assert!(!metas[1].is_writable);
+    assert!(!metas[1].is_signer);
+}
+
+#[test]
+fn optional_derivable_some_resolved_uses_caller_addresses() {
+    let (optional_pda, _) = accounts::OptionalDerivableBuilderCase::find_optional_pda_address();
+    let accounts = accounts::OptionalDerivableBuilderCaseResolved {
+        system_program: Some(solana_sdk_ids::system_program::ID),
+        optional_pda: Some(optional_pda),
+    };
+    let metas = accounts.to_account_metas(None);
+    assert_eq!(metas.len(), 2);
+    assert_eq!(metas[0].pubkey, solana_sdk_ids::system_program::ID);
+    assert_eq!(metas[1].pubkey, optional_pda);
+}
+
+#[test]
 fn generated_accounts_still_allow_runtime_validation_failures() {
     let (mut svm, payer, authority) = setup();
     let (vault, _) = accounts::InitializeVault::find_vault_address(&authority.pubkey());


### PR DESCRIPTION
Fixes finding AI # 20

`*Resolved` stripped `Option` and always derived optional `Program/PDA` as `Some(address)`, so the program-id sentinel was unreachable. Those fields now stay caller-provided `Option` on `*Resolved`; `None` emits the sentinel.