### PR TITLE
Fix/v1.2 realloc payer box

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -440,6 +440,7 @@ fn generate_constraint_realloc(
     let account_name = field.to_string();
     let new_space = &c.space;
     let payer = &c.payer;
+    let payer_ref = generate_realloc_payer_ref(payer, accs);
 
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, field);
     let payer_optional_check = optional_check_scope.generate_check(payer);
@@ -484,7 +485,7 @@ fn generate_constraint_realloc(
                 }
             } else {
                 let __lamport_amt = __field_info.lamports().checked_sub(__new_rent_minimum).unwrap();
-                anchor_lang::Lamports::add_lamports(&#payer, __lamport_amt)?;
+                anchor_lang::Lamports::add_lamports(#payer_ref, __lamport_amt)?;
                 anchor_lang::Lamports::sub_lamports(&__field_info, __lamport_amt)?;
             }
 
@@ -1873,4 +1874,19 @@ fn generate_account_ref(field: &Field) -> proc_macro2::TokenStream {
         }
         _ => quote!(AsRef::<AccountInfo>::as_ref(&#name)),
     }
+}
+
+fn generate_realloc_payer_ref(
+    payer: &syn::Expr,
+    accs: &AccountsStruct,
+) -> proc_macro2::TokenStream {
+    accs.fields
+        .iter()
+        .find_map(|field| match field {
+            AccountField::Field(field) if field.ident == parser::tts_to_string(payer) => {
+                Some(generate_account_ref(field))
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| quote!(&#payer.to_account_info()))
 }

--- a/tests/realloc/programs/realloc/src/lib.rs
+++ b/tests/realloc/programs/realloc/src/lib.rs
@@ -12,7 +12,21 @@ pub mod realloc {
         Ok(())
     }
 
+    pub fn initialize_box_payer(ctx: Context<InitializeBoxPayer>) -> Result<()> {
+        ctx.accounts.payer.data = vec![0];
+        ctx.accounts.payer.bump = ctx.bumps.payer;
+        Ok(())
+    }
+
     pub fn realloc(ctx: Context<Realloc>, len: u16) -> Result<()> {
+        ctx.accounts
+            .sample
+            .data
+            .resize_with(len as usize, Default::default);
+        Ok(())
+    }
+
+    pub fn realloc_box_payer(ctx: Context<ReallocBoxPayer>, len: u16) -> Result<()> {
         ctx.accounts
             .sample
             .data
@@ -52,6 +66,23 @@ pub struct Initialize<'info> {
 }
 
 #[derive(Accounts)]
+pub struct InitializeBoxPayer<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        init,
+        payer = authority,
+        seeds = [b"payer"],
+        bump,
+        space = Sample::space(1),
+    )]
+    pub payer: Box<Account<'info, Sample>>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 #[instruction(len: u16)]
 pub struct Realloc<'info> {
     #[account(mut)]
@@ -66,6 +97,32 @@ pub struct Realloc<'info> {
         realloc::zero = false,
     )]
     pub sample: Account<'info, Sample>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(len: u16)]
+pub struct ReallocBoxPayer<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"sample"],
+        bump = sample.bump,
+        realloc = Sample::space(len as usize),
+        realloc::payer = payer,
+        realloc::zero = false,
+    )]
+    pub sample: Account<'info, Sample>,
+
+    #[account(
+        mut,
+        seeds = [b"payer"],
+        bump = payer.bump,
+    )]
+    pub payer: Box<Account<'info, Sample>>,
 
     pub system_program: Program<'info, System>,
 }

--- a/tests/realloc/tests/realloc.ts
+++ b/tests/realloc/tests/realloc.ts
@@ -12,10 +12,15 @@ describe("realloc", () => {
     .payer as anchor.web3.Keypair;
 
   let sample: anchor.web3.PublicKey;
+  let payer: anchor.web3.PublicKey;
 
   before(async () => {
     [sample] = await anchor.web3.PublicKey.findProgramAddress(
       [Buffer.from("sample")],
+      program.programId
+    );
+    [payer] = await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from("payer")],
       program.programId
     );
   });
@@ -48,6 +53,16 @@ describe("realloc", () => {
     }
   });
 
+  it("initializes boxed realloc payer", async () => {
+    await program.methods
+      .initializeBoxPayer()
+      .accounts({ authority: authority.publicKey, payer })
+      .rpc();
+
+    const payerAccount = await program.account.sample.fetch(payer);
+    assert.lengthOf(payerAccount.data, 1);
+  });
+
   it("realloc additive", async () => {
     await program.methods
       .realloc(5)
@@ -63,6 +78,41 @@ describe("realloc", () => {
       .realloc(1)
       .accounts({ authority: authority.publicKey, sample })
       .rpc();
+
+    const s = await program.account.sample.fetch(sample);
+    assert.lengthOf(s.data, 1);
+  });
+
+  it("realloc subtractive with boxed payer", async () => {
+    await program.methods
+      .realloc(5)
+      .accounts({ authority: authority.publicKey, sample })
+      .rpc();
+
+    const beforeSample = await program.provider.connection.getAccountInfo(
+      sample
+    );
+    const beforePayer = await program.provider.connection.getAccountInfo(payer);
+    assert.isNotNull(beforeSample);
+    assert.isNotNull(beforePayer);
+
+    await program.methods
+      .reallocBoxPayer(1)
+      .accounts({
+        authority: authority.publicKey,
+        sample,
+        payer,
+      })
+      .rpc();
+
+    const afterSample = await program.provider.connection.getAccountInfo(
+      sample
+    );
+    const afterPayer = await program.provider.connection.getAccountInfo(payer);
+    assert.isNotNull(afterSample);
+    assert.isNotNull(afterPayer);
+    assert.isBelow(afterSample!.lamports, beforeSample!.lamports);
+    assert.isAbove(afterPayer!.lamports, beforePayer!.lamports);
 
     const s = await program.account.sample.fetch(sample);
     assert.lengthOf(s.data, 1);


### PR DESCRIPTION
#4642 regressed realloc shrink refunds for boxed payers by calling `Lamports::add_lamports(&payer, ...) `directly. The fix normalizes the payer to `&AccountInfo` in codegen and adds boxed-payer regression coverage.