### PR TITLE
fix(lang-v2): use renamed anchor-lang crate in account derive and diagnostics

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2156,7 +2156,7 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
         // bitvec and u8 field-offset domain. Top-level field count alone is
         // not enough: Nested<Inner> expands to Inner::HEADER_SIZE slots.
         const _: () = assert!(
-            <#name as anchor_lang_v2::TryAccounts>::HEADER_SIZE <= 255,
+            <#name as anchor_lang::TryAccounts>::HEADER_SIZE <= 255,
             "`Accounts` flattened HEADER_SIZE must be <= 255 (duplicate-tracking domain)"
         );
 

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -147,7 +147,7 @@ fn nested_accounts_flattened_header_size_must_fit_u8_domain() {
         .collect();
     let source = format!(
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
@@ -922,7 +922,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
-#[derive(anchor_lang::wincode::SchemaRead, anchor_lang::wincode::SchemaWrite)]
+#[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct Data {
     pub value: u64,
 }
@@ -1324,8 +1324,8 @@ fn associated_token_init_rejects_optional_sibling_refs() {
     compile_fail_case(
         "associated_token_init_rejects_optional_sibling_refs",
         r#"
-use anchor_lang_v2::prelude::*;
-use anchor_spl_v2::{
+use anchor_lang::prelude::*;
+use anchor_spl::{
     associated_token::AssociatedToken,
     mint::Mint,
     token::{Token, TokenAccount},
@@ -1492,7 +1492,7 @@ fn optional_sibling_seed_is_rejected() {
     compile_fail_case(
         "optional_sibling_seed_non_init",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 
@@ -1513,7 +1513,7 @@ pub struct Bad {
     compile_fail_case(
         "optional_sibling_seed_init",
         r#"
-use anchor_lang_v2::prelude::*;
+use anchor_lang::prelude::*;
 
 declare_id!("11111111111111111111111111111111");
 


### PR DESCRIPTION
### Summary
In PR #4909, a static assertion checking the flattened header size limit was introduced in `lang-v2/derive`:
```rust
const _: () = assert!(
    <#name as anchor_lang_v2::TryAccounts>::HEADER_SIZE <= 255,
    "`Accounts` flattened HEADER_SIZE must be <= 255 (duplicate-tracking domain)"
);
```
In PR #4915 (`ci: port release infrastructure to anchor-next`), `lang-v2` was officially renamed to `anchor-lang`.

Because the derive macro expands in the scope of the consuming program crate (which depends on `anchor-lang`), programs deriving `Accounts` fail compilation with:
```text
error[E0433]: cannot find module or crate `anchor_lang_v2` in this scope
```

### Changes
1. Update `<#name as anchor_lang_v2::TryAccounts>` to `<#name as anchor_lang::TryAccounts>` in `lang-v2/derive/src/lib.rs`.
2. Update stale `anchor_lang_v2` / `anchor_spl_v2` imports in `lang-v2/tests/macro_diagnostics.rs`.
3. Use `AnchorSerialize` / `AnchorDeserialize` in empty-seeds diagnostics fixture.