### PR TITLE
fix(lang): Respect realloc::zero constraint

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -440,6 +440,7 @@ fn generate_constraint_realloc(
     let account_name = field.to_string();
     let new_space = &c.space;
     let payer = &c.payer;
+    let zero = &c.zero;
     let payer_ref = generate_realloc_payer_ref(payer, accs);
 
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, field);
@@ -489,7 +490,7 @@ fn generate_constraint_realloc(
                 anchor_lang::Lamports::sub_lamports(&__field_info, __lamport_amt)?;
             }
 
-            __field_info.resize(#new_space)?;
+            __field_info.realloc(#new_space, #zero)?;
             __reallocs.insert(#field.key());
         }
     }

--- a/lang/syn/tests/accounts_constraints.rs
+++ b/lang/syn/tests/accounts_constraints.rs
@@ -1,0 +1,42 @@
+use {
+    anchor_syn::AccountsStruct,
+    quote::ToTokens,
+};
+
+#[test]
+fn test_realloc_zero_codegen() {
+    let accs: AccountsStruct = syn::parse_str(
+        r#"
+        pub struct ReallocTest<'info> {
+            #[account(mut, realloc = 100, realloc::payer = payer, realloc::zero = true)]
+            pub data: Account<'info, MyData>,
+            #[account(mut)]
+            pub payer: Signer<'info>,
+            pub system_program: Program<'info, System>,
+        }
+        "#,
+    )
+    .unwrap();
+
+    let tokens = accs.to_token_stream().to_string();
+    assert!(tokens.contains("realloc (100 , true)"));
+}
+
+#[test]
+fn test_realloc_zero_false_codegen() {
+    let accs: AccountsStruct = syn::parse_str(
+        r#"
+        pub struct ReallocTest<'info> {
+            #[account(mut, realloc = 100, realloc::payer = payer, realloc::zero = false)]
+            pub data: Account<'info, MyData>,
+            #[account(mut)]
+            pub payer: Signer<'info>,
+            pub system_program: Program<'info, System>,
+        }
+        "#,
+    )
+    .unwrap();
+
+    let tokens = accs.to_token_stream().to_string();
+    assert!(tokens.contains("realloc (100 , false)"));
+}


### PR DESCRIPTION
**`realloc::zero` dropped in codegen**: `ConstraintReallocGroup.zero` was parsed by `realloc_zero` into the AST, but `generate_constraint_realloc` called `__field_info.resize(#new_space)?` without passing the zeroing parameter. This updates codegen to call `__field_info.realloc(#new_space, #zero)?` so that newly expanded memory is properly zero-initialized when `realloc::zero = true` is requested.

