### PR TITLE
Fix/v1.2 zeroed discriminator

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -46,8 +46,8 @@ fn is_zeroed_discriminator(discr: &Expr) -> bool {
 
 fn gen_custom_discriminator_check(discrim: &Expr) -> proc_macro2::TokenStream {
     quote_spanned! {discrim.span() =>
-        const __ANCHOR_DISCRIMINATOR_CHECK: [(); {
-            const fn __anchor_check_discriminator(discriminator: &[u8]) -> usize {
+        const __ANCHOR_DISCRIMINATOR_CHECK: () = {
+                let discriminator = <Self as anchor_lang::Discriminator>::DISCRIMINATOR;
                 if discriminator.is_empty() {
                     panic!("all-zero or empty discriminators are not supported");
                 }
@@ -61,10 +61,6 @@ fn gen_custom_discriminator_check(discrim: &Expr) -> proc_macro2::TokenStream {
                 }
 
                 panic!("all-zero or empty discriminators are not supported");
-            }
-
-            __anchor_check_discriminator(<Self as anchor_lang::Discriminator>::DISCRIMINATOR)
-        }] = [];
     }
 }
 

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -9,7 +9,7 @@ use {
         parse_macro_input,
         spanned::Spanned,
         token::Paren,
-        Expr, Ident, LitStr, Token,
+        Ident, LitStr, Token,
     },
 };
 
@@ -17,52 +17,6 @@ mod id;
 
 #[cfg(feature = "lazy-account")]
 mod lazy;
-
-fn is_zero_lit(lit: &syn::Lit) -> bool {
-    match lit {
-        syn::Lit::Int(val) => val.base10_parse::<u128>().is_ok_and(|v| v == 0),
-        syn::Lit::Byte(val) => val.value() == 0,
-        syn::Lit::ByteStr(val) => val.value().iter().all(|byte| *byte == 0),
-        _ => false,
-    }
-}
-
-// Fast-path obvious literal forms so simple mistakes still get a direct
-// compile_error! on the user-provided expression span.
-fn is_zeroed_discriminator(discr: &Expr) -> bool {
-    match discr {
-        Expr::Reference(syn::ExprReference { expr, .. })
-        | Expr::Paren(syn::ExprParen { expr, .. })
-        | Expr::Group(syn::ExprGroup { expr, .. }) => is_zeroed_discriminator(expr),
-        Expr::Lit(syn::ExprLit { lit, .. }) => is_zero_lit(lit),
-        Expr::Array(arr) => arr.elems.iter().all(is_zeroed_discriminator),
-        // [0; N] is all zeroed for any N, and [X; 0] is empty.
-        Expr::Repeat(rep) => {
-            is_zeroed_discriminator(&rep.expr) || is_zeroed_discriminator(&rep.len)
-        }
-        _ => false,
-    }
-}
-
-fn gen_custom_discriminator_check(discrim: &Expr) -> proc_macro2::TokenStream {
-    quote_spanned! {discrim.span() =>
-        const __ANCHOR_DISCRIMINATOR_CHECK: () = {
-                let discriminator = <Self as anchor_lang::Discriminator>::DISCRIMINATOR;
-                if discriminator.is_empty() {
-                    panic!("all-zero or empty discriminators are not supported");
-                }
-
-                let mut i = 0;
-                while i < discriminator.len() {
-                    if discriminator[i] != 0 {
-                        return 0;
-                    }
-                    i += 1;
-                }
-
-                panic!("all-zero or empty discriminators are not supported");
-    }
-}
 
 /// An attribute for a data structure representing a Solana account.
 ///
@@ -159,21 +113,29 @@ pub fn account(
     let account_name_str = account_name.to_string();
     let (impl_gen, type_gen, where_clause) = account_strct.generics.split_for_impl();
 
-    let (discriminator, discriminator_check) = match args.overrides.and_then(|ov| ov.discriminator)
-    {
+    let discriminator = match args.overrides.and_then(|ov| ov.discriminator) {
         Some(discrim) => {
-            let zero_err = is_zeroed_discriminator(&discrim).then(||
-                quote_spanned! {discrim.span() => compile_error!("all-zero or empty discriminators are not supported");}
-            );
-            (
-                quote! {
-                    {
-                        #zero_err
-                        #discrim
+            quote_spanned! {discrim.span() =>
+                {
+                    let discriminator = #discrim;
+                    if discriminator.is_empty() {
+                        panic!("all-zero or empty discriminators are not supported");
                     }
-                },
-                gen_custom_discriminator_check(&discrim),
-            )
+
+                    let mut i = 0;
+                    while i < discriminator.len() {
+                        if discriminator[i] != 0 {
+                            break;
+                        }
+                        i += 1;
+                    }
+
+                    if i == discriminator.len() {
+                        panic!("all-zero or empty discriminators are not supported");
+                    }
+                    discriminator
+                }
+            }
         }
         None => {
             // Namespace the discriminator to prevent collisions.
@@ -183,10 +145,7 @@ pub fn account(
                 &namespace
             };
 
-            (
-                gen_discriminator(namespace, account_name),
-                proc_macro2::TokenStream::new(),
-            )
+            gen_discriminator(namespace, account_name)
         }
     };
 
@@ -254,11 +213,6 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
                     const DISCRIMINATOR: &'static [u8] = #discriminator;
-                }
-
-                #[automatically_derived]
-                impl #impl_gen #account_name #type_gen #where_clause {
-                    #discriminator_check
                 }
 
                 // This trait is useful for clients deserializing accounts.
@@ -337,11 +291,6 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
                     const DISCRIMINATOR: &'static [u8] = #discriminator;
-                }
-
-                #[automatically_derived]
-                impl #impl_gen #account_name #type_gen #where_clause {
-                    #discriminator_check
                 }
 
                 #owner_impl
@@ -683,42 +632,4 @@ pub fn declare_id(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     #[allow(unreachable_code)]
     proc_macro::TokenStream::from(ret)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[allow(clippy::expect_used)]
-    fn zeroed(source: &str) -> bool {
-        let expr = syn::parse_str(source).expect("test expression should parse");
-        is_zeroed_discriminator(&expr)
-    }
-
-    #[test]
-    fn detects_zeroed_discriminator_literals() {
-        assert!(zeroed("0"));
-        assert!(zeroed("b'\\x00'"));
-        assert!(zeroed("b\"\""));
-        assert!(zeroed("b\"\\x00\\x00\""));
-
-        assert!(!zeroed("1"));
-        assert!(!zeroed("b'a'"));
-        assert!(!zeroed("b\"\\x00\\x01\""));
-        assert!(!zeroed("\"\""));
-    }
-
-    #[test]
-    fn detects_zeroed_discriminator_collections() {
-        assert!(zeroed("&[0, (0)]"));
-        assert!(zeroed("[]"));
-        assert!(zeroed("[0; N]"));
-        assert!(zeroed("[1; 0]"));
-        assert!(zeroed("(&b\"\\x00\" )"));
-
-        assert!(!zeroed("&[0, 1]"));
-        assert!(!zeroed("[1; N]"));
-        assert!(!zeroed("MY_DISC"));
-        assert!(!zeroed("get_disc()"));
-    }
 }

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -27,6 +27,8 @@ fn is_zero_lit(lit: &syn::Lit) -> bool {
     }
 }
 
