### PR TITLE
v2: Bump wincode to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -10334,19 +10333,6 @@ name = "wincode"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc91ddd8c932a38bbec58ed536d9e93ce9cd01b6af9b6de3c501132cf98ddec6"
-dependencies = [
- "pastey",
- "proc-macro2",
- "quote",
- "thiserror 2.0.18",
- "wincode-derive 0.4.5",
-]
-
-[[package]]
-name = "wincode"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
  "pastey",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -33,7 +32,6 @@ dependencies = [
  "bytemuck",
  "pinocchio",
  "pinocchio-system",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -46,7 +44,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -220,7 +217,6 @@ name = "alt-cpi"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -401,7 +397,7 @@ dependencies = [
  "quote",
  "serde_json",
  "sha2 0.10.9",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "syn 2.0.117",
 ]
 
@@ -443,8 +439,7 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "sha2 0.10.9",
- "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
+ "solana-address 2.7.0",
  "solana-instruction 3.4.0",
  "solana-msg 3.1.0",
  "solana-program-error 3.0.0",
@@ -531,7 +526,7 @@ dependencies = [
  "pinocchio",
  "pinocchio-token",
  "pinocchio-token-2022",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-instruction 3.4.0",
  "solana-program-error 3.0.0",
  "solana-program-pack 3.1.0",
@@ -1289,7 +1284,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1399,7 +1393,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1411,7 +1404,6 @@ dependencies = [
  "callee",
  "pinocchio",
  "pinocchio-system",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1628,7 +1620,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1778,7 +1769,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1792,7 +1782,6 @@ dependencies = [
  "pinocchio-system",
  "serde_json",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -1973,7 +1962,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2082,7 +2070,6 @@ name = "declare-program-cpi"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2090,7 +2077,6 @@ name = "declare-program-errors"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2098,7 +2084,6 @@ name = "declare-program-events"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2106,7 +2091,6 @@ name = "declare-program-optional"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2114,7 +2098,6 @@ name = "declare-program-returns"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2122,7 +2105,6 @@ name = "declare-program-serialization"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2130,7 +2112,6 @@ name = "declare-program-surface"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2138,7 +2119,6 @@ name = "declare-program-types"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2200,7 +2180,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2286,7 +2265,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2332,7 +2310,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2489,7 +2466,6 @@ name = "equivalence-metadata-spy"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2506,7 +2482,6 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2529,7 +2504,6 @@ dependencies = [
  "anchor-spl",
  "pinocchio",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2557,7 +2531,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2586,7 +2559,6 @@ name = "external-cpi"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2728,7 +2700,6 @@ name = "foreign-borsh-account"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2985,7 +2956,6 @@ name = "hash-cpi"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -3448,7 +3418,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -3546,7 +3515,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -3789,7 +3757,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "solana-account 3.4.0",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-address-lookup-table-interface 3.0.1",
  "solana-bpf-loader-program",
  "solana-builtins",
@@ -3928,7 +3896,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -4251,7 +4218,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -4259,7 +4225,6 @@ name = "optional-callee"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -4346,7 +4311,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -4392,8 +4356,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
+ "solana-address 2.7.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-view",
  "solana-program-error 3.0.0",
 ]
@@ -4405,7 +4369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47216785b5877051afa074920e88b5990c4ce74f0da94c7cb5a139684c48ffe"
 dependencies = [
  "pinocchio",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -4415,7 +4379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825f59c8348e5c2d3fd56432ef927f5819542b3b05fae4f5b6869801113e775e"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-program-error 3.0.0",
 ]
@@ -4427,7 +4391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57dbab5718ab6ae446b2217c47598fabd29173a09bd32b05344f031739db92b8"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-program-error 3.0.0",
 ]
@@ -4554,7 +4518,6 @@ name = "program-interface"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -5036,7 +4999,6 @@ name = "return-callee"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -5044,7 +5006,6 @@ name = "return-spoof"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -5390,7 +5351,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -5796,7 +5756,7 @@ checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
  "bincode",
  "serde_core",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-program-error 3.0.0",
  "solana-program-memory 3.1.0",
 ]
@@ -5807,7 +5767,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-program-error 3.0.0",
 ]
 
@@ -5817,14 +5777,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
+checksum = "01332a01c0a3098404d55a724c8d9a92aed4a50fe40a7dd0c7a51e29274c14de"
 dependencies = [
  "borsh 1.6.1",
  "bytemuck",
@@ -5836,11 +5796,11 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64 3.0.1",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error 3.0.0",
  "solana-sanitize 3.0.1",
  "solana-sha256-hasher 3.1.0",
- "wincode 0.5.4",
+ "wincode 0.6.1",
 ]
 
 [[package]]
@@ -5994,7 +5954,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -6404,9 +6364,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.0.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-derivation-path"
@@ -6489,7 +6449,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
 dependencies = [
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
  "solana-pubkey 4.1.0",
 ]
 
@@ -6691,7 +6651,7 @@ dependencies = [
  "borsh 1.6.1",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
  "solana-pubkey 4.1.0",
 ]
@@ -6715,8 +6675,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
+ "solana-address 2.7.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error 3.0.0",
 ]
 
@@ -6802,7 +6762,7 @@ dependencies = [
  "five8 1.0.0",
  "five8_core 1.0.0",
  "rand 0.9.2",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -7014,7 +6974,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -7521,7 +7481,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b06bd918d60111ee1f97de817113e2040ca0cedb740099ee8d646233f6b906c"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -7816,7 +7776,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -7861,7 +7821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
 dependencies = [
  "k256",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -8268,7 +8228,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-instruction 3.4.0",
  "solana-msg 3.1.0",
  "solana-program-error 3.0.0",
@@ -8387,7 +8347,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-sdk-ids 3.1.0",
 ]
 
@@ -8453,7 +8413,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-hash 4.2.0",
  "solana-instruction 3.4.0",
  "solana-instruction-error",
@@ -8771,7 +8731,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -8813,7 +8772,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -8901,7 +8859,6 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9317,7 +9274,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "solana-account 3.4.0",
- "solana-address 2.6.0",
+ "solana-address 2.7.0",
  "solana-keypair",
  "solana-loader-v3-interface 6.1.0",
  "solana-message 3.0.1",
@@ -9476,7 +9433,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9486,7 +9442,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9496,7 +9451,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9506,7 +9460,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9516,7 +9469,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9526,7 +9478,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9536,7 +9487,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9546,7 +9496,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9556,7 +9505,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9566,7 +9514,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9576,7 +9523,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9586,7 +9532,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9596,7 +9541,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9606,7 +9550,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9616,7 +9559,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9626,7 +9568,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "solana-program-error 3.0.0",
- "wincode 0.5.4",
 ]
 
 [[package]]
@@ -9635,7 +9576,6 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "wincode 0.5.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
  "solana-sha256-hasher 3.1.0",
  "solana-system-interface 2.0.0",
  "solana-sysvar 3.1.1",
- "wincode 0.5.4",
+ "wincode 0.6.1",
 ]
 
 [[package]]
@@ -4308,9 +4308,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -10399,7 +10399,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "thiserror 2.0.18",
- "wincode-derive",
+ "wincode-derive 0.4.5",
 ]
 
 [[package]]
@@ -10412,7 +10412,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "thiserror 2.0.18",
- "wincode-derive",
+ "wincode-derive 0.4.5",
+]
+
+[[package]]
+name = "wincode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive 0.5.1",
 ]
 
 [[package]]
