### PR TITLE
fix(v2): disable release LTO on macOS toolchains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,8 @@ anchor-lang-idl = { path = "idl", version = "=0.2.0" }
 anchor-lang-idl-spec = { path = "idl/spec", version = "=0.1.0" }
 
 [profile.release]
-lto = true
+# Apple clang's LTO reader cannot consume bitcode emitted by newer Rust LLVM versions.
+lto = false
 
 [profile.release.package.anchor-cli]
 codegen-units = 1


### PR DESCRIPTION
## Summary
- disable workspace release LTO to avoid Apple clang bitcode incompatibility with newer Rust LLVM versions
- retain the anchor-cli single codegen-unit release setting


## Testing
- `cargo build -p anchor-cli --release --locked`