### PR TITLE
Fix/v1.2 macro hygiene

### DIFF
--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -103,10 +103,10 @@ fn create_error(error_code: Expr, source: bool, account_name: Option<Expr>) -> T
     let error_origin = match (source, account_name) {
         (false, None) => quote! { None },
         (false, Some(account_name)) => quote! {
-            Some(anchor_lang::error::ErrorOrigin::AccountName(#account_name.to_string()))
+            Some(::anchor_lang::error::ErrorOrigin::AccountName(#account_name.to_string()))
         },
         (true, _) => quote! {
-            Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
+            Some(::anchor_lang::error::ErrorOrigin::Source(::anchor_lang::error::Source {
                 filename: file!(),
                 line: line!()
             }))
@@ -114,8 +114,8 @@ fn create_error(error_code: Expr, source: bool, account_name: Option<Expr>) -> T
     };
 
     TokenStream::from(quote! {
-        anchor_lang::error::Error::from(
-            anchor_lang::error::AnchorError {
+        ::anchor_lang::error::Error::from(
+            ::anchor_lang::error::AnchorError {
                 error_name: #error_code.name(),
                 error_code_number: #error_code.into(),
                 error_msg: #error_code.to_string(),

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -742,12 +742,12 @@ pub mod __private {
 macro_rules! require {
     ($invariant:expr, $error:tt $(,)?) => {
         if !($invariant) {
-            return Err(anchor_lang::error!($crate::ErrorCode::$error));
+            return ::core::result::Result::Err($crate::error!($crate::error::ErrorCode::$error));
         }
     };
     ($invariant:expr, $error:expr $(,)?) => {
         if !($invariant) {
-            return Err(anchor_lang::error!($error));
+            return ::core::result::Result::Err($crate::error!($error));
         }
     };
 }
@@ -771,13 +771,17 @@ macro_rules! require {
 macro_rules! require_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_values(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(error!(anchor_lang::error::ErrorCode::RequireEqViolated)
-                .with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireEqViolated)
+                    .with_values(($value1, $value2)),
+            );
         }
     };
 }
@@ -801,13 +805,17 @@ macro_rules! require_eq {
 macro_rules! require_neq {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_values(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(error!(anchor_lang::error::ErrorCode::RequireNeqViolated)
-                .with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireNeqViolated)
+                    .with_values(($value1, $value2)),
+            );
         }
     };
 }
@@ -831,13 +839,17 @@ macro_rules! require_neq {
 macro_rules! require_keys_eq {
     ($value1: expr, $value2: expr, $error_code:expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(anchor_lang::error!($error_code).with_pubkeys(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_pubkeys(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 != $value2 {
-            return Err(error!(anchor_lang::error::ErrorCode::RequireKeysEqViolated)
-                .with_pubkeys(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireKeysEqViolated)
+                    .with_pubkeys(($value1, $value2)),
+            );
         }
     };
 }
@@ -861,13 +873,15 @@ macro_rules! require_keys_eq {
 macro_rules! require_keys_neq {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(anchor_lang::error!($error_code).with_pubkeys(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_pubkeys(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 == $value2 {
-            return Err(
-                error!(anchor_lang::error::ErrorCode::RequireKeysNeqViolated)
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireKeysNeqViolated)
                     .with_pubkeys(($value1, $value2)),
             );
         }
@@ -893,13 +907,17 @@ macro_rules! require_keys_neq {
 macro_rules! require_gt {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 <= $value2 {
-            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_values(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 <= $value2 {
-            return Err(error!(anchor_lang::error::ErrorCode::RequireGtViolated)
-                .with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireGtViolated)
+                    .with_values(($value1, $value2)),
+            );
         }
     };
 }
@@ -921,13 +939,17 @@ macro_rules! require_gt {
 macro_rules! require_gte {
     ($value1: expr, $value2: expr, $error_code: expr $(,)?) => {
         if $value1 < $value2 {
-            return Err(anchor_lang::error!($error_code).with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($error_code).with_values(($value1, $value2)),
+            );
         }
     };
     ($value1: expr, $value2: expr $(,)?) => {
         if $value1 < $value2 {
-            return Err(error!(anchor_lang::error::ErrorCode::RequireGteViolated)
-                .with_values(($value1, $value2)));
+            return ::core::result::Result::Err(
+                $crate::error!($crate::error::ErrorCode::RequireGteViolated)
+                    .with_values(($value1, $value2)),
+            );
         }
     };
 }
@@ -954,10 +976,10 @@ macro_rules! require_gte {
 #[macro_export]
 macro_rules! err {
     ($error:tt $(,)?) => {
-        Err(anchor_lang::error!($crate::ErrorCode::$error))
+        ::core::result::Result::Err($crate::error!($crate::error::ErrorCode::$error))
     };
     ($error:expr $(,)?) => {
-        Err(anchor_lang::error!($error))
+        ::core::result::Result::Err($crate::error!($error))
     };
 }
 
@@ -965,7 +987,7 @@ macro_rules! err {
 #[macro_export]
 macro_rules! source {
     () => {
-        anchor_lang::error::Source {
+        $crate::error::Source {
             filename: file!(),
             line: line!(),
         }

--- a/lang/tests/macro_hygiene.rs
+++ b/lang/tests/macro_hygiene.rs
@@ -1,0 +1,201 @@
+use {
+    ::anchor_lang as anchor_lang_crate,
+    anchor_lang_crate::{
+        err, require, require_eq, require_gt, require_gte, require_keys_eq, require_keys_neq,
+        require_neq, solana_program::pubkey::Pubkey,
+    },
+};
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+struct Hijacked;
+
+#[allow(dead_code)]
+impl Hijacked {
+    fn with_values<T>(self, _values: T) -> Self {
+        self
+    }
+
+    fn with_pubkeys<T>(self, _pubkeys: T) -> Self {
+        self
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! error {
+    ($($tt:tt)*) => {
+        Hijacked
+    };
+}
+
+#[allow(dead_code, non_snake_case)]
+fn Err<T>(_value: T) -> anchor_lang_crate::Result<()> {
+    Ok(())
+}
+
+#[allow(dead_code, unused_imports)]
+mod anchor_lang {
+    pub use crate::shadowed_error as error;
+}
+
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! shadowed_error {
+    ($($tt:tt)*) => {
+        $crate::Hijacked
+    };
+}
+
+fn err_tt_arm() -> anchor_lang_crate::Result<()> {
+    err!(RequireViolated)
+}
+
+fn err_expr_arm() -> anchor_lang_crate::Result<()> {
+    err!(anchor_lang_crate::error::ErrorCode::RequireViolated)
+}
+
+fn assert_error(result: anchor_lang_crate::Result<()>, code: anchor_lang_crate::error::ErrorCode) {
+    assert_eq!(result, ::core::result::Result::Err(code.into()));
+}
+
+#[test]
+fn require_and_err_ignore_shadowed_callers() {
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require!(false, RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require!(false, anchor_lang_crate::error::ErrorCode::RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        err_tt_arm(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        err_expr_arm(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+}
+
+#[test]
+fn comparison_macros_ignore_shadowed_callers() {
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_eq!(1, 2);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireEqViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_eq!(1, 2, anchor_lang_crate::error::ErrorCode::RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_neq!(1, 1);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireNeqViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_neq!(1, 1, anchor_lang_crate::error::ErrorCode::RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            let left = Pubkey::new_unique();
+            let right = Pubkey::new_unique();
+            require_keys_eq!(left, right);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireKeysEqViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            let left = Pubkey::new_unique();
+            let right = Pubkey::new_unique();
+            require_keys_eq!(
+                left,
+                right,
+                anchor_lang_crate::error::ErrorCode::RequireViolated
+            );
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            let key = Pubkey::new_unique();
+            require_keys_neq!(key, key);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireKeysNeqViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            let key = Pubkey::new_unique();
+            require_keys_neq!(
+                key,
+                key,
+                anchor_lang_crate::error::ErrorCode::RequireViolated
+            );
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_gt!(1, 2);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireGtViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_gt!(1, 2, anchor_lang_crate::error::ErrorCode::RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_gte!(1, 2);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireGteViolated,
+    );
+
+    assert_error(
+        (|| -> anchor_lang_crate::Result<()> {
+            require_gte!(1, 2, anchor_lang_crate::error::ErrorCode::RequireViolated);
+            Ok(())
+        })(),
+        anchor_lang_crate::error::ErrorCode::RequireViolated,
+    );
+}


### PR DESCRIPTION
#4639 still let caller shadowing turn failed `require!`, `err!`, and comparison checks into `Ok(())`. Now we are fixing fully qualified `Err`,` error!`, and Anchor `error` paths, and added regression tests covering shadowed `error`, `Err`, and `anchor_lang`.