### PR TITLE
Fix/stale anchor lang v2 paths

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2156,7 +2156,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         // bitvec and u8 field-offset domain. Top-level field count alone is
         // not enough: Nested<Inner> expands to Inner::HEADER_SIZE slots.
         const _: () = assert!(
-            <#name as anchor_lang_v2::TryAccounts>::HEADER_SIZE <= 255,
+            <#name as anchor_lang::TryAccounts>::HEADER_SIZE <= 255,
             "`Accounts` flattened HEADER_SIZE must be <= 255 (duplicate-tracking domain)"
         );
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -922,7 +922,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
-#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+#[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct Data {
     pub value: u64,
 }

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -147,7 +147,7 @@ fn nested_accounts_flattened_header_size_must_fit_u8_domain() {
         .collect();
     let source = format!(
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
@@ -1324,7 +1324,7 @@ fn associated_token_init_rejects_optional_sibling_refs() {
     compile_fail_case(
         "associated_token_init_rejects_optional_sibling_refs",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 use anchor_spl_v2::{
     associated_token::AssociatedToken,
     mint::Mint,
@@ -1492,7 +1492,7 @@ fn optional_sibling_seed_is_rejected() {
     compile_fail_case(
         "optional_sibling_seed_non_init",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
@@ -1513,7 +1513,7 @@ pub struct Bad {
     compile_fail_case(
         "optional_sibling_seed_init",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 


### PR DESCRIPTION
This PR fixes the broken `#[derive(Accounts)]` codegen path and the failing macro_diagnostics tests.

- fix(lang-v2): Accounts codegen emitted dead `anchor_lang_v2` path, breaking every `#[derive(Accounts)]` and same stale path in 4 tests `lang-v2/tests/macro_diagnostics.rs`
- fix(lang-v2): Replace `anchor_lang::wincode::SchemaRead, anchor_lang::wincode::Schema` with `AnchorSerialize, AnchorDeserialize`