### PR TITLE
fix(borsh): encode layouts larger than 1000 bytes without error

### DIFF
--- a/ts/packages/anchor/src/coder/borsh/accounts.ts
+++ b/ts/packages/anchor/src/coder/borsh/accounts.ts
@@ -1,6 +1,7 @@
 import bs58 from "bs58";
 import { Buffer } from "buffer";
 import { Layout } from "buffer-layout";
+import { encodeLayout } from "@anchor-lang/borsh";
 import { Idl, IdlDiscriminator } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import { AccountsCoder } from "../index.js";
@@ -48,13 +49,11 @@ export class BorshAccountsCoder<A extends string = string>
   }
 
   public async encode<T = any>(accountName: A, account: T): Promise<Buffer> {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const layout = this.accountLayouts.get(accountName);
     if (!layout) {
       throw new Error(`Unknown account: ${accountName}`);
     }
-    const len = layout.layout.encode(account, buffer);
-    const accountData = buffer.slice(0, len);
+    const accountData = encodeLayout(layout.layout, account);
     const discriminator = this.accountDiscriminator(accountName);
     return Buffer.concat([discriminator, accountData]);
   }

--- a/ts/packages/anchor/src/coder/borsh/instruction.ts
+++ b/ts/packages/anchor/src/coder/borsh/instruction.ts
@@ -44,14 +44,12 @@ export class BorshInstructionCoder implements InstructionCoder {
    * Encodes a program instruction.
    */
   public encode(ixName: string, ix: any): Buffer {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const encoder = this.ixLayouts.get(ixName);
     if (!encoder) {
       throw new Error(`Unknown method: ${ixName}`);
     }
 
-    const len = encoder.layout.encode(ix, buffer);
-    const data = buffer.slice(0, len);
+    const data = borsh.encodeLayout(encoder.layout, ix);
 
     return Buffer.concat([Buffer.from(encoder.discriminator), data]);
   }

--- a/ts/packages/anchor/src/coder/borsh/types.ts
+++ b/ts/packages/anchor/src/coder/borsh/types.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import { Layout } from "buffer-layout";
+import { encodeLayout } from "@anchor-lang/borsh";
 import { Idl } from "../../idl.js";
 import { IdlCoder } from "./idl.js";
 import { TypesCoder } from "../index.js";
@@ -30,14 +31,12 @@ export class BorshTypesCoder<N extends string = string> implements TypesCoder {
   }
 
   public encode<T = any>(name: N, type: T): Buffer {
-    const buffer = Buffer.alloc(1000); // TODO: use a tighter buffer.
     const layout = this.typeLayouts.get(name);
     if (!layout) {
       throw new Error(`Unknown type: ${name}`);
     }
-    const len = layout.encode(type, buffer);
 
-    return buffer.slice(0, len);
+    return encodeLayout(layout, type);
   }
 
   public decode<T = any>(name: N, data: Buffer): T {

--- a/ts/packages/anchor/tests/coder-accounts.spec.ts
+++ b/ts/packages/anchor/tests/coder-accounts.spec.ts
@@ -233,4 +233,52 @@ describe("coder.accounts", () => {
       assert.deepEqual(coder.accounts.decode("MyAcc", encoded), myAcc);
     });
   });
+
+  test("Can encode and decode accounts larger than 1000 bytes", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "basic_0",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          discriminator: [],
+          accounts: [],
+          args: [],
+        },
+      ],
+      accounts: [
+        {
+          name: "BigAccount",
+          discriminator: [0, 1, 2, 3, 4, 5, 6, 7],
+        },
+      ],
+      types: [
+        {
+          name: "BigAccount",
+          type: {
+            kind: "struct",
+            fields: [
+              {
+                name: "data",
+                type: "bytes",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const coder = new BorshCoder(idl);
+
+    const bigAccount = {
+      data: Buffer.alloc(5000, 1),
+    };
+
+    coder.accounts.encode("BigAccount", bigAccount).then((encoded) => {
+      assert.deepEqual(coder.accounts.decode("BigAccount", encoded), bigAccount);
+    });
+  });
 });

--- a/ts/packages/anchor/tests/coder-instructions.spec.ts
+++ b/ts/packages/anchor/tests/coder-instructions.spec.ts
@@ -167,4 +167,40 @@ describe("coder.instructions", () => {
     assert.deepStrictEqual(decodedSomeNone?.data["arg"], null);
     assert.deepStrictEqual(decodedSomeSome?.data["arg"], 1);
   });
+
+  test("Can encode and decode instruction args larger than 1000 bytes", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "test",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "bigArg",
+          discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+          accounts: [],
+          args: [
+            {
+              name: "arg",
+              type: "bytes",
+            },
+          ],
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const idlIx = idl.instructions[0];
+    const bigBuffer = Buffer.alloc(5000, 1);
+
+    const encoded = coder.instruction.encode(
+      idlIx.name,
+      toInstruction(idlIx, bigBuffer)
+    );
+    const decoded = coder.instruction.decode(encoded);
+
+    assert.deepStrictEqual(decoded?.data[idlIx.args[0].name], bigBuffer);
+  });
 });

