### PR TITLE
fix(idl): skip PDA metadata for explicit bumps

### DIFF
--- a/examples/tutorial/basic-4/tests/basic-4.js
+++ b/examples/tutorial/basic-4/tests/basic-4.js
@@ -51,6 +51,7 @@ describe("basic-4", () => {
     await program.methods
       .increment()
       .accounts({
+        counter: counterPubkey,
         authority: provider.wallet.publicKey,
       })
       .rpc();

--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -221,6 +221,10 @@ fn get_pda(acc: &Field, accounts: &AccountsStruct) -> TokenStream {
 
     // Seeds
     let seed_constraints = acc.constraints.seeds.as_ref();
+    // `find_program_address` only derives the canonical bump.
+    if matches!(seed_constraints, Some(constraints) if constraints.bump.is_some()) {
+        return quote! { None };
+    }
     let pda = seed_constraints
         .map(|seed| seed.seeds.iter().map(parse_default))
         .and_then(|seeds| seeds.collect::<Result<Vec<_>>>().ok())

--- a/tests/auction-house/tests/auction-house.ts
+++ b/tests/auction-house/tests/auction-house.ts
@@ -66,6 +66,9 @@ describe("auction-house", () => {
   let metadata: PublicKey;
   let auctionHouse: PublicKey;
   let auctionHouseFeeAccount: PublicKey;
+  let auctionHouseTreasury: PublicKey;
+  let sellerTradeState: PublicKey;
+  let buyerTradeState: PublicKey;
 
   // Buyer specific vars.
   const buyerWallet = Keypair.generate();
@@ -160,8 +163,43 @@ describe("auction-house", () => {
       [PREFIX, _auctionHouse.toBuffer(), FEE_PAYER],
       AUCTION_HOUSE_PROGRAM_ID
     );
+    const [_auctionHouseTreasury] = await PublicKey.findProgramAddress(
+      [PREFIX, _auctionHouse.toBuffer(), TREASURY],
+      AUCTION_HOUSE_PROGRAM_ID
+    );
+    const buyerPrice = new u64(2 * 10 ** 9);
+    const tokenSize = new u64(1);
+    const [_sellerTradeState] = await PublicKey.findProgramAddress(
+      [
+        PREFIX,
+        sellerWallet.publicKey.toBuffer(),
+        _auctionHouse.toBuffer(),
+        sellerTokenAccount.toBuffer(),
+        treasuryMint.toBuffer(),
+        nftMintClient.publicKey.toBuffer(),
+        buyerPrice.toArrayLike(Buffer, "le", 8),
+        tokenSize.toArrayLike(Buffer, "le", 8),
+      ],
+      AUCTION_HOUSE_PROGRAM_ID
+    );
+    const [_buyerTradeState] = await PublicKey.findProgramAddress(
+      [
+        PREFIX,
+        buyerWallet.publicKey.toBuffer(),
+        _auctionHouse.toBuffer(),
+        sellerTokenAccount.toBuffer(),
+        treasuryMint.toBuffer(),
+        nftMintClient.publicKey.toBuffer(),
+        buyerPrice.toArrayLike(Buffer, "le", 8),
+        tokenSize.toArrayLike(Buffer, "le", 8),
+      ],
+      AUCTION_HOUSE_PROGRAM_ID
+    );
     auctionHouse = _auctionHouse;
     auctionHouseFeeAccount = _auctionHouseFeeAccount;
+    auctionHouseTreasury = _auctionHouseTreasury;
+    sellerTradeState = _sellerTradeState;
+    buyerTradeState = _buyerTradeState;
   });
 
   it("Funds the buyer with lamports so that it can bid", async () => {
@@ -243,6 +281,8 @@ describe("auction-house", () => {
         receiptAccount: buyerWallet.publicKey,
         treasuryMint,
         authority,
+        auctionHouse,
+        auctionHouseFeeAccount,
       })
       .signers([authorityKeypair])
       .rpc();
@@ -261,6 +301,8 @@ describe("auction-house", () => {
         metadata,
         authority,
         treasuryMint,
+        auctionHouse,
+        auctionHouseFeeAccount,
       })
       .signers([authorityKeypair])
       .rpc();
@@ -278,6 +320,9 @@ describe("auction-house", () => {
         tokenAccount: sellerTokenAccount,
         authority,
         treasuryMint,
+        auctionHouse,
+        auctionHouseFeeAccount,
+        tradeState: sellerTradeState,
       })
       .signers([authorityKeypair])
       .rpc();
@@ -295,6 +340,8 @@ describe("auction-house", () => {
         metadata,
         authority,
         treasuryMint,
+        auctionHouse,
+        auctionHouseFeeAccount,
       })
       .signers([authorityKeypair])
       .rpc();
@@ -315,6 +362,8 @@ describe("auction-house", () => {
         tokenAccount: sellerTokenAccount,
         metadata,
         authority,
+        auctionHouse,
+        auctionHouseFeeAccount,
       })
       .signers([authorityKeypair])
       .rpc();
@@ -325,10 +374,6 @@ describe("auction-house", () => {
   it("Executes a trade", async () => {
     const [buyerEscrow] = await PublicKey.findProgramAddress(
       [PREFIX, auctionHouse.toBuffer(), buyerWallet.publicKey.toBuffer()],
-      AUCTION_HOUSE_PROGRAM_ID
-    );
-    const [auctionHouseTreasury] = await PublicKey.findProgramAddress(
-      [PREFIX, auctionHouse.toBuffer(), TREASURY],
       AUCTION_HOUSE_PROGRAM_ID
     );
     const airdropSig = await authorityClient.provider.connection.requestAirdrop(
@@ -360,6 +405,11 @@ describe("auction-house", () => {
         sellerPaymentReceiptAccount: sellerWallet.publicKey,
         buyerReceiptTokenAccount: buyerTokenAccount,
         authority,
+        auctionHouse,
+        auctionHouseFeeAccount,
+        auctionHouseTreasury,
+        buyerTradeState,
+        sellerTradeState,
       })
       .rpc();
 
@@ -386,6 +436,8 @@ describe("auction-house", () => {
         authority,
         treasuryMint,
         feeWithdrawalDestination,
+        auctionHouse,
+        auctionHouseFeeAccount,
       })
       .rpc();
     console.log("withdrawFromFee:", txSig);
@@ -398,6 +450,8 @@ describe("auction-house", () => {
         treasuryMint,
         authority,
         treasuryWithdrawalDestination,
+        auctionHouse,
+        auctionHouseTreasury,
       })
       .rpc();
     console.log("txSig:", txSig);
@@ -423,6 +477,7 @@ describe("auction-house", () => {
           feeWithdrawalDestination,
           treasuryWithdrawalDestination,
           treasuryWithdrawalDestinationOwner,
+          auctionHouse,
         })
         .instruction()
     );

--- a/tests/idl/idls/relations.json
+++ b/tests/idl/idls/relations.json
@@ -69,20 +69,7 @@
           ]
         },
         {
-          "name": "account",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  115,
-                  101,
-                  101,
-                  100
-                ]
-              }
-            ]
-          }
+          "name": "account"
         },
         {
           "name": "nested",
@@ -94,20 +81,7 @@
               ]
             },
             {
-              "name": "account",
-              "pda": {
-                "seeds": [
-                  {
-                    "kind": "const",
-                    "value": [
-                      115,
-                      101,
-                      101,
-                      100
-                    ]
-                  }
-                ]
-              }
+              "name": "account"
             }
           ]
         }

--- a/tests/pda-derivation/programs/pda-derivation/src/lib.rs
+++ b/tests/pda-derivation/programs/pda-derivation/src/lib.rs
@@ -44,6 +44,10 @@ pub mod pda_derivation {
         Ok(())
     }
 
+    pub fn explicit_bump(_ctx: Context<ExplicitBump>, _bump: u8) -> Result<()> {
+        Ok(())
+    }
+
     pub fn associated_token_resolution(_ctx: Context<AssociatedTokenResolution>) -> Result<()> {
         Ok(())
     }
@@ -173,6 +177,14 @@ pub struct TestSeedConstant<'info> {
     )]
     account: Account<'info, MyAccount>,
     system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(bump: u8)]
