### PR TITLE
chore: use underscore-delimited clippy lint names

### DIFF
--- a/lang/attribute/access-control/Cargo.toml
+++ b/lang/attribute/access-control/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [dependencies]
 proc-macro2 = "1"

--- a/lang/attribute/account/Cargo.toml
+++ b/lang/attribute/account/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 anchor-debug = ["anchor-syn/anchor-debug"]

--- a/lang/attribute/constant/Cargo.toml
+++ b/lang/attribute/constant/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 anchor-debug = ["anchor-syn/anchor-debug"]

--- a/lang/attribute/error/Cargo.toml
+++ b/lang/attribute/error/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 anchor-debug = ["anchor-syn/anchor-debug"]

--- a/lang/attribute/event/Cargo.toml
+++ b/lang/attribute/event/Cargo.toml
@@ -15,11 +15,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 anchor-debug = ["anchor-syn/anchor-debug"]

--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 anchor-debug = ["anchor-syn/anchor-debug"]

--- a/lang/derive/accounts/Cargo.toml
+++ b/lang/derive/accounts/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 allow-missing-optionals = ["anchor-syn/allow-missing-optionals"]

--- a/lang/derive/serde/Cargo.toml
+++ b/lang/derive/serde/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 idl-build = ["anchor-syn/idl-build"]

--- a/lang/derive/space/Cargo.toml
+++ b/lang/derive/space/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 proc-macro = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [dependencies]
 proc-macro2 = "1"

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2021"
 workspace = true
 
 [lints.clippy]
-unwrap-used = "deny"
-expect-used = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 panic = "deny"
 unimplemented = "deny"
-indexing-slicing = "deny"
+indexing_slicing = "deny"
 
 [features]
 allow-missing-optionals = []


### PR DESCRIPTION
Clippy lint names are underscored, and recent nightly versions have begun warning on these hyphenated manifest entries.