--- a/ts/packages/anchor/tests/coder-types.spec.ts
+++ b/ts/packages/anchor/tests/coder-types.spec.ts
@@ -97,4 +97,45 @@ describe("coder.types", () => {
       testing.toString()
     );
   });
+
+  test("Can encode and decode types larger than 1000 bytes", () => {
+    const idl: Idl = {
+      address: "Test111111111111111111111111111111111111111",
+      metadata: {
+        name: "basic_0",
+        version: "0.0.0",
+        spec: "0.1.0",
+      },
+      instructions: [
+        {
+          name: "initialize",
+          accounts: [],
+          args: [],
+          discriminator: [],
+        },
+      ],
+      types: [
+        {
+          name: "BigPayload",
+          type: {
+            kind: "struct",
+            fields: [
+              {
+                name: "data",
+                type: "bytes",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const coder = new BorshCoder(idl);
+    const bigPayload = {
+      data: Buffer.alloc(5000, 1),
+    };
+    const encoded = coder.types.encode("BigPayload", bigPayload);
+
+    assert.deepEqual(coder.types.decode("BigPayload", encoded), bigPayload);
+  });
 });

--- a/ts/packages/borsh/src/index.ts
+++ b/ts/packages/borsh/src/index.ts
@@ -428,3 +428,44 @@ export function map<K, V>(
     property
   );
 }
+
+/**
+ * Encode `src` into a freshly allocated buffer of exactly the right size.
+ *
+ * Fixed-size layouts allocate `layout.span` bytes exactly. Variable-size
+ * layouts (a `vec`, `str`, `map`, or a struct containing one) start with a
+ * scratch buffer and grow it by doubling whenever the write overruns it.
+ * Growth is capped so a pathological size cannot balloon memory.
+ */
+export function encodeLayout<T>(layout: Layout<T>, src: T): Buffer {
+  if (layout.span > 0) {
+    const buffer = Buffer.alloc(layout.span);
+    const len = layout.encode(src, buffer);
+    return buffer.slice(0, len);
+  }
+
+  // Max serialized size is bounded by what an account/tx can hold. This is
+  // far above any real value while still guarding against unbounded growth.
+  const MAX_ENCODE_SIZE = 10 * 1024 * 1024;
+
+  let buffer = Buffer.alloc(1000);
+  for (;;) {
+    try {
+      const len = layout.encode(src, buffer);
+      return buffer.slice(0, len);
+    } catch (err) {
+      const overflow = (e: unknown): boolean =>
+        e instanceof RangeError &&
+        /overruns Buffer|remaining bytes/.test((e as Error).message);
+      // Only a too-small destination overruns the buffer; other RangeErrors
+      // are genuine input errors and must not be retried.
+      if (!overflow(err)) {
+        throw err;
+      }
+      if (buffer.length >= MAX_ENCODE_SIZE) {
+        throw err;
+      }
+      buffer = Buffer.alloc(buffer.length * 2);
+    }
+  }
+}


### PR DESCRIPTION
This is the anchor-next equivalent of #4961. On this branch the bug is still live in three places.

The account, instruction and type coders allocate a fixed 1000 byte buffer and write straight into it. Any payload over about 996 bytes throws `encoding overruns Buffer` and can never be encoded. A program whose instruction args, account fields or user-defined types carry a string, bytes or vec larger than ~1KB is unusable from the TS SDK on this branch.

### Changes

- Add an `encodeLayout` helper to `@anchor-lang/borsh`. It allocates exactly `layout.span` bytes for fixed-size layouts and doubles a scratch buffer (capped at 10 MiB) for variable-size layouts, so the returned buffer is always exactly the serialized length.
- Route `BorshAccountsCoder.encode`, `BorshInstructionCoder.encode` and `BorshTypesCoder.encode` through it.

### Tests

Added regression tests to the coder suites that round-trip a 5000 byte payload through each coder path. Before this change they throw `encoding overruns Buffer`; after it they pass.
