### PR TITLE
fix(lang): Detect bytemuck derives by path in #[zero_copy]

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -1,7 +1,9 @@
 extern crate proc_macro;
 
 use {
-    anchor_syn::{codegen::program::common::gen_discriminator, Overrides},
+    anchor_syn::{
+        codegen::program::common::gen_discriminator, parser::is_bytemuck_derive, Overrides,
+    },
     quote::{quote, quote_spanned, ToTokens},
     syn::{
         parenthesized,
@@ -601,17 +603,6 @@ pub fn zero_copy(
 
     #[allow(unreachable_code)]
     proc_macro::TokenStream::from(ret)
-}
-
-// Exact `bytemuck::<leaf>` path, same rule as the IDL build's detection.
-fn is_bytemuck_derive(path: &syn::Path, expected_leaf: &str) -> bool {
-    let mut segments = path.segments.iter();
-
-    matches!(
-        (segments.next(), segments.next(), segments.next()),
-        (Some(first), Some(second), None)
-            if first.ident == "bytemuck" && second.ident == expected_leaf
-    )
 }
 
 /// Convenience macro to define a static public key.

--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -544,14 +544,15 @@ pub fn zero_copy(
         if !attr.path().is_ident("derive") {
             continue;
         }
-        if let syn::Meta::List(list) = &attr.meta {
-            let tokens_str = list.tokens.to_string();
-            if tokens_str.contains("bytemuck :: Pod") {
+        if let Err(err) = attr.parse_nested_meta(|meta| {
+            if is_bytemuck_derive(&meta.path, "Pod") {
                 has_pod_attr = true;
-            }
-            if tokens_str.contains("bytemuck :: Zeroable") {
+            } else if is_bytemuck_derive(&meta.path, "Zeroable") {
                 has_zeroable_attr = true;
             }
+            Ok(())
+        }) {
+            return err.into_compile_error().into();
         }
     }
 
@@ -600,6 +601,17 @@ pub fn zero_copy(
 
     #[allow(unreachable_code)]
     proc_macro::TokenStream::from(ret)
+}
+
+// Exact `bytemuck::<leaf>` path, same rule as the IDL build's detection.
+fn is_bytemuck_derive(path: &syn::Path, expected_leaf: &str) -> bool {
+    let mut segments = path.segments.iter();
+
+    matches!(
+        (segments.next(), segments.next(), segments.next()),
+        (Some(first), Some(second), None)
+            if first.ident == "bytemuck" && second.ident == expected_leaf
+    )
 }
 
 /// Convenience macro to define a static public key.

--- a/lang/syn/src/idl/defined.rs
+++ b/lang/syn/src/idl/defined.rs
@@ -1,6 +1,6 @@
 use {
     super::common::{get_idl_module_path, get_no_docs},
-    crate::parser::docs,
+    crate::parser::{docs, is_bytemuck_derive},
     proc_macro2::TokenStream,
     quote::quote,
     syn::{spanned::Spanned, Result},
@@ -325,16 +325,6 @@ where
         },
         defined,
     ))
-}
-
-fn is_bytemuck_derive(path: &syn::Path, expected_leaf: &str) -> bool {
-    let mut segments = path.segments.iter();
-
-    matches!(
-        (segments.next(), segments.next(), segments.next()),
-        (Some(first), Some(second), None)
-            if first.ident == "bytemuck" && second.ident == expected_leaf
-    )
 }
 
 fn trim_attr_start(value: &str) -> &str {

--- a/lang/syn/src/parser/mod.rs
+++ b/lang/syn/src/parser/mod.rs
@@ -7,3 +7,14 @@ pub mod program;
 pub fn tts_to_string<T: quote::ToTokens>(item: T) -> String {
     item.to_token_stream().to_string()
 }
+
+/// Matches an exact `bytemuck::<expected_leaf>` derive path, nothing shorter or longer.
+pub fn is_bytemuck_derive(path: &syn::Path, expected_leaf: &str) -> bool {
+    let mut segments = path.segments.iter();
+
+    matches!(
+        (segments.next(), segments.next(), segments.next()),
+        (Some(first), Some(second), None)
+            if first.ident == "bytemuck" && second.ident == expected_leaf
+    )
+}

--- a/lang/tests/zero_copy.rs
+++ b/lang/tests/zero_copy.rs
@@ -7,6 +7,27 @@ pub struct UnalignedZeroCopy {
     pub value: u128,
 }
 
+// Explicit bytemuck derives must suppress the injected ones (E0119 otherwise).
+#[account(zero_copy)]
+#[derive(bytemuck::Pod, bytemuck::Zeroable)]
+pub struct ExplicitBytemuckDerives {
+    pub value: u64,
+}
+
+// Deriving only Zeroable must still get Pod injected. Compile-only check.
+#[account(zero_copy)]
+#[derive(bytemuck::Zeroable)]
+pub struct OnlyZeroableDerived {
+    pub value: u64,
+}
+
+#[test]
+fn zero_copy_accepts_explicit_bytemuck_derives() {
+    let account = ExplicitBytemuckDerives { value: 7 };
+    let bytes = anchor_lang::__private::bytemuck::bytes_of(&account);
+    assert_eq!(bytes, 7u64.to_le_bytes());
+}
+
 #[test]
 fn zero_copy_try_deserialize_handles_unaligned_bytes() {
     let account = UnalignedZeroCopy { value: 42 };


### PR DESCRIPTION

```rust
#[zero_copy]
#[derive(bytemuck::Pod, bytemuck::Zeroable)]
pub struct MyAccount { ... }
```

fails with E0119. The attribute should skip injecting its own derives when they
are already written, but the check string-matches "bytemuck :: Pod" and rustc
1.76 stopped printing the spaces (rust-lang/rust#114571), so it never matches.

Fix is the one #4215 and #4936 applied to the IDL copy of this check: parse the
derive list and match the exact `bytemuck::{Pod,Zeroable}` path. An unqualified
`#[derive(Pod)]` via import stays undetected, same as on the IDL side.

One question: I duplicated `is_bytemuck_derive` in the attribute crate since the
anchor-syn one is private and behind idl-build. May be worth to export it instead if you
prefer, to have single source of truth.

Tested: new struct in `lang/tests/zero_copy.rs` fails with E0119 on master and
compiles with the patch. 
