### PR TITLE
fix(lang): remove invalid ? operator from Migration doc examples

### DIFF
--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -84,7 +84,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: ctx.accounts.my_account.data * 2,
-/// })?;
+/// });
 ///
 /// // Use migrated data (safe to call multiple times!)
 /// msg!("New field: {}", migrated.new_field);
@@ -236,7 +236,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 42,
-    ///     })?;
+    ///     });
     ///
     ///     // Use migrated...
     ///     msg!("Migrated data: {}", migrated.data);

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -97,7 +97,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: 0,
-/// })?;
+/// });
 ///
 /// // Mutate the new data
 /// migrated.new_field = 42;
@@ -118,7 +118,7 @@ pub enum MigrationInner<From, To> {
 ///         let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///             data: ctx.accounts.my_account.data,
 ///             new_field: ctx.accounts.my_account.data * 2,
-///         })?;
+///         });
 ///
 ///         msg!("Migrated! New field: {}", migrated.new_field);
 ///         Ok(())
@@ -272,7 +272,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 0,
-    ///     })?;
+    ///     });
     ///
     ///     // Mutate the migrated value
     ///     migrated.new_field = 42;


### PR DESCRIPTION
## Problem
The `into_inner()` and `into_inner_mut()` methods return references (`&T` and 
`&mut T`), not `Result` types. The `?` operator is only valid for `Result` 
types, so these doc examples are invalid and won't compile.

## Solution
Remove the invalid `?` operator from three doc comment examples in `migration.rs`.

## Files Changed
- `lang/src/accounts/migration.rs` (3 examples fixed at lines 100, 120, 275)

## Why This Matters
- Makes documentation match actual code behavior  
- Prevents users from copying invalid examples
- Aligns with documentation already fixed in earlier commits