### PR TITLE
ci: Restore JS client checks on anchor-next

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -174,3 +174,18 @@ jobs:
             ( cd "$prog" && cargo check )
             echo "::endgroup::"
           done
+
+  test-ts:
+    name: ts Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20.18.0"
+      - run: cd ts/packages/borsh && yarn --frozen-lockfile && yarn build
+      - run: cd ts/packages/anchor-errors && yarn --frozen-lockfile && yarn build
+      - run: cd ts/packages/anchor && yarn --frozen-lockfile
+      - run: cd ts/packages/anchor && yarn test
+      - run: cd ts/packages/anchor && yarn lint

--- a/ts/packages/anchor/src/program/index.ts
+++ b/ts/packages/anchor/src/program/index.ts
@@ -276,20 +276,20 @@ export class Program<IDL extends Idl = Idl> {
    */
   public discriminator(
     kind: "instruction" | "account" | "event",
-    name: string,
+    name: string
   ): Buffer {
     const section =
       kind === "instruction"
         ? this._rawIdl.instructions
         : kind === "account"
-          ? this._rawIdl.accounts ?? []
-          : this._rawIdl.events ?? [];
-    const entry = (section as Array<{ name: string; discriminator?: number[] }>).find(
-      (e) => e.name === name,
-    );
+        ? this._rawIdl.accounts ?? []
+        : this._rawIdl.events ?? [];
+    const entry = (
+      section as Array<{ name: string; discriminator?: number[] }>
+    ).find((e) => e.name === name);
     if (!entry?.discriminator) {
       throw new Error(
-        `anchor: no ${kind} named '${name}' with a discriminator in the IDL`,
+        `anchor: no ${kind} named '${name}' with a discriminator in the IDL`
       );
     }
     return Buffer.from(entry.discriminator);

--- a/ts/packages/anchor/src/program/namespace/views.ts
+++ b/ts/packages/anchor/src/program/namespace/views.ts
@@ -1,5 +1,9 @@
 import { PublicKey } from "@solana/web3.js";
-import { Idl, IdlInstructionAccountItem, isCompositeAccounts } from "../../idl.js";
+import {
+  Idl,
+  IdlInstructionAccountItem,
+  isCompositeAccounts,
+} from "../../idl.js";
 import { SimulateFn } from "./simulate.js";
 import {
   AllInstructions,
@@ -13,7 +17,9 @@ import { decode } from "../../utils/bytes/base64";
 // still disqualifies an instruction from being surfaced as a view.
 function hasWritableAccount(accounts: IdlInstructionAccountItem[]): boolean {
   return accounts.some((a) =>
-    isCompositeAccounts(a) ? hasWritableAccount(a.accounts) : a.writable === true
+    isCompositeAccounts(a)
+      ? hasWritableAccount(a.accounts)
+      : a.writable === true
   );
 }
 


### PR DESCRIPTION
This PR restores CI coverage for the JS client (`ts/`) on anchor-next.

The JS client checks used to run through `reusable-tests.yaml`, whose only caller (`no-caching-tests.yaml`) is disabled on this branch as a legacy v1 pipeline, leaving `ts/` with no CI at all. This PR adds a `test-ts` job to the active `tests.yaml`, mirroring the `ts` steps of the legacy Core Tests job: build the local workspace dependencies, then test and lint `@anchor-lang/core`.

It also formats `program/index.ts` and `program/namespace/views.ts` with the workspace's prettier (2.8.0). These files were formatted with prettier 3 conventions, which the restored lint step rejects. No logic changes: that part of the diff is prettier output only.

Restoring this coverage ahead of the JS client modernisation work means every follow-up PR gets build/test/lint verification.