### PR TITLE
docs: clarify security boundaries

### DIFF
--- a/.cspell-anchor-dictionary.txt
+++ b/.cspell-anchor-dictionary.txt
@@ -36,6 +36,7 @@ duplicative
 footguns
 flamegraph
 flamegraphs
+footgun
 fumadocs
 Fumadocs
 getrandom

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,34 @@ For bugs that affect production code, we will pay up to X SOL tokens according t
 
 If you do not receive a response in the advisory, send an email to anchor-security@solana.org with the full URL of the advisory you have created. DO NOT include attachments or provide detail sufficient for exploitation regarding the security issue in this email. **Only provide such details in the advisory**.
 
+## Security boundaries
+
+Not every safety check performed by Anchor is a security boundary.
+
+Some checks are defense-in-depth or anti-footgun measures intended to
+prevent accidental misuse, improve developer experience, or catch
+incorrect program behavior early. A failure of such a check does not
+necessarily represent a vulnerability in Anchor.
+
+A security-boundary issue is one where an attacker can bypass a
+fundamental security property that Anchor is responsible for enforcing,
+such as:
+
+- account ownership validation
+- account discriminator validation
+- signer/authentication requirements enforced by Anchor
+- memory-safety guarantees
+- other fundamental invariants enforced by the Anchor framework
+
+By contrast, protections that primarily prevent accidental misuse,
+developer mistakes, or incorrect program construction should generally
+be considered defense-in-depth or anti-footgun measures rather than
+security boundaries.
+
+If you are unsure whether an issue crosses a security boundary, please
+report it through the security reporting process with a proof of concept
+and let the security team determine its classification.
+
 ## Incident Response Process
 
 In case an incident is discovered or reported, the following process will be followed to contain, respond and remediate:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,16 @@ such as:
 By contrast, protections that primarily prevent accidental misuse,
 developer mistakes, or incorrect program construction should generally
 be considered defense-in-depth or anti-footgun measures rather than
-security boundaries.
+security boundaries. For example, duplicate mutable account checks help
+prevent multiple mutable references to the same account in an
+instruction, but bypassing this check is not by itself a security
+boundary violation.
+
+Compile-time checks that are part of the IDL building process are also
+not security boundaries when they can be bypassed by disabling IDL
+generation with `--no-idl`. These checks can help catch incorrect
+program definitions during development, but they do not enforce a
+security property at runtime.
 
 If you are unsure whether an issue crosses a security boundary, please
 report it through the security reporting process with a proof of concept


### PR DESCRIPTION
## Summary

Clarifies the distinction between Anchor security boundaries and
defense-in-depth / anti-footgun protections in the security policy.

This makes it clearer which types of issues may represent a security
boundary violation and helps reporters determine the appropriate
reporting path.

## Changes

- Define what constitutes a security-boundary issue.
- Identify examples of fundamental Anchor security properties.
- Clarify that not every Anchor safety check represents a security boundary.
- Explain how uncertain security reports should be handled.

## Branch Target

This change is documentation-only and does not contain breaking changes,
so it targets the current `master` branch.

Closes #4857