### PR TITLE
fix(lang-v2): allow PDA signer remaining accounts on CPI handles

### DIFF
--- a/lang-v2/src/context_cpi.rs
+++ b/lang-v2/src/context_cpi.rs
@@ -79,7 +79,8 @@ impl<'a, T: ToCpiAccounts<'a>> CpiContext<'a, T> {
         let mut handles = self.accounts.to_cpi_handles();
         let mut optional_sentinel_flags = self.accounts.optional_account_sentinel_flags();
 
-        // Append remaining accounts using the handle's flags.
+        // Append remaining accounts using the handle's writable/signer flags
+        // so PDA remaining accounts marked with `as_signer()` emit signer metas.
         for handle in &self.remaining_accounts {
             instruction_accounts.push(InstructionAccount::new(
                 handle.address(),

--- a/lang-v2/src/traits.rs
+++ b/lang-v2/src/traits.rs
@@ -25,6 +25,9 @@ use {
 pub struct CpiHandle<'a> {
     view: &'a AccountView,
     writable: bool,
+    /// CPI meta signer bit. Defaults to the transaction view; set via
+    /// [`CpiHandle::as_signer`] for PDA remaining accounts.
+    signer: bool,
     borrow_check: bool,
     relax_readonly_borrow: bool,
 }
@@ -36,6 +39,7 @@ pub struct CpiHandle<'a> {
 #[derive(Clone, Copy)]
 pub struct CpiHandleMut<'a> {
     view: &'a AccountView,
+    signer: bool,
     borrow_check: bool,
 }
 
@@ -64,6 +68,7 @@ impl<'a> CpiHandle<'a> {
         Self {
             view,
             writable: false,
+            signer: view.is_signer(),
             borrow_check,
             relax_readonly_borrow,
         }
@@ -79,6 +84,7 @@ impl<'a> CpiHandle<'a> {
         Self {
             view,
             writable: true,
+            signer: view.is_signer(),
             borrow_check,
             relax_readonly_borrow: false,
         }
@@ -100,10 +106,28 @@ impl<'a> CpiHandle<'a> {
         self.writable
     }
 
-    /// Whether the underlying account is a signer on the transaction.
+    /// Whether this handle should be marked as a signer in CPI account metas.
+    ///
+    /// Defaults to the underlying transaction view. PDA remaining accounts
+    /// that will be signed via [`crate::CpiContext::with_signer`] should call
+    /// [`CpiHandle::as_signer`] so the callee sees a signer meta.
     #[inline(always)]
     pub fn is_signer(&self) -> bool {
-        self.view.is_signer()
+        self.signer
+    }
+
+    /// Mark this handle as a signer for CPI account metas.
+    ///
+    /// Transaction signers are already detected from the view. Use this for
+    /// PDA remaining accounts: `with_remaining_accounts` copies
+    /// [`CpiHandle::is_signer`] onto each remaining `InstructionAccount`, and
+    /// `invoke_signed` still requires matching [`crate::CpiContext::with_signer`]
+    /// seeds at runtime.
+    #[must_use]
+    #[inline(always)]
+    pub fn as_signer(mut self) -> Self {
+        self.signer = true;
+        self
     }
 
     /// Erase to a readonly CPI handle.
@@ -112,7 +136,10 @@ impl<'a> CpiHandle<'a> {
     /// `CpiHandleMut` field can emit a second readonly meta/handle pair.
     #[inline(always)]
     pub fn into_readonly(self) -> CpiHandle<'a> {
-        Self::readonly_with_flags(self.view, self.borrow_check, self.relax_readonly_borrow)
+        let mut handle =
+            Self::readonly_with_flags(self.view, self.borrow_check, self.relax_readonly_borrow);
+        handle.signer = self.signer;
+        handle
     }
 
     /// Access the underlying `AccountView` for CPI account construction.
@@ -162,7 +189,11 @@ impl<'a> CpiHandleMut<'a> {
 
     #[inline(always)]
     fn writable_with_borrow_check(view: &'a AccountView, borrow_check: bool) -> Self {
-        Self { view, borrow_check }
+        Self {
+            view,
+            signer: view.is_signer(),
+            borrow_check,
+        }
     }
 
     /// The account's on-chain address.
@@ -177,10 +208,22 @@ impl<'a> CpiHandleMut<'a> {
         true
     }
 
-    /// Whether the underlying account is a signer on the transaction.
+    /// Whether this handle should be marked as a signer in CPI account metas.
+    ///
+    /// See [`CpiHandle::is_signer`].
     #[inline(always)]
     pub fn is_signer(&self) -> bool {
-        self.view.is_signer()
+        self.signer
+    }
+
+    /// Mark this handle as a signer for CPI account metas.
+    ///
+    /// See [`CpiHandle::as_signer`].
+    #[must_use]
+    #[inline(always)]
+    pub fn as_signer(mut self) -> Self {
+        self.signer = true;
+        self
     }
 
     /// Erase to a readonly [`CpiHandle`].
@@ -189,7 +232,9 @@ impl<'a> CpiHandleMut<'a> {
     /// still emit a second readonly meta/handle pair.
     #[inline(always)]
     pub fn into_readonly(self) -> CpiHandle<'a> {
-        CpiHandle::readonly_with_borrow_check(self.view, self.borrow_check)
+        let mut handle = CpiHandle::readonly_with_borrow_check(self.view, self.borrow_check);
+        handle.signer = self.signer;
+        handle
     }
 }
 
@@ -199,6 +244,7 @@ impl<'a> From<CpiHandleMut<'a>> for CpiHandle<'a> {
         Self {
             view: handle.view,
             writable: true,
+            signer: handle.signer,
             borrow_check: handle.borrow_check,
             relax_readonly_borrow: false,
         }

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -162,6 +162,32 @@ fn account_view_converts_to_cpi_handles() {
 }
 
 #[test]
+fn cpi_handle_as_signer_overrides_transaction_view() {
+    let buffer = account_view([1; 32], false);
+    let view = unsafe { buffer.view() };
+    assert!(!view.is_signer());
+
+    let handle = CpiHandle::readonly(&view);
+    assert!(!handle.is_signer());
+    assert!(handle.as_signer().is_signer());
+
+    let mut_buffer = account_view([3; 32], true);
+    let mut writable_view = unsafe { mut_buffer.view() };
+    let mut_handle = CpiHandleMut::writable(&mut writable_view);
+    assert!(!mut_handle.is_signer());
+    let mut_signer = mut_handle.as_signer();
+    assert!(mut_signer.is_signer());
+
+    let erased: CpiHandle = mut_signer.into();
+    assert!(erased.is_signer());
+    assert!(erased.is_writable());
+    let signer_buffer = AccountBuffer::<{ MIN_ACCOUNT_BUF + 8 }>::new();
+    signer_buffer.init([4; 32], [9; 32], 8, true, false, false);
+    let signer_view = unsafe { signer_buffer.view() };
+    assert!(CpiHandle::readonly(&signer_view).is_signer());
+}
+
+#[test]
 fn checked_invoke_rejects_missing_handle() {
     let ix = instruction(Address::new_from_array([1; 32]), false);
 
@@ -369,6 +395,23 @@ fn invoke_ix_allows_signer_meta_without_tx_signer_when_seeds_are_supplied() {
 
     CpiContext::new_with_signer(&program, accounts, &[&[b"pda", &[7]]])
         .invoke_ix(ix)
+        .unwrap();
+}
+
+#[test]
+fn invoke_remaining_pda_as_signer_with_seeds() {
+    let program = ID;
+    let typed_buffer = account_view([1; 32], false);
+    let remaining_buffer = account_view([2; 32], false);
+    let typed_view = unsafe { typed_buffer.view() };
+    let remaining_view = unsafe { remaining_buffer.view() };
+    let accounts = ReadonlyCpi {
+        account: typed_view.to_cpi_handle(),
+    };
+
+    CpiContext::new_with_signer(&program, accounts, &[&[b"pda", &[7]]])
+        .with_remaining_accounts(vec![CpiHandle::readonly(&remaining_view).as_signer()])
+        .invoke(&[])
         .unwrap();
 }
 


### PR DESCRIPTION
Fixes finding AI # 35
Remaining CPI accounts inherited signer status from the transaction view, so PDA remaining accounts could not be marked signers even when with_signer seeds were present. Now, the given `CpiHandle/CpiHandleMut` an `as_signer()` override (like writable) and use it when invoke builds remaining account metas.