### PR TITLE
lang: add opt-in private diagnostics

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -43,6 +43,7 @@ lazy-account = [
     "anchor-attribute-account/lazy-account",
     "anchor-derive-serde/lazy-account",
 ]
+private-program = ["anchor-lang-error/private-program"]
 
 [dependencies]
 anchor-attribute-access-control = { workspace = true }

--- a/lang/attribute/error/src/lib.rs
+++ b/lang/attribute/error/src/lib.rs
@@ -8,7 +8,7 @@ use {
     },
     proc_macro::TokenStream,
     quote::quote,
-    syn::{parse_macro_input, Expr},
+    syn::parse_macro_input,
 };
 
 /// Generates `Error` and `type Result<T> = Result<T, Error>` types to be
@@ -96,32 +96,7 @@ pub fn error_code(
 pub fn error(ts: proc_macro::TokenStream) -> TokenStream {
     let input = parse_macro_input!(ts as ErrorInput);
     let error_code = input.error_code;
-    create_error(error_code, true, None)
-}
-
-fn create_error(error_code: Expr, source: bool, account_name: Option<Expr>) -> TokenStream {
-    let error_origin = match (source, account_name) {
-        (false, None) => quote! { None },
-        (false, Some(account_name)) => quote! {
-            Some(anchor_lang::error::ErrorOrigin::AccountName(#account_name.to_string()))
-        },
-        (true, _) => quote! {
-            Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
-                filename: file!(),
-                line: line!()
-            }))
-        },
-    };
-
     TokenStream::from(quote! {
-        anchor_lang::error::Error::from(
-            anchor_lang::error::AnchorError {
-                error_name: #error_code.name(),
-                error_code_number: #error_code.into(),
-                error_msg: #error_code.to_string(),
-                error_origin: #error_origin,
-                compared_values: None
-            }
-        )
+        anchor_lang::__anchor_error!(#error_code, source)
     })
 }

--- a/lang/error/Cargo.toml
+++ b/lang/error/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [features]
 default = ["borsh"]
 borsh = ["dep:borsh", "solana-program-error/borsh"]
+private-program = []
 
 [dependencies]
 anchor-attribute-error = { workspace = true }

--- a/lang/error/src/lib.rs
+++ b/lang/error/src/lib.rs
@@ -11,11 +11,82 @@ use {
 /// The starting point for user defined error codes.
 pub const ERROR_CODE_OFFSET: u32 = 6000;
 
+/// Construct an Anchor error while keeping diagnostic generation controlled by
+/// the `anchor-lang/private-program` feature. This is exported for Anchor's
+/// generated code and is not a stable public API.
+#[cfg(not(feature = "private-program"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_error {
+    ($error_code:expr) => {{
+        let error_code = $error_code;
+        $crate::Error::from($crate::AnchorError {
+            error_name: error_code.name(),
+            error_code_number: error_code.into(),
+            error_msg: error_code.to_string(),
+            error_origin: None,
+            compared_values: None,
+        })
+    }};
+    ($error_code:expr, source) => {{
+        let error_code = $error_code;
+        $crate::Error::from($crate::AnchorError {
+            error_name: error_code.name(),
+            error_code_number: error_code.into(),
+            error_msg: error_code.to_string(),
+            error_origin: Some($crate::ErrorOrigin::Source($crate::Source {
+                filename: file!(),
+                line: line!(),
+            })),
+            compared_values: None,
+        })
+    }};
+}
+
+#[cfg(feature = "private-program")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_error {
+    ($error_code:expr) => {{
+        let error_code_number: u32 = ($error_code).into();
+        $crate::Error::from($crate::AnchorError {
+            error_name: ::std::string::String::new(),
+            error_code_number,
+            error_msg: ::std::string::String::new(),
+            error_origin: None,
+            compared_values: None,
+        })
+    }};
+    ($error_code:expr, source) => {
+        $crate::__anchor_error!($error_code)
+    };
+}
+
+#[cfg(not(feature = "private-program"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_with_account_name {
+    ($error:expr, $account_name:expr) => {
+        ($error).with_account_name($account_name)
+    };
+}
+
+#[cfg(feature = "private-program")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_with_account_name {
+    ($error:expr, $account_name:expr) => {{
+        let error = $error;
+        error
+    }};
+}
+
 // `#[error_code]` macro below accesses `anchor_lang::error::...` so set up
 // a fake module for it.
 mod anchor_lang {
+    pub(crate) use crate::__anchor_error;
     pub(crate) mod error {
-        pub(crate) use crate::{AnchorError, Error};
+        pub(crate) use crate::Error;
     }
 }
 
