### PR TITLE
fix(cli): support rustc argfiles in RUSTC_WRAPPER

### DIFF
--- a/cli/src/debugger/rustc_wrapper.rs
+++ b/cli/src/debugger/rustc_wrapper.rs
@@ -27,12 +27,42 @@
 //! The wrapper adds ~1ms of fork+exec overhead per rustc invocation.
 //! This is negligible compared to actual compilation time.
 
-use std::process;
+use std::{
+    ffi::OsString,
+    fs,
+    path::Path,
+    process,
+};
 
 /// Env var set by `anchor debugger` before calling `cargo build-sbf`.
 /// When present, the process knows it was invoked as a RUSTC_WRAPPER
 /// and should rewrite args instead of running the normal CLI.
 pub const WRAPPER_SENTINEL: &str = "__ANCHOR_RUSTC_WRAPPER";
+
+fn rewrite_rustc_args(args: &[OsString], cwd: &Path) -> Vec<OsString> {
+    args.iter()
+        .flat_map(|arg| {
+            let Some(path) = arg.to_str().and_then(|arg| arg.strip_prefix('@')) else {
+                return vec![arg.clone()];
+            };
+
+            match fs::read_to_string(path) {
+                Ok(contents) => contents
+                    .lines()
+                    .map(|line| {
+                        let arg = line.trim();
+                        if arg == "-Zremap-cwd-prefix=" {
+                            format!("-Zremap-cwd-prefix={}", cwd.display()).into()
+                        } else {
+                            arg.into()
+                        }
+                    })
+                    .collect(),
+                Err(_) => vec![arg.clone()],
+            }
+        })
+        .collect()
+}
 
 /// If we're running as a RUSTC_WRAPPER (sentinel env var is set),
 /// rewrite the rustc args and exec the real compiler. Never returns.
@@ -44,7 +74,7 @@ pub fn maybe_exec_as_wrapper() -> bool {
         return false;
     }
 
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<OsString> = std::env::args_os().collect();
     // RUSTC_WRAPPER invocation: argv[0]=anchor, argv[1]=rustc, argv[2..]=args
     if args.len() < 2 {
         eprintln!("anchor rustc-wrapper: expected <rustc> <args...>");
@@ -52,23 +82,11 @@ pub fn maybe_exec_as_wrapper() -> bool {
     }
 
     let rustc = &args[1];
-    let cwd = std::env::current_dir()
-        .map(|p| p.display().to_string())
-        .unwrap_or_default();
-
-    let rewritten: Vec<String> = args[2..]
-        .iter()
-        .map(|arg| {
-            if arg == "-Zremap-cwd-prefix=" {
-                format!("-Zremap-cwd-prefix={cwd}")
-            } else {
-                arg.clone()
-            }
-        })
-        .collect();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let rewritten = rewrite_rustc_args(&args[2..], &cwd);
 
     let status = process::Command::new(rustc)
-        .args(&rewritten)
+        .args(rewritten)
         .status()
         .unwrap_or_else(|e| {
             eprintln!("anchor rustc-wrapper: failed to exec {rustc}: {e}");
@@ -76,4 +94,65 @@ pub fn maybe_exec_as_wrapper() -> bool {
         });
 
     process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, tempfile::tempdir};
+
+    #[test]
+    fn rewrites_direct_rustc_args() {
+        let cwd = Path::new("/workspace/project");
+        let args = [
+            OsString::from("--crate-name"),
+            OsString::from("project"),
+            OsString::from("-Zremap-cwd-prefix="),
+            OsString::from("src/lib.rs"),
+        ];
+
+        assert_eq!(
+            rewrite_rustc_args(&args, cwd),
+            [
+                OsString::from("--crate-name"),
+                OsString::from("project"),
+                OsString::from("-Zremap-cwd-prefix=/workspace/project"),
+                OsString::from("src/lib.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn expands_and_rewrites_rustc_argfile() {
+        let temp = tempdir().unwrap();
+        let argfile_dir = temp.path().join("path with spaces");
+        fs::create_dir(&argfile_dir).unwrap();
+        let argfile = argfile_dir.join("rustc args");
+        fs::write(
+            &argfile,
+            "--crate-name\nproject\n\n-Zremap-cwd-prefix=\nsrc/lib.rs\n",
+        )
+        .unwrap();
+
+        let args = [OsString::from(format!("@{}", argfile.display()))];
+        assert_eq!(
+            rewrite_rustc_args(&args, Path::new("/workspace/project")),
+            [
+                OsString::from("--crate-name"),
+                OsString::from("project"),
+                OsString::from(""),
+                OsString::from("-Zremap-cwd-prefix=/workspace/project"),
+                OsString::from("src/lib.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_unreadable_argfile_reference() {
+        let args = [OsString::from("@path that does not exist")];
+
+        assert_eq!(
+            rewrite_rustc_args(&args, Path::new("/workspace/project")),
+            args
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4873.

- Support rustc argument-file invocations in `RUSTC_WRAPPER`.
- Preserve existing rustc argument handling.
- Add regression coverage for argfile behavior.

## Testing

- `git diff --check` — passed
- VS Code diagnostics for `cli/src/debugger/rustc_wrapper.rs` — no errors
- `cargo fmt --all -- --check` — blocked: `cargo` is not installed in the environment
- `cargo test -p anchor-cli debugger::rustc_wrapper` — blocked: `cargo` is not installed in the environment

## Issue

Fixes #4873