### PR TITLE
ci: update workflows to ignore documentation and markdown changes

### DIFF
--- a/.github/workflows/locked-in.yaml
+++ b/.github/workflows/locked-in.yaml
@@ -11,9 +11,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
   pull_request:

--- a/.github/workflows/locked-in.yaml
+++ b/.github/workflows/locked-in.yaml
@@ -19,9 +19,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
   workflow_dispatch:

--- a/.github/workflows/locked-in.yaml
+++ b/.github/workflows/locked-in.yaml
@@ -8,8 +8,24 @@ name: Locked-in
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -5,7 +5,14 @@ on:
     branches:
       - master
     paths-ignore:
+      # Docs/changelog cannot affect these tests.
       - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
 
 permissions:
   contents: read

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -8,9 +8,7 @@ on:
       # Docs/changelog cannot affect these tests.
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
 

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -5,10 +5,23 @@ on:
     branches:
       - master
     paths-ignore:
+      # Docs/changelog cannot affect these tests.
       - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/template-tests.yaml
+++ b/.github/workflows/template-tests.yaml
@@ -8,18 +8,14 @@ on:
       # Docs/changelog cannot affect these tests.
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
   workflow_dispatch:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,9 +8,7 @@ on:
       # Docs/changelog cannot affect these tests.
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
   pull_request:
@@ -20,9 +18,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "docs-v2/**"
-      - "*.md"
       - "**/*.md"
-      - "*.mdx"
       - "**/*.mdx"
       - ".cspell-anchor-dictionary.txt"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,13 +5,26 @@ on:
     branches:
       - master
     paths-ignore:
+      # Docs/changelog cannot affect these tests.
       - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
   pull_request:
     branches:
       - master
       - anchor-next
     paths-ignore:
       - "docs/**"
+      - "docs-v2/**"
+      - "*.md"
+      - "**/*.md"
+      - "*.mdx"
+      - "**/*.mdx"
+      - ".cspell-anchor-dictionary.txt"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Docs, changelog, and markdown-only changes cannot affect compiled code, but they currently still trigger Tests. So ignore those paths on the expensive workflows. 
- Cspell keeps running via Global Linters so spelling on `.md` / `.mdx` is still checked.
