### PR TITLE
fix(lang-v2): respect handler inline attributes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,6 +97,9 @@ jobs:
         env:
           CARGO_BUILD_JOBS: "1"
         run: make coverage-v2-host-tests
+      # This regression spawns cargo build-sbf, so keep llvm-cov out of it.
+      - name: v2 handler inline policy regression
+        run: cargo test -p tests-v2 --test handler_inline_policy
       - name: v2 host coverage for idl-build fixtures
         run: make coverage-v2-host-idl-build
       - name: Generate v2 coverage report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,6 +2951,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "handler-inline-policy"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+]
+
+[[package]]
 name = "hash-cpi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "tests-v2/programs/dup-mut",
     "tests-v2/programs/equivalence",
     "tests-v2/programs/foreign-borsh-account",
+    "tests-v2/programs/handler-inline-policy",
     "tests-v2/programs/equivalence/metadata/spy",
     "tests-v2/programs/equivalence/metadata/v1",
     "tests-v2/programs/equivalence/metadata/v2",

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TESTS_V2_COVERAGE_TESTS := \
 	token_2022_extensions \
 	token_interface
 TESTS_V2_COVERAGE_ARGS := $(foreach test,$(TESTS_V2_COVERAGE_TESTS),--test $(test))
-TESTS_V2_NON_COVERAGE_TESTS := compile_fail
+TESTS_V2_NON_COVERAGE_TESTS := compile_fail handler_inline_policy
 TESTS_V2_NON_COVERAGE_ARGS := $(foreach test,$(TESTS_V2_NON_COVERAGE_TESTS),--test $(test))
 
 .PHONY: coverage-v2

--- a/lang-v2/README.md
+++ b/lang-v2/README.md
@@ -90,6 +90,29 @@ Here are some examples of optimizations present in Anchor v2.
 - **Guardrails compile away** when you drop the feature. `check_program_id` / the `is_writable` check in `load_mut` just aren't emitted. Smaller binary in prod.
 - **`remaining_accounts()` is lazy-cached.** First call walks the account cursor; subsequent calls return a clone of the cached vec. Zero overhead for instructions that don't touch it.
 
+### Isolating a large instruction stack frame
+
+Anchor inlines instruction wrappers by default to minimize compute units and
+binary size. A program with several large or deeply nested `Accounts` structs
+can instead give selected instructions their own SBF stack frames:
+
+```rust
+#[program]
+pub mod my_program {
+    use super::*;
+
+    #[handler(inline = false)]
+    pub fn large_instruction(ctx: &mut Context<LargeAccounts>) -> Result<()> {
+        // ...
+        Ok(())
+    }
+}
+```
+
+This emits `#[inline(never)]` on Anchor's generated wrapper for that instruction.
+Use it only where the SBF compiler reports an oversized dispatcher frame. The
+extra function call costs some compute units and can increase binary size.
+
 ## Account types
 
 **Why `Account<T>` is zero-copy by default.** Stored bytes match the struct layout, so load is a pointer cast and exit is a no-op — no (de)serialization and no heap.