@@ -347,11 +418,23 @@ impl From<ProgramErrorWithOrigin> for Error {
 }
 
 impl From<TryFromIntError> for Error {
+    #[cfg(not(feature = "private-program"))]
     fn from(e: TryFromIntError) -> Self {
         Self::AnchorError(Box::new(AnchorError {
             error_name: ErrorCode::InvalidNumericConversion.name(),
             error_code_number: ErrorCode::InvalidNumericConversion.into(),
             error_msg: format!("{e}"),
+            error_origin: None,
+            compared_values: None,
+        }))
+    }
+
+    #[cfg(feature = "private-program")]
+    fn from(_: TryFromIntError) -> Self {
+        Self::AnchorError(Box::new(AnchorError {
+            error_name: String::new(),
+            error_code_number: ErrorCode::InvalidNumericConversion.into(),
+            error_msg: String::new(),
             error_origin: None,
             compared_values: None,
         }))
@@ -365,6 +448,7 @@ impl From<std::convert::Infallible> for Error {
 }
 
 impl Error {
+    #[cfg(not(feature = "private-program"))]
     pub fn log(&self) {
         match self {
             Error::ProgramError(program_error) => program_error.log(),
@@ -372,6 +456,11 @@ impl Error {
         }
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn log(&self) {}
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_account_name(mut self, account_name: impl ToString) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {
@@ -384,6 +473,13 @@ impl Error {
         self
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_account_name(self, _: impl ToString) -> Self {
+        self
+    }
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_source(mut self, source: Source) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {
@@ -396,6 +492,13 @@ impl Error {
         self
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_source(self, _: Source) -> Self {
+        self
+    }
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_pubkeys(mut self, pubkeys: (Pubkey, Pubkey)) -> Self {
         let pubkeys = Some(ComparedValues::Pubkeys((pubkeys.0, pubkeys.1)));
         match &mut self {
@@ -405,6 +508,13 @@ impl Error {
         self
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_pubkeys(self, _: (Pubkey, Pubkey)) -> Self {
+        self
+    }
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_values(mut self, values: (impl ToString, impl ToString)) -> Self {
         match &mut self {
             Error::AnchorError(ae) => {
@@ -420,6 +530,12 @@ impl Error {
                 )))
             }
         };
+        self
+    }
+
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_values(self, _: (impl ToString, impl ToString)) -> Self {
         self
     }
 }
@@ -446,6 +562,7 @@ impl Display for ProgramErrorWithOrigin {
 }
 
 impl ProgramErrorWithOrigin {
+    #[cfg(not(feature = "private-program"))]
     pub fn log(&self) {
         match &self.error_origin {
             None => {
@@ -494,13 +611,31 @@ impl ProgramErrorWithOrigin {
         }
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn log(&self) {}
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_source(mut self, source: Source) -> Self {
         self.error_origin = Some(ErrorOrigin::Source(source));
         self
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_source(self, _: Source) -> Self {
+        self
+    }
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_account_name(mut self, account_name: impl ToString) -> Self {
         self.error_origin = Some(ErrorOrigin::AccountName(account_name.to_string()));
+        self
+    }
+
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_account_name(self, _: impl ToString) -> Self {
         self
     }
 }
@@ -537,6 +672,7 @@ pub struct AnchorError {
 }
 
 impl AnchorError {
+    #[cfg(not(feature = "private-program"))]
     pub fn log(&self) {
         match &self.error_origin {
             None => {
@@ -584,13 +720,31 @@ impl AnchorError {
         }
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn log(&self) {}
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_source(mut self, source: Source) -> Self {
         self.error_origin = Some(ErrorOrigin::Source(source));
         self
     }
 
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_source(self, _: Source) -> Self {
+        self
+    }
+
+    #[cfg(not(feature = "private-program"))]
     pub fn with_account_name(mut self, account_name: impl ToString) -> Self {
         self.error_origin = Some(ErrorOrigin::AccountName(account_name.to_string()));
+        self
+    }
+
+    #[cfg(feature = "private-program")]
+    #[inline(always)]
+    pub fn with_account_name(self, _: impl ToString) -> Self {
         self
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -42,6 +42,8 @@ mod common;
 pub mod context;
 pub use anchor_lang_error as error;
 #[doc(hidden)]
+pub use anchor_lang_error::__anchor_error;
+#[doc(hidden)]
 pub mod event;
 #[doc(hidden)]
 pub mod idl;
@@ -155,6 +157,13 @@ pub use anchor_attribute_event::{emit_cpi, event_cpi};
 pub use idl::IdlBuild;
 
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(not(feature = "private-program"))]
+#[path = "private_program/original.rs"]
+mod private_program;
+#[cfg(feature = "private-program")]
+#[path = "private_program/private.rs"]
+mod private_program;
 
 // Deprecated message for AccountInfo usage in Accounts struct
 #[deprecated(

--- a/lang/src/private_program/original.rs
+++ b/lang/src/private_program/original.rs
@@ -1,0 +1,7 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_log_instruction {
+    ($name:expr) => {
+        $crate::prelude::msg!($name)
+    };
+}

--- a/lang/src/private_program/private.rs
+++ b/lang/src/private_program/private.rs
@@ -1,0 +1,5 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __anchor_log_instruction {
+    ($name:expr) => {};
+}

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -400,9 +400,12 @@ fn generate_duplicate_mutable_checks(accs: &AccountsStruct) -> proc_macro2::Toke
             quote! {
                 for key in #composite_name.duplicate_mutable_account_keys() {
                     if !__mutable_accounts.insert(key) {
-                        return Err(anchor_lang::error::Error::from(
-                            anchor_lang::error::ErrorCode::ConstraintDuplicateMutableAccount
-                        ).with_account_name(format!("{}", key)));
+                        return Err(anchor_lang::error::__anchor_with_account_name!(
+                            anchor_lang::error::Error::from(
+                                anchor_lang::error::ErrorCode::ConstraintDuplicateMutableAccount
+                            ),
+                            format!("{}", key)
+                        ));
                     }
                 }
             }

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -81,15 +81,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
 
         impl From<#enum_name> for anchor_lang::error::Error {
             fn from(error_code: #enum_name) -> anchor_lang::error::Error {
-                anchor_lang::error::Error::from(
-                    anchor_lang::error::AnchorError {
-                        error_name: error_code.name(),
-                        error_code_number: error_code.into(),
-                        error_msg: error_code.to_string(),
-                        error_origin: None,
-                        compared_values: None
-                    }
-                )
+                anchor_lang::__anchor_error!(error_code)
             }
         }
 

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -110,7 +110,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     __ix_data: &'info [u8],
                 ) -> anchor_lang::Result<()> {
                     #[cfg(not(feature = "no-log-ix-name"))]
-                    anchor_lang::prelude::msg!(#ix_name_log);
+                    anchor_lang::__anchor_log_instruction!(#ix_name_log);
 
                     #param_validation
                     // Deserialize data.

--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -135,7 +135,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             data_len: u64,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlCreateAccount");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlCreateAccount");
 
             if program_id != accounts.program.key {
                 return Err(anchor_lang::error::ErrorCode::IdlInstructionInvalidProgram.into());
@@ -202,7 +202,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             data_len: u64,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlResizeAccount");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlResizeAccount");
 
             let data_len: usize = data_len as usize;
 
@@ -249,7 +249,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             accounts: &mut IdlCloseAccount,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlCloseAccount");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlCloseAccount");
 
             Ok(())
         }
@@ -260,7 +260,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             accounts: &mut IdlCreateBuffer,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlCreateBuffer");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlCreateBuffer");
 
             let mut buffer = &mut accounts.buffer;
             buffer.authority = *accounts.authority.key;
@@ -274,7 +274,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             idl_data: Vec<u8>,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlWrite");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlWrite");
 
             let prev_len: usize = ::std::convert::TryInto::<usize>::try_into(accounts.idl.data_len).unwrap();
             let new_len: usize = prev_len.checked_add(idl_data.len()).unwrap() as usize;
@@ -296,7 +296,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             new_authority: Pubkey,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlSetAuthority");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlSetAuthority");
 
             accounts.idl.authority = new_authority;
             Ok(())
@@ -308,7 +308,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             accounts: &mut IdlSetBuffer,
         ) -> anchor_lang::Result<()> {
             #[cfg(not(feature = "no-log-ix-name"))]
-            anchor_lang::prelude::msg!("Instruction: IdlSetBuffer");
+            anchor_lang::__anchor_log_instruction!("Instruction: IdlSetBuffer");
 
             accounts.idl.data_len = accounts.buffer.data_len;
 

--- a/lang/tests/private_program.rs
+++ b/lang/tests/private_program.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "private-program")]
+
+use {anchor_lang::prelude::*, std::cell::Cell};
+
+#[error_code]
+enum PrivateError {
+    #[msg("private error message")]
+    Secret,
+}
+
+fn comparison_failure() -> Result<()> {
+    require_eq!(7u64, 9u64, PrivateError::Secret);
+    Ok(())
+}
+
+#[test]
+fn errors_keep_only_the_numeric_code() {
+    let error = comparison_failure().unwrap_err();
+    let Error::AnchorError(error) = error else {
+        panic!("expected Anchor error");
+    };
+
+    assert_eq!(error.error_code_number, 6000);
+    assert!(error.error_name.is_empty());
+    assert!(error.error_msg.is_empty());
+    assert!(error.error_origin.is_none());
+    assert!(error.compared_values.is_none());
+}
+
+#[test]
+fn discarded_diagnostics_are_not_evaluated() {
+    let evaluated = Cell::new(false);
+    let error = anchor_lang::error::__anchor_with_account_name!(
+        anchor_lang::error!(PrivateError::Secret),
+        {
+            evaluated.set(true);
+            "secret-account"
+        }
+    );
+    assert!(!evaluated.get());
+    let Error::AnchorError(error) = error else {
+        panic!("expected Anchor error");
+    };
+    assert_eq!(error.error_code_number, 6000);
+
+    anchor_lang::__anchor_log_instruction!({
+        evaluated.set(true);
+        "Instruction: Secret"
+    });
+    assert!(!evaluated.get());
+}


### PR DESCRIPTION
## Plain-English summary

Program errors can reveal internal names, messages, source locations, and account labels. This adds an opt-in build feature that keeps the useful numeric error code while leaving those extra details out.

Normal builds behave exactly as before.

## What changes

- Adds the anchor-lang/private-program Cargo feature.
- Removes Anchor-generated error details and instruction-name logs when enabled.
- Keeps numeric errors, program behavior, layouts, explicit application logs, events, and IDL documentation unchanged.
- Avoids evaluating diagnostic-only account labels in private mode.

## Verification

- Default and private anchor-lang checks pass.
- Private diagnostics tests pass.
- Focused clippy passes with warnings denied.

## Stack

This is PR 1 of 6 and is intentionally limited to the language-level diagnostic policy. CLI support, compiler hardening, artifact auditing, and end-to-end evidence are separate follow-up PRs.