+// Fast-path obvious literal forms so simple mistakes still get a direct
+// compile_error! on the user-provided expression span.
 fn is_zeroed_discriminator(discr: &Expr) -> bool {
     match discr {
         Expr::Reference(syn::ExprReference { expr, .. })
@@ -39,6 +41,30 @@ fn is_zeroed_discriminator(discr: &Expr) -> bool {
             is_zeroed_discriminator(&rep.expr) || is_zeroed_discriminator(&rep.len)
         }
         _ => false,
+    }
+}
+
+fn gen_custom_discriminator_check(discrim: &Expr) -> proc_macro2::TokenStream {
+    quote_spanned! {discrim.span() =>
+        const __ANCHOR_DISCRIMINATOR_CHECK: [(); {
+            const fn __anchor_check_discriminator(discriminator: &[u8]) -> usize {
+                if discriminator.is_empty() {
+                    panic!("all-zero or empty discriminators are not supported");
+                }
+
+                let mut i = 0;
+                while i < discriminator.len() {
+                    if discriminator[i] != 0 {
+                        return 0;
+                    }
+                    i += 1;
+                }
+
+                panic!("all-zero or empty discriminators are not supported");
+            }
+
+            __anchor_check_discriminator(<Self as anchor_lang::Discriminator>::DISCRIMINATOR)
+        }] = [];
     }
 }
 
@@ -137,17 +163,21 @@ pub fn account(
     let account_name_str = account_name.to_string();
     let (impl_gen, type_gen, where_clause) = account_strct.generics.split_for_impl();
 
-    let discriminator = match args.overrides.and_then(|ov| ov.discriminator) {
+    let (discriminator, discriminator_check) = match args.overrides.and_then(|ov| ov.discriminator)
+    {
         Some(discrim) => {
             let zero_err = is_zeroed_discriminator(&discrim).then(||
                 quote_spanned! {discrim.span() => compile_error!("all-zero or empty discriminators are not supported");}
             );
-            quote! {
-                {
-                    #zero_err
-                    #discrim
-                }
-            }
+            (
+                quote! {
+                    {
+                        #zero_err
+                        #discrim
+                    }
+                },
+                gen_custom_discriminator_check(&discrim),
+            )
         }
         None => {
             // Namespace the discriminator to prevent collisions.
@@ -157,7 +187,10 @@ pub fn account(
                 &namespace
             };
 
-            gen_discriminator(namespace, account_name)
+            (
+                gen_discriminator(namespace, account_name),
+                proc_macro2::TokenStream::new(),
+            )
         }
     };
 
@@ -225,6 +258,11 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
                     const DISCRIMINATOR: &'static [u8] = #discriminator;
+                }
+
+                #[automatically_derived]
+                impl #impl_gen #account_name #type_gen #where_clause {
+                    #discriminator_check
                 }
 
                 // This trait is useful for clients deserializing accounts.
