### PR TITLE
Fix/v1.2 bytemuck derive detection

### DIFF
--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -211,26 +211,15 @@ where
             continue;
         }
 
-        let _ = attr.parse_nested_meta(|meta| {
-            let has_bytemuck_segment = meta.path.segments.iter().any(|s| s.ident == "bytemuck");
-
-            if has_bytemuck_segment {
-                let has_unsafe_segment = meta
-                    .path
-                    .segments
-                    .iter()
-                    .any(|s| s.ident.to_string().to_ascii_lowercase().contains("unsafe"));
-
-                let is_pod = meta.path.segments.last().is_some_and(|s| s.ident == "Pod");
-
-                if has_unsafe_segment {
-                    saw_bytemuck_unsafe = true;
-                } else if is_pod {
-                    saw_bytemuck_pod = true;
-                }
+        attr.parse_nested_meta(|meta| {
+            if is_bytemuck_derive(&meta.path, "Unsafe") {
+                saw_bytemuck_unsafe = true;
+            } else if is_bytemuck_derive(&meta.path, "Pod") {
+                saw_bytemuck_pod = true;
             }
+
             Ok(())
-        });
+        })?;
     }
 
     let serialization = if saw_bytemuck_unsafe {
@@ -336,6 +325,16 @@ where
         },
         defined,
     ))
+}
+
+fn is_bytemuck_derive(path: &syn::Path, expected_leaf: &str) -> bool {
+    let mut segments = path.segments.iter();
+
+    matches!(
+        (segments.next(), segments.next(), segments.next()),
+        (Some(first), Some(second), None)
+            if first.ident == "bytemuck" && second.ident == expected_leaf
+    )
 }
 
 fn trim_attr_start(value: &str) -> &str {

--- a/lang/syn/tests/idl_attributes.rs
+++ b/lang/syn/tests/idl_attributes.rs
@@ -5,15 +5,27 @@ use {
     syn::{parse_quote, ItemStruct},
 };
 
-fn check_serialization(item: ItemStruct, expected: &str) {
+fn serialization_expr(item: ItemStruct) -> String {
     let stream = impl_idl_build_struct(&item);
     let output = stream.to_string();
-    assert!(
-        output.contains(expected),
-        "Output did not contain expected serialization: '{}'. Got: '{}'",
-        expected,
-        output
-    );
+
+    let needle = "IdlSerialization :: ";
+    let start = match output.find(needle) {
+        Some(start) => start,
+        None => unreachable!("Output did not contain serialization marker. Got: '{output}'"),
+    };
+    let rest = &output[start + needle.len()..];
+    let end = match rest.find(',') {
+        Some(end) => end,
+        None => unreachable!("Output did not terminate serialization expression. Got: '{output}'"),
+    };
+
+    rest[..end].trim().to_owned()
+}
+
+fn check_serialization(item: ItemStruct, expected: &str) {
+    let actual = serialization_expr(item);
+    assert_eq!(actual, expected, "Unexpected serialization expression");
 }
 
 #[test]
@@ -23,7 +35,7 @@ fn test_bytemuck_unsafe_qualified() {
             #[derive(bytemuck::Unsafe)]
             struct Foo {}
         },
-        "IdlSerialization :: BytemuckUnsafe",
+        "BytemuckUnsafe",
     );
 }
 
@@ -34,7 +46,7 @@ fn test_bytemuck_safe() {
             #[derive(bytemuck::Pod)]
             struct Foo {}
         },
-        "IdlSerialization :: Bytemuck",
+        "Bytemuck",
     );
 }
 
@@ -45,7 +57,7 @@ fn test_bytemuck_non_pod_ignored() {
             #[derive(bytemuck::AnyBitPattern)]
             struct Foo {}
         },
-        "IdlSerialization :: default",
+        "default ()",
     );
 }
 
@@ -56,7 +68,46 @@ fn test_false_positive_prevention() {
             #[derive(MyUnsafeMacro)]
             struct Foo {}
         },
-        "IdlSerialization :: default",
+        "default ()",
+    );
+}
+
+#[test]
+fn test_non_exact_bytemuck_unsafe_ignored() {
+    check_serialization(
+        parse_quote! {
+            #[derive(bytemuck::NotUnsafe)]
+            struct Foo {}
+        },
+        "default ()",
+    );
+}
+
+#[test]
+fn test_nested_bytemuck_path_ignored() {
+    check_serialization(
+        parse_quote! {
+            #[derive(foo::bytemuck::Pod)]
+            struct Foo {}
+        },
+        "default ()",
+    );
+}
+
+#[test]
+fn test_invalid_derive_meta_surfaces() {
+    let item = syn::parse_str::<ItemStruct>(
+        r#"
+        #[derive(bytemuck::Pod())]
+        struct Foo {}
+        "#,
+    )
+    .unwrap();
+    let output = impl_idl_build_struct(&item).to_string();
+
+    assert!(
+        output.contains("compile_error !"),
+        "Output did not contain compile_error for invalid derive metadata. Got: '{output}'",
     );
 }
 
@@ -67,6 +118,6 @@ fn test_bytemuck_safe_then_unsafe() {
             #[derive(bytemuck::Pod, bytemuck::Unsafe)]
             struct Foo {}
         },
-        "IdlSerialization :: BytemuckUnsafe",
+        "BytemuckUnsafe",
     );
 }


### PR DESCRIPTION
`bytemuck` derive detection still matched lookalikes and ignored parse errors. The patch requires exact `bytemuck::{Pod,Unsafe}` paths, propagates invalid derive metadata, and adds exact-serialization regression tests.