### PR TITLE
Docs: non-functional docs/spell fixes

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -461,9 +461,9 @@ pub fn handle_system_log(this_program_str: &str, log: &str) -> (Option<String>, 
     if log.starts_with(&format!("Program {this_program_str} log:")) {
         (Some(this_program_str.to_string()), false)
     } else {
-        static SUCESS_RE: LazyLock<Regex> =
+        static SUCCESS_RE: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"^Program ([1-9A-HJ-NP-Za-km-z]+) success$").unwrap());
-        if SUCESS_RE.is_match(log) {
+        if SUCCESS_RE.is_match(log) {
             (None, true)
         } else {
             (None, false)

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -84,7 +84,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: ctx.accounts.my_account.data * 2,
-/// })?;
+/// });
 ///
 /// // Use migrated data (safe to call multiple times!)
 /// msg!("New field: {}", migrated.new_field);
@@ -236,7 +236,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 42,
-    ///     })?;
+    ///     });
     ///
     ///     // Use migrated...
     ///     msg!("Migrated data: {}", migrated.data);

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -97,7 +97,7 @@ pub enum MigrationInner<From, To> {
 /// let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
 ///     data: ctx.accounts.my_account.data,
 ///     new_field: 0,
-/// })?;
+/// });
 ///
 /// // Mutate the new data
 /// migrated.new_field = 42;
@@ -118,7 +118,7 @@ pub enum MigrationInner<From, To> {
 ///         let migrated = ctx.accounts.my_account.into_inner(AccountV2 {
 ///             data: ctx.accounts.my_account.data,
 ///             new_field: ctx.accounts.my_account.data * 2,
-///         })?;
+///         });
 ///
 ///         msg!("Migrated! New field: {}", migrated.new_field);
 ///         Ok(())
@@ -272,7 +272,7 @@ where
     ///     let migrated = ctx.accounts.my_account.into_inner_mut(AccountV2 {
     ///         data: ctx.accounts.my_account.data,
     ///         new_field: 0,
-    ///     })?;
+    ///     });
     ///
     ///     // Mutate the migrated value
     ///     migrated.new_field = 42;


### PR DESCRIPTION
- fix(lang): remove invalid ? operator from Migration doc examples #4976 
- refactor(client): correct success regex naming #4970

