### PR TITLE
fix(lang-v2): register declare_program! imported IDL type aliases

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -3507,18 +3507,28 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                 });
             }
             "type" => {
-                let alias = type_obj.get("alias").ok_or_else(|| {
+                let alias_value = type_obj.get("alias").ok_or_else(|| {
                     syn::Error::new(
                         ident.span(),
                         format!("type alias `{name}` is missing alias"),
                     )
                 })?;
-                let alias = declare_idl_type_to_tokens(alias, ident.span())?;
-                let impl_generics = &generics.impl_generics;
-                out.push(quote! {
-                    #(#docs)*
-                    pub type #ident #impl_generics = #alias;
-                });
+                let alias = declare_idl_type_to_tokens(alias_value, ident.span())?;
+                let idl_impl = gen_declare_program_idl_account_type_impl(
+                    &ident,
+                    &generics,
+                    idl_account_entry.as_ref(),
+                    &idl_type_def,
+                    &[alias.clone()],
+                );
+                out.push(gen_declare_program_type_alias(
+                    &ident,
+                    &generics,
+                    &docs,
+                    alias_value,
+                    alias,
+                    idl_impl,
+                ));
             }
             _ => {
                 return Err(syn::Error::new(
@@ -4023,6 +4033,54 @@ fn gen_declare_program_type_generics(
         idl_where_clause,
         pod_where_clause,
     })
+}
+
+fn declare_idl_type_is_pod_primitive(value: &serde_json::Value) -> bool {
+    value.as_str().is_some_and(|name| {
+        matches!(
+            name,
+            "bool" | "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "f32" | "u64" | "i64" | "f64"
+                | "u128" | "i128"
+        )
+    })
+}
+
+fn gen_declare_program_type_alias(
+    ident: &Ident,
+    generics: &DeclareTypeGenerics,
+    docs: &[TokenStream2],
+    alias_value: &serde_json::Value,
+    alias: TokenStream2,
+    idl_impl: TokenStream2,
+) -> TokenStream2 {
+    let impl_generics = &generics.impl_generics;
+    let ty_generics = &generics.ty_generics;
+    let is_pod_primitive = declare_idl_type_is_pod_primitive(alias_value);
+    let extra_derives = if is_pod_primitive {
+        quote! {
+            Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug,
+        }
+    } else {
+        quote! {}
+    };
+    let pod_impls = if is_pod_primitive {
+        let where_clause = &generics.pod_where_clause;
+        quote! {
+            unsafe impl #impl_generics anchor_lang::bytemuck::Pod for #ident #ty_generics #where_clause {}
+            unsafe impl #impl_generics anchor_lang::bytemuck::Zeroable for #ident #ty_generics #where_clause {}
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        #(#docs)*
+        #[repr(transparent)]
+        #[derive(Clone, #extra_derives anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+        pub struct #ident #impl_generics(pub #alias);
+        #idl_impl
+        #pod_impls
+    }
 }
 
 fn gen_declare_program_idl_account_type_impl(

--- a/tests-v2/src/declare-program/types.rs
+++ b/tests-v2/src/declare-program/types.rs
@@ -26,6 +26,8 @@ fn declared_weird_types_compile_and_serialize() {
     assert_idl_type::<weird_types::GenericBox<u64>>();
     assert_idl_type::<weird_types::FixedBytes<4>>();
     assert_idl_type::<weird_types::NestedGeneric<u16, 4>>();
+    assert_idl_type::<weird_types::AliasU64>();
+    assert_idl_type::<weird_types::BoxedU64>();
     assert_idl_type::<weird_types::WeirdEnum<u16, 4>>();
     assert_idl_type::<weird_types::DocumentedBorsh>();
     assert_idl_type::<weird_types::PackedBytemuck>();
@@ -45,13 +47,28 @@ fn declared_weird_types_compile_and_serialize() {
         .contains("\"docs\":[\"A borsh type with docs and explicit repr metadata.\"]"));
     assert!(documented_type_def.contains("\"repr\":{\"kind\":\"c\"}"));
 
+    let alias_type_def = <weird_types::AliasU64 as IdlAccountType>::__IDL_TYPE_DEF
+        .expect("AliasU64 should retain its IDL alias definition");
+    assert!(alias_type_def.contains("\"name\":\"AliasU64\""));
+    assert!(alias_type_def.contains("\"alias\":\"u64\""));
+
+    let mut accounts = Vec::new();
+    let mut types = Vec::new();
+    <weird_types::AliasU64 as IdlAccountType>::__register_idl_deps(&mut accounts, &mut types);
+    assert!(types.iter().any(|ty| ty.contains("\"name\":\"AliasU64\"")));
+
+    types.clear();
+    <weird_types::BoxedU64 as IdlAccountType>::__register_idl_deps(&mut accounts, &mut types);
+    assert!(types.iter().any(|ty| ty.contains("\"name\":\"BoxedU64\"")));
+    assert!(types.iter().any(|ty| ty.contains("\"name\":\"GenericBox\"")));
+
     let data = weird_types::instruction::UseWeirdTypes {
         float32: 1.5,
         float64: -2.25,
         unit: weird_types::UnitMarker,
         empty: weird_types::EmptyNamed {},
         tuple: weird_types::PairTuple(7, true),
-        alias: 99,
+        alias: weird_types::AliasU64(99),
         generic: weird_types::GenericBox { value: 123 },
         fixed: weird_types::FixedBytes { data: [1, 2, 3, 4] },
         nested: weird_types::NestedGeneric {
@@ -63,7 +80,7 @@ fn declared_weird_types_compile_and_serialize() {
             fixed: [11, 12, 13, 14],
             boxed: weird_types::GenericBox { value: 15 },
         },
-        boxed_alias: weird_types::GenericBox { value: 777 },
+        boxed_alias: weird_types::BoxedU64(weird_types::GenericBox { value: 777 }),
         documented: weird_types::DocumentedBorsh { value: 31337 },
     }
     .data();


### PR DESCRIPTION
Fixes finding AI # 17
`declare_program!` imported IDL aliases were plain Rust type aliases, so IDL lowering emitted defined references but dependency registration only saw the underlying type, leaving alias definitions out of generated IDL. Now we emit imported aliases as transparent newtypes with `IdlAccountType` registration and forward dependency collection to the alias target, matching local Pod alias behavior.
