### PR TITLE
fix(lang-v2): honor bytemuckunsafe in declare_program! imports

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -3356,8 +3356,14 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
         let docs = gen_declare_program_docs(ty_def, ident.span());
         let repr = gen_declare_program_repr(ty_def, ident.span())?;
         let serialization = declare_type_serialization(ty_def, ident.span())?;
-        let bytemuck_repr = if repr.is_none() && serialization.is_bytemuck() {
-            quote! { #[repr(C)] }
+        // Safe bytemuck defaults to repr(C). `bytemuckunsafe` matches v1
+        // `#[zero_copy(unsafe)]`: packed Rust layout when the IDL omits repr.
+        let bytemuck_repr = if repr.is_none() {
+            match serialization {
+                DeclareTypeSerialization::Bytemuck => quote! { #[repr(C)] },
+                DeclareTypeSerialization::BytemuckUnsafe => quote! { #[repr(Rust, packed)] },
+                DeclareTypeSerialization::Borsh => quote! {},
+            }
         } else {
             quote! { #repr }
         };
@@ -3441,7 +3447,9 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     .unwrap_or_default();
                 let pod_impls = serialization
                     .is_bytemuck()
-                    .then(|| gen_declare_program_pod_impls(&ident, &generics, &fields))
+                    .then(|| {
+                        gen_declare_program_pod_impls(&ident, &generics, &fields, serialization)
+                    })
                     .unwrap_or_default();
                 let impl_generics = &generics.impl_generics;
                 out.push(match fields {
@@ -3610,6 +3618,10 @@ enum DeclareTypeSerialization {
 impl DeclareTypeSerialization {
     fn is_bytemuck(self) -> bool {
         matches!(self, Self::Bytemuck | Self::BytemuckUnsafe)
+    }
+
+    fn is_bytemuck_unsafe(self) -> bool {
+        matches!(self, Self::BytemuckUnsafe)
     }
 }
 
@@ -4215,10 +4227,21 @@ fn gen_declare_program_pod_impls(
     ident: &Ident,
     generics: &DeclareTypeGenerics,
     fields: &DeclareTypeFields,
+    serialization: DeclareTypeSerialization,
 ) -> TokenStream2 {
-    let field_types = fields.tys();
     let impl_generics = &generics.impl_generics;
     let ty_generics = &generics.ty_generics;
+    // `bytemuckunsafe` is an explicit opt-out of safe Pod derivability:
+    // imported layouts may include padding or non-Pod fields. Emit the
+    // unsafe impls without field-Pod / no-padding assertions.
+    if serialization.is_bytemuck_unsafe() {
+        return quote! {
+            unsafe impl #impl_generics anchor_lang::bytemuck::Pod for #ident #ty_generics {}
+            unsafe impl #impl_generics anchor_lang::bytemuck::Zeroable for #ident #ty_generics {}
+        };
+    }
+
+    let field_types = fields.tys();
     let generic_where_clause = &generics.pod_where_clause;
     let where_clause = if field_types.is_empty() {
         generic_where_clause.clone()

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -3616,6 +3616,8 @@ enum DeclareTypeSerialization {
 }
 
 impl DeclareTypeSerialization {
+    // This intentionally matches both `Bytemuck` and `BytemuckUnsafe`.
+    // Use `is_bytemuck_unsafe` when the unsafe-only distinction matters.
     fn is_bytemuck(self) -> bool {
         matches!(self, Self::Bytemuck | Self::BytemuckUnsafe)
     }

--- a/tests-v2/programs/declare-program/serialization/idls/serialization.json
+++ b/tests-v2/programs/declare-program/serialization/idls/serialization.json
@@ -54,6 +54,10 @@
     {
       "name": "UnsafeZeroCopyAccount",
       "discriminator": [41, 42, 43, 44, 45, 46, 47, 48]
+    },
+    {
+      "name": "PaddedUnsafeAccount",
+      "discriminator": [51, 52, 53, 54, 55, 56, 57, 58]
     }
   ],
   "types": [
@@ -146,6 +150,43 @@
             "type": {
               "array": ["u8", 4]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PaddedUnsafeAccount",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "flag",
+            "type": "bool"
+          },
+          {
+            "name": "wide",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PackedUnsafeAccount",
+      "serialization": "bytemuckunsafe",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "type": "u8"
+          },
+          {
+            "name": "wide",
+            "type": "u64"
           }
         ]
       }

--- a/tests-v2/src/declare-program/serialization.rs
+++ b/tests-v2/src/declare-program/serialization.rs
@@ -58,6 +58,10 @@ fn declared_program_type_serialization_controls_account_traits() {
     assert_borsh_account_wrapper_idl::<serialization::ExplicitBorshAccount>();
     assert_zero_copy_account::<serialization::ZeroCopyAccount>();
     assert_zero_copy_account::<serialization::UnsafeZeroCopyAccount>();
+    assert_zero_copy_account::<serialization::PaddedUnsafeAccount>();
+
+    fn assert_pod<T: anchor_lang::bytemuck::Pod + anchor_lang::bytemuck::Zeroable>() {}
+    assert_pod::<serialization::PackedUnsafeAccount>();
 
     assert!(
         <serialization::ImplicitBorshAccount as anchor_lang::IdlAccountType>::__IDL_ACCOUNT_ENTRY
@@ -85,6 +89,10 @@ fn declared_program_type_serialization_controls_account_traits() {
     assert_eq!(
         <serialization::UnsafeZeroCopyAccount as Discriminator>::DISCRIMINATOR,
         &[41, 42, 43, 44, 45, 46, 47, 48]
+    );
+    assert_eq!(
+        <serialization::PaddedUnsafeAccount as Discriminator>::DISCRIMINATOR,
+        &[51, 52, 53, 54, 55, 56, 57, 58]
     );
 
     assert_eq!(
@@ -123,6 +131,30 @@ fn declared_program_type_serialization_controls_account_traits() {
     assert_eq!(&zero_bytes[..8], &0x0102_0304_0506_0708u64.to_le_bytes());
     assert_eq!(&zero_bytes[8..12], &0x1112_1314u32.to_le_bytes());
     assert_eq!(&zero_bytes[12..16], b"zero");
+
+    // `bytemuckunsafe` must accept layouts that fail safe Pod checks:
+    // non-Pod `bool` plus repr(C) padding after it, and the v1 default
+    // packed layout when the IDL omits repr.
+    assert_eq!(core::mem::size_of::<serialization::PaddedUnsafeAccount>(), 16);
+    assert_eq!(core::mem::align_of::<serialization::PaddedUnsafeAccount>(), 8);
+    let mut padded_bytes = [0u8; 16];
+    padded_bytes[0] = 1;
+    padded_bytes[8..16].copy_from_slice(&0x0102_0304_0506_0708u64.to_le_bytes());
+    let padded: serialization::PaddedUnsafeAccount =
+        anchor_lang::bytemuck::pod_read_unaligned(&padded_bytes);
+    assert!(padded.flag);
+    assert_eq!(padded.wide, 0x0102_0304_0506_0708);
+
+    assert_eq!(core::mem::size_of::<serialization::PackedUnsafeAccount>(), 9);
+    assert_eq!(core::mem::align_of::<serialization::PackedUnsafeAccount>(), 1);
+    let mut packed_bytes = [0u8; 9];
+    packed_bytes[0] = 7;
+    packed_bytes[1..9].copy_from_slice(&99u64.to_le_bytes());
+    let packed: serialization::PackedUnsafeAccount =
+        anchor_lang::bytemuck::pod_read_unaligned(&packed_bytes);
+    assert_eq!(packed.tag, 7);
+    let packed_wide = packed.wide;
+    assert_eq!(packed_wide, 99);
 }
 
 #[test]


### PR DESCRIPTION
Fixing finding AI # 28
`declare_program!` collapsed `bytemuckunsafe` into safe `bytemuck`, so imported unsafe zero-copy types were rejected unless they were already `Pod` and padding-free. Now this PR keep safe bytemuck checks for bytemuck, and for `bytemuckunsafe` emit unchecked `Pod` impls with v1’s packed default when repr is omitted.