### PR TITLE
ci: upload AVM with test CLI artifact

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -97,12 +97,15 @@ jobs:
         if: env.CARGO_PROFILE == 'debug'
       - run: cargo install --path cli anchor-cli --locked --force --features idl-localnet-testing
         if: env.CARGO_PROFILE != 'debug'
+      - run: cargo install --path avm --locked --force
 
-      - run: chmod +x ~/.cargo/bin/anchor
+      - run: chmod +x ~/.cargo/bin/anchor ~/.cargo/bin/avm
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
-          path: ~/.cargo/bin/anchor
+          path: |
+            ~/.cargo/bin/anchor
+            ~/.cargo/bin/avm
 
       - uses: ./.github/actions/git-diff/
 
@@ -119,7 +122,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +rwx ~/.cargo/bin/anchor
+      - run: chmod +rwx ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
@@ -159,7 +162,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +rwx ~/.cargo/bin/anchor
+      - run: chmod +rwx ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - run: cd ${{ matrix.node.path }} && anchor build --skip-lint --ignore-keys
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -184,7 +187,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
+      - run: chmod +x ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -237,7 +240,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
+      - run: chmod +x ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - run: surfpool start --ci --offline &
         name: start surfpool
@@ -331,7 +334,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
+      - run: chmod +x ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - name: Init project
         working-directory: /tmp
@@ -498,7 +501,7 @@ jobs:
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
+      - run: chmod +x ~/.cargo/bin/anchor ~/.cargo/bin/avm
 
       - run: ${{ matrix.node.cmd }}
         name: ${{ matrix.node.path }} program test


### PR DESCRIPTION
Build and upload AVM alongside the test CLI artifact so jobs that honor `toolchain.anchor_version` can install the requested Anchor version instead of falling back to the built CLI.