### PR TITLE
fix(lang-v2): omit PDA metadata for explicit bumps

### DIFF
--- a/lang-v2/derive/src/parse.rs
+++ b/lang-v2/derive/src/parse.rs
@@ -2348,18 +2348,23 @@ pub fn parse_field(
         None => (None, None, None),
     };
     let idl_docs = crate::idl::extract_doc_lines(&field.attrs);
-    let idl_pda = attrs.seeds.as_ref().and_then(|seeds_expr| {
-        let seeds = crate::idl::classify_seed_list(seeds_expr, field_names, ix_arg_names)?;
-        let program = match attrs.seeds_program.as_ref() {
-            Some(program_expr) => Some(crate::idl::classify_program_seed(
-                program_expr,
-                field_names,
-                ix_arg_names,
-            )?),
-            None => None,
-        };
-        Some(IdlPdaMeta { seeds, program })
-    });
+    let idl_pda = if matches!(attrs.bump.as_ref(), Some(Some(_))) {
+        // Explicit bumps may be non-canonical, so clients need the address.
+        None
+    } else {
+        attrs.seeds.as_ref().and_then(|seeds_expr| {
+            let seeds = crate::idl::classify_seed_list(seeds_expr, field_names, ix_arg_names)?;
+            let program = match attrs.seeds_program.as_ref() {
+                Some(program_expr) => Some(crate::idl::classify_program_seed(
+                    program_expr,
+                    field_names,
+                    ix_arg_names,
+                )?),
+                None => None,
+            };
+            Some(IdlPdaMeta { seeds, program })
+        })
+    };
     let idl_field_ty: Option<syn::Type> = {
         let base_ty = option_inner.unwrap_or(field_ty);
         if let Type::Path(_) = base_ty {

--- a/tests-v2/tests/idl_metadata.rs
+++ b/tests-v2/tests/idl_metadata.rs
@@ -60,6 +60,16 @@ fn fn_seed_expression_emits_const_seed_bytes() {
 }
 
 #[test]
+fn explicit_bump_omits_pda_metadata() {
+    let items = parse_accounts(&seeds::CheckLiteralUntrustedBump::__idl_accounts());
+    let account = single_account(&items, 1);
+    assert!(
+        account.pda.is_none(),
+        "explicit-bump account should require a caller-supplied address"
+    );
+}
+
+#[test]
 fn mixed_supported_seeds_preserve_const_and_account_metadata() {
     let items = parse_accounts(&seeds::CheckMixed::__idl_accounts());
     let account = single_account(&items, 1);


### PR DESCRIPTION
## Summary

Accounts declared with `bump = <expr>` may use a non-canonical PDA. The v2 IDL currently emits `pda` metadata for them, causing the TypeScript resolver to derive the canonical address.

Omit PDA metadata for explicit bumps so callers provide the account address, matching the Rust client behavior from #4892. Add a regression test around the generated v2 IDL.

Fixes #4979.

## Branch Target

`anchor-next`, because this fixes the anchor-v2 IDL path.

## Testing

- `cargo test -p tests-v2 --test idl_metadata -- --test-threads=1`
- `./.github/scripts/check-v2-test-inventory.sh`
- v2 Rust component tests (`anchor-derive-accounts`, `anchor-lang`, `anchor-spl`, `anchor-cli`)
- TypeScript package tests and lint
- Miri Tree Borrows for `anchor-lang` and `anchor-spl`
- `cargo check` for `bench/programs/*/anchor-v2`