### PR TITLE
feat(avm): remind users to install current build-sbf tools

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -40,6 +40,10 @@ pub use {
 
 /// Checked at most once per hour.
 const UPDATE_CHECK_INTERVAL_SECS: i64 = 60 * 60;
+/// Check the locally cached `cargo build-sbf` toolchain at most once per day.
+const CARGO_BUILD_SBF_CHECK_INTERVAL_SECS: i64 = 24 * 60 * 60;
+const PLATFORM_TOOLS_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/anza-xyz/platform-tools/releases/latest";
 const NIGHTLY_MANIFEST_URL: &str =
     "https://anchor-releases.s3-eu-west-1.amazonaws.com/nightly/latest/manifest.json";
 const NIGHTLY_S3_BASE_URL: &str = "https://anchor-releases.s3-eu-west-1.amazonaws.com/";
@@ -1415,6 +1419,119 @@ pub fn check_avm_version_and_warn() {
     }
 }
 
+// ── cargo build-sbf platform-tools reminder ─────────────────────────────────
+
+fn cargo_build_sbf_check_file_path() -> PathBuf {
+    AVM_HOME.join(".cargo-build-sbf-check")
+}
+
+/// The cache stores one of two states:
+///   Success: `{unix_ts}\n{platform_tools_version}`
+///   Error:   `{unix_ts}\n0`
+enum CargoBuildSbfCheckCacheState {
+    Success(i64, String),
+    Error(i64),
+    Missing,
+}
+
+fn read_cargo_build_sbf_check_cache() -> CargoBuildSbfCheckCacheState {
+    let Ok(content) = fs::read_to_string(cargo_build_sbf_check_file_path()) else {
+        return CargoBuildSbfCheckCacheState::Missing;
+    };
+    let mut lines = content.lines();
+    let Some(timestamp) = lines.next().and_then(|line| line.parse().ok()) else {
+        return CargoBuildSbfCheckCacheState::Missing;
+    };
+    match lines.next() {
+        Some("0") | None => CargoBuildSbfCheckCacheState::Error(timestamp),
+        Some(version) if !version.is_empty() => {
+            CargoBuildSbfCheckCacheState::Success(timestamp, version.to_string())
+        }
+        _ => CargoBuildSbfCheckCacheState::Missing,
+    }
+}
+
+fn write_cargo_build_sbf_check_cache(version: &str) {
+    let content = format!("{}\n{version}", Utc::now().timestamp());
+    let _ = fs::create_dir_all(&*AVM_HOME);
+    let _ = fs::write(cargo_build_sbf_check_file_path(), content);
+}
+
+fn write_cargo_build_sbf_check_error_cache() {
+    let content = format!("{}\n0", Utc::now().timestamp());
+    let _ = fs::create_dir_all(&*AVM_HOME);
+    let _ = fs::write(cargo_build_sbf_check_file_path(), content);
+}
+
+#[derive(Deserialize)]
+struct LatestPlatformToolsRelease {
+    tag_name: String,
+}
+
+fn parse_platform_tools_release_tag(tag: &str) -> Result<String> {
+    let Some(version) = tag.strip_prefix('v') else {
+        bail!("Latest platform-tools release has an invalid tag `{tag}`");
+    };
+    if version.split('.').count() < 2
+        || version
+            .split('.')
+            .any(|component| component.is_empty() || !component.chars().all(|c| c.is_ascii_digit()))
+    {
+        bail!("Latest platform-tools release has an invalid tag `{tag}`");
+    }
+    Ok(tag.to_string())
+}
+
+fn get_latest_platform_tools_version_with_client(
+    client: &reqwest::blocking::Client,
+) -> Result<String> {
+    let response = client
+        .get(PLATFORM_TOOLS_LATEST_RELEASE_URL)
+        .header(USER_AGENT, "avm https://github.com/otter-sec/anchor")
+        .send()
+        .with_context(|| format!("Sending GET {PLATFORM_TOOLS_LATEST_RELEASE_URL}"))?;
+    if !response.status().is_success() {
+        bail!(
+            "Fetching the latest platform-tools release failed with status {}",
+            response.status()
+        );
+    }
+    let release = response
+        .json::<LatestPlatformToolsRelease>()
+        .context("Parsing the latest platform-tools release")?;
+    parse_platform_tools_release_tag(&release.tag_name)
+}
+
+fn warn_if_cargo_build_sbf_platform_tools_are_missing(version: &str) {
+    if let Ok(false) = platform_tools::cargo_build_sbf_platform_tools_installed(version) {
+        eprintln!(
+            "The latest cargo build-sbf platform-tools ({version}) is not installed. Run `cargo \
+             build-sbf --tools-version {version} --install-only` to install it."
+        );
+    }
+}
+
+/// Fetch the latest platform-tools release and warn when it is absent from
+/// `cargo build-sbf`'s cache. The check, including failures, is cached for 24
+/// hours in `$AVM_HOME/.cargo-build-sbf-check`; no toolchain is installed
+/// automatically.
+pub fn check_latest_cargo_build_sbf_and_warn() {
+    let now = Utc::now().timestamp();
+    match read_cargo_build_sbf_check_cache() {
+        CargoBuildSbfCheckCacheState::Success(timestamp, _version)
+            if now - timestamp < CARGO_BUILD_SBF_CHECK_INTERVAL_SECS => {}
+        CargoBuildSbfCheckCacheState::Error(timestamp)
+            if now - timestamp < CARGO_BUILD_SBF_CHECK_INTERVAL_SECS => {}
+        _ => match get_latest_platform_tools_version_with_client(&HTTP_CLIENT) {
+            Ok(version) => {
+                write_cargo_build_sbf_check_cache(&version);
+                warn_if_cargo_build_sbf_platform_tools_are_missing(&version);
+            }
+            Err(_) => write_cargo_build_sbf_check_error_cache(),
+        },
+    }
+}
+
 /// Update AVM itself by re-running `cargo install`.
 ///
 /// - Default: installs the latest stable release via `--tag`.