+pub struct ExplicitBump<'info> {
+    #[account(seeds = [b"explicit-bump"], bump = bump)]
+    /// CHECK: Address is validated by the PDA constraints.
+    pub pda: UncheckedAccount<'info>,
 }
 
 #[derive(Accounts)]

--- a/tests/pda-derivation/tests/typescript.spec.ts
+++ b/tests/pda-derivation/tests/typescript.spec.ts
@@ -6,6 +6,27 @@ import { PdaDerivation } from "../target/types/pda_derivation";
 import { expect } from "chai";
 const encode = anchor.utils.bytes.utf8.encode;
 
+function findNonCanonicalPda(
+  seeds: Buffer[],
+  programId: PublicKey
+): [PublicKey, number] {
+  const [, canonicalBump] = PublicKey.findProgramAddressSync(seeds, programId);
+
+  for (let bump = canonicalBump - 1; bump >= 0; bump--) {
+    try {
+      const pda = PublicKey.createProgramAddressSync(
+        [...seeds, Buffer.from([bump])],
+        programId
+      );
+      return [pda, bump];
+    } catch {
+      // This bump is on-curve; keep looking.
+    }
+  }
+
+  throw new Error("Unable to find a non-canonical PDA");
+}
+
 describe("typescript", () => {
   // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
@@ -106,6 +127,35 @@ describe("typescript", () => {
 
   it("Can use constant seed ref", async () => {
     await program.methods.testSeedConstant().rpc();
+  });
+
+  it("Does not auto-resolve explicit-bump PDAs", async () => {
+    const seeds = [Buffer.from("explicit-bump")];
+    const [nonCanonicalPda, bump] = findNonCanonicalPda(
+      seeds,
+      program.programId
+    );
+    const [canonicalPda] = PublicKey.findProgramAddressSync(
+      seeds,
+      program.programId
+    );
+    expect(nonCanonicalPda.equals(canonicalPda)).is.false;
+
+    const pdaAccount = program.idl.instructions
+      .find((ix) => ix.name === "explicitBump")!
+      .accounts.find((acc) => acc.name === "pda")!;
+    expect(pdaAccount).not.to.have.property("pda");
+
+    const keys = await program.methods
+      .explicitBump(bump)
+      .accountsPartial({})
+      .pubkeys();
+    expect(keys.pda).to.be.undefined;
+
+    await program.methods
+      .explicitBump(bump)
+      .accounts({ pda: nonCanonicalPda })
+      .rpc();
   });
 
   it("Can resolve associated token accounts", async () => {

--- a/tests/relations-derivation/tests/typescript.spec.ts
+++ b/tests/relations-derivation/tests/typescript.spec.ts
@@ -22,14 +22,14 @@ describe("typescript", () => {
   });
 
   it("Derives relationss", async () => {
+    const [account] = await PublicKey.findProgramAddress(
+      [Buffer.from("seed", "utf-8")],
+      program.programId
+    );
     const tx = await program.methods.testRelation().accounts({
+      account,
       nested: {
-        account: (
-          await PublicKey.findProgramAddress(
-            [Buffer.from("seed", "utf-8")],
-            program.programId
-          )
-        )[0],
+        account,
       },
     });
 


### PR DESCRIPTION
## Summary

Accounts using `bump = <expr>` may accept a non-canonical PDA, but the TypeScript resolver currently derives the canonical address from the IDL.

Skip PDA metadata for explicit bumps so callers provide those accounts themselves. The regression test verifies that the account is left unresolved and that a non-canonical PDA works when supplied.

This matches the Rust client behavior from #4892.

Fixes #4979.

## Branch Target

`master`. This fixes the existing TypeScript resolver path and does not change the IDL schema.

## Testing

- `cargo build`
- `cargo test -- --test-threads=1`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cd tests/pda-derivation && anchor test --skip-lint && npx tsc --noEmit`
- `cd tests/idl && ./test.sh`
- `cd tests && yarn prettier pda-derivation/tests/typescript.spec.ts --check`