### PR TITLE
Fix/v1.2 declare program namespaces

### DIFF
--- a/lang/attribute/program/Cargo.toml
+++ b/lang/attribute/program/Cargo.toml
@@ -31,4 +31,4 @@ anyhow = "1"
 heck = "0.3"
 proc-macro2 = "1"
 quote = "1"
-syn = { workspace = true, features = ["full"] }
+syn = { workspace = true, features = ["full", "visit-mut"] }

--- a/lang/attribute/program/src/declare_program/common.rs
+++ b/lang/attribute/program/src/declare_program/common.rs
@@ -81,11 +81,27 @@ pub fn convert_idl_type_to_str(ty: &IdlType, is_const: bool) -> Result<String, s
         IdlType::I128 => "i128".into(),
         IdlType::U256 => "u256".into(),
         IdlType::I256 => "i256".into(),
-        IdlType::Bytes => if is_const { "&[u8]" } else { "Vec<u8>" }.into(),
-        IdlType::String => if is_const { "&str" } else { "String" }.into(),
-        IdlType::Pubkey => "Pubkey".into(),
-        IdlType::Option(ty) => format!("Option<{}>", convert_idl_type_to_str(ty, is_const)?),
-        IdlType::Vec(ty) => format!("Vec<{}>", convert_idl_type_to_str(ty, is_const)?),
+        IdlType::Bytes => if is_const {
+            "&[u8]"
+        } else {
+            "::std::vec::Vec<u8>"
+        }
+        .into(),
+        IdlType::String => if is_const {
+            "&str"
+        } else {
+            "::std::string::String"
+        }
+        .into(),
+        IdlType::Pubkey => "anchor_lang::prelude::Pubkey".into(),
+        IdlType::Option(ty) => format!(
+            "::core::option::Option<{}>",
+            convert_idl_type_to_str(ty, is_const)?
+        ),
+        IdlType::Vec(ty) => format!(
+            "::std::vec::Vec<{}>",
+            convert_idl_type_to_str(ty, is_const)?
+        ),
         IdlType::Array(ty, len) => format!(
             "[{}; {}]",
             convert_idl_type_to_str(ty, is_const)?,
@@ -835,11 +851,17 @@ mod tests {
         assert_eq!(s(&IdlType::Bool), "bool");
         assert_eq!(s(&IdlType::U8), "u8");
         assert_eq!(s(&IdlType::U64), "u64");
-        assert_eq!(s(&IdlType::String), "String");
-        assert_eq!(s(&IdlType::Pubkey), "Pubkey");
+        assert_eq!(s(&IdlType::String), "::std::string::String");
+        assert_eq!(s(&IdlType::Pubkey), "anchor_lang::prelude::Pubkey");
 
-        assert_eq!(s(&IdlType::Option(Box::new(IdlType::U64))), "Option<u64>");
-        assert_eq!(s(&IdlType::Vec(Box::new(IdlType::String))), "Vec<String>");
+        assert_eq!(
+            s(&IdlType::Option(Box::new(IdlType::U64))),
+            "::core::option::Option<u64>"
+        );
+        assert_eq!(
+            s(&IdlType::Vec(Box::new(IdlType::String))),
+            "::std::vec::Vec<::std::string::String>"
+        );
 
         assert_eq!(
             s(&IdlType::Array(

--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -125,14 +125,16 @@ fn gen_id(idl: &Idl) -> proc_macro2::TokenStream {
 
     quote! {
         #[doc = #doc]
-        pub static ID: Pubkey = __ID;
+        pub static ID: anchor_lang::prelude::Pubkey = __ID;
 
         /// Const version of `ID`
-        pub const ID_CONST: Pubkey = __ID_CONST;
+        pub const ID_CONST: anchor_lang::prelude::Pubkey = __ID_CONST;
 
         /// The name is intentionally prefixed with `__` in order to reduce to possibility of name
         /// clashes with the crate's `ID`.
-        static __ID: Pubkey = Pubkey::from_str_const(#address);
-        const __ID_CONST : Pubkey = Pubkey::from_str_const(#address);
+        static __ID: anchor_lang::prelude::Pubkey =
+            anchor_lang::prelude::Pubkey::from_str_const(#address);
+        const __ID_CONST: anchor_lang::prelude::Pubkey =
+            anchor_lang::prelude::Pubkey::from_str_const(#address);
     }
 }

--- a/lang/attribute/program/src/declare_program/mods/accounts.rs
+++ b/lang/attribute/program/src/declare_program/mods/accounts.rs
@@ -102,7 +102,7 @@ pub fn gen_accounts_mod(idl: &Idl) -> proc_macro2::TokenStream {
             }
 
             impl anchor_lang::Owner for #name {
-                fn owner() -> Pubkey {
+                fn owner() -> anchor_lang::prelude::Pubkey {
                     #program_id
                 }
             }

--- a/lang/attribute/program/src/declare_program/mods/constants.rs
+++ b/lang/attribute/program/src/declare_program/mods/constants.rs
@@ -2,9 +2,11 @@ use {
     super::common::{convert_idl_type_to_str, gen_docs},
     anchor_lang_idl::types::{Idl, IdlType},
     quote::{format_ident, quote, ToTokens},
+    syn::visit_mut::VisitMut,
 };
 
 pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
+    let defined_paths = get_defined_paths(idl);
     let constants = idl.constants.iter().map(|c| {
         let name = format_ident!("{}", c.name);
         let docs = gen_docs(&c.docs);
@@ -22,12 +24,14 @@ pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
             clippy::unwrap_used,
             reason = "IDL constant values are valid Rust expressions by construction"
         )]
-        let val = syn::parse_str::<syn::Expr>(&c.value)
-            .unwrap()
-            .to_token_stream();
+        let mut val = syn::parse_str::<syn::Expr>(&c.value).unwrap();
+        DefinedPathQualifier::new(&defined_paths).visit_expr_mut(&mut val);
+        let val = val.to_token_stream();
         let val = match &c.ty {
             IdlType::Bytes => quote! { &#val },
-            IdlType::Pubkey => quote!(Pubkey::from_str_const(stringify!(#val))),
+            IdlType::Pubkey => quote!(anchor_lang::prelude::Pubkey::from_str_const(
+                stringify!(#val)
+            )),
             _ => val,
         };
 
@@ -44,5 +48,75 @@ pub fn gen_constants_mod(idl: &Idl) -> proc_macro2::TokenStream {
 
             #(#constants)*
         }
+    }
+}
+
+fn get_defined_paths(idl: &Idl) -> Vec<Vec<String>> {
+    let mut paths = idl
+        .accounts
+        .iter()
+        .map(|acc| acc.name.as_str())
+        .chain(idl.events.iter().map(|event| event.name.as_str()))
+        .chain(idl.types.iter().map(|ty| ty.name.as_str()))
+        .map(|name| name.split("::").map(str::to_owned).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    paths.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    paths.dedup();
+    paths
+}
+
+struct DefinedPathQualifier<'a> {
+    defined_paths: &'a [Vec<String>],
+}
+
+impl<'a> DefinedPathQualifier<'a> {
+    fn new(defined_paths: &'a [Vec<String>]) -> Self {
+        Self { defined_paths }
+    }
+
+    fn qualify_path(&self, path: &mut syn::Path) {
+        if path.leading_colon.is_some() || path.segments.is_empty() {
+            return;
+        }
+
+        let Some(first_segment) = path.segments.first() else {
+            return;
+        };
+        let first = first_segment.ident.to_string();
+        if matches!(first.as_str(), "__defined" | "crate" | "self" | "super") {
+            return;
+        }
+
+        let path_idents = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>();
+        let should_qualify = self
+            .defined_paths
+            .iter()
+            .any(|defined| path_idents.starts_with(defined));
+        if !should_qualify {
+            return;
+        }
+
+        let old_segments = path.segments.clone();
+        path.segments = syn::punctuated::Punctuated::new();
+        path.segments.push(format_ident!("__defined").into());
+        path.segments.extend(old_segments);
+    }
+}
+
+impl VisitMut for DefinedPathQualifier<'_> {
+    fn visit_expr_path_mut(&mut self, expr_path: &mut syn::ExprPath) {
+        syn::visit_mut::visit_expr_path_mut(self, expr_path);
+        if expr_path.qself.is_none() {
+            self.qualify_path(&mut expr_path.path);
+        }
+    }
+
+    fn visit_expr_struct_mut(&mut self, expr_struct: &mut syn::ExprStruct) {
+        syn::visit_mut::visit_expr_struct_mut(self, expr_struct);
+        self.qualify_path(&mut expr_struct.path);
     }
 }

--- a/lang/attribute/program/src/declare_program/mods/internal.rs
+++ b/lang/attribute/program/src/declare_program/mods/internal.rs
@@ -65,7 +65,7 @@ fn gen_internal_args_mod(idl: &Idl) -> proc_macro2::TokenStream {
         let program_id = get_canonical_program_id();
         let impl_owner = quote! {
             impl anchor_lang::Owner for #ix_struct_name {
-                fn owner() -> Pubkey {
+                fn owner() -> anchor_lang::prelude::Pubkey {
                     #program_id
                 }
             }

--- a/lang/attribute/program/src/declare_program/mods/program.rs
+++ b/lang/attribute/program/src/declare_program/mods/program.rs
@@ -17,7 +17,7 @@ pub fn gen_program_mod(program_name: &str) -> proc_macro2::TokenStream {
             pub struct #name;
 
             impl anchor_lang::Id for #name {
-                fn id() -> Pubkey {
+                fn id() -> anchor_lang::prelude::Pubkey {
                     #id
                 }
             }

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -424,6 +424,21 @@ pub fn gen_idl_type(
             .unwrap_or_default()
     }
 
+    fn path_is(path: &syn::TypePath, segments: &[&str]) -> bool {
+        path.path.segments.len() == segments.len()
+            && path
+                .path
+                .segments
+                .iter()
+                .zip(segments.iter())
+                .all(|(segment, expected)| segment.ident == *expected)
+    }
+
+    fn path_is_builtin(path: &syn::TypePath, simple: &str, qualified: &[&[&str]]) -> bool {
+        the_only_segment_is(path, simple)
+            || qualified.iter().any(|segments| path_is(path, segments))
+    }
+
     fn get_angle_bracketed_type_args(seg: &syn::PathSegment) -> Result<Vec<&syn::Type>> {
         match &seg.arguments {
             syn::PathArguments::AngleBracketed(ab) => Ok(ab
@@ -497,24 +512,39 @@ pub fn gen_idl_type(
             Ok((quote! { #idl::IdlType::I128 }, vec![]))
         }
         syn::Type::Path(path)
-            if the_only_segment_is(path, "String") || the_only_segment_is(path, "str") =>
+            if path_is_builtin(path, "String", &[&["std", "string", "String"]])
+                || the_only_segment_is(path, "str") =>
         {
             Ok((quote! { #idl::IdlType::String }, vec![]))
         }
-        syn::Type::Path(path) if the_only_segment_is(path, "Pubkey") => {
+        syn::Type::Path(path)
+            if path_is_builtin(path, "Pubkey", &[&["anchor_lang", "prelude", "Pubkey"]]) =>
+        {
             Ok((quote! { #idl::IdlType::Pubkey }, vec![]))
         }
-        syn::Type::Path(path) if the_only_segment_is(path, "Option") => {
-            let segment = get_first_segment(path)?;
+        syn::Type::Path(path)
+            if path_is_builtin(
+                path,
+                "Option",
+                &[&["core", "option", "Option"], &["std", "option", "Option"]],
+            ) =>
+        {
+            let segment = get_last_segment(path)?;
             let arg = get_first_type_arg(segment)?;
             let (inner, defined) = gen_idl_type(arg, generic_params)?;
             Ok((quote! { #idl::IdlType::Option(Box::new(#inner)) }, defined))
         }
-        syn::Type::Path(path) if the_only_segment_is(path, "Vec") => {
-            let segment = get_first_segment(path)?;
+        syn::Type::Path(path)
+            if path_is_builtin(
+                path,
+                "Vec",
+                &[&["std", "vec", "Vec"], &["alloc", "vec", "Vec"]],
+            ) =>
+        {
+            let segment = get_last_segment(path)?;
             let arg = get_first_type_arg(segment)?;
             match arg {
-                syn::Type::Path(path) if the_only_segment_is(path, "u8") => {
+                syn::Type::Path(path) if path_is_builtin(path, "u8", &[]) => {
                     return Ok((quote! {#idl::IdlType::Bytes}, vec![]));
                 }
                 _ => (),
@@ -522,8 +552,14 @@ pub fn gen_idl_type(
             let (inner, defined) = gen_idl_type(arg, generic_params)?;
             Ok((quote! { #idl::IdlType::Vec(Box::new(#inner)) }, defined))
         }
-        syn::Type::Path(path) if the_only_segment_is(path, "Box") => {
-            let segment = get_first_segment(path)?;
+        syn::Type::Path(path)
+            if path_is_builtin(
+                path,
+                "Box",
+                &[&["std", "boxed", "Box"], &["alloc", "boxed", "Box"]],
+            ) =>
+        {
+            let segment = get_last_segment(path)?;
             let arg = get_first_type_arg(segment)?;
             gen_idl_type(arg, generic_params)
         }
@@ -794,5 +830,13 @@ fn get_first_segment(type_path: &syn::TypePath) -> Result<&syn::PathSegment> {
         .path
         .segments
         .first()
+        .ok_or_else(|| syn::Error::new_spanned(type_path, "Expected a non-empty type path"))
+}
+
+fn get_last_segment(type_path: &syn::TypePath) -> Result<&syn::PathSegment> {
+    type_path
+        .path
+        .segments
+        .last()
         .ok_or_else(|| syn::Error::new_spanned(type_path, "Expected a non-empty type path"))
 }

--- a/lang/syn/tests/idl_qualified_builtins.rs
+++ b/lang/syn/tests/idl_qualified_builtins.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "idl-build")]
+
+use {
+    anchor_syn::idl::impl_idl_build_struct,
+    syn::{parse_quote, ItemStruct},
+};
+
+#[test]
+fn qualified_builtin_paths_lower_to_builtin_idl_types() {
+    let item: ItemStruct = parse_quote! {
+        struct QualifiedBuiltins {
+            pubkeys: ::std::vec::Vec<anchor_lang::prelude::Pubkey>,
+            maybe: ::core::option::Option<u8>,
+            label: ::std::string::String,
+        }
+    };
+
+    let output = impl_idl_build_struct(&item).to_string();
+
+    for expected in [
+        "IdlType :: Vec (Box :: new (anchor_lang :: idl :: types :: IdlType :: Pubkey))",
+        "IdlType :: Option (Box :: new (anchor_lang :: idl :: types :: IdlType :: U8))",
+        "IdlType :: String",
+    ] {
+        assert!(
+            output.contains(expected),
+            "Output did not contain expected IDL type fragment: '{expected}'. Got: '{output}'",
+        );
+    }
+
+    for unexpected in [
+        "< :: std :: vec :: Vec < anchor_lang :: prelude :: Pubkey > > :: get_full_path",
+        "< :: core :: option :: Option < u8 > > :: get_full_path",
+        "< :: std :: string :: String > :: get_full_path",
+        "< anchor_lang :: prelude :: Pubkey > :: get_full_path",
+    ] {
+        assert!(
+            !output.contains(unexpected),
+            "Output incorrectly treated a qualified builtin as a defined type: '{unexpected}'. Got: '{output}'",
+        );
+    }
+}

--- a/lang/syn/tests/idl_qualified_builtins.rs
+++ b/lang/syn/tests/idl_qualified_builtins.rs
@@ -36,7 +36,8 @@ fn qualified_builtin_paths_lower_to_builtin_idl_types() {
     ] {
         assert!(
             !output.contains(unexpected),
-            "Output incorrectly treated a qualified builtin as a defined type: '{unexpected}'. Got: '{output}'",
+            "Output incorrectly treated a qualified builtin as a defined type: '{unexpected}'. \
+             Got: '{output}'",
         );
     }
 }

--- a/tests/declare-program/idls/constants_namespace.json
+++ b/tests/declare-program/idls/constants_namespace.json
@@ -1,0 +1,52 @@
+{
+  "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+  "metadata": {
+    "name": "constants_namespace",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Regression coverage for declare_program! constant namespace qualification"
+  },
+  "instructions": [],
+  "accounts": [],
+  "events": [],
+  "types": [
+    {
+      "name": "Mode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Ready"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mode",
+            "type": {
+              "defined": {
+                "name": "Mode"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "CONFIG",
+      "type": {
+        "defined": {
+          "name": "Config"
+        }
+      },
+      "value": "Config { mode: Mode::Ready }"
+    }
+  ]
+}

--- a/tests/declare-program/idls/pubkey_shadow.json
+++ b/tests/declare-program/idls/pubkey_shadow.json
@@ -1,0 +1,49 @@
+{
+  "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+  "metadata": {
+    "name": "pubkey_shadow",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Regression coverage for declare_program! builtin type shadowing"
+  },
+  "instructions": [
+    {
+      "name": "accept_holder",
+      "discriminator": [1, 2, 3, 4, 5, 6, 7, 8],
+      "accounts": [],
+      "args": [
+        {
+          "name": "holder",
+          "type": {
+            "defined": {
+              "name": "Holder"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [],
+  "events": [],
+  "types": [
+    {
+      "name": "Pubkey",
+      "type": {
+        "kind": "type",
+        "alias": "u8"
+      }
+    },
+    {
+      "name": "Holder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/declare-program/programs/declare-program/tests/constants_namespace.rs
+++ b/tests/declare-program/programs/declare-program/tests/constants_namespace.rs
@@ -1,0 +1,9 @@
+use anchor_lang::prelude::*;
+
+declare_program!(constants_namespace);
+use constants_namespace::{constants::CONFIG, types::Mode};
+
+#[test]
+fn defined_constant_values_resolve_through_defined_namespace() {
+    assert!(matches!(CONFIG.mode, Mode::Ready));
+}

--- a/tests/declare-program/programs/declare-program/tests/pubkey_shadow.rs
+++ b/tests/declare-program/programs/declare-program/tests/pubkey_shadow.rs
@@ -1,0 +1,13 @@
+use anchor_lang::prelude::*;
+
+declare_program!(pubkey_shadow);
+
+#[test]
+fn builtin_pubkey_types_are_not_shadowed_by_idl_names() {
+    let holder = pubkey_shadow::types::Holder {
+        key: anchor_lang::prelude::Pubkey::default(),
+    };
+    let _: anchor_lang::prelude::Pubkey = holder.key;
+
+    let _ = pubkey_shadow::client::args::AcceptHolder { holder };
+}


### PR DESCRIPTION
#4776 qualified constant types but not constant values, and still emitted shadowable builtin types bare. The patch qualifies defined-value paths and builtin/container types, with PoCs covering both regressions.