@@ -1621,6 +1738,21 @@ mod tests {
             sha256_hex(b"anchor"),
             "79bfb0e2ba76b9d447606ddbcc494834f05a4c11deb052e74b49ea307a3c5bcd"
         );
+    }
+
+    #[test]
+    fn platform_tools_release_tag_is_strictly_validated() {
+        assert_eq!(parse_platform_tools_release_tag("v1.57").unwrap(), "v1.57");
+        assert_eq!(
+            parse_platform_tools_release_tag("v1.57.1").unwrap(),
+            "v1.57.1"
+        );
+        for invalid in ["1.57", "v1", "v1.", "v1.x", "v1.57/../../tmp"] {
+            assert!(
+                parse_platform_tools_release_tag(invalid).is_err(),
+                "accepted invalid tag {invalid}"
+            );
+        }
     }
 
     #[test]

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -216,6 +216,7 @@ pub fn entry(opts: Cli) -> Result<()> {
         Commands::SelfUpdate { .. } | Commands::Nightly { .. } | Commands::Completions { .. }
     ) {
         avm::check_avm_version_and_warn();
+        avm::check_latest_cargo_build_sbf_and_warn();
     }
 
     match opts.command {
@@ -378,6 +379,8 @@ pub fn entry(opts: Cli) -> Result<()> {
 
 fn anchor_proxy() -> Result<()> {
     let args = std::env::args().skip(1).collect::<Vec<String>>();
+
+    avm::check_latest_cargo_build_sbf_and_warn();
 
     if avm::ensure_nightly_active()?.is_some() {
         return spawn_anchor(avm::nightly_anchor_binary_path(), args);

--- a/avm/src/platform_tools.rs
+++ b/avm/src/platform_tools.rs
@@ -552,6 +552,32 @@ pub fn platform_tools_version_path(version: &str) -> PathBuf {
     get_platform_tools_dir_path().join(version)
 }
 
+/// Path used by `cargo build-sbf` for a cached platform-tools release.
+///
+/// This is intentionally separate from AVM's own platform-tools directory:
+/// invoking `cargo build-sbf --install-only` stores its toolchain in the
+/// shared Solana cache.
+pub fn cargo_build_sbf_platform_tools_path(version: &str) -> Result<PathBuf> {
+    let version = if version.starts_with('v') {
+        version.to_string()
+    } else {
+        format!("v{version}")
+    };
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow!("Could not find home directory"))?
+        .join(".cache")
+        .join("solana")
+        .join(version)
+        .join("platform-tools"))
+}
+
+/// Return whether `cargo build-sbf` has a usable cached platform-tools release.
+pub fn cargo_build_sbf_platform_tools_installed(version: &str) -> Result<bool> {
+    Ok(looks_installed(&cargo_build_sbf_platform_tools_path(
+        version,
+    )?))
+}
+
 /// List installed platform-tools versions, lexicographically ordered.
 pub fn read_installed_platform_tools() -> Result<Vec<String>> {
     let dir = get_platform_tools_dir_path();
@@ -1032,6 +1058,14 @@ mod tests {
 
         std::fs::write(dir.path().join("rust/marker"), b"").unwrap();
         assert!(looks_installed(dir.path()));
+    }
+
+    #[test]
+    fn cargo_build_sbf_cache_path_normalizes_the_version() {
+        let with_v = cargo_build_sbf_platform_tools_path("v1.54").unwrap();
+        let without_v = cargo_build_sbf_platform_tools_path("1.54").unwrap();
+        assert_eq!(with_v, without_v);
+        assert!(with_v.ends_with(".cache/solana/v1.54/platform-tools"));
     }
 
     #[test]

--- a/docs/content/docs/references/avm.mdx
+++ b/docs/content/docs/references/avm.mdx
@@ -147,6 +147,11 @@ requirement, AVM considers hosted Solana CLI versions satisfying that
 requirement and prefers one whose platform-tools rustc can compile the locked
 program dependency graph.
 
+AVM also queries the latest platform-tools release at most once every 24 hours
+and checks whether it is present in `cargo build-sbf`'s cache. If it is
+missing, AVM prints the exact `cargo build-sbf --install-only` command needed
+to install it; it never installs the toolchain automatically.
+
 ## Self-update
 
 ```shell


### PR DESCRIPTION
## Summary
- check Anza platform-tools releases at most once every 24 hours
- warn with the matching `cargo build-sbf --install-only` command when the latest toolchain is absent
- cache successful and failed checks without installing anything automatically