@@ -10422,6 +10435,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262d55d1261f31e2cfe49cc6385a421d14d99faa0526bbe3cc1bda0d3005c62"
 dependencies = [
  "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d582d9fc9d813264407a9e16bfa16846ccf15ef032f9bbcd700741bdc00255"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/bench/programs/helloworld/anchor-v2/Cargo.toml
+++ b/bench/programs/helloworld/anchor-v2/Cargo.toml
@@ -28,7 +28,6 @@ borsh = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 anchor-v2-testing = { path = "../../../../v2-testing" }

--- a/bench/programs/multisig/anchor-v2/Cargo.toml
+++ b/bench/programs/multisig/anchor-v2/Cargo.toml
@@ -26,7 +26,6 @@ anchor-lang = { path = "../../../../lang-v2", default-features = false, features
 borsh = { version = "1", optional = true }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 anchor-v2-testing = { path = "../../../../v2-testing" }

--- a/bench/programs/nested/anchor-v2/Cargo.toml
+++ b/bench/programs/nested/anchor-v2/Cargo.toml
@@ -23,7 +23,6 @@ anchor-lang = { path = "../../../../lang-v2", default-features = false, features
 borsh = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 anchor-v2-testing = { path = "../../../../v2-testing" }

--- a/bench/programs/prop-amm/anchor-v2/Cargo.toml
+++ b/bench/programs/prop-amm/anchor-v2/Cargo.toml
@@ -31,7 +31,6 @@ anchor-asm-v2-runtime = { path = "../../../../asm-v2/runtime" }
 borsh = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [build-dependencies]
 anchor-asm-v2 = { path = "../../../../asm-v2" }

--- a/bench/programs/vault/anchor-v2/Cargo.toml
+++ b/bench/programs/vault/anchor-v2/Cargo.toml
@@ -26,7 +26,6 @@ borsh = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 anchor-v2-testing = { path = "../../../../v2-testing" }

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -311,7 +311,6 @@ idl-build = []
 # Once anchor-lang is published to crates.io, swap to: anchor-lang = "{3}"
 anchor-lang = {{ git = "https://github.com/otter-sec/anchor.git", branch = "anchor-next" }}
 solana-program-log = {{ version = "1.1", features = ["macro"] }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 {4}
 
 [lints.rust]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -38,7 +38,6 @@ solana-transaction.workspace = true
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 url = "2"
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 solana-keypair.workspace = true

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -739,23 +739,18 @@ fn parse_logs_response<
 
 #[cfg(test)]
 mod tests {
-    // Mock event: minimal manual impl avoiding the `#[event]` macro, which
-    // depends on the `wincode` derive (anchor-lang transitively pulls it
-    // in but the re-exported derive's generated code references the bare
-    // `wincode` path, not visible from this crate). The test only needs
-    // `Event + SchemaRead + Discriminator` for type inference inside
-    // `parse_logs_response::<MockEvent>`.
-    // The wincode derive macros emit `::wincode::…` paths, so `wincode` must
-    // be present in this crate's extern-prelude (added as a direct dep).
+    // Mock event: minimal manual implementation avoiding `#[event]`. Anchor's
+    // derives use Anchor's Wincode re-export, so this crate needs no direct
+    // Wincode dependency. The test only needs `Event + SchemaRead +
+    // Discriminator` for type inference inside `parse_logs_response::<MockEvent>`.
     use {
-        anchor_lang::{Discriminator, Event},
+        anchor_lang::{AnchorDeserialize, AnchorSerialize, Discriminator, Event},
         futures::{SinkExt, StreamExt},
         solana_rpc_client_api::response::RpcResponseContext,
         std::sync::atomic::{AtomicU64, Ordering},
         tokio_tungstenite::tungstenite::Message,
-        wincode::{SchemaRead, SchemaWrite},
     };
-    #[derive(Debug, Clone, Copy, SchemaWrite, SchemaRead)]
+    #[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize)]
     pub struct MockEvent {}
     impl Discriminator for MockEvent {
         const DISCRIMINATOR: &'static [u8] = &[0; 8];

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -54,7 +54,7 @@ solana-sha256-hasher = { version = "3.1", features = ["sha2"] }
 solana-system-interface = { version = "2.0", features = ["bincode"] }
 solana-sysvar = "3.1.1"
 bytemuck = { version = "1", features = ["derive"] }
-wincode = { version = "0.5", features = ["derive"] }
+wincode = { version = "0.6", features = ["derive"] }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = "5.0"

--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -44,7 +44,7 @@ anchor-derive-accounts = { workspace = true }
 # "account-resize" lets AccountView::resize enforce MAX_PERMITTED_DATA_INCREASE.
 pinocchio = { workspace = true, features = ["copy", "account-resize"] }
 pinocchio-system = "0.6"
-solana-address = { version = "2.0", features = ["bytemuck", "syscalls", "curve25519", "wincode"] }
+solana-address = { version = "2.7.0", features = ["bytemuck", "syscalls", "curve25519", "wincode"] }
 solana-instruction = { version = "3", default-features = false }
 solana-program-error = "3.0"
 solana-msg = { version = "3.1", default-features = false, features = ["alloc"] }
@@ -55,9 +55,6 @@ solana-system-interface = { version = "2.0", features = ["bincode"] }
 solana-sysvar = "3.1.1"
 bytemuck = { version = "1", features = ["derive"] }
 wincode = { version = "0.6", features = ["derive"] }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = "5.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 sha2 = "0.10"

--- a/lang-v2/README.md
+++ b/lang-v2/README.md
@@ -81,7 +81,7 @@ Here are some examples of optimizations present in Anchor v2.
 
 - **PDA bumps precomputed at macro time.** If your seeds are all literals, the derive runs the PDA search during compilation and bakes the canonical bump in as a `const`. This lets us skip the runtime PDA search entirely.
 - **Skip the on-curve check for program-owned PDAs.** If the program already owns the account, it had to be created via signed CPI — which did the curve check at the time. Verification can just hash-and-compare. Saves ~1,000 CU per verify.
-- **Wincode events by default.** Much cheaper than borsh on SBF, and still handles `Vec` / `String` / `Option` / enums. 3–10× cheaper than borsh.
+- **Wincode events by default.** `#[event]` automatically derives Anchor's Wincode-backed serialization, so programs do not need a direct Wincode dependency. It still handles `Vec` / `String` / `Option` / enums and is 3–10× cheaper than borsh on SBF.
 - **`#[event(bytemuck)]` for fixed-size events.** The struct's `repr(C)` Pod layout already matches the wire format, so emitting is just disc + one memcpy of the body. No per-field encoding, with compile-time rejection of padded layouts.
 - **Alignment-1 Pod wrappers** (`PodU64`, `PodI128`, `PodBool`, ...). Integers stored as `[u8; N]` so the whole `#[account]` struct casts directly from the account's raw bytes. Zero deserialization.
 - **`PodVec<T, MAX>`**: fixed-capacity vec with a `u16` length, stored inline in the account. Variable-length data without heap allocation.

--- a/lang-v2/derive/Cargo.toml
+++ b/lang-v2/derive/Cargo.toml
@@ -21,5 +21,5 @@ sha2 = "0.10"
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
 bs58 = "0.5"
 serde_json = "1"
-solana-address = "2.0"
+solana-address = "2.7.0"
 anchor-lang-idl = { workspace = true, features = ["convert"] }

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -29,6 +29,40 @@ pub fn derive_accounts(input: TokenStream) -> TokenStream {
     TokenStream::from(impl_accounts(&input))
 }
 
+/// Derive a wincode schema writer through Anchor's public re-export.
+///
+/// The generated duplicate item is erased after wincode emits the impl so a
+/// downstream crate does not need a direct `wincode` dependency or its
+/// `#[wincode(crate = ...)]` escape hatch.
+#[proc_macro_derive(AnchorSerialize, attributes(wincode))]
+pub fn anchor_serialize(input: TokenStream) -> TokenStream {
+    derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaWrite))
+}
+
+/// Derive a wincode schema reader through Anchor's public re-export.
+#[proc_macro_derive(AnchorDeserialize, attributes(wincode))]
+pub fn anchor_deserialize(input: TokenStream) -> TokenStream {
+    derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaRead))
+}
+
+fn derive_wincode_schema(input: TokenStream, schema_derive: TokenStream2) -> TokenStream {
+    let input = TokenStream2::from(input);
+    quote! {
+        #[derive(#schema_derive)]
+        #[wincode(crate = "anchor_lang::wincode")]
+        #[anchor_lang::__erase]
+        #input
+    }
+    .into()
+}
+
+/// Removes the duplicate item emitted by the schema-derive wrappers.
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn __erase(_: TokenStream, _: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
 // ---------------------------------------------------------------------------
 // #[derive(ToCpiAccounts)]
 // ---------------------------------------------------------------------------
@@ -881,7 +915,7 @@ fn emit_args_deser(args: &[(&Ident, &Type)], struct_name: &str, inline_error: bo
             }
         };
         quote! {
-            #[derive(anchor_lang::wincode::SchemaRead)]
+            #[derive(anchor_lang::AnchorDeserialize)]
             struct #struct_ident #lt_decl { #(#names: #arg_types,)* }
             let __args: #struct_ident #lt_use = #error_handling;
             #(let #names = __args.#names;)*
@@ -2252,7 +2286,9 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let (struct_attrs, pod_impls) = if is_borsh {
         (
-            quote! { #[derive(anchor_lang::wincode::SchemaWrite, anchor_lang::wincode::SchemaRead)] },
+            quote! {
+                #[derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)]
+            },
             quote! {},
         )
     } else {
@@ -3394,7 +3430,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     DeclareTypeFields::Named { fields, .. } => quote! {
                         #(#docs)*
                         #repr
-                        #[derive(Clone, anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+                        #[derive(Clone, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
                         pub struct #ident #impl_generics {
                             #(#fields)*
                         }
@@ -3415,7 +3451,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     DeclareTypeFields::Tuple { fields, .. } => quote! {
                         #(#docs)*
                         #repr
-                        #[derive(Clone, anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+                        #[derive(Clone, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
                         pub struct #ident #impl_generics(#(#fields),*);
                         #discriminator_impl
                         #account_deserialize_impl
@@ -3434,7 +3470,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                     DeclareTypeFields::Unit => quote! {
                         #(#docs)*
                         #repr
-                        #[derive(Clone, anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+                        #[derive(Clone, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
                         pub struct #ident #impl_generics;
                         #discriminator_impl
                         #account_deserialize_impl
@@ -3498,7 +3534,7 @@ fn gen_declare_program_types(idl: &serde_json::Value) -> syn::Result<Vec<TokenSt
                 out.push(quote! {
                     #(#docs)*
                     #repr
-                    #[derive(Clone, anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+                    #[derive(Clone, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
                     pub enum #ident #impl_generics {
                         #(#variant_tokens)*
                     }
@@ -4958,7 +4994,7 @@ fn process_handler(
     };
     let instruction_struct = quote! {
         #(#handler_cfg_attrs)*
-        #[derive(anchor_lang::wincode::SchemaWrite)]
+        #[derive(anchor_lang::AnchorSerialize)]
         pub struct #ix_struct_name #ix_lt_decl {
             #(pub #extra_arg_names: #extra_arg_types,)*
         }
@@ -5821,7 +5857,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
             // No `repr(C)` — wincode is layout-agnostic (it walks the derived
             // schema, not the in-memory byte layout) so the compiler is free
             // to pick whichever Rust layout is best.
-            #[derive(anchor_lang::wincode::SchemaWrite)]
+            #[derive(anchor_lang::AnchorSerialize)]
             #(#attrs)*
             #vis struct #name #fields
 

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -29,17 +29,23 @@ pub fn derive_accounts(input: TokenStream) -> TokenStream {
     TokenStream::from(impl_accounts(&input))
 }
 
-/// Derive a wincode schema writer through Anchor's public re-export.
+/// Derive Anchor's Wincode-backed serialization implementation.
 ///
-/// The generated duplicate item is erased after wincode emits the impl so a
-/// downstream crate does not need a direct `wincode` dependency or its
-/// `#[wincode(crate = ...)]` escape hatch.
+/// Use `#[derive(AnchorSerialize)]` rather than deriving Wincode's
+/// `SchemaWrite` directly. The generated duplicate item is erased after
+/// Wincode emits the impl, so a downstream crate needs neither a direct
+/// `wincode` dependency nor the `#[wincode(crate = ...)]` escape hatch.
+/// Wincode attributes remain supported when required.
 #[proc_macro_derive(AnchorSerialize, attributes(wincode))]
 pub fn anchor_serialize(input: TokenStream) -> TokenStream {
     derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaWrite))
 }
 
-/// Derive a wincode schema reader through Anchor's public re-export.
+/// Derive Anchor's Wincode-backed deserialization implementation.
+///
+/// Use `#[derive(AnchorDeserialize)]` rather than deriving Wincode's
+/// `SchemaRead` directly. See [`AnchorSerialize`] for why no direct Wincode
+/// dependency is needed.
 #[proc_macro_derive(AnchorDeserialize, attributes(wincode))]
 pub fn anchor_deserialize(input: TokenStream) -> TokenStream {
     derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaRead))
@@ -2433,7 +2439,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// The same applies to custom structs passed as `#[program]` instruction
 /// arguments: the IDL build resolves every arg type through
 /// `IdlAccountType`, so a plain args struct (typically deriving
-/// `wincode::SchemaRead` / `wincode::SchemaWrite` for the wire format)
+/// `AnchorDeserialize` / `AnchorSerialize` for the wire format)
 /// additionally needs this derive or `anchor idl build` fails to compile.
 ///
 /// Unlike `#[account]`, this derive carries **none** of the account-kind
@@ -2467,7 +2473,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 ///
 /// // Custom instruction-argument struct.
-/// #[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+/// #[derive(Clone, Copy, AnchorDeserialize, AnchorSerialize, IdlType)]
 /// pub struct MyArgs {
 ///     pub amount: u64,
 ///     pub tag: [u8; 3],
@@ -3781,7 +3787,7 @@ fn gen_declare_program_events(idl: &serde_json::Value) -> syn::Result<TokenStrea
                             self,
                             anchor_lang::BORSH_CONFIG,
                         )
-                        .expect("declared event serialization cannot fail for derived SchemaWrite types");
+                        .expect("declared event serialization cannot fail for derived AnchorSerialize types");
                         data
                     }
                 }
@@ -5676,8 +5682,8 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
 ///
 /// Two modes:
 ///
-/// **Default (`#[event]`, wincode).** Derives `wincode::SchemaWrite` and
-/// serializes via `wincode::config::serialize_into` with `BORSH_CONFIG`, so
+/// **Default (`#[event]`, wincode).** Derives `AnchorSerialize` and
+/// serializes via Wincode with `BORSH_CONFIG`, so
 /// the on-chain wire format is byte-compatible with borsh while keeping
 /// wincode's faster encoding path. Supports arbitrary layouts, including
 /// `Vec`/`String`/`Option`/enums, and is materially cheaper than borsh on
@@ -5853,7 +5859,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     match mode {
         EventMode::Wincode => TokenStream::from(quote! {
-            // `#[derive(wincode::SchemaWrite)]` lays down the per-field encoder.
+            // `#[derive(AnchorSerialize)]` lays down the Wincode per-field encoder.
             // No `repr(C)` — wincode is layout-agnostic (it walks the derived
             // schema, not the in-memory byte layout) so the compiler is free
             // to pick whichever Rust layout is best.
@@ -5881,7 +5887,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
                         anchor_lang::BORSH_CONFIG,
                     )
                         .expect("`#[event]` wincode serialization cannot fail for \
-                                 derived SchemaWrite types");
+                                 derived AnchorSerialize types");
                     buf
                 }
             }

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -111,7 +111,8 @@ pub fn rent_exempt_lamports(space: usize) -> Result<u64, ProgramError> {
 #[cfg(target_os = "solana")]
 macro_rules! pda_find_loop {
     ($seeds:expr, $program_id:expr, |$h:ident, $b:ident| $on_found:expr) => {{
-        use solana_address::syscalls::{sol_curve_validate_point, sol_sha256};
+        use solana_address::syscalls::sol_curve_validate_point;
+        use solana_sha256_hasher::sol_sha256;
         const CURVE25519_EDWARDS: u64 = 0;
         const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
@@ -313,7 +314,7 @@ fn check_off_curve(addr: &Address) -> Result<(), ProgramError> {
 #[cfg(target_os = "solana")]
 #[inline(always)]
 fn hash_pda_seeds(seeds: &[&[u8]], program_id: &Address) -> Result<Address, ProgramError> {
-    use solana_address::syscalls::sol_sha256;
+    use solana_sha256_hasher::sol_sha256;
     const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
     validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;

--- a/lang-v2/src/cpi.rs
+++ b/lang-v2/src/cpi.rs
@@ -111,7 +111,7 @@ pub fn rent_exempt_lamports(space: usize) -> Result<u64, ProgramError> {
 #[cfg(target_os = "solana")]
 macro_rules! pda_find_loop {
     ($seeds:expr, $program_id:expr, |$h:ident, $b:ident| $on_found:expr) => {{
-        use solana_define_syscall::definitions::{sol_curve_validate_point, sol_sha256};
+        use solana_address::syscalls::{sol_curve_validate_point, sol_sha256};
         const CURVE25519_EDWARDS: u64 = 0;
         const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
@@ -293,7 +293,7 @@ pub fn find_and_verify_program_address_skip_curve(
 #[cfg(target_os = "solana")]
 #[inline(always)]
 fn check_off_curve(addr: &Address) -> Result<(), ProgramError> {
-    use solana_define_syscall::definitions::sol_curve_validate_point;
+    use solana_address::syscalls::sol_curve_validate_point;
     const CURVE25519_EDWARDS: u64 = 0;
     let on_curve = unsafe {
         sol_curve_validate_point(
@@ -313,7 +313,7 @@ fn check_off_curve(addr: &Address) -> Result<(), ProgramError> {
 #[cfg(target_os = "solana")]
 #[inline(always)]
 fn hash_pda_seeds(seeds: &[&[u8]], program_id: &Address) -> Result<Address, ProgramError> {
-    use solana_define_syscall::definitions::sol_sha256;
+    use solana_address::syscalls::sol_sha256;
     const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
     validate_pda_seeds(seeds, MAX_PDA_SEEDS_TOTAL)?;

--- a/lang-v2/src/hash.rs
+++ b/lang-v2/src/hash.rs
@@ -5,7 +5,7 @@
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     #[cfg(target_os = "solana")]
     {
-        use solana_address::syscalls::sol_sha256;
+        use solana_sha256_hasher::sol_sha256;
         let slices: [&[u8]; 1] = [data];
         let mut out = core::mem::MaybeUninit::<[u8; 32]>::uninit();
         // SAFETY: slices is a valid single-element array; sol_sha256 writes

--- a/lang-v2/src/hash.rs
+++ b/lang-v2/src/hash.rs
@@ -5,7 +5,7 @@
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     #[cfg(target_os = "solana")]
     {
-        use solana_define_syscall::definitions::sol_sha256;
+        use solana_address::syscalls::sol_sha256;
         let slices: [&[u8]; 1] = [data];
         let mut out = core::mem::MaybeUninit::<[u8; 32]>::uninit();
         // SAFETY: slices is a valid single-element array; sol_sha256 writes

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -170,7 +170,7 @@ pub use {
     accounts::{AccountInitialize, SlabInit},
     anchor_derive_accounts::{
         access_control, account, constant, declare_program, emit, error_code, event, pod_wrapper,
-        program, Accounts, InitSpace, ToCpiAccounts,
+        program, Accounts, AnchorDeserialize, AnchorSerialize, InitSpace, ToCpiAccounts, __erase,
     },
     bytemuck,
     context::{Bumps, Context, MutMask},

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -122,7 +122,9 @@ pub const MAX_PAYER_SEEDS: usize = 16;
 pub const MAX_PAYER_SEEDS_WITH_BUMP: usize = MAX_PAYER_SEEDS + 1;
 
 /// Concrete type of [`BORSH_CONFIG`]. Spelled out so downstream callers can
-/// name it in trait bounds (e.g. `T: wincode::SchemaRead<'de, BorshConfig>`).
+/// name it in manual trait bounds (e.g.
+/// `T: anchor_lang::wincode::SchemaRead<'de, BorshConfig>`). Most programs
+/// should derive [`AnchorDeserialize`] and [`AnchorSerialize`] instead.
 pub type BorshConfig = wincode::config::Configuration<
     true,
     { wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT },

--- a/lang-v2/src/prelude.rs
+++ b/lang-v2/src/prelude.rs
@@ -58,6 +58,8 @@ pub use crate::{
     // Derive macros
     Accounts,
     AnchorAccount,
+    AnchorDeserialize,
+    AnchorSerialize,
     Bumps,
     // Context
     Context,

--- a/lang-v2/tests/account_wrapper_checks.rs
+++ b/lang-v2/tests/account_wrapper_checks.rs
@@ -21,8 +21,8 @@ use {
         },
         programs::{System, Token},
         testing::AccountBuffer,
-        wincode::{SchemaRead, SchemaWrite},
-        Accounts, AnchorAccount, Discriminator, ErrorCode, Ids, Owner, TryAccounts,
+        Accounts, AnchorAccount, AnchorDeserialize, AnchorSerialize, Discriminator, ErrorCode,
+        Ids, Owner, TryAccounts,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::address::Address,
@@ -41,7 +41,7 @@ impl Ids for TestInterface {
     }
 }
 
-#[derive(SchemaRead, SchemaWrite, Default)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default)]
 struct Counter {
     value: u64,
 }

--- a/lang-v2/tests/borsh_exit_semantics.rs
+++ b/lang-v2/tests/borsh_exit_semantics.rs
@@ -20,8 +20,7 @@ use {
     anchor_lang::{
         prelude::BorshAccount,
         testing::AccountBuffer,
-        wincode::{SchemaRead, SchemaWrite},
-        AnchorAccount, Discriminator, Owner,
+        AnchorAccount, AnchorDeserialize, AnchorSerialize, Discriminator, Owner,
     },
     pinocchio::{account::RuntimeAccount, address::Address},
     solana_program_error::ProgramError,
@@ -30,7 +29,7 @@ use {
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 const FOREIGN_PROGRAM_ID: [u8; 32] = [0x24; 32];
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone, PartialEq, Debug)]
 struct Counter {
     value: u64,
 }
@@ -44,7 +43,7 @@ impl Discriminator for Counter {
     const DISCRIMINATOR: &'static [u8] = &[0xff, 0xb0, 0x04, 0xf5, 0xbc, 0xfd, 0x7c, 0x19];
 }
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone, PartialEq, Debug)]
 struct ForeignCounter {
     value: u64,
 }
@@ -57,7 +56,7 @@ impl Discriminator for ForeignCounter {
     const DISCRIMINATOR: &'static [u8] = &[0x23, 0xaa, 0x41, 0x17, 0x83, 0x62, 0xdd, 0x09];
 }
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone, PartialEq, Debug)]
 struct ShrinkableBytes {
     items: Vec<u8>,
 }

--- a/lang-v2/tests/close_semantics.rs
+++ b/lang-v2/tests/close_semantics.rs
@@ -50,8 +50,8 @@ use {
         accounts::Slab,
         prelude::BorshAccount,
         testing::AccountBuffer,
-        wincode::{SchemaRead, SchemaWrite},
-        AccountClose, AccountRealloc, AnchorAccount, Discriminator, Owner,
+        AccountClose, AccountRealloc, AnchorAccount, AnchorDeserialize, AnchorSerialize,
+        Discriminator, Owner,
     },
     bytemuck::{Pod, Zeroable},
     pinocchio::{account::RuntimeAccount, address::Address},
@@ -59,7 +59,7 @@ use {
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone)]
 struct Vault {
     authority: [u8; 32],
     balance: u64,

--- a/lang-v2/tests/lamports.rs
+++ b/lang-v2/tests/lamports.rs
@@ -6,8 +6,7 @@ use {
     anchor_lang::{
         prelude::{BorshAccount, Lamports},
         testing::AccountBuffer,
-        wincode::{SchemaRead, SchemaWrite},
-        AnchorAccount, Discriminator, Owner,
+        AnchorAccount, AnchorDeserialize, AnchorSerialize, Discriminator, Owner,
     },
     pinocchio::address::Address,
     solana_program_error::ProgramError,
@@ -15,7 +14,7 @@ use {
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone)]
 struct Counter {
     value: u64,
 }

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -21,7 +21,6 @@ publish = false
 
 [dependencies]
 anchor-lang = {{ path = "{}" }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 
 [features]
 idl-build = []
@@ -219,9 +218,9 @@ fn init_space_rejects_wincode_field_overrides() {
     compile_fail_case(
         "init_space_wincode_skip",
         r#"
-use anchor_lang::InitSpace;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize, InitSpace};
 
-#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(InitSpace, AnchorDeserialize, AnchorSerialize)]
 pub struct Bad {
     #[wincode(skip)]
     pub skipped: u64,
@@ -237,9 +236,9 @@ pub struct Bad {
     compile_fail_case(
         "init_space_wincode_skip_default_val",
         r#"
-use anchor_lang::InitSpace;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize, InitSpace};
 
-#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(InitSpace, AnchorDeserialize, AnchorSerialize)]
 pub struct Bad {
     #[wincode(skip(default_val = 9))]
     pub skipped: u64,
@@ -255,9 +254,9 @@ pub struct Bad {
     compile_fail_case(
         "init_space_wincode_with",
         r#"
-use anchor_lang::InitSpace;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize, InitSpace};
 
-#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(InitSpace, AnchorDeserialize, AnchorSerialize)]
 pub struct Bad {
     #[wincode(with = "shim::ByteCodec")]
     pub packed: u64,
@@ -276,9 +275,9 @@ mod shim {
     compile_fail_case(
         "init_space_wincode_tag_encoding",
         r#"
-use anchor_lang::InitSpace;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize, InitSpace};
 
-#[derive(InitSpace, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(InitSpace, AnchorDeserialize, AnchorSerialize)]
 #[wincode(tag_encoding = "u32")]
 pub enum Bad {
     A([u8; 32]),
@@ -301,9 +300,9 @@ fn idl_generation_rejects_wincode_field_overrides() {
     compile_fail_case(
         "idl_type_wincode_skip",
         r#"
-use anchor_lang::IdlType;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize, IdlType};
 
-#[derive(IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(IdlType, AnchorDeserialize, AnchorSerialize)]
 pub struct Bad {
     #[wincode(skip)]
     pub skipped: u64,
@@ -746,7 +745,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
-#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+#[derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct SeedBuf(Vec<u8>);
 
 impl SeedBuf {
@@ -755,7 +754,7 @@ impl SeedBuf {
     }
 }
 
-#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+#[derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct SeedConfig {
     pub seed: SeedBuf,
 }
@@ -791,7 +790,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
-#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+#[derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct Data {
     pub value: u64,
 }

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -9,9 +9,8 @@ use {
             program,
         },
         testing::{AccountBuffer, MIN_ACCOUNT_BUF},
-        wincode::{SchemaRead, SchemaWrite},
-        Address, AnchorAccount, CpiContext, CpiHandle, CpiHandleMut, Discriminator, Owner,
-        ToCpiAccounts, ToCpiHandle, ToCpiHandleMut,
+        Address, AnchorAccount, AnchorDeserialize, AnchorSerialize, CpiContext, CpiHandle,
+        CpiHandleMut, Discriminator, Owner, ToCpiAccounts, ToCpiHandle, ToCpiHandleMut,
     },
     bytemuck::{Pod, Zeroable},
     solana_program_error::ProgramError,
@@ -57,7 +56,7 @@ impl Discriminator for PodCounter {
     const DISCRIMINATOR: &'static [u8] = &[0x4c, 0xde, 0x7f, 0x28, 0x61, 0x2f, 0x07, 0x73];
 }
 
-#[derive(SchemaRead, SchemaWrite, Default, Clone, PartialEq, Debug)]
+#[derive(AnchorDeserialize, AnchorSerialize, Default, Clone, PartialEq, Debug)]
 struct BorshCounter {
     value: u64,
 }

--- a/lang-v2/tests/serialized_account_custom_codec.rs
+++ b/lang-v2/tests/serialized_account_custom_codec.rs
@@ -5,8 +5,8 @@
 //!
 //! 1. A hand-rolled fixed-size little-endian codec (`LeCodec`) — represents
 //!    a user with no schema library at all, just raw bytes.
-//! 2. A wincode-derive codec (`WincodeCodec`) — represents a user pulling in
-//!    a third-party schema library.
+//! 2. A Wincode-backed codec (`WincodeCodec`) — uses Anchor's derives and
+//!    public Wincode re-export without a direct Wincode dependency.
 //!
 //! Each codec is exercised through the same lifecycle as `BorshAccount<T>`:
 //! `load`, `load_mut` + mutate + `exit`, `release_borrow` + `reacquire_borrow_mut`,
@@ -20,11 +20,10 @@ use {
     anchor_lang::{
         accounts::{AnchorAccountSerialize, SerializedAccount},
         testing::AccountBuffer,
-        AnchorAccount, Discriminator, Owner,
+        wincode, AnchorAccount, AnchorDeserialize, AnchorSerialize, Discriminator, Owner,
     },
     pinocchio::{account::RuntimeAccount, address::Address},
     solana_program_error::ProgramError,
-    wincode::{SchemaRead, SchemaWrite},
 };
 
 const PROGRAM_ID: [u8; 32] = [0x42; 32];
@@ -304,14 +303,14 @@ fn le_codec_exit_on_transient_zero_lamport_account_serializes() {
 }
 
 // =========================================================================
-// Codec 2: wincode (third-party schema library).
+// Codec 2: Wincode through Anchor's public re-export.
 // =========================================================================
 //
 // Demonstrates that `AnchorAccountSerialize<T>` can be implemented by
 // delegating to an external schema framework. We use the same
 // borsh-compatible wire config that v2 uses for events / instruction args.
 
-#[derive(Default, Clone, PartialEq, Debug, SchemaRead, SchemaWrite)]
+#[derive(Default, Clone, PartialEq, Debug, AnchorDeserialize, AnchorSerialize)]
 struct Ledger {
     balance: u64,
     nonce: u32,
@@ -328,8 +327,8 @@ impl Discriminator for Ledger {
 }
 
 /// Wincode-backed codec. Bounds restrict `T` to schemas that round-trip
-/// through themselves (`Src = T`, `Dst = T`), matching the contract
-/// `wincode::serialize` / `wincode::deserialize` expose at the crate root.
+/// through themselves (`Src = T`, `Dst = T`), matching the contract exposed
+/// by Anchor's `wincode::serialize` / `wincode::deserialize` re-export.
 struct WincodeCodec;
 
 impl<T> AnchorAccountSerialize<T> for WincodeCodec
@@ -627,4 +626,3 @@ fn sixteen_byte_discriminator_rejects_classic_eight_byte_prefix() {
     let err = WideAccount::load(view).err();
     assert_eq!(err, Some(ProgramError::AccountDataTooSmall));
 }
-

--- a/lang-v2/tests/update_hook_order.rs
+++ b/lang-v2/tests/update_hook_order.rs
@@ -4,9 +4,8 @@ use {
     anchor_lang::{
         accounts::{BorshAccount, Signer, UncheckedAccount},
         testing::AccountBuffer,
-        wincode::{SchemaRead, SchemaWrite},
-        AccountConstraint, Accounts, AnchorAccount, Discriminator, ErrorCode, Nested, Owner,
-        TryAccounts,
+        AccountConstraint, Accounts, AnchorAccount, AnchorDeserialize, AnchorSerialize,
+        Discriminator, ErrorCode, Nested, Owner, TryAccounts,
     },
     core::{mem::size_of, ptr},
     pinocchio::address::Address,
@@ -20,7 +19,7 @@ const PROGRAM_ID: [u8; 32] = [0x42; 32];
 const OLD_AUTHORITY: [u8; 32] = [0x10; 32];
 const NEW_AUTHORITY: [u8; 32] = [0x20; 32];
 
-#[derive(SchemaRead, SchemaWrite, Clone, Copy)]
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy)]
 struct Vault {
     current_authority: Address,
 }
@@ -33,7 +32,7 @@ impl Discriminator for Vault {
     const DISCRIMINATOR: &'static [u8] = &[0x41, 0x75, 0x74, 0x68, 0x56, 0x61, 0x75, 0x6c];
 }
 
-#[derive(SchemaRead, SchemaWrite, Clone, Copy)]
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy)]
 struct StepCounter {
     value: u64,
 }

--- a/spl-v2/Cargo.toml
+++ b/spl-v2/Cargo.toml
@@ -22,7 +22,7 @@ pinocchio-token = "0.6"
 pinocchio-token-2022 = "0.3"
 bytemuck = { version = "1", features = ["derive"] }
 borsh = "1.6.1"
-solana-address = { version = "2.0", features = ["bytemuck"] }
+solana-address = { version = "2.7.0", features = ["bytemuck"] }
 solana-instruction = "3.0"
 solana-program-error = "3.0"
 solana-pubkey = "3.0"

--- a/tests-v2/Cargo.toml
+++ b/tests-v2/Cargo.toml
@@ -75,7 +75,7 @@ anchor-spl = { path = "../spl-v2" }
 anchor-lang-idl-spec = { path = "../idl/spec", version = "0.1.0" }
 bytemuck = { version = "1", features = ["derive"] }
 proptest = "1"
-solana-address = "2.0"
+solana-address = "2.7.0"
 solana-loader-v3-interface.workspace = true
 solana-program-option = "3.1"
 solana-program-pack = "3.1"

--- a/tests-v2/programs/account-address-constraints/Cargo.toml
+++ b/tests-v2/programs/account-address-constraints/Cargo.toml
@@ -23,7 +23,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/account-meta-signer-overrides/Cargo.toml
+++ b/tests-v2/programs/account-meta-signer-overrides/Cargo.toml
@@ -20,7 +20,6 @@ anchor-lang = { path = "../../../lang-v2", default-features = false, features = 
 bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/accounts/Cargo.toml
+++ b/tests-v2/programs/accounts/Cargo.toml
@@ -23,7 +23,6 @@ foreign-borsh-account = { path = "../foreign-borsh-account" }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/accounts/src/lib.rs
+++ b/tests-v2/programs/accounts/src/lib.rs
@@ -48,7 +48,7 @@ pub struct LedgerEntry {
 /// Plain instruction-argument struct — not an account, not an event. The
 /// `IdlType` derive is what lets the idl-build arg-type walk resolve it
 /// (`IdlAccountType`); without it `--features idl-build` fails to compile.
-#[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(Clone, Copy, IdlType, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct BumpArgs {
     pub amount: u64,
     pub tag: [u8; 4],

--- a/tests-v2/programs/borsh-realloc/Cargo.toml
+++ b/tests-v2/programs/borsh-realloc/Cargo.toml
@@ -19,7 +19,6 @@ anchor-lang = { path = "../../../lang-v2", default-features = false, features = 
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/callee/Cargo.toml
+++ b/tests-v2/programs/callee/Cargo.toml
@@ -20,7 +20,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/caller/Cargo.toml
+++ b/tests-v2/programs/caller/Cargo.toml
@@ -20,7 +20,6 @@ bytemuck = { version = "1", features = ["derive"] }
 callee = { path = "../callee", features = ["cpi"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/client-builders/Cargo.toml
+++ b/tests-v2/programs/client-builders/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/constraint-values/Cargo.toml
+++ b/tests-v2/programs/constraint-values/Cargo.toml
@@ -23,7 +23,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/constraints/Cargo.toml
+++ b/tests-v2/programs/constraints/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]
 anchor-lang-idl-spec = { path = "../../../idl/spec", version = "0.1.0" }

--- a/tests-v2/programs/custom-constraints/Cargo.toml
+++ b/tests-v2/programs/custom-constraints/Cargo.toml
@@ -19,7 +19,6 @@ anchor-lang = { path = "../../../lang-v2", default-features = false, features = 
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/cpi/Cargo.toml
+++ b/tests-v2/programs/declare-program/cpi/Cargo.toml
@@ -16,7 +16,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/cpi/programs/alt-cpi/Cargo.toml
+++ b/tests-v2/programs/declare-program/cpi/programs/alt-cpi/Cargo.toml
@@ -17,7 +17,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/cpi/programs/external-cpi/Cargo.toml
+++ b/tests-v2/programs/declare-program/cpi/programs/external-cpi/Cargo.toml
@@ -17,7 +17,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/cpi/programs/external-cpi/src/lib.rs
+++ b/tests-v2/programs/declare-program/cpi/programs/external-cpi/src/lib.rs
@@ -16,7 +16,7 @@ pub struct Store {
     pub last_tag: [u8; 3],
 }
 
-#[derive(Clone, Copy, IdlType, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(Clone, Copy, IdlType, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct MyArgs {
     pub amount: u64,
     pub tag: [u8; 3],

--- a/tests-v2/programs/declare-program/cpi/programs/hash-cpi/Cargo.toml
+++ b/tests-v2/programs/declare-program/cpi/programs/hash-cpi/Cargo.toml
@@ -17,7 +17,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/errors/Cargo.toml
+++ b/tests-v2/programs/declare-program/errors/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/events/Cargo.toml
+++ b/tests-v2/programs/declare-program/events/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/optional/Cargo.toml
+++ b/tests-v2/programs/declare-program/optional/Cargo.toml
@@ -16,7 +16,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/optional/programs/optional-callee/Cargo.toml
+++ b/tests-v2/programs/declare-program/optional/programs/optional-callee/Cargo.toml
@@ -16,7 +16,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/returns/Cargo.toml
+++ b/tests-v2/programs/declare-program/returns/Cargo.toml
@@ -16,7 +16,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/returns/programs/return-callee/Cargo.toml
+++ b/tests-v2/programs/declare-program/returns/programs/return-callee/Cargo.toml
@@ -17,7 +17,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/returns/programs/return-callee/src/lib.rs
+++ b/tests-v2/programs/declare-program/returns/programs/return-callee/src/lib.rs
@@ -17,7 +17,7 @@ pub struct ReturnStore {
     pub _padding: [u8; 5],
 }
 
-#[derive(Clone, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(Clone, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct ReturnPayload {
     pub amount: u64,
     pub label: String,

--- a/tests-v2/programs/declare-program/returns/programs/return-spoof/Cargo.toml
+++ b/tests-v2/programs/declare-program/returns/programs/return-spoof/Cargo.toml
@@ -17,7 +17,6 @@ no-log-ix-name = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/serialization/Cargo.toml
+++ b/tests-v2/programs/declare-program/serialization/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/surface/Cargo.toml
+++ b/tests-v2/programs/declare-program/surface/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/declare-program/types/Cargo.toml
+++ b/tests-v2/programs/declare-program/types/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 
 [dependencies]
 anchor-lang = { path = "../../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/derives/Cargo.toml
+++ b/tests-v2/programs/derives/Cargo.toml
@@ -22,7 +22,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/derives/src/lib.rs
+++ b/tests-v2/programs/derives/src/lib.rs
@@ -78,8 +78,9 @@ pub struct QualifiedUserTypeHolder<const N: usize> {
 
 // ---- #[event] -------------------------------------------------------------
 
-/// Default-mode event (wincode with a borsh-compatible wire format).
-/// `emit!` serializes via `Event::data()` and calls `sol_log_data`, which
+/// Default-mode event (Wincode with a borsh-compatible wire format).
+/// `#[event]` derives `AnchorSerialize` automatically; `emit!` serializes via
+/// `Event::data()` and calls `sol_log_data`, which
 /// surfaces to clients as a `Program data: <base64>` log line.
 #[event]
 pub struct Bumped {
@@ -157,8 +158,8 @@ pub mod derives_test {
     }
 
     /// Exercises Pod arithmetic + PodBool + pod_wrapper assignment on-chain.
-    /// Also emits a default-mode (wincode) event so the test can inspect the
-    /// `Program data:` log line.
+    /// Also emits a default-mode Wincode event (automatically deriving
+    /// `AnchorSerialize`) so the test can inspect the `Program data:` log line.
     #[discrim = 1]
     pub fn bump(ctx: &mut Context<Bump>, amount: u64, step: i32) -> Result<()> {
         let c = &mut ctx.accounts.counter;

--- a/tests-v2/programs/dispatch-remaining/Cargo.toml
+++ b/tests-v2/programs/dispatch-remaining/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/dup-mut/Cargo.toml
+++ b/tests-v2/programs/dup-mut/Cargo.toml
@@ -20,7 +20,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/equivalence/metadata/spy/Cargo.toml
+++ b/tests-v2/programs/equivalence/metadata/spy/Cargo.toml
@@ -18,7 +18,6 @@ idl-build = []
 
 [dependencies]
 anchor-lang = { path = "../../../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/equivalence/metadata/v2/Cargo.toml
+++ b/tests-v2/programs/equivalence/metadata/v2/Cargo.toml
@@ -19,7 +19,6 @@ idl-build = []
 [dependencies]
 anchor-lang = { path = "../../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../../spl-v2", features = ["guardrails", "metadata"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/equivalence/spl/v2/Cargo.toml
+++ b/tests-v2/programs/equivalence/spl/v2/Cargo.toml
@@ -21,5 +21,4 @@ anchor-lang = { path = "../../../../../lang-v2", default-features = false, featu
 anchor-spl = { path = "../../../../../spl-v2", features = ["guardrails"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 

--- a/tests-v2/programs/event-cpi/Cargo.toml
+++ b/tests-v2/programs/event-cpi/Cargo.toml
@@ -22,7 +22,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/foreign-borsh-account/Cargo.toml
+++ b/tests-v2/programs/foreign-borsh-account/Cargo.toml
@@ -10,7 +10,6 @@ idl-build = []
 
 [dependencies]
 anchor-lang = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/init-space-usability/Cargo.toml
+++ b/tests-v2/programs/init-space-usability/Cargo.toml
@@ -21,7 +21,6 @@ anchor-lang = { path = "../../../lang-v2", default-features = false, features = 
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/ix-macro/Cargo.toml
+++ b/tests-v2/programs/ix-macro/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/min-ix-data-len/Cargo.toml
+++ b/tests-v2/programs/min-ix-data-len/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/optional-accounts/Cargo.toml
+++ b/tests-v2/programs/optional-accounts/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/pda-payer/Cargo.toml
+++ b/tests-v2/programs/pda-payer/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/program-interface/Cargo.toml
+++ b/tests-v2/programs/program-interface/Cargo.toml
@@ -13,7 +13,6 @@ cpi = []
 
 [dependencies]
 anchor-lang = { path = "../../../lang-v2" }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/program-interface/src/lib.rs
+++ b/tests-v2/programs/program-interface/src/lib.rs
@@ -9,7 +9,7 @@ pub mod declared {
         anchor_lang::address!("Con9ukTn9BRPXWcjS2UBbuN3NnCwy1hcaDNZ9Hb8QMNp");
 }
 
-#[derive(Clone, Copy, wincode::SchemaWrite)]
+#[derive(Clone, Copy, anchor_lang::AnchorSerialize)]
 pub struct ComplexArgs {
     pub amount: u64,
     pub tag: [u8; 3],

--- a/tests-v2/programs/seeds/Cargo.toml
+++ b/tests-v2/programs/seeds/Cargo.toml
@@ -21,7 +21,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/space-annotation/Cargo.toml
+++ b/tests-v2/programs/space-annotation/Cargo.toml
@@ -22,7 +22,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/spl-ata/Cargo.toml
+++ b/tests-v2/programs/spl-ata/Cargo.toml
@@ -23,7 +23,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/spl/Cargo.toml
+++ b/tests-v2/programs/spl/Cargo.toml
@@ -23,7 +23,6 @@ bytemuck = { version = "1", features = ["derive"] }
 pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
 pinocchio-system = "0.6"
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/cpi-guard/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/cpi-guard/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/default-account-state/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/default-account-state/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/group-member-pointer/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/group-member-pointer/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/group-pointer/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/group-pointer/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/immutable-owner/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/immutable-owner/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/interest-bearing-mint/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/interest-bearing-mint/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/memo-transfer/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/memo-transfer/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/metadata-pointer/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/metadata-pointer/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/mint-close-authority/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/mint-close-authority/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/non-transferable/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/non-transferable/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/pausable/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/pausable/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/permanent-delegate/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/permanent-delegate/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/token-group/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/token-group/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/token-metadata/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/token-metadata/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/transfer-fee/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/transfer-fee/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-2022-extensions/transfer-hook/Cargo.toml
+++ b/tests-v2/programs/token-2022-extensions/transfer-hook/Cargo.toml
@@ -19,7 +19,6 @@ no-log-ix-name = []
 anchor-lang = { path = "../../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../../spl-v2", features = ["guardrails"] }
 solana-program-error = "3.0"
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/programs/token-interface/Cargo.toml
+++ b/tests-v2/programs/token-interface/Cargo.toml
@@ -19,7 +19,6 @@ idl-build = []
 [dependencies]
 anchor-lang = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
 anchor-spl = { path = "../../../spl-v2", features = ["guardrails"] }
-wincode = { version = "0.5", features = ["derive"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/tests-v2/tests/borsh_borrow_alignment.rs
+++ b/tests-v2/tests/borsh_borrow_alignment.rs
@@ -3,8 +3,8 @@ use anchor_lang::{wincode, BORSH_CONFIG};
 #[test]
 fn borsh_config_still_deserializes_align_one_borrowed_bytes() {
     let values: &[u8] = b"anchor borrow checks";
-    let encoded = wincode::config::serialize(values, BORSH_CONFIG).unwrap();
+    let encoded = anchor_lang::wincode::config::serialize(values, BORSH_CONFIG).unwrap();
 
-    let decoded: &[u8] = wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
+    let decoded: &[u8] = anchor_lang::wincode::config::deserialize(&encoded, BORSH_CONFIG).unwrap();
     assert_eq!(decoded, values);
 }

--- a/tests-v2/tests/cfg_semantics.rs
+++ b/tests-v2/tests/cfg_semantics.rs
@@ -25,7 +25,6 @@ publish = false
 
 [dependencies]
 anchor-lang = {{ path = "{}" }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 
 [features]
 idl-build = []

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -2294,7 +2294,7 @@ pub struct Resize {
     .expect_pass();
 }
 
-// otter-sec/anchor#4850 — a plain arg struct with only the wincode schema
+// otter-sec/anchor#4850 — a plain arg struct with only Anchor's serialization
 // derives has no `IdlAccountType` impl, so idl-build compilation must fail
 // with a diagnostic that points at `#[derive(IdlType)]` (the old message
 // suggested `#[account]`, which drags in Pod/discriminator baggage).

--- a/tests-v2/tests/compile_fail.rs
+++ b/tests-v2/tests/compile_fail.rs
@@ -90,7 +90,6 @@ publish = false
 
 [dependencies]
 anchor-lang = {{ path = "{}" }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 {}
 
 [features]
@@ -457,7 +456,7 @@ fn namespaced_constraints_accept_qualified_constants_as_values() {
         r#"
 use anchor_lang::prelude::*;
 
-#[derive(Default, wincode::SchemaRead, wincode::SchemaWrite)]
+#[derive(Default, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)]
 pub struct Counter {
     pub value: u64,
 }
@@ -2268,7 +2267,7 @@ fn realloc_on_borsh_account_alias_compiles() {
         r#"
 use anchor_lang::prelude::*;
 
-#[derive(wincode::SchemaRead, wincode::SchemaWrite, Default)]
+#[derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize, Default)]
 pub struct Data {
     pub value: u64,
 }
@@ -2330,7 +2329,7 @@ pub mod defined_args {
 #[test]
 fn idl_build_rejects_arg_struct_without_idl_type_derive() {
     let source =
-        DEFINED_ARGS_PROGRAM.replace("DERIVE_LIST", "wincode::SchemaRead, wincode::SchemaWrite");
+        DEFINED_ARGS_PROGRAM.replace("DERIVE_LIST", "anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize");
     CompileCase::new("idl_build_arg_struct_missing_idl_type", &source)
         .features(&["idl-build"])
         .check_tests()
@@ -2344,7 +2343,7 @@ fn idl_build_rejects_arg_struct_without_idl_type_derive() {
 fn idl_build_accepts_arg_struct_with_idl_type_derive() {
     let source = DEFINED_ARGS_PROGRAM.replace(
         "DERIVE_LIST",
-        "IdlType, wincode::SchemaRead, wincode::SchemaWrite",
+        "IdlType, anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize",
     );
     CompileCase::new("idl_build_arg_struct_with_idl_type", &source)
         .features(&["idl-build"])

--- a/tests-v2/tests/declare_program_idl_deps.rs
+++ b/tests-v2/tests/declare_program_idl_deps.rs
@@ -79,7 +79,6 @@ publish = false
 
 [dependencies]
 anchor-lang = {{ path = "{}" }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 
 [workspace]
 "#,

--- a/tests-v2/tests/derives.rs
+++ b/tests-v2/tests/derives.rs
@@ -300,7 +300,7 @@ fn emit_wincode_event_logs_program_data() {
     let counter = do_initialize(&mut svm, &payer);
 
     // bump with amount=12345, step=-7. `emit!` inside the handler fires a
-    // wincode-serialized Bumped event.
+    // Wincode-serialized Bumped event; `#[event]` supplies AnchorSerialize.
     let mut data = vec![1];
     data.extend_from_slice(&12345u64.to_le_bytes());
     data.extend_from_slice(&(-7i32).to_le_bytes());
@@ -319,7 +319,8 @@ fn emit_wincode_event_logs_program_data() {
         "discriminator mismatch"
     );
 
-    // Default-mode event uses wincode with a borsh-compatible wire format:
+    // Default-mode event uses Wincode with a borsh-compatible wire format;
+    // `#[event]` derives AnchorSerialize automatically:
     // u64 LE (8) + i32 LE (4) + bool (1 byte). Total = 21 including disc.
     assert_eq!(bytes.len(), 21);
     let amount = u64::from_le_bytes(bytes[8..16].try_into().unwrap());

--- a/tests-v2/tests/idl_defined_args.rs
+++ b/tests-v2/tests/idl_defined_args.rs
@@ -1,7 +1,7 @@
 //! Plain `#[derive(IdlType)]` structs used as instruction arguments must
 //! resolve through `IdlAccountType` and land in the IDL's `types[]`.
 //! Regression coverage for otter-sec/anchor#4850 — an arg struct deriving
-//! only the wincode schema traits used to fail `--features idl-build`
+//! only `AnchorDeserialize` / `AnchorSerialize` used to fail `--features idl-build`
 //! compilation with an unsatisfied `IdlAccountType` bound.
 
 use {

--- a/tests-v2/tests/instruction_prefix.rs
+++ b/tests-v2/tests/instruction_prefix.rs
@@ -25,7 +25,6 @@ publish = false
 
 [dependencies]
 anchor-lang = {{ path = "{}" }}
-wincode = {{ version = "0.5", features = ["derive"] }}
 
 [workspace]
 "#,


### PR DESCRIPTION
Closes #4937

This makes us compatible with newer solana-address. This also imports the borsh-derive hack used by v1 to allow derives to be used via the wincode re-export.