### PR TITLE
fix(borsh): encode layouts larger than 1000 bytes without error

### DIFF
--- a/ts/packages/anchor/src/coder/borsh/accounts.ts
+++ b/ts/packages/anchor/src/coder/borsh/accounts.ts
@@ -1,6 +1,7 @@
 import bs58 from "bs58";
 import { Buffer } from "buffer";
 import { Layout } from "buffer-layout";
+import * as borsh from "@anchor-lang/borsh";
 import { Idl, IdlDiscriminator } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import { AccountsCoder } from "../index.js";
@@ -48,13 +49,11 @@ export class BorshAccountsCoder<A extends string = string>
   }
 
   public async encode<T = any>(accountName: A, account: T): Promise<Buffer> {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const layout = this.accountLayouts.get(accountName);
     if (!layout) {
       throw new Error(`Unknown account: ${accountName}`);
     }
-    const len = layout.layout.encode(account, buffer);
-    const accountData = buffer.slice(0, len);
+    const accountData = borsh.encodeLayout(layout.layout, account);
     const discriminator = this.accountDiscriminator(accountName);
     return Buffer.concat([discriminator, accountData]);
   }

--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -48,7 +48,6 @@ export class BorshInstructionCoder implements InstructionCoder {
    * Encodes a program instruction.
    */
   public encode(ixName: string, ix: any): Buffer {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const encoder = this.ixLayouts.get(ixName);
     if (!encoder) {
       throw new Error(`Unknown method: ${ixName}`);
@@ -89,8 +88,7 @@ export class BorshInstructionCoder implements InstructionCoder {
       ix,
       this.idl.types
     );
-    const len = encoder.layout.encode(ixWithDefinedOptions, buffer);
-    const data = buffer.slice(0, len);
+    const data = borsh.encodeLayout(encoder.layout, ixWithDefinedOptions);
 
     return Buffer.concat([Buffer.from(encoder.discriminator), data]);
   }

--- a/ts/packages/anchor/src/coder/borsh/types.ts
+++ b/ts/packages/anchor/src/coder/borsh/types.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import { Layout } from "buffer-layout";
+import * as borsh from "@anchor-lang/borsh";
 import { Idl } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import { TypesCoder } from "../index.js";
@@ -30,14 +31,12 @@ export class BorshTypesCoder<N extends string = string> implements TypesCoder {
   }
 
   public encode<T = any>(name: N, type: T): Buffer {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const layout = this.typeLayouts.get(name);
     if (!layout) {
       throw new Error(`Unknown type: ${name}`);
     }
-    const len = layout.encode(type, buffer);
 
-    return buffer.slice(0, len);
+    return borsh.encodeLayout(layout, type);
   }
 
   public decode<T = any>(name: N, data: Buffer): T {

--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
 import BN from "bn.js";
+import { PublicKey } from "@solana/web3.js";
+import { Buffer } from "buffer";
 import { BorshCoder } from "../src";
 import { Idl, IdlType } from "../src/idl";
 import { toInstruction } from "../src/program/common";
@@ -660,5 +662,47 @@ describe("coder.instructions", () => {
     );
     assert.strictEqual(decoded?.data["wrapper"].Fields.someArg, null);
     assert.ok(decoded?.data["wrapper"].Fields.someArg2.eq(new BN(0x3030)));
+  });
+
+  test("encodes instruction arguments larger than 1000 bytes without truncation", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+          accounts: [],
+          args: [
+            {
+              name: "keys",
+              type: {
+                vec: "pubkey",
+              },
+            },
+          ],
+        },
+      ],
+      types: [],
+    };
+
+    const idlIx = idl.instructions[0];
+    const coder = new BorshCoder(idl);
+
+    // 32 public keys serialize to 4 + 32*32 = 1028 bytes, exceeding the
+    // encoder's default 1000-byte scratch buffer.
+    const keys = Array.from({ length: 32 }, (_, i) =>
+      new PublicKey(Buffer.alloc(32, i))
+    );
+
+    const encoded = coder.instruction.encode(idlIx.name, { keys });
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.strictEqual(encoded.length, 8 + 4 + 32 * 32);
+    assert.deepStrictEqual(decoded?.data["keys"], keys);
   });
 });

