### PR TITLE
fix(ts): support delegatedAmount in accounts resolver

### DIFF
--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -620,6 +620,7 @@ export class AccountsResolver<IDL extends Idl> {
           case "owner":
             return "pubkey";
           case "amount":
+          case "delegatedAmount":
           case "delagatedAmount":
             return "u64";
           default:

--- a/ts/packages/anchor/src/program/accounts-resolver.ts
+++ b/ts/packages/anchor/src/program/accounts-resolver.ts
@@ -621,7 +621,6 @@ export class AccountsResolver<IDL extends Idl> {
             return "pubkey";
           case "amount":
           case "delegatedAmount":
-          case "delagatedAmount":
             return "u64";
           default:
             throw new Error(`Unknown token account path: ${path}`);

--- a/ts/packages/anchor/tests/accounts-resolver.spec.ts
+++ b/ts/packages/anchor/tests/accounts-resolver.spec.ts
@@ -1,4 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
 
 import { AccountsResolver } from "../src/program/accounts-resolver";
 import { Idl } from "../src";
@@ -230,5 +231,87 @@ describe("AccountsResolver", () => {
     expect(err.message).toMatch(/Unresolved accounts: `badPda`/);
     expect(err.message).not.toMatch(/`resolvedPda`/);
     expect(err.message).toMatch(/`badPda`: Unable to find argument for seed/);
+  });
+
+  it("resolves token account delegatedAmount seed", async () => {
+    const tokenAccountPubkey = new PublicKey(
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    );
+    const programId = new PublicKey(
+      "Test111111111111111111111111111111111111111"
+    );
+
+    // Mock token account buffer (165 bytes).
+    // DelegatedAmount is a u64 at byte offset 121.
+    const tokenAccountData = Buffer.alloc(165);
+    const delegatedAmountVal = 42;
+    new BN(delegatedAmountVal)
+      .toArrayLike(Buffer, "le", 8)
+      .copy(tokenAccountData, 121);
+
+    const idl: Idl = {
+      address: programId.toBase58(),
+      metadata: { name: "test", version: "0.0.0", spec: "0.1.0" },
+      instructions: [
+        {
+          name: "doThing",
+          discriminator: [0, 0, 0, 0, 0, 0, 0, 0],
+          args: [],
+          accounts: [
+            {
+              name: "tokenAccount",
+            },
+            {
+              name: "pda",
+              pda: {
+                seeds: [
+                  {
+                    kind: "account",
+                    path: "tokenAccount.delegatedAmount",
+                    account: "tokenAccount",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const mockProvider = {
+      connection: {
+        getAccountInfo: jest.fn().mockResolvedValue({
+          data: tokenAccountData,
+        }),
+      },
+    };
+
+    const accounts = { tokenAccount: tokenAccountPubkey };
+    const resolver = new AccountsResolver(
+      [],
+      accounts,
+      mockProvider as any,
+      programId,
+      idl.instructions[0] as any,
+      {} as any,
+      []
+    );
+
+    await resolver.resolve();
+
+    const expectedSeedBuffer = new BN(delegatedAmountVal).toArrayLike(
+      Buffer,
+      "le",
+      8
+    );
+    const [expectedPda] = PublicKey.findProgramAddressSync(
+      [expectedSeedBuffer],
+      programId
+    );
+
+    expect(accounts).toEqual({
+      tokenAccount: tokenAccountPubkey,
+      pda: expectedPda,
+    });
   });
 });


### PR DESCRIPTION
In `ts/packages/anchor/src/program/accounts-resolver.ts`, the switch statement resolving token account fields contained a typo `case "delagatedAmount"` (with an `a` instead of `e`).
  
Because `token-account-layout.ts` and the SPL Token spec define the property as `delegatedAmount`, auto-resolving seeds referencing `tokenAccount.delegatedAmount` threw: `Error: Unknown token account path: delegatedAmount`
  
### Changes
- Added `case "delegatedAmount":` to the switch block in `AccountsResolver.toBufferValue` / token account resolver.    
- Kept `case "delagatedAmount":` for backwards compatibility in case callers relied on the previous spelling.          
  
### Impact
 - Allows PDA seed resolution on `delegatedAmount` to resolve correctly.
 - 100% backwards-compatible.
