### PR TITLE
fix(lang): add bounds validation to LazyAccount field accessors

### DIFF
--- a/lang/attribute/account/src/lazy.rs
+++ b/lang/attribute/account/src/lazy.rs
@@ -128,8 +128,23 @@ pub fn gen_lazy(strct: &syn::ItemStruct) -> syn::Result<TokenStream> {
 
                     // Deserialize and write
                     let offset = self.#offset_of_ident();
+                    let data = self.__info.data.borrow();
+                    
+                    // Bounds check for offset before calculating size (important for unsized types)
+                    // For unsized types, size_of needs to read from data buffer starting at offset
+                    if offset > data.len() {
+                        return Err(anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into());
+                    }
+                    
+                    drop(data);  // Drop borrow before calling size_of which may borrow data again
                     let size = self.#size_of_ident();
                     let data = self.__info.data.borrow();
+                    
+                    // Bounds check: ensure the field data is within the account buffer
+                    if offset.saturating_add(size) > data.len() {
+                        return Err(anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into());
+                    }
+                    
                     let val = anchor_lang::AnchorDeserialize::try_from_slice(
                         &data[offset..offset + size]
                     )?;
@@ -239,7 +254,13 @@ pub fn gen_lazy(strct: &syn::ItemStruct) -> syn::Result<TokenStream> {
                 if all_uninit {
                     // Nothing is initialized, initialize all
                     let offset = #disc_len;
-                    let mut data = self.__info.data.borrow();
+                    let data = self.__info.data.borrow();
+                    
+                    // Bounds check: ensure there's data after the discriminator
+                    if offset > data.len() {
+                        return Err(anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into());
+                    }
+                    
                     let val = anchor_lang::AnchorDeserialize::deserialize(&mut &data[offset..])?;
                     unsafe { self.__account.borrow_mut().as_mut_ptr().write(val) };
 

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -84,7 +84,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: ctx.accounts.my_account.data * 2,
-/// })?;
+/// });
 ///
 /// // Use migrated data (safe to call multiple times!)
 /// msg!("New field: {}", migrated.new_field);
@@ -236,7 +236,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 42,
-    ///     })?;
+    ///     });
     ///
     ///     // Use migrated...
     ///     msg!("Migrated data: {}", migrated.data);

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -97,7 +97,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: 0,
-/// })?;
+/// });
 ///
 /// // Mutate the new data
 /// migrated.new_field = 42;
@@ -118,7 +118,7 @@ pub enum MigrationInner<From, To> {
 ///         let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///             data: ctx.accounts.my_account.data,
 ///             new_field: ctx.accounts.my_account.data * 2,
-///         })?;
+///         });
 ///
 ///         msg!("Migrated! New field: {}", migrated.new_field);
 ///         Ok(())
@@ -272,7 +272,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 0,
-    ///     })?;
+    ///     });
     ///
     ///     // Mutate the migrated value
     ///     migrated.new_field = 42;


### PR DESCRIPTION
# Prevent LazyAccount field accessors from panicking on truncated account data

## Summary
This PR hardens `LazyAccount` field access against truncated or malformed account data.

Currently, `LazyAccount::try_from` validates the account owner and discriminator, but it does not verify that the remaining serialized account data is large enough for the declared account layout.

As a result, account data containing a valid discriminator but a truncated body can successfully pass `LazyAccount::try_from`. A later call to a generated lazy field accessor such as `load_<field>()` can then panic due to an out-of-bounds slice instead of returning a structured Anchor error.

This PR adds bounds validation to lazy field access so malformed account data returns an error rather than aborting through a Rust panic.

## Problem
`LazyAccount::try_from` currently verifies:

- The account data is large enough to contain the discriminator.
- The discriminator matches `T::DISCRIMINATOR`.
- The account owner matches `T::owner()`.

However, it does not validate that the serialized body contains enough data for individual fields.

For example:

```rust
#[account]
pub struct FixedAccount {
    pub value: u64,
}