### PR TITLE
fix(spl): Fix duplicate authority in group_pointer_update

### DIFF
--- a/spl/src/token_2022_extensions/group_pointer.rs
+++ b/spl/src/token_2022_extensions/group_pointer.rs
@@ -42,7 +42,7 @@ pub fn group_pointer_update<'info>(
         ctx.accounts.token_program_id.key,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
-        &[ctx.accounts.authority.key],
+        &[],
         group_address,
     )?;
     anchor_lang::solana_program::program::invoke_signed(


### PR DESCRIPTION
`group_pointer_update` was passing `&[ctx.accounts.authority.key]` into `multisig_signers`, causing `authority` to be marked as a non-signer and duplicated in the generated instruction accounts.
  
### Changes
* Pass `&[]` into `spl_token_2022::extension::group_pointer::instruction::update`, aligning with single-authority CPIs across other Token-2022 extension helpers (such as `group_member_pointer` and `transfer_hook`).