@@ -303,6 +341,11 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Discriminator for #account_name #type_gen #where_clause {
                     const DISCRIMINATOR: &'static [u8] = #discriminator;
+                }
+
+                #[automatically_derived]
+                impl #impl_gen #account_name #type_gen #where_clause {
+                    #discriminator_check
                 }
 
                 #owner_impl

--- a/tests/custom-discriminator/Anchor.toml
+++ b/tests/custom-discriminator/Anchor.toml
@@ -1,5 +1,5 @@
 [workspace]
-exclude = ["programs/ambiguous-discriminator"]
+exclude = ["programs/ambiguous-discriminator", "programs/zeroed-discriminator"]
 
 [features]
 resolution = true
@@ -8,6 +8,7 @@ skip-lint = false
 [programs.localnet]
 ambiguous-discriminator = "AmbiguousDiscriminator111111111111111111111"
 custom_discriminator = "CustomDiscriminator111111111111111111111111"
+zeroed-discriminator = "Fg6PaFpoGXkYsidMpWxTWqkZP8eM5uZuN4fKwvVZZzCk"
 
 [provider]
 cluster = "Localnet"

--- a/tests/custom-discriminator/programs/zeroed-discriminator/Cargo.toml
+++ b/tests/custom-discriminator/programs/zeroed-discriminator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "zeroed-discriminator"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "zeroed_discriminator"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/custom-discriminator/programs/zeroed-discriminator/Xargo.toml
+++ b/tests/custom-discriminator/programs/zeroed-discriminator/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/custom-discriminator/programs/zeroed-discriminator/src/lib.rs
+++ b/tests/custom-discriminator/programs/zeroed-discriminator/src/lib.rs
@@ -1,0 +1,32 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWxTWqkZP8eM5uZuN4fKwvVZZzCk");
+
+const fn zeroed_account_disc_inner() -> &'static [u8] {
+    &[1 - 1, 2 - 2, 3 - 3, 4 - 4]
+}
+
+const ZEROED_ACCOUNT_DISC: &'static [u8] = zeroed_account_disc_inner();
+
+macro_rules! zeroed_account_disc {
+    () => {
+        ZEROED_ACCOUNT_DISC
+    };
+}
+
+#[program]
+pub mod zeroed_discriminator {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}
+
+#[account(discriminator = zeroed_account_disc!())]
+pub struct ZeroedAccount {
+    pub field: u8,
+}

--- a/tests/custom-discriminator/tests/zeroed-discriminator.ts
+++ b/tests/custom-discriminator/tests/zeroed-discriminator.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { spawnSync } from "child_process";
 
-describe("ambiguous-discriminator", () => {
+describe("zeroed-discriminator", () => {
   const anchorTomlPath = "Anchor.toml";
   const anchorToml = fs.readFileSync(anchorTomlPath, { encoding: "utf8" });
 
@@ -10,7 +10,7 @@ describe("ambiguous-discriminator", () => {
       anchorTomlPath,
       anchorToml.replace(
         'exclude = ["programs/ambiguous-discriminator", "programs/zeroed-discriminator"]',
-        'exclude = ["programs/zeroed-discriminator"]'
+        'exclude = ["programs/ambiguous-discriminator"]'
       )
     );
   });
@@ -19,25 +19,24 @@ describe("ambiguous-discriminator", () => {
     fs.writeFileSync(anchorTomlPath, anchorToml);
   });
 
-  it("Returns ambiguous discriminator error on builds", () => {
+  it("rejects zeroed account discriminators on no-idl builds", () => {
     const result = spawnSync("anchor", [
-      "idl",
       "build",
+      "--no-idl",
+      "--ignore-keys",
       "-p",
-      "ambiguous-discriminator",
+      "zeroed-discriminator",
     ]);
     if (result.status === 0) {
-      throw new Error("Ambiguous errors did not make building the IDL fail");
+      throw new Error("Zeroed discriminator build unexpectedly succeeded");
     }
 
     const output = result.output.toString();
     if (
-      !output.includes(
-        "Error: Ambiguous discriminators for accounts `AnotherAccount` and `SomeAccount`"
-      )
+      !output.includes("all-zero or empty discriminators are not supported")
     ) {
       throw new Error(
-        `Ambiguous discriminators did not return the expected error: "${output}"`
+        `Zeroed discriminator build did not return the expected error: "${output}"`
       );
     }
   });


### PR DESCRIPTION
no-IDL builds could accept zeroed custom account discriminators hidden behind const evaluation. this fix forces compile-time validation of the final discriminator slice and adds a regression test covering the no-IDL build path.