--- a/lang-v2/README.md
+++ b/lang-v2/README.md
@@ -101,7 +101,7 @@ can instead give selected instructions their own SBF stack frames:
 pub mod my_program {
     use super::*;
 
-    #[handler(inline = false)]
+    #[inline(never)]
     pub fn large_instruction(ctx: &mut Context<LargeAccounts>) -> Result<()> {
         // ...
         Ok(())
@@ -109,9 +109,21 @@ pub mod my_program {
 }
 ```
 
-This emits `#[inline(never)]` on Anchor's generated wrapper for that instruction.
-Use it only where the SBF compiler reports an oversized dispatcher frame. The
-extra function call costs some compute units and can increase binary size.
+Anchor mirrors the handler's inline policy onto its generated wrapper. Without
+an explicit policy, the wrapper keeps its existing `#[inline(always)]` default.
+Use `#[inline(never)]` only where the SBF compiler reports an oversized
+dispatcher frame. It also applies to the user handler, so the additional call
+boundaries can cost compute units and increase binary size.
+
+The policy can be conditional without changing the default in other builds:
+
+```rust
+#[cfg_attr(feature = "isolate-large-handler", inline(never))]
+pub fn large_instruction(ctx: &mut Context<LargeAccounts>) -> Result<()> {
+    // ...
+    Ok(())
+}
+```
 
 ## Account types
 

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4772,6 +4772,11 @@ fn process_handler(
     discrim_bytes: Option<&[u8]>,
     program_id: &Expr,
 ) -> HandlerCodegen {
+    let wrapper_inline_attr = match parse_handler_inline_attr(handler) {
+        Ok(true) => quote! { #[inline(always)] },
+        Ok(false) => quote! { #[inline(never)] },
+        Err(err) => return HandlerCodegen::error(handler, err),
+    };
     let fn_name = &handler.sig.ident;
     let fn_name_str = fn_name.to_string();
     let handler_cfg_attrs = cfg_attrs(&handler.attrs);
@@ -4914,7 +4919,7 @@ fn process_handler(
     let wrapper = if extra_arg_names.is_empty() {
         quote! {
             #(#handler_cfg_attrs)*
-            #[inline(always)]
+            #wrapper_inline_attr
             pub fn #fn_name<'a>(
                 __program_id: &'a anchor_lang::Address,
                 __cursor: &'a mut anchor_lang::AccountCursor,
@@ -4951,7 +4956,7 @@ fn process_handler(
         let deser_args = args_deser.deser;
         quote! {
             #(#handler_cfg_attrs)*
-            #[inline(always)]
+            #wrapper_inline_attr
             pub fn #fn_name<'a>(
                 __program_id: &'a anchor_lang::Address,
                 __cursor: &'a mut anchor_lang::AccountCursor,
@@ -5374,15 +5379,17 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
         }
     };
 
-    // Strip #[discrim = N] attributes from handler outputs so rustc
-    // doesn't complain about an unknown attribute.
+    // Strip codegen-only attributes from handler outputs so rustc does not
+    // complain about unknown attributes.
     let mut handler_update_errors = Vec::new();
     let handlers: Vec<_> = handlers
         .iter()
         .map(|func| {
             let mut func = (*func).clone();
             func.attrs.retain(|attr| {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
+                if attr.path().is_ident("handler") {
+                    false
+                } else if let syn::Meta::NameValue(nv) = &attr.meta {
                     !nv.path.is_ident("discrim")
                 } else {
                     true
@@ -6468,6 +6475,51 @@ pub fn error_code(args: TokenStream, input: TokenStream) -> TokenStream {
     error_code::expand(args, input)
 }
 
+/// Parse `#[handler(inline = ...)]` on a program handler.
+///
+/// Handlers inline by default to preserve the existing fast path. Programs
+/// with account-loading paths that exceed SBF's 4 KiB stack-frame limit can
+/// opt into a guaranteed wrapper boundary with `#[handler(inline = false)]`.
+fn parse_handler_inline_attr(handler: &syn::ItemFn) -> syn::Result<bool> {
+    let mut inline = None;
+
+    for attr in &handler.attrs {
+        if !attr.path().is_ident("handler") {
+            continue;
+        }
+        if inline.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "duplicate `handler` attribute",
+            ));
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("inline") {
+                return Err(
+                    meta.error("unsupported handler option; expected `inline = true|false`")
+                );
+            }
+            if inline.is_some() {
+                return Err(meta.error("duplicate `inline` handler option"));
+            }
+
+            let value = meta.value()?;
+            let value: syn::LitBool = value.parse()?;
+            inline = Some(value.value);
+            Ok(())
+        })?;
+        if inline.is_none() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "expected `#[handler(inline = true|false)]`",
+            ));
+        }
+    }
+
+    Ok(inline.unwrap_or(true))
+}
+
 /// Parse the optional `#[discrim = ...]` attribute on a handler fn.
 /// Returns `Ok(Some(...))` if present, `Ok(None)` if absent,
 /// or `Err` with a properly-spanned diagnostic on malformed input.
@@ -6715,6 +6767,83 @@ mod tests {
             ),
             "expected generic instruction-arg coercion impl in wrapper: {wrapper}"
         );
+    }
+
+    #[test]
+    fn process_handler_respects_wrapper_inline_policy() {
+        let handlers: [(syn::ItemFn, &str); 3] = [
+            (
+                syn::parse_quote! {
+                    pub fn default_inline(ctx: &mut Context<DefaultInline>) -> Result<()> {
+                        let _ = ctx;
+                        Ok(())
+                    }
+                },
+                "always",
+            ),
+            (
+                syn::parse_quote! {
+                    #[handler(inline = false)]
+                    pub fn no_inline(
+                        ctx: &mut Context<NoInline>,
+                        amount: u64,
+                    ) -> Result<()> {
+                        let _ = (ctx, amount);
+                        Ok(())
+                    }
+                },
+                "never",
+            ),
+            (
+                syn::parse_quote! {
+                    #[handler(inline = true)]
+                    pub fn explicit_inline(ctx: &mut Context<ExplicitInline>) -> Result<()> {
+                        let _ = ctx;
+                        Ok(())
+                    }
+                },
+                "always",
+            ),
+        ];
+        let mod_name: syn::Ident = syn::parse_quote!(my_program);
+        let program_id: syn::Expr = syn::parse_quote!(crate::ID);
+
+        for (handler, expected_policy) in handlers {
+            let generated = process_handler(&handler, &mod_name, None, &program_id);
+            let wrapper: syn::ItemFn =
+                syn::parse2(generated.wrapper).expect("handler wrapper should be a function");
+            let inline_attr = wrapper
+                .attrs
+                .iter()
+                .find(|attr| attr.path().is_ident("inline"))
+                .expect("handler wrapper should have an inline attribute");
+
+            let syn::Meta::List(inline_meta) = &inline_attr.meta else {
+                panic!("handler wrapper should specify an inline policy: {inline_attr:?}");
+            };
+            assert_eq!(inline_meta.tokens.to_string(), expected_policy);
+        }
+    }
+
+    #[test]
+    fn handler_inline_policy_rejects_invalid_options() {
+        let attrs: [syn::Attribute; 4] = [
+            syn::parse_quote!(#[handler(inline = false, inline = true)]),
+            syn::parse_quote!(#[handler(inline = "sometimes")]),
+            syn::parse_quote!(#[handler(stack = "large")]),
+            syn::parse_quote!(#[handler()]),
+        ];
+
+        for attr in attrs {
+            let mut handler: syn::ItemFn = syn::parse_quote! {
+                pub fn invalid(ctx: &mut Context<Invalid>) -> Result<()> {
+                    let _ = ctx;
+                    Ok(())
+                }
+            };
+            handler.attrs.push(attr);
+            assert!(parse_handler_inline_attr(&handler).is_err());
+        }
     }
 
     #[test]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -4766,15 +4766,100 @@ fn extract_result_return_type(output: &syn::ReturnType) -> syn::Result<Option<Ty
     }
 }
 
+struct HandlerInlinePolicy {
+    condition: Option<TokenStream2>,
+    inline: syn::Meta,
+}
+
+fn collect_handler_inline_policies(
+    meta: &syn::Meta,
+    outer_condition: Option<TokenStream2>,
+    policies: &mut Vec<HandlerInlinePolicy>,
+) -> syn::Result<()> {
+    if meta.path().is_ident("inline") {
+        policies.push(HandlerInlinePolicy {
+            condition: outer_condition,
+            inline: meta.clone(),
+        });
+        return Ok(());
+    }
+
+    let syn::Meta::List(list) = meta else {
+        return Ok(());
+    };
+    if !list.path.is_ident("cfg_attr") {
+        return Ok(());
+    }
+
+    let nested = list.parse_args_with(
+        syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
+    )?;
+    let mut nested = nested.iter();
+    let Some(predicate) = nested.next() else {
+        return Ok(());
+    };
+    let predicate = quote! { #predicate };
+    let condition = Some(match outer_condition {
+        Some(outer) => quote! { all(#outer, #predicate) },
+        None => predicate,
+    });
+
+    for meta in nested {
+        collect_handler_inline_policies(meta, condition.clone(), policies)?;
+    }
+
+    Ok(())
+}
+
+/// Mirror a handler's standard Rust inline policy onto its generated wrapper.
+///
+/// The wrapper stays `#[inline(always)]` when no explicit policy applies. For
+/// conditional policies, a complementary `cfg_attr` preserves that default
+/// when none of their conditions apply.
+fn handler_wrapper_inline_attrs(handler: &syn::ItemFn) -> syn::Result<Vec<TokenStream2>> {
+    let mut policies = Vec::new();
+    for attr in &handler.attrs {
+        collect_handler_inline_policies(&attr.meta, None, &mut policies)?;
+    }
+
+    if policies.is_empty() {
+        return Ok(vec![quote! { #[inline(always)] }]);
+    }
+
+    let mut attrs = Vec::with_capacity(policies.len() + 1);
+    let mut conditions = Vec::new();
+    let mut has_unconditional_policy = false;
+
+    for policy in policies {
+        let inline = policy.inline;
+        if let Some(condition) = policy.condition {
+            attrs.push(quote! { #[cfg_attr(#condition, #inline)] });
+            conditions.push(condition);
+        } else {
+            attrs.push(quote! { #[#inline] });
+            has_unconditional_policy = true;
+        }
+    }
+
+    if !has_unconditional_policy {
+        let fallback = match conditions.as_slice() {
+            [condition] => quote! { not(#condition) },
+            _ => quote! { not(any(#(#conditions),*)) },
+        };
+        attrs.push(quote! { #[cfg_attr(#fallback, inline(always))] });
+    }
+
+    Ok(attrs)
+}
+
 fn process_handler(
     handler: &syn::ItemFn,
     mod_name: &Ident,
     discrim_bytes: Option<&[u8]>,
     program_id: &Expr,
 ) -> HandlerCodegen {
-    let wrapper_inline_attr = match parse_handler_inline_attr(handler) {
-        Ok(true) => quote! { #[inline(always)] },
-        Ok(false) => quote! { #[inline(never)] },
+    let wrapper_inline_attrs = match handler_wrapper_inline_attrs(handler) {
+        Ok(attrs) => attrs,
         Err(err) => return HandlerCodegen::error(handler, err),
     };
     let fn_name = &handler.sig.ident;
@@ -4919,7 +5004,7 @@ fn process_handler(
     let wrapper = if extra_arg_names.is_empty() {
         quote! {
             #(#handler_cfg_attrs)*
-            #wrapper_inline_attr
+            #(#wrapper_inline_attrs)*
             pub fn #fn_name<'a>(
                 __program_id: &'a anchor_lang::Address,
                 __cursor: &'a mut anchor_lang::AccountCursor,
@@ -4956,7 +5041,7 @@ fn process_handler(
         let deser_args = args_deser.deser;
         quote! {
             #(#handler_cfg_attrs)*
-            #wrapper_inline_attr
+            #(#wrapper_inline_attrs)*
             pub fn #fn_name<'a>(
                 __program_id: &'a anchor_lang::Address,
                 __cursor: &'a mut anchor_lang::AccountCursor,
@@ -5379,17 +5464,15 @@ fn impl_program(module: &ItemMod, config: &ProgramConfig) -> TokenStream2 {
         }
     };
 
-    // Strip codegen-only attributes from handler outputs so rustc does not
-    // complain about unknown attributes.
+    // Strip the codegen-only discriminator attribute from handler outputs so
+    // rustc does not complain about an unknown attribute.
     let mut handler_update_errors = Vec::new();
     let handlers: Vec<_> = handlers
         .iter()
         .map(|func| {
             let mut func = (*func).clone();
             func.attrs.retain(|attr| {
-                if attr.path().is_ident("handler") {
-                    false
-                } else if let syn::Meta::NameValue(nv) = &attr.meta {
+                if let syn::Meta::NameValue(nv) = &attr.meta {
                     !nv.path.is_ident("discrim")
                 } else {
                     true
@@ -6475,51 +6558,6 @@ pub fn error_code(args: TokenStream, input: TokenStream) -> TokenStream {
     error_code::expand(args, input)
 }
 
-/// Parse `#[handler(inline = ...)]` on a program handler.
-///
-/// Handlers inline by default to preserve the existing fast path. Programs
-/// with account-loading paths that exceed SBF's 4 KiB stack-frame limit can
-/// opt into a guaranteed wrapper boundary with `#[handler(inline = false)]`.
-fn parse_handler_inline_attr(handler: &syn::ItemFn) -> syn::Result<bool> {
-    let mut inline = None;
-
-    for attr in &handler.attrs {
-        if !attr.path().is_ident("handler") {
-            continue;
-        }
-        if inline.is_some() {
-            return Err(syn::Error::new_spanned(
-                attr,
-                "duplicate `handler` attribute",
-            ));
-        }
-
-        attr.parse_nested_meta(|meta| {
-            if !meta.path.is_ident("inline") {
-                return Err(
-                    meta.error("unsupported handler option; expected `inline = true|false`")
-                );
-            }
-            if inline.is_some() {
-                return Err(meta.error("duplicate `inline` handler option"));
-            }
-
-            let value = meta.value()?;
-            let value: syn::LitBool = value.parse()?;
-            inline = Some(value.value);
-            Ok(())
-        })?;
-        if inline.is_none() {
-            return Err(syn::Error::new_spanned(
-                attr,
-                "expected `#[handler(inline = true|false)]`",
-            ));
-        }
-    }
-
-    Ok(inline.unwrap_or(true))
-}
-
 /// Parse the optional `#[discrim = ...]` attribute on a handler fn.
 /// Returns `Ok(Some(...))` if present, `Ok(None)` if absent,
 /// or `Err` with a properly-spanned diagnostic on malformed input.
@@ -6770,8 +6808,8 @@ mod tests {
     }
 
     #[test]
-    fn process_handler_respects_wrapper_inline_policy() {
-        let handlers: [(syn::ItemFn, &str); 3] = [
+    fn wrapper_inline_policy_mirrors_standard_attributes() {
+        let handlers: [(syn::ItemFn, TokenStream2); 4] = [
             (
                 syn::parse_quote! {
                     pub fn default_inline(ctx: &mut Context<DefaultInline>) -> Result<()> {
@@ -6779,11 +6817,21 @@ mod tests {
                         Ok(())
                     }
                 },
-                "always",
+                quote! { #[inline(always)] },
             ),
             (
                 syn::parse_quote! {
-                    #[handler(inline = false)]
+                    #[inline]
+                    pub fn hinted_inline(ctx: &mut Context<HintedInline>) -> Result<()> {
+                        let _ = ctx;
+                        Ok(())
+                    }
+                },
+                quote! { #[inline] },
+            ),
+            (
+                syn::parse_quote! {
+                    #[inline(never)]
                     pub fn no_inline(
                         ctx: &mut Context<NoInline>,
                         amount: u64,
@@ -6792,58 +6840,163 @@ mod tests {
                         Ok(())
                     }
                 },
-                "never",
+                quote! { #[inline(never)] },
             ),
             (
                 syn::parse_quote! {
-                    #[handler(inline = true)]
+                    #[inline(always)]
                     pub fn explicit_inline(ctx: &mut Context<ExplicitInline>) -> Result<()> {
                         let _ = ctx;
                         Ok(())
                     }
                 },
-                "always",
+                quote! { #[inline(always)] },
             ),
         ];
-        let mod_name: syn::Ident = syn::parse_quote!(my_program);
-        let program_id: syn::Expr = syn::parse_quote!(crate::ID);
 
         for (handler, expected_policy) in handlers {
-            let generated = process_handler(&handler, &mod_name, None, &program_id);
-            let wrapper: syn::ItemFn =
-                syn::parse2(generated.wrapper).expect("handler wrapper should be a function");
-            let inline_attr = wrapper
-                .attrs
-                .iter()
-                .find(|attr| attr.path().is_ident("inline"))
-                .expect("handler wrapper should have an inline attribute");
-
-            let syn::Meta::List(inline_meta) = &inline_attr.meta else {
-                panic!("handler wrapper should specify an inline policy: {inline_attr:?}");
-            };
-            assert_eq!(inline_meta.tokens.to_string(), expected_policy);
+            let actual =
+                handler_wrapper_inline_attrs(&handler).expect("inline policy should parse");
+            assert_eq!(
+                quote! { #(#actual)* }.to_string(),
+                expected_policy.to_string()
+            );
         }
     }
 
     #[test]
-    fn handler_inline_policy_rejects_invalid_options() {
-        let attrs: [syn::Attribute; 4] = [
-            syn::parse_quote!(#[handler(inline = false, inline = true)]),
-            syn::parse_quote!(#[handler(inline = "sometimes")]),
-            syn::parse_quote!(#[handler(stack = "large")]),
-            syn::parse_quote!(#[handler()]),
-        ];
+    fn wrapper_inline_policy_preserves_conditional_default() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
 
-        for attr in attrs {
-            let mut handler: syn::ItemFn = syn::parse_quote! {
-                pub fn invalid(ctx: &mut Context<Invalid>) -> Result<()> {
-                    let _ = ctx;
-                    Ok(())
-                }
-            };
-            handler.attrs.push(attr);
-            assert!(parse_handler_inline_attr(&handler).is_err());
-        }
+        let actual =
+            handler_wrapper_inline_attrs(&handler).expect("conditional policy should parse");
+        let expected = quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            #[cfg_attr(not(feature = "isolate"), inline(always))]
+        };
+        assert_eq!(quote! { #(#actual)* }.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn wrapper_inline_policy_combines_nested_conditions() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(
+                feature = "outer",
+                cfg_attr(feature = "inner", inline(never))
+            )]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
+
+        let actual = handler_wrapper_inline_attrs(&handler).expect("nested policy should parse");
+        let expected = quote! {
+            #[cfg_attr(all(feature = "outer", feature = "inner"), inline(never))]
+            #[cfg_attr(
+                not(all(feature = "outer", feature = "inner")),
+                inline(always)
+            )]
+        };
+        assert_eq!(quote! { #(#actual)* }.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn wrapper_inline_policy_preserves_mutually_exclusive_policies() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            #[cfg_attr(not(feature = "isolate"), inline(always))]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
+
+        let actual = handler_wrapper_inline_attrs(&handler).expect("policies should parse");
+        let expected = quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            #[cfg_attr(not(feature = "isolate"), inline(always))]
+            #[cfg_attr(
+                not(any(feature = "isolate", not(feature = "isolate"))),
+                inline(always)
+            )]
+        };
+        assert_eq!(quote! { #(#actual)* }.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn wrapper_inline_policy_defaults_when_no_condition_matches() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(feature = "small-stack", inline(never))]
+            #[cfg_attr(feature = "hot-path", inline(always))]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
+
+        let actual = handler_wrapper_inline_attrs(&handler).expect("policies should parse");
+        let expected = quote! {
+            #[cfg_attr(feature = "small-stack", inline(never))]
+            #[cfg_attr(feature = "hot-path", inline(always))]
+            #[cfg_attr(
+                not(any(feature = "small-stack", feature = "hot-path")),
+                inline(always)
+            )]
+        };
+        assert_eq!(quote! { #(#actual)* }.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn wrapper_inline_policy_does_not_add_fallback_to_unconditional_policy() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            #[inline(always)]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
+
+        let actual = handler_wrapper_inline_attrs(&handler).expect("policies should parse");
+        let expected = quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            #[inline(always)]
+        };
+        assert_eq!(quote! { #(#actual)* }.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn process_handler_emits_conditional_wrapper_inline_policy() {
+        let handler: syn::ItemFn = syn::parse_quote! {
+            #[cfg_attr(feature = "isolate", inline(never))]
+            pub fn conditional(ctx: &mut Context<Conditional>) -> Result<()> {
+                let _ = ctx;
+                Ok(())
+            }
+        };
+        let mod_name: syn::Ident = syn::parse_quote!(my_program);
+        let program_id: syn::Expr = syn::parse_quote!(crate::ID);
+        let generated = process_handler(&handler, &mod_name, None, &program_id);
+        let wrapper: syn::ItemFn =
+            syn::parse2(generated.wrapper).expect("handler wrapper should be a function");
+        let attrs: Vec<_> = wrapper
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg_attr"))
+            .collect();
+
+        assert_eq!(attrs.len(), 2);
+        let first = &attrs[0].meta;
+        let second = &attrs[1].meta;
+        assert!(quote!(#first).to_string().contains("inline (never)"));
+        assert!(quote!(#second).to_string().contains("inline (always)"));
     }
 
     #[test]

--- a/tests-v2/programs/handler-inline-policy/Cargo.toml
+++ b/tests-v2/programs/handler-inline-policy/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "handler-inline-policy"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+default = ["no-log-ix-name"]
+force-inline = []
+no-entrypoint = []
+no-log-ix-name = []
+idl-build = []
+
+[dependencies]
+anchor-lang = { path = "../../../lang-v2", default-features = false, features = ["alloc"] }
+
+[lints.rust.unexpected_cfgs]
+level = "allow"

--- a/tests-v2/programs/handler-inline-policy/Cargo.toml
+++ b/tests-v2/programs/handler-inline-policy/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 default = ["no-log-ix-name"]
-force-inline = []
+isolate-handlers = []
 no-entrypoint = []
 no-log-ix-name = []
 idl-build = []

--- a/tests-v2/programs/handler-inline-policy/src/lib.rs
+++ b/tests-v2/programs/handler-inline-policy/src/lib.rs
@@ -1,0 +1,87 @@
+use anchor_lang::prelude::*;
+
+declare_id!("6NxceYZNn23ERJ6rDPENG8iT5bz7osPqiQeWukHaYsRs");
+
+#[account(borsh)]
+pub struct LargeState {
+    pub values: [u64; 120],
+}
+
+macro_rules! large_accounts {
+    ($outer:ident, $inner:ident) => {
+        #[derive(Accounts)]
+        pub struct $inner {
+            pub account_0: BorshAccount<LargeState>,
+            pub account_1: BorshAccount<LargeState>,
+            pub account_2: BorshAccount<LargeState>,
+            pub account_3: BorshAccount<LargeState>,
+        }
+
+        #[derive(Accounts)]
+        pub struct $outer {
+            pub inner_0: Nested<$inner>,
+        }
+    };
+}
+
+large_accounts!(LargeOne, InnerOne);
+large_accounts!(LargeTwo, InnerTwo);
+large_accounts!(LargeThree, InnerThree);
+large_accounts!(LargeFour, InnerFour);
+
+#[cfg(not(feature = "force-inline"))]
+#[program]
+pub mod handler_inline_policy {
+    use super::*;
+
+    #[handler(inline = false)]
+    pub fn instruction_one(_ctx: &mut Context<LargeOne>) -> Result<()> {
+        Ok(())
+    }
+
+    #[handler(inline = false)]
+    pub fn instruction_two(_ctx: &mut Context<LargeTwo>) -> Result<()> {
+        Ok(())
+    }
+
+    #[handler(inline = false)]
+    pub fn instruction_three(_ctx: &mut Context<LargeThree>) -> Result<()> {
+        Ok(())
+    }
+
+    #[handler(inline = false)]
+    pub fn instruction_four(_ctx: &mut Context<LargeFour>) -> Result<()> {
+        Ok(())
+    }
+
+    #[handler(inline = false)]
+    pub fn instruction_five(_ctx: &mut Context<LargeOne>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "force-inline")]
+#[program]
+pub mod handler_inline_policy {
+    use super::*;
+
+    pub fn instruction_one(_ctx: &mut Context<LargeOne>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn instruction_two(_ctx: &mut Context<LargeTwo>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn instruction_three(_ctx: &mut Context<LargeThree>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn instruction_four(_ctx: &mut Context<LargeFour>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn instruction_five(_ctx: &mut Context<LargeOne>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/tests-v2/programs/handler-inline-policy/src/lib.rs
+++ b/tests-v2/programs/handler-inline-policy/src/lib.rs
@@ -29,58 +29,31 @@ large_accounts!(LargeTwo, InnerTwo);
 large_accounts!(LargeThree, InnerThree);
 large_accounts!(LargeFour, InnerFour);
 
-#[cfg(not(feature = "force-inline"))]
 #[program]
 pub mod handler_inline_policy {
     use super::*;
 
-    #[handler(inline = false)]
+    #[cfg_attr(feature = "isolate-handlers", inline(never))]
     pub fn instruction_one(_ctx: &mut Context<LargeOne>) -> Result<()> {
         Ok(())
     }
 
-    #[handler(inline = false)]
+    #[cfg_attr(feature = "isolate-handlers", inline(never))]
     pub fn instruction_two(_ctx: &mut Context<LargeTwo>) -> Result<()> {
         Ok(())
     }
 
-    #[handler(inline = false)]
+    #[cfg_attr(feature = "isolate-handlers", inline(never))]
     pub fn instruction_three(_ctx: &mut Context<LargeThree>) -> Result<()> {
         Ok(())
     }
 
-    #[handler(inline = false)]
+    #[cfg_attr(feature = "isolate-handlers", inline(never))]
     pub fn instruction_four(_ctx: &mut Context<LargeFour>) -> Result<()> {
         Ok(())
     }
 
-    #[handler(inline = false)]
-    pub fn instruction_five(_ctx: &mut Context<LargeOne>) -> Result<()> {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "force-inline")]
-#[program]
-pub mod handler_inline_policy {
-    use super::*;
-
-    pub fn instruction_one(_ctx: &mut Context<LargeOne>) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn instruction_two(_ctx: &mut Context<LargeTwo>) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn instruction_three(_ctx: &mut Context<LargeThree>) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn instruction_four(_ctx: &mut Context<LargeFour>) -> Result<()> {
-        Ok(())
-    }
-
+    #[cfg_attr(feature = "isolate-handlers", inline(never))]
     pub fn instruction_five(_ctx: &mut Context<LargeOne>) -> Result<()> {
         Ok(())
     }

--- a/tests-v2/tests/cfg_semantics.rs
+++ b/tests-v2/tests/cfg_semantics.rs
@@ -52,7 +52,11 @@ live = []
 }
 
 fn compile_pass_case(name: &str, source: &str) {
-    let output = cargo_case(name, source, "check", &[]);
+    compile_pass_case_with_features(name, source, &[]);
+}
+
+fn compile_pass_case_with_features(name: &str, source: &str, features: &[&str]) {
+    let output = cargo_case(name, source, "check", features);
     assert!(
         output.status.success(),
         "{name} failed to compile\n\nstdout:\n{}\n\nstderr:\n{}",
@@ -98,6 +102,36 @@ pub mod gated_program {
 pub struct Noop {}
 "#,
     );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
+fn cfg_attr_inline_policy_compiles_in_both_branches() {
+    let source = r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod conditional_inline {
+    use super::*;
+
+    #[cfg_attr(feature = "live", inline(never))]
+    #[cfg_attr(not(feature = "live"), inline(always))]
+    pub fn run(_ctx: &mut Context<Noop>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Noop {}
+"#;
+
+    compile_pass_case("tests_v2_cfg_attr_inline_default", source);
+    compile_pass_case_with_features("tests_v2_cfg_attr_inline_never", source, &["live"]);
 }
 
 #[test]

--- a/tests-v2/tests/handler_inline_policy.rs
+++ b/tests-v2/tests/handler_inline_policy.rs
@@ -1,0 +1,47 @@
+use std::{path::Path, process::Command};
+
+fn build_fixture(manifest_dir: &Path, force_inline: bool) -> String {
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("handler-inline-policy");
+    let mut command = Command::new("cargo");
+    command
+        .env("CARGO_TARGET_DIR", target_dir)
+        .args(["build-sbf", "--tools-version", "v1.52", "--manifest-path"])
+        .arg(manifest_dir.join("Cargo.toml"));
+    if force_inline {
+        command.args(["--features", "force-inline"]);
+    }
+
+    let output = command.output().expect("run cargo build-sbf");
+    let build_log = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "handler inline policy fixture did not build:\n{build_log}"
+    );
+    build_log
+}
+
+#[test]
+fn handler_inline_false_prevents_dispatcher_stack_overflow() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("programs")
+        .join("handler-inline-policy");
+
+    let forced_inline_log = build_fixture(&manifest_dir, true);
+    assert!(
+        forced_inline_log.contains("__anchor_dispatch_internal")
+            && forced_inline_log.contains("exceeded max offset of 4096"),
+        "forced-inline fixture must reproduce the dispatcher overflow:\n{forced_inline_log}"
+    );
+
+    let isolated_log = build_fixture(&manifest_dir, false);
+    assert!(
+        !isolated_log.contains("exceeded max offset of 4096"),
+        "isolated handlers must stay within the SBF frame limit:\n{isolated_log}"
+    );
+}

--- a/tests-v2/tests/handler_inline_policy.rs
+++ b/tests-v2/tests/handler_inline_policy.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, process::Command};
 
-fn build_fixture(manifest_dir: &Path, force_inline: bool) -> String {
+fn build_fixture(manifest_dir: &Path, isolate_handlers: bool) -> String {
     let target_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("target")
         .join("handler-inline-policy");
@@ -9,8 +9,8 @@ fn build_fixture(manifest_dir: &Path, force_inline: bool) -> String {
         .env("CARGO_TARGET_DIR", target_dir)
         .args(["build-sbf", "--tools-version", "v1.52", "--manifest-path"])
         .arg(manifest_dir.join("Cargo.toml"));
-    if force_inline {
-        command.args(["--features", "force-inline"]);
+    if isolate_handlers {
+        command.args(["--features", "isolate-handlers"]);
     }
 
     let output = command.output().expect("run cargo build-sbf");
@@ -27,19 +27,19 @@ fn build_fixture(manifest_dir: &Path, force_inline: bool) -> String {
 }
 
 #[test]
-fn handler_inline_false_prevents_dispatcher_stack_overflow() {
+fn conditional_inline_never_prevents_dispatcher_stack_overflow() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("programs")
         .join("handler-inline-policy");
 
-    let forced_inline_log = build_fixture(&manifest_dir, true);
+    let default_inline_log = build_fixture(&manifest_dir, false);
     assert!(
-        forced_inline_log.contains("__anchor_dispatch_internal")
-            && forced_inline_log.contains("exceeded max offset of 4096"),
-        "forced-inline fixture must reproduce the dispatcher overflow:\n{forced_inline_log}"
+        default_inline_log.contains("__anchor_dispatch_internal")
+            && default_inline_log.contains("exceeded max offset of 4096"),
+        "default-inline fixture must reproduce the dispatcher overflow:\n{default_inline_log}"
     );
 
-    let isolated_log = build_fixture(&manifest_dir, false);
+    let isolated_log = build_fixture(&manifest_dir, true);
     assert!(
         !isolated_log.contains("exceeded max offset of 4096"),
         "isolated handlers must stay within the SBF frame limit:\n{isolated_log}"


### PR DESCRIPTION
## Summary

- mirror standard Rust `#[inline]`, `#[inline(always)]`, and
  `#[inline(never)]` attributes onto generated instruction wrappers
- preserve the existing `#[inline(always)]` wrapper default for
  unannotated handlers
- support conditional and nested `cfg_attr` inline policies without
  leaking attributes into generated code
- allow selected handlers to isolate account loading from the shared
  SBF dispatcher frame
- retain the SBF regression and dedicated CI execution

This keeps account validation on Anchor's normal `run_handler` path.

Using `#[inline(never)]` also applies the policy to the user handler, so
isolated instructions may use additional compute units and binary space.

Fixes #4941.

## Branch Target

This is a v2-only change and targets `anchor-next`.

## Testing

- `cargo test --locked -p anchor-derive-accounts`
- `cargo test --locked -p anchor-lang --tests`
- `cargo test --locked -p tests-v2 --test handler_inline_policy`
- `cargo test --locked -p tests-v2 --tests --no-run`
- `cargo check --locked -p handler-inline-policy --all-targets --all-features`