### PR TITLE
fix(lang): Enforce mut constraint on Migration accounts

### DIFF
--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -387,6 +387,18 @@ fn constraints_cross_checks(fields: &[AccountField]) -> ParseResult<()> {
         }
     }
 
+    // MIGRATION
+    for field in fields {
+        if let AccountField::Field(f) = field {
+            if matches!(f.ty, Ty::Migration(_)) && !f.constraints.is_mutable() {
+                return Err(ParseError::new(
+                    f.ident.span(),
+                    "Migration accounts must be mutable. Add `#[account(mut)]`",
+                ));
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/lang/syn/tests/migration_mut.rs
+++ b/lang/syn/tests/migration_mut.rs
@@ -1,0 +1,30 @@
+use anchor_syn::AccountsStruct;
+
+#[test]
+fn test_migration_requires_mut_constraint() {
+    let result = syn::parse_str::<AccountsStruct>(
+        r#"
+        pub struct MigrateTest<'info> {
+            pub state: Migration<'info, V1, V2>,
+        }
+        "#,
+    );
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("Migration accounts must be mutable"));
+}
+
+#[test]
+fn test_migration_with_mut_constraint_succeeds() {
+    let result = syn::parse_str::<AccountsStruct>(
+        r#"
+        pub struct MigrateTest<'info> {
+            #[account(mut)]
+            pub state: Migration<'info, V1, V2>,
+        }
+        "#,
+    );
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
`Migration<'info, From, To>` relies on `AccountsExit::exit` to persist the migrated state to storage. Because `exit.rs` skips generating exit routines for non-mutable fields (`match f.constraints.is_mutable() { false => quote! {} }`), declaring a `Migration` without `#[account(mut)]` resulted in silent state loss despite the instruction succeeding.
  
This PR adds a compile-time check in `constraints_cross_checks` requiring `Migration` accounts to be marked `mut`.
  
### Testing
- Added unit tests in `lang/syn/tests/migration_mut.rs` verifying:
   - `Migration` without `#[account(mut)]` produces a compile-time parse error.
   - `Migration` with `#[account(mut)]` parses successfully.
- `cargo test -p anchor-syn` passed.
- `cargo clippy -p anchor-syn -- -D warnings` passed (0 warnings).
