### PR TITLE
ci: reduce test suite overhead

### DIFF
--- a/.github/workflows/ci-metrics.yaml
+++ b/.github/workflows/ci-metrics.yaml
@@ -1,0 +1,49 @@
+name: CI Metrics
+
+on:
+  workflow_run:
+    workflows: [Tests, Template Tests]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  summarize:
+    name: Summarize CI usage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish timing summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW: ${{ github.event.workflow_run.name }}
+          CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+        run: |
+          job_metrics=$(gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" \
+            | jq -rs '
+                [.[].jobs[]
+                 | select(.started_at != null and .completed_at != null)
+                 | {name, minutes: (((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601)) / 60)}]
+                | {count: length, runner_minutes: (map(.minutes) | add // 0), slowest: max_by(.minutes)}')
+
+          wall_minutes=$(jq -nr \
+            --arg start "$CREATED_AT" --arg end "$UPDATED_AT" \
+            '((($end | fromdateiso8601) - ($start | fromdateiso8601)) / 60)')
+
+          {
+            echo "## $WORKFLOW timing"
+            echo
+            echo "| Jobs | Wall time | Runner-minutes | Slowest job |"
+            echo "| ---: | ---: | ---: | --- |"
+            printf '| %s | %.1f min | %.1f min | %s (%.1f min) |\n' \
+              "$(jq -r '.count' <<<"$job_metrics")" "$wall_minutes" \
+              "$(jq -r '.runner_minutes' <<<"$job_metrics")" \
+              "$(jq -r '.slowest.name' <<<"$job_metrics")" \
+              "$(jq -r '.slowest.minutes' <<<"$job_metrics")"
+            echo
+            echo "[View workflow run]($RUN_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -52,23 +52,48 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Rust-only test templates: `--javascript` and `--package-manager` don't
-  # apply, so the matrix is just template × test-template (2 × 3 = 6 cells).
-  template-rust-tests:
-    name: ${{ matrix.template }} + ${{ matrix.test_template }}
+  # The Rust rows are exhaustive (2 layouts × 3 runners). The eight JS rows
+  # cover every layout/runner/language combination and pair every package
+  # manager with both values of those dimensions, without a 32-cell product.
+  template-tests:
+    name: ${{ matrix.name }}
     needs: build-cli
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        template: [single, multiple]
-        test_template: [rust, mollusk, litesvm]
+        include:
+          - { name: "single + rust", template: single, test_template: rust, kind: rust }
+          - { name: "multiple + rust", template: multiple, test_template: rust, kind: rust }
+          - { name: "single + mollusk", template: single, test_template: mollusk, kind: rust }
+          - { name: "multiple + mollusk", template: multiple, test_template: mollusk, kind: rust }
+          - { name: "single + litesvm", template: single, test_template: litesvm, kind: rust }
+          - { name: "multiple + litesvm", template: multiple, test_template: litesvm, kind: rust }
+          - { name: "single + mocha + typescript + npm", template: single, test_template: mocha, language: typescript, package_manager: npm, javascript: false, kind: js }
+          - { name: "multiple + jest + javascript + npm", template: multiple, test_template: jest, language: javascript, package_manager: npm, javascript: true, kind: js }
+          - { name: "single + mocha + javascript + yarn", template: single, test_template: mocha, language: javascript, package_manager: yarn, javascript: true, kind: js }
+          - { name: "multiple + jest + typescript + yarn", template: multiple, test_template: jest, language: typescript, package_manager: yarn, javascript: false, kind: js }
+          - { name: "single + jest + typescript + pnpm", template: single, test_template: jest, language: typescript, package_manager: pnpm, javascript: false, kind: js }
+          - { name: "multiple + mocha + javascript + pnpm", template: multiple, test_template: mocha, language: javascript, package_manager: pnpm, javascript: true, kind: js }
+          - { name: "single + jest + javascript + bun", template: single, test_template: jest, language: javascript, package_manager: bun, javascript: true, kind: js }
+          - { name: "multiple + mocha + typescript + bun", template: multiple, test_template: mocha, language: typescript, package_manager: bun, javascript: false, kind: js }
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
       - uses: ./.github/actions/setup-surfpool/
+
+      - if: matrix.kind == 'js'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - if: matrix.kind == 'js' && matrix.package_manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - if: matrix.kind == 'js' && matrix.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
 
       - uses: actions/download-artifact@v4
         with:
@@ -76,12 +101,6 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      # Match `tests-v2/src/lib.rs::build_program`. Pre-install so concurrent
-      # `cargo build-sbf` invocations don't race on the platform-tools rename.
-      # Cache platform-tools so the matrix cells don't each re-download it via
-      # the GitHub releases API (unauthenticated, so shared runner IPs get
-      # rate-limited and the install dies with "Failed to parse Github
-      # response"); retry the cold-cache install for the same reason.
       - uses: actions/cache@v4
         name: Cache SBF platform tools
         with:
@@ -97,37 +116,36 @@ jobs:
           shell: bash
           command: cargo build-sbf --tools-version v1.52 --install-only
 
-      # Cache the generated project's `target/` so subsequent runs reuse
-      # compiled deps. Restored before `anchor init` (which is invoked with
-      # `--force`, leaving `target/` intact); the deps don't depend on the
-      # template-files diff, so a partial restore from a prior commit is
-      # always a hit. Per-cell key avoids cross-pollination — different
-      # test templates pull different dev-deps.
       - uses: actions/cache@v4
         with:
           path: /tmp/my_program/target/
           key: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-${{ github.sha }}
           restore-keys: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-
+      - if: matrix.kind == 'js'
+        uses: actions/cache@v4
+        with:
+          path: /tmp/my_program/node_modules/
+          key: template-nm-${{ runner.os }}-${{ matrix.test_template }}-${{ matrix.language }}-${{ matrix.package_manager }}-${{ github.sha }}
+          restore-keys: template-nm-${{ runner.os }}-${{ matrix.test_template }}-${{ matrix.language }}-${{ matrix.package_manager }}-
 
       - name: anchor init
         working-directory: /tmp
         run: |
           mkdir -p my_program
+          extra_args="--no-install"
+          if [ "${{ matrix.kind }}" = "js" ]; then
+            extra_args="--package-manager ${{ matrix.package_manager }}"
+            if [ "${{ matrix.javascript }}" = "true" ]; then
+              extra_args="$extra_args --javascript"
+            fi
+          fi
           anchor init my_program \
             --template ${{ matrix.template }} \
             --test-template ${{ matrix.test_template }} \
+            $extra_args \
             --no-git \
-            --no-install \
             --force
 
-      # Redirect every `git = ".../anchor.git"` dep in the generated
-      # project to this PR's checkout so PR changes are exercised. Without
-      # this, `anchor init` resolves anchor-lang / anchor-client /
-      # anchor-v2-testing from upstream `anchor-next`, masking any local
-      # changes. Listed crates that the lockfile doesn't reference are
-      # silently ignored (Cargo emits a warning, not an error). The rust
-      # test template has its own non-workspace `tests/Cargo.toml`, so
-      # we patch it separately when present.
       - name: Patch generated project to use PR checkout
         env:
           REPO: ${{ github.workspace }}
@@ -147,116 +165,6 @@ jobs:
           if [ -f /tmp/my_program/tests/Cargo.toml ]; then
             patch_block /tmp/my_program/tests/Cargo.toml
           fi
-
-      - name: anchor test
-        working-directory: /tmp/my_program
-        run: anchor test
-
-  # JS-based test templates: cross-product over template × language ×
-  # package manager (2 × 2 × 2 × 4 = 32 cells).
-  template-js-tests:
-    name: ${{ matrix.template }} + ${{ matrix.test_template }} + ${{ matrix.language }} + ${{ matrix.package_manager }}
-    needs: build-cli
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        template: [single, multiple]
-        test_template: [mocha, jest]
-        language: [typescript, javascript]
-        package_manager: [npm, yarn, pnpm, bun]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup/
-      - uses: ./.github/actions/setup-solana/
-      - uses: ./.github/actions/setup-surfpool/
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      # Each PM gets its own setup. Corepack's shim approach didn't work
-      # reliably without a `packageManager` field in package.json, and
-      # ubuntu-latest only ships yarn classic pre-installed.
-      #   - npm: bundled with Node (no setup needed)
-      #   - yarn: pre-installed on ubuntu-latest as yarn classic
-      #   - pnpm: pnpm/action-setup adds the binary to PATH
-      #   - bun:  oven-sh/setup-bun does the same
-      - if: matrix.package_manager == 'pnpm'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - if: matrix.package_manager == 'bun'
-        uses: oven-sh/setup-bun@v2
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: anchor-cli
-          path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
-
-      # Cache + retry for the same GitHub releases API rate-limit flake as in
-      # `template-rust-tests` above.
-      - uses: actions/cache@v4
-        name: Cache SBF platform tools
-        with:
-          path: ~/.cache/solana/v1.52/platform-tools
-          key: solana-platform-tools-${{ runner.os }}-v1.52
-      - uses: nick-fields/retry@v2
-        name: Install SBF platform tools
-        with:
-          retry_wait_seconds: 60
-          timeout_minutes: 10
-          max_attempts: 5
-          retry_on: error
-          shell: bash
-          command: cargo build-sbf --tools-version v1.52 --install-only
-
-      # Cache cargo `target/` and `node_modules/` for the generated project.
-      # `anchor init --force` leaves both alone, so the dirs survive a fresh
-      # init. Caching keys are per-cell so e.g. `mocha+ts+npm` doesn't pull
-      # `jest+js+pnpm`'s lockfile artifacts. `restore-keys` lets a stale
-      # commit's cache hit when the SHA-suffixed primary key misses.
-      - uses: actions/cache@v4
-        with:
-          path: /tmp/my_program/target/
-          key: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-${{ github.sha }}
-          restore-keys: template-target-${{ runner.os }}-${{ matrix.template }}-${{ matrix.test_template }}-
-      - uses: actions/cache@v4
-        with:
-          path: /tmp/my_program/node_modules/
-          key: template-nm-${{ runner.os }}-${{ matrix.test_template }}-${{ matrix.language }}-${{ matrix.package_manager }}-${{ github.sha }}
-          restore-keys: template-nm-${{ runner.os }}-${{ matrix.test_template }}-${{ matrix.language }}-${{ matrix.package_manager }}-
-
-      - name: anchor init
-        working-directory: /tmp
-        run: |
-          mkdir -p my_program
-          anchor init my_program \
-            --template ${{ matrix.template }} \
-            --test-template ${{ matrix.test_template }} \
-            --package-manager ${{ matrix.package_manager }} \
-            ${{ matrix.language == 'javascript' && '--javascript' || '' }} \
-            --no-git \
-            --force
-
-      # Redirect git deps to this PR's checkout. See the rust matrix above
-      # for the rationale; JS templates only carry git deps through the
-      # program crate (no separate `tests/Cargo.toml`).
-      - name: Patch generated project to use PR checkout
-        env:
-          REPO: ${{ github.workspace }}
-        run: |
-          cat <<EOF >> /tmp/my_program/Cargo.toml
-
-          [patch."https://github.com/otter-sec/anchor.git"]
-          anchor-lang = { path = "$REPO/lang-v2" }
-          anchor-derive-accounts = { path = "$REPO/lang-v2/derive" }
-          anchor-client = { path = "$REPO/client" }
-          anchor-spl = { path = "$REPO/spl-v2" }
-          anchor-v2-testing = { path = "$REPO/v2-testing" }
-          EOF
 
       - name: anchor test
         working-directory: /tmp/my_program

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -154,61 +154,17 @@ jobs:
       - name: Run CLI Tests
         run: cargo test -p anchor-cli
 
-      # Install the `anchor` bin to `~/.cargo/bin` (already on PATH via
-      # rustup). Shared `./target/` via `--target-dir` means the build
-      # reuses artifacts from prior `cargo test -p anchor-cli` instead
-      # of starting from scratch in a temp tree; `--debug` skips release
-      # opt (smoke test — runtime speed doesn't matter).
-      - name: Install CLI
-        run: cargo install --path cli --locked --debug --force --target-dir ./target
-
-      # `anchor debugger` smoke test. These bench crates have no
-      # Anchor.toml, so the CLI falls into loose mode and runs the full
-      # pipeline: `cargo build-sbf` → `cargo test --features profile` →
-      # TUI. We wrap in `script` so crossterm can enter raw mode on a
-      # pty (GHA stdin/stdout aren't ttys) and `timeout` kills the TUI
-      # once it's in its event loop.
-      #
-      # Failure handling: each `prog` is run in its own subshell so
-      # `cd` is scoped (no `popd` bookkeeping) and so `|| rc=$?`
-      # captures the inner pipeline's exit status directly. Build and
-      # TUI phases are kept distinct so a build break is reported as
-      # such instead of bleeding into a confusing TUI failure.
-      #
-      # Exit-code semantics for the TUI phase:
-      #   124 → timeout-killed (TUI was still alive — success)
-      #     0 → clean exit (rare in CI; legal)
-      #   else → real failure; dump the pty log
-      - name: anchor debugger TUI launches for bench anchor-v2 programs
+      # The CLI test suite above compiles and unit-tests the debugger. Check
+      # each loose-mode bench fixture too, without building SBF artifacts or
+      # starting an interactive TUI that CI can only verify by timing out.
+      # `cargo check` deliberately excludes integration tests: they include the
+      # SBF .so emitted by `cargo build-sbf`, which is outside this compile
+      # compatibility check.
+      - name: Check anchor debugger bench fixtures
         run: |
           set -euo pipefail
-          fail=0
           for prog in bench/programs/*/anchor-v2; do
-            echo "::group::anchor debugger in $prog"
-            log=$(mktemp)
-
-            # Build phase — surface build breaks as a distinct error.
-            if ! ( cd "$prog" && anchor coverage ); then
-              echo "::error::`anchor coverage` failed in $prog"
-              fail=1
-              rm -f "$log"
-              echo "::endgroup::"
-              continue
-            fi
-
-            # TUI phase — `|| rc=$?` captures the subshell exit cleanly
-            # without toggling `set +e`/`set -e` around it.
-            rc=0
-            ( cd "$prog" && timeout --kill-after=30 30 \
-                script -qec 'anchor debugger --skip-build' "$log" ) || rc=$?
-
-            if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
-              echo "::error::anchor debugger failed in $prog (exit $rc)"
-              cat "$log"
-              fail=1
-            fi
-
-            rm -f "$log"
+            echo "::group::cargo check in $prog"
+            ( cd "$prog" && cargo check )
             echo "::endgroup::"
           done
-          exit "$fail"

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -8,6 +8,11 @@ fn cargo_case(
 ) -> std::process::Output {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let crate_dir = manifest_dir.join("target/macro-diagnostics").join(name);
+    // Keep sources isolated for clear per-case diagnostics, but share Cargo
+    // artifacts across cases. The Rust test harness may invoke these helpers
+    // concurrently; Cargo coordinates the target-directory lock and avoids
+    // recompiling anchor-lang and its dependencies for every fixture.
+    let target_dir = manifest_dir.join("target/macro-diagnostics-target");
     let src_dir = crate_dir.join("src");
     fs::create_dir_all(&src_dir).unwrap();
     fs::write(
@@ -37,6 +42,7 @@ live = []
     fs::write(src_dir.join("lib.rs"), source).unwrap();
 
     Command::new("cargo")
+        .env("CARGO_TARGET_DIR", target_dir)
         .arg(command)
         .arg("--offline")
         .arg("--manifest-path")


### PR DESCRIPTION
## Summary

- reduce the template-test matrix from 38 jobs to a 14-case covering matrix
- add workflow timing summaries for Tests and Template Tests
- share Cargo artifacts across macro diagnostic fixtures
- replace debugger TUI timeout smoke tests with compile checks for the loose-workspace fixtures

## Validation

- `rustfmt --check lang-v2/tests/macro_diagnostics.rs`
- `cargo test -p anchor-lang --test macro_diagnostics`
- workflow YAML parses via Ruby
- verified `cargo check` for representative library and no-library debugger fixtures

The debugger change deliberately replaces interactive TUI liveness coverage with deterministic compilation coverage; the CLI test suite continues to compile and unit-test debugger code.