### PR TITLE
chore(ci): Use new dtolnay/rust-toolchain version scheme

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -46,9 +46,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
 
       - name: Install dependencies (Linux)

--- a/.github/workflows/nightly-attested-binaries.yaml
+++ b/.github/workflows/nightly-attested-binaries.yaml
@@ -50,9 +50,8 @@ jobs:
           ref: master
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
 
       - name: Install dependencies (Linux)

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -28,9 +28,7 @@ jobs:
       - name: Force fetch upstream tags
         run: git fetch --tags --force
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -35,9 +35,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install cargo-release
         run: cargo install cargo-release --version 1.1.1 --locked

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,11 +124,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          # FIXME: https://github.com/rust-lang/cargo/issues/17093
-          # Stable cargo has a publishing bug. Switch back to stable when the fix is out
-          toolchain: nightly
+      # FIXME: https://github.com/rust-lang/cargo/issues/17093
+      # Stable cargo has a publishing bug. Switch back to stable when the fix is out
+      - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
 
       - name: Install cargo-release
         run: cargo install cargo-release --version 1.1.1 --locked

--- a/.github/workflows/semver-checks.yaml
+++ b/.github/workflows/semver-checks.yaml
@@ -25,9 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache cargo registry and builds
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
This workflow was changed to use the release version as the target toolchain to install; fix zizmor by using the new scheme.