--- a/ts/packages/borsh/src/index.ts
+++ b/ts/packages/borsh/src/index.ts
@@ -548,6 +548,49 @@ export function vecU8(property?: string): Layout<Buffer> {
   return new BytesLayout(property);
 }
 
+/**
+ * Encodes `src` with `layout`, allocating a buffer that is guaranteed to fit
+ * the serialized value.
+ *
+ * Fixed-size layouts allocate exactly `layout.span` bytes. Variable-size
+ * layouts (Vec, String, Option, ...) start with a 1000-byte buffer and grow
+ * on overflow, so values larger than the initial allocation are never dropped:
+ * Buffer.copy otherwise stops silently once the destination is full, and the
+ * underlying layouts surface the overrun as a RangeError.
+ */
+export function encodeLayout<T>(layout: Layout<T>, src: T): Buffer {
+  if (layout.span > 0) {
+    const buffer = Buffer.alloc(layout.span);
+    const len = layout.encode(src, buffer);
+    return buffer.slice(0, len);
+  }
+
+  // Max serialized size is bounded by what an account/tx can hold. This is
+  // far above any real value while still guarding against unbounded growth.
+  const MAX_ENCODE_SIZE = 10 * 1024 * 1024;
+
+  let buffer = Buffer.alloc(1000);
+  for (;;) {
+    try {
+      const len = layout.encode(src, buffer);
+      return buffer.slice(0, len);
+    } catch (err) {
+      const overflow = (e: unknown): boolean =>
+        e instanceof RangeError &&
+        /overruns Buffer|remaining bytes/.test((e as Error).message);
+      // Only a too-small destination overruns the buffer; other RangeErrors
+      // are genuine input errors and must not be retried.
+      if (!overflow(err)) {
+        throw err;
+      }
+      if (buffer.length >= MAX_ENCODE_SIZE) {
+        throw err;
+      }
+      buffer = Buffer.alloc(buffer.length * 2);
+    }
+  }
+}
+
 export function str(property?: string): Layout<string> {
   return new WrappedLayout(
     vecU8(),


### PR DESCRIPTION
## Summary

The Borsh instruction, account, and type coders in the TS package allocate a
fixed `Buffer.alloc(1000)` scratch buffer for every encode. Any payload that
serializes to more than 1000 bytes fails hard: buffer-layout throws
`RangeError: encoding overruns Buffer` (or the borsh length guards throw
`Invalid bytes: need N bytes, only M remaining`), so the data can never be
encoded at all.

This is not an exotic case. A single instruction taking `Vec<PublicKey>` with
32 entries serializes to 4 + 32*32 = 1028 bytes, and Solana transactions allow
instruction data well past that (the tx size cap is 1232 bytes, and account /
type payloads have no such limit). Multi-KB `Vec<u8>` arguments, large account
structs, and batch operations all hit this wall with a confusing error instead
of working.

## Change

Add `encodeLayout()` to `@anchor-lang/borsh`:

- Fixed-size layouts (`layout.span > 0`) allocate exactly `layout.span` bytes.
- Variable-size layouts (Vec, String, Option, ...) start with a 1000-byte
  buffer and grow on overflow, so values larger than the initial allocation
  are never dropped. Genuine input errors are rethrown, not retried.

Route `BorshInstructionCoder.encode`, `BorshAccountsCoder.encode`, and
`BorshTypesCoder.encode` through it, removing the duplicated
`Buffer.alloc(1000)` / `slice` pattern.

## Tests

Add a regression test in `coder-instructions.spec.ts` that encodes an
instruction with 32 public keys (1028 bytes) and asserts the round-trip is
intact. Without the fix it throws `RangeError: encoding overruns Buffer`;
with the fix it passes. The full coder suite (instruction/account/type/malformed
lengths) passes: 33/33.
