### PR TITLE
fix(lang-v2): drop the lifetime arguments from the CPI instruction literal

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4417,7 +4417,10 @@ fn process_handler(
                 __ctx: anchor_lang_v2::CpiContext<'a, accounts::#accounts_type<'a>>,
                 #(#extra_arg_names: #extra_arg_types,)*
             ) #ret_ty {
-                let __ix = super::instruction::#ix_struct_name #ix_lt_use_local {
+                // No lifetime arguments on the literal: a struct expression
+                // cannot carry them, and the type is already fixed by the
+                // annotation below.
+                let __ix = super::instruction::#ix_struct_name {
                     #(#extra_arg_names,)*
                 };
                 let __data = <

--- a/tests-v2/programs/callee/src/lib.rs
+++ b/tests-v2/programs/callee/src/lib.rs
@@ -17,6 +17,18 @@ pub mod callee {
         Ok(())
     }
 
+    /// Handler with an argument that borrows instruction data. The
+    /// borrow gives the generated instruction struct a lifetime
+    /// parameter. Drives the `has_ref_args` branch of the cpi-wrapper
+    /// codegen. Regression: the wrapper wrote the lifetime into the
+    /// struct literal, which does not parse, so any program with a
+    /// borrowing handler failed to compile.
+    pub fn set_data_from_bytes(ctx: &mut Context<SetData>, bytes: &[u8]) -> Result<()> {
+        require_eq!(bytes.len(), 8, ErrorCode::InstructionDidNotDeserialize);
+        ctx.accounts.data.value = u64::from_le_bytes(bytes.try_into().unwrap());
+        Ok(())
+    }
+
     /// No-extra-args handler reusing `SetData`. Drives the
     /// `extra_arg_names.is_empty()` branch in the cpi-wrapper codegen and
     /// the dedupe of `cpi::accounts` re-exports — `noop` and `set_data`

--- a/tests-v2/programs/caller/src/lib.rs
+++ b/tests-v2/programs/caller/src/lib.rs
@@ -36,6 +36,19 @@ pub mod caller {
         Ok(())
     }
 
+    /// CPIs into `set_data_from_bytes`, whose `&[u8]` argument gives the
+    /// generated instruction struct a lifetime parameter. Exercises the
+    /// ref-args branch of the auto-generated cpi wrapper.
+    pub fn proxy_set_data_from_bytes(ctx: &mut Context<ProxySetData>, bytes: &[u8]) -> Result<()> {
+        let cpi_accounts = callee::cpi::accounts::SetData {
+            data: ctx.accounts.callee_data.cpi_handle_mut(),
+            authority: ctx.accounts.authority.cpi_handle(),
+        };
+        let cpi_ctx = CpiContext::new(ctx.accounts.callee_program.address(), cpi_accounts);
+        callee::cpi::set_data_from_bytes(cpi_ctx, bytes);
+        Ok(())
+    }
+
     /// CPIs into the no-args `noop` handler — exercises the empty-args
     /// branch of the auto-generated cpi wrapper.
     pub fn proxy_noop(ctx: &mut Context<ProxySetData>) -> Result<()> {

--- a/tests-v2/tests/cpi.rs
+++ b/tests-v2/tests/cpi.rs
@@ -152,6 +152,44 @@ fn test_cpi_set_data() {
     assert_eq!(stored_value, 42, "CPI should have set value to 42");
 }
 
+/// Regression: a handler argument that borrows instruction data gives
+/// the generated instruction struct a lifetime parameter. The cpi
+/// wrapper wrote that lifetime into the struct literal, and a struct
+/// expression cannot carry lifetime arguments, so every program with
+/// such a handler failed to compile. Routes a `&[u8]` argument through
+/// `caller::cpi -> callee::set_data_from_bytes` end to end.
+#[test]
+fn test_cpi_ref_args() {
+    let (mut svm, payer) = setup();
+    let authority = keypair_for("authority");
+    svm.airdrop(&authority.pubkey(), 1_000_000_000).unwrap();
+    let data_pda = init_data_account(&mut svm, &payer, &authority);
+
+    let value: u64 = 4242;
+    let bytes = value.to_le_bytes();
+    let proxy_data = caller::instruction::ProxySetDataFromBytes { bytes: &bytes }.data();
+    let proxy_metas = vec![
+        AccountMeta::new(data_pda, false),
+        AccountMeta::new_readonly(authority.pubkey(), true),
+        AccountMeta::new_readonly(callee_id(), false),
+    ];
+    send_instruction(
+        &mut svm,
+        caller_id(),
+        proxy_data,
+        proxy_metas,
+        &payer,
+        &[&authority],
+    )
+    .expect("caller::proxy_set_data_from_bytes should succeed");
+
+    let account = svm
+        .get_account(&data_pda)
+        .expect("data account should exist");
+    let stored_value = u64::from_le_bytes(account.data[8..16].try_into().unwrap());
+    assert_eq!(stored_value, 4242, "CPI should have set value to 4242");
+}
+
 fn call_raw(
     svm: &mut LiteSVM,
     program: Pubkey,


### PR DESCRIPTION
A handler argument that borrows instruction data gives the generated instruction struct a lifetime parameter. The CPI wrapper wrote that parameter into the struct expression, and Rust cannot parse a struct literal that carries lifetime arguments. Every program with such a handler failed to compile, whether or not it enabled the `cpi` feature.

The `InstructionData` call below the literal names the type in full, so inference already fixes the lifetime and the literal does not need it.