### PR TITLE
lang: skip exit re-serialization when the account is no longer owned by the program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- lang: Skip re-serializing accounts on exit when the account is no longer owned by the program. ([#5011](https://github.com/otter-sec/anchor/pull/5011)).
+- lang: On exit, do not write accounts that are no longer owned by the program: unchanged data is tolerated, unpersisted modifications are an error. ([#5011](https://github.com/otter-sec/anchor/pull/5011)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- lang: Skip re-serializing `Account`, `AccountLoader`, `LazyAccount` and `Migration` on exit when the account is no longer owned by the program, e.g. after being reassigned via CPI in the same instruction.
+
 ### Breaking
 
 ## [1.2.0] - 2026-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- lang: Skip re-serializing `Account`, `AccountLoader`, `LazyAccount` and `Migration` on exit when the account is no longer owned by the program, e.g. after being reassigned via CPI in the same instruction.
+- lang: Skip re-serializing accounts on exit when the account is no longer owned by the program. ([#5011](https://github.com/otter-sec/anchor/pull/5011)).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- lang: On exit, do not write accounts that are no longer owned by the program: unchanged data is tolerated, unpersisted modifications are an error. ([#5011](https://github.com/otter-sec/anchor/pull/5011)).
+- lang: Raise an error when modifying data in an account that has had it's ownership changed. ([#5011](https://github.com/otter-sec/anchor/pull/5011)).
 
 ### Breaking
 

--- a/docs/content/docs/references/account-types.mdx
+++ b/docs/content/docs/references/account-types.mdx
@@ -12,11 +12,12 @@ for implementation details.
 
 <Callout title="Persistence on exit">
   Typed accounts (`Account`, `AccountLoader`, `LazyAccount`, `Migration`) are
-  written back to the account data when the instruction returns only if the
-  account is still owned by the program and has not been closed. If ownership
-  moved during the instruction, for example because the account was reassigned
-  via CPI, the data is left untouched. Call `exit` before such a CPI if pending
-  changes must be persisted first.
+  written back to the account data when the instruction returns if the account
+  is still owned by the program and has not been closed. If ownership moved
+  during the instruction, for example because the account was reassigned via
+  CPI, the account is not written: exit succeeds when the account data already
+  matches the in-memory value and fails with `AccountOwnedByWrongProgram`
+  otherwise. Call `exit` before such a CPI to persist pending changes.
 </Callout>
 
 ## Account Types

--- a/docs/content/docs/references/account-types.mdx
+++ b/docs/content/docs/references/account-types.mdx
@@ -10,6 +10,15 @@ See the account types
 [source code](https://github.com/otter-sec/anchor/tree/62865c636aecc6974fc9cfebfc6cf08ca4f0bb72/lang/src/accounts)
 for implementation details.
 
+<Callout title="Persistence on exit">
+  Typed accounts (`Account`, `AccountLoader`, `LazyAccount`, `Migration`) are
+  written back to the account data when the instruction returns only if the
+  account is still owned by the program and has not been closed. If ownership
+  moved during the instruction, for example because the account was reassigned
+  via CPI, the data is left untouched. Call `exit` before such a CPI if pending
+  changes must be persisted first.
+</Callout>
+
 ## Account Types
 
 ### `Account<'info, T>`

--- a/lang/attribute/account/src/lazy.rs
+++ b/lang/attribute/account/src/lazy.rs
@@ -276,14 +276,19 @@ pub fn gen_lazy(strct: &syn::ItemStruct) -> syn::Result<TokenStream> {
             // initialized rather than deserializing the whole account, and then serializing it
             // back, which consumes a lot more CUs than it should for most accounts.
             fn exit(&self, program_id: &anchor_lang::prelude::Pubkey) -> anchor_lang::Result<()> {
-                // Only persist if the account is still owned by the current
-                // program and not closed.
+                // Only persist if the owner is the current program and the account is not closed
                 if &<#ident as anchor_lang::Owner>::owner() == program_id
-                    && self.__info.owner == program_id
                     && !anchor_lang::__private::is_closed(self.__info)
                 {
                     // Make sure all fields are initialized
                     let acc = self.load()?;
+                    if self.__info.owner != program_id {
+                        return anchor_lang::__private::exit_unowned(
+                            self.__info,
+                            program_id,
+                            |writer| acc.try_serialize(writer),
+                        );
+                    }
                     let mut data = self.__info.try_borrow_mut_data()?;
                     let dst: &mut [u8] = &mut data;
                     let mut writer = anchor_lang::__private::BpfWriter::new(dst);

--- a/lang/attribute/account/src/lazy.rs
+++ b/lang/attribute/account/src/lazy.rs
@@ -276,8 +276,10 @@ pub fn gen_lazy(strct: &syn::ItemStruct) -> syn::Result<TokenStream> {
             // initialized rather than deserializing the whole account, and then serializing it
             // back, which consumes a lot more CUs than it should for most accounts.
             fn exit(&self, program_id: &anchor_lang::prelude::Pubkey) -> anchor_lang::Result<()> {
-                // Only persist if the owner is the current program and the account is not closed
+                // Only persist if the account is still owned by the current
+                // program and not closed.
                 if &<#ident as anchor_lang::Owner>::owner() == program_id
+                    && self.__info.owner == program_id
                     && !anchor_lang::__private::is_closed(self.__info)
                 {
                     // Make sure all fields are initialized

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -40,6 +40,15 @@ use {
 /// - `Account.info.owner == T::owner()`
 /// - `!(Account.info.owner == SystemProgram && Account.info.lamports() == 0)`
 ///
+/// # Persistence
+///
+/// When the instruction returns, `mut` accounts are serialized back into the
+/// account data only if the account is still owned by the program and has
+/// not been closed. If ownership moved during the instruction, for example
+/// because the account was reassigned via CPI, the data is left untouched.
+/// Call [`exit`](crate::AccountsExit::exit) before such a CPI if pending
+/// changes must be persisted first.
+///
 /// # Example
 /// ```ignore
 /// use anchor_lang::prelude::*;

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -43,11 +43,13 @@ use {
 /// # Persistence
 ///
 /// When the instruction returns, `mut` accounts are serialized back into the
-/// account data only if the account is still owned by the program and has
-/// not been closed. If ownership moved during the instruction, for example
-/// because the account was reassigned via CPI, the data is left untouched.
-/// Call [`exit`](crate::AccountsExit::exit) before such a CPI if pending
-/// changes must be persisted first.
+/// account data if the account is still owned by the program and has not
+/// been closed. If ownership moved during the instruction, for example
+/// because the account was reassigned via CPI, the account is not written:
+/// exit succeeds when the account data already matches the in-memory value
+/// and fails with `AccountOwnedByWrongProgram` otherwise. Call
+/// [`exit`](crate::AccountsExit::exit) before such a CPI to persist pending
+/// changes.
 ///
 /// # Example
 /// ```ignore
@@ -266,14 +268,13 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Account<'a, T> {
         expected_owner: &Pubkey,
         program_id: &Pubkey,
     ) -> Result<()> {
-        // Only persist if the account is still owned by the current program
-        // and not closed. Ownership can move away mid-instruction (e.g. when
-        // reassigned via CPI); writing then fails under direct mapping with
-        // `ExternalAccountDataModified` and is pointless otherwise.
-        if expected_owner == program_id
-            && self.info.owner == program_id
-            && !crate::common::is_closed(self.info)
-        {
+        // Only persist if the owner is the current program and the account is not closed.
+        if expected_owner == program_id && !crate::common::is_closed(self.info) {
+            if self.info.owner != program_id {
+                return crate::common::exit_unowned(self.info, program_id, |writer| {
+                    self.account.try_serialize(writer)
+                });
+            }
             let mut data = self.info.try_borrow_mut_data()?;
             let dst: &mut [u8] = &mut data;
             let mut writer = BpfWriter::new(dst);

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -257,8 +257,14 @@ impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Account<'a, T> {
         expected_owner: &Pubkey,
         program_id: &Pubkey,
     ) -> Result<()> {
-        // Only persist if the owner is the current program and the account is not closed.
-        if expected_owner == program_id && !crate::common::is_closed(self.info) {
+        // Only persist if the account is still owned by the current program
+        // and not closed. Ownership can move away mid-instruction (e.g. when
+        // reassigned via CPI); writing then fails under direct mapping with
+        // `ExternalAccountDataModified` and is pointless otherwise.
+        if expected_owner == program_id
+            && self.info.owner == program_id
+            && !crate::common::is_closed(self.info)
+        {
             let mut data = self.info.try_borrow_mut_data()?;
             let dst: &mut [u8] = &mut data;
             let mut writer = BpfWriter::new(dst);

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -266,8 +266,12 @@ impl<'info, B, T: ZeroCopy + Owner> Accounts<'info, B> for AccountLoader<'info, 
 impl<'info, T: ZeroCopy + Owner> AccountsExit<'info> for AccountLoader<'info, T> {
     // The account *cannot* be loaded when this is called.
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
-        // Only persist if the owner is the current program and the account is not closed.
-        if &T::owner() == program_id && !crate::common::is_closed(self.acc_info) {
+        // Only persist if the account is still owned by the current program
+        // and not closed.
+        if &T::owner() == program_id
+            && self.acc_info.owner == program_id
+            && !crate::common::is_closed(self.acc_info)
+        {
             // Guard against truncation: refuse to rewrite the discriminator over an undersized buffer.
             let required = T::DISCRIMINATOR.len() + mem::size_of::<T>();
             if self.acc_info.try_data_len()? < required {

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -29,8 +29,9 @@ use {
 /// - `load` when the account is not mutable
 /// - `load_mut` when the account is mutable
 ///
-/// On exit, the account discriminator is written back only if the account is
-/// still owned by the program and has not been closed.
+/// On exit, the account discriminator is written back if the account is still
+/// owned by the program and has not been closed. If ownership moved during
+/// the instruction, a missing discriminator is an error.
 ///
 /// For more details on zero-copy-deserialization, see the
 /// [`account`](crate::account) attribute.
@@ -269,16 +270,17 @@ impl<'info, B, T: ZeroCopy + Owner> Accounts<'info, B> for AccountLoader<'info, 
 impl<'info, T: ZeroCopy + Owner> AccountsExit<'info> for AccountLoader<'info, T> {
     // The account *cannot* be loaded when this is called.
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
-        // Only persist if the account is still owned by the current program
-        // and not closed.
-        if &T::owner() == program_id
-            && self.acc_info.owner == program_id
-            && !crate::common::is_closed(self.acc_info)
-        {
+        // Only persist if the owner is the current program and the account is not closed.
+        if &T::owner() == program_id && !crate::common::is_closed(self.acc_info) {
             // Guard against truncation: refuse to rewrite the discriminator over an undersized buffer.
             let required = T::DISCRIMINATOR.len() + mem::size_of::<T>();
             if self.acc_info.try_data_len()? < required {
                 return Err(ErrorCode::AccountDidNotDeserialize.into());
+            }
+            if self.acc_info.owner != program_id {
+                return crate::common::exit_unowned(self.acc_info, program_id, |writer| {
+                    Ok(writer.write_all(T::DISCRIMINATOR)?)
+                });
             }
             let mut data = self.acc_info.try_borrow_mut_data()?;
             let dst: &mut [u8] = &mut data;

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -29,6 +29,9 @@ use {
 /// - `load` when the account is not mutable
 /// - `load_mut` when the account is mutable
 ///
+/// On exit, the account discriminator is written back only if the account is
+/// still owned by the program and has not been closed.
+///
 /// For more details on zero-copy-deserialization, see the
 /// [`account`](crate::account) attribute.
 /// <p style=";padding:0.75em;border: 1px solid #ee6868">

--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -54,8 +54,9 @@ use {
 ///   non-inlined, meaning that they're less likely to cause stack violation errors.
 /// - Each individual field can be deserialized with the generated `load_<field>` and
 ///   `load_mut_<field>` methods.
-/// - Changes are serialized on exit only if the account is still owned by the
-///   program and has not been closed.
+/// - Changes are serialized on exit if the account is still owned by the
+///   program and has not been closed. If ownership moved during the
+///   instruction, unpersisted changes are an error.
 ///
 /// # Example
 ///

--- a/lang/src/accounts/lazy_account.rs
+++ b/lang/src/accounts/lazy_account.rs
@@ -54,6 +54,8 @@ use {
 ///   non-inlined, meaning that they're less likely to cause stack violation errors.
 /// - Each individual field can be deserialized with the generated `load_<field>` and
 ///   `load_mut_<field>` methods.
+/// - Changes are serialized on exit only if the account is still owned by the
+///   program and has not been closed.
 ///
 /// # Example
 ///

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -40,9 +40,10 @@ pub enum MigrationInner<From, To> {
 /// accounts already in the `To` format will be rejected with an error.
 ///
 /// The migrated data is stored in memory and will be serialized to the account
-/// when the instruction exits, provided the account is still owned by the
-/// program and has not been closed. On exit, the account must be in the
-/// migrated state or an error will be returned.
+/// when the instruction exits. On exit, the account must be in the migrated
+/// state or an error will be returned. If ownership moved during the
+/// instruction, the account is not written: exit succeeds only when the
+/// account data already matches the migrated value.
 ///
 /// This type is typically used with the `realloc` constraint to resize the account
 /// during migration.
@@ -359,9 +360,8 @@ where
     To: AccountSerialize + Owner,
 {
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
-        // Skip if the account is closed or no longer owned by the current
-        // program.
-        if crate::common::is_closed(self.info) || self.info.owner != program_id {
+        // Check if account is closed
+        if crate::common::is_closed(self.info) {
             return Ok(());
         }
 
@@ -377,6 +377,12 @@ where
                 if &expected_owner != program_id {
                     return Err(Error::from(ErrorCode::InvalidProgramId)
                         .with_pubkeys((*program_id, expected_owner)));
+                }
+
+                if self.info.owner != program_id {
+                    return crate::common::exit_unowned(self.info, program_id, |writer| {
+                        to.try_serialize(writer)
+                    });
                 }
 
                 // Serialize the migrated data

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -358,8 +358,9 @@ where
     To: AccountSerialize + Owner,
 {
     fn exit(&self, program_id: &Pubkey) -> Result<()> {
-        // Check if account is closed
-        if crate::common::is_closed(self.info) {
+        // Skip if the account is closed or no longer owned by the current
+        // program.
+        if crate::common::is_closed(self.info) || self.info.owner != program_id {
             return Ok(());
         }
 

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -39,9 +39,10 @@ pub enum MigrationInner<From, To> {
 /// schema (`To`). During deserialization, the account must be in the `From` format -
 /// accounts already in the `To` format will be rejected with an error.
 ///
-/// The migrated data is stored in memory and will be serialized to the account when the
-/// instruction exits. On exit, the account must be in the migrated state or an error will
-/// be returned.
+/// The migrated data is stored in memory and will be serialized to the account
+/// when the instruction exits, provided the account is still owned by the
+/// program and has not been closed. On exit, the account must be in the
+/// migrated state or an error will be returned.
 ///
 /// This type is typically used with the `realloc` constraint to resize the account
 /// during migration.

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -1,7 +1,11 @@
-use crate::{
-    prelude::{Id, System},
-    solana_program::{account_info::AccountInfo, system_program},
-    Lamports, Result,
+use {
+    crate::{
+        error::{Error, ErrorCode},
+        prelude::{Id, System},
+        solana_program::{account_info::AccountInfo, pubkey::Pubkey, system_program},
+        Lamports, Result,
+    },
+    std::io::{self, Write},
 };
 
 pub(crate) fn close<'info>(
@@ -18,4 +22,57 @@ pub(crate) fn close<'info>(
 
 pub fn is_closed(info: &AccountInfo) -> bool {
     info.owner == &System::id() && info.data_is_empty()
+}
+
+/// Exit path for an account that is no longer owned by the program, e.g.
+/// after being reassigned via CPI. Mirrors the runtime: unchanged data is
+/// tolerated, a modification is an error.
+pub fn exit_unowned<F>(info: &AccountInfo, program_id: &Pubkey, serialize: F) -> Result<()>
+where
+    F: FnOnce(&mut CompareWriter<'_>) -> Result<()>,
+{
+    let data = info.try_borrow_data()?;
+    let mut writer = CompareWriter::new(&data);
+    serialize(&mut writer)?;
+    if writer.matches() {
+        Ok(())
+    } else {
+        Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+            .with_pubkeys((*info.owner, *program_id)))
+    }
+}
+
+/// `Write` sink that checks written bytes against an existing buffer
+/// instead of storing them.
+pub struct CompareWriter<'a> {
+    data: &'a [u8],
+    pos: usize,
+    matches: bool,
+}
+
+impl<'a> CompareWriter<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self {
+            data,
+            pos: 0,
+            matches: true,
+        }
+    }
+
+    pub fn matches(&self) -> bool {
+        self.matches
+    }
+}
+
+impl Write for CompareWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let end = self.pos.saturating_add(buf.len());
+        self.matches &= self.data.get(self.pos..end) == Some(buf);
+        self.pos = end;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }

--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -27,6 +27,7 @@ pub fn is_closed(info: &AccountInfo) -> bool {
 /// Exit path for an account that is no longer owned by the program, e.g.
 /// after being reassigned via CPI. Mirrors the runtime: unchanged data is
 /// tolerated, a modification is an error.
+#[doc(hidden)]
 pub fn exit_unowned<F>(info: &AccountInfo, program_id: &Pubkey, serialize: F) -> Result<()>
 where
     F: FnOnce(&mut CompareWriter<'_>) -> Result<()>,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -607,7 +607,10 @@ pub mod prelude {
 pub mod __private {
     use crate::solana_program::pubkey::Pubkey;
     pub use {
-        crate::{bpf_writer::BpfWriter, common::is_closed},
+        crate::{
+            bpf_writer::BpfWriter,
+            common::{exit_unowned, is_closed},
+        },
         anchor_attribute_account::ZeroCopyAccessor,
         base64, bytemuck,
     };

--- a/lang/tests/exit_owner.rs
+++ b/lang/tests/exit_owner.rs
@@ -1,8 +1,6 @@
 //! `exit` must not re-serialize an account whose ownership moved away from the program
 //! mid-instruction (e.g. reassigned via CPI); such a write fails under direct mapping.
 
-#[cfg(feature = "lazy-account")]
-use anchor_lang::accounts::lazy_account::LazyAccount;
 use anchor_lang::{
     accounts::{account_loader::AccountLoader, migration::Migration},
     prelude::*,
@@ -100,21 +98,6 @@ fn exit_with_data_borrowed<'info>(
     exit().is_ok()
 }
 
-#[cfg(feature = "lazy-account")]
-fn lazy_account_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
-    let key = Pubkey::new_unique();
-    let owner = crate::ID;
-    let mut lamports = 0;
-    let mut data = Data::DISCRIMINATOR.to_vec();
-    data.extend_from_slice(&0u64.to_le_bytes());
-    let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
-    let account: LazyAccount<Data> = LazyAccount::try_from_unchecked(&info).unwrap();
-    if let Some(new_owner) = new_owner {
-        info.assign(new_owner);
-    }
-    exit_with_data_borrowed(&info, || account.exit(&crate::ID))
-}
-
 fn migration_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
     let key = Pubkey::new_unique();
     let owner = crate::ID;
@@ -130,18 +113,6 @@ fn migration_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
     exit_with_data_borrowed(&info, || AccountsExit::exit(&account, &crate::ID))
 }
 
-#[cfg(feature = "lazy-account")]
-#[test]
-fn lazy_account_exit_writes_when_owned() {
-    assert!(!lazy_account_exit_succeeds(None));
-}
-
-#[cfg(feature = "lazy-account")]
-#[test]
-fn lazy_account_exit_skips_when_owner_changed() {
-    assert!(lazy_account_exit_succeeds(Some(&Pubkey::new_unique())));
-}
-
 #[test]
 fn migration_exit_writes_when_owned() {
     assert!(!migration_exit_succeeds(None));
@@ -150,4 +121,34 @@ fn migration_exit_writes_when_owned() {
 #[test]
 fn migration_exit_skips_when_owner_changed() {
     assert!(migration_exit_succeeds(Some(&Pubkey::new_unique())));
+}
+
+#[cfg(feature = "lazy-account")]
+mod lazy_account {
+    use super::*;
+    use anchor_lang::accounts::lazy_account::LazyAccount;
+
+    fn lazy_account_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
+        let key = Pubkey::new_unique();
+        let owner = crate::ID;
+        let mut lamports = 0;
+        let mut data = Data::DISCRIMINATOR.to_vec();
+        data.extend_from_slice(&0u64.to_le_bytes());
+        let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+        let account: LazyAccount<Data> = LazyAccount::try_from_unchecked(&info).unwrap();
+        if let Some(new_owner) = new_owner {
+            info.assign(new_owner);
+        }
+        exit_with_data_borrowed(&info, || account.exit(&crate::ID))
+    }
+
+    #[test]
+    fn lazy_account_exit_writes_when_owned() {
+        assert!(!lazy_account_exit_succeeds(None));
+    }
+
+    #[test]
+    fn lazy_account_exit_skips_when_owner_changed() {
+        assert!(lazy_account_exit_succeeds(Some(&Pubkey::new_unique())));
+    }
 }

--- a/lang/tests/exit_owner.rs
+++ b/lang/tests/exit_owner.rs
@@ -125,8 +125,7 @@ fn migration_exit_skips_when_owner_changed() {
 
 #[cfg(feature = "lazy-account")]
 mod lazy_account {
-    use super::*;
-    use anchor_lang::accounts::lazy_account::LazyAccount;
+    use {super::*, anchor_lang::accounts::lazy_account::LazyAccount};
 
     fn lazy_account_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
         let key = Pubkey::new_unique();

--- a/lang/tests/exit_owner.rs
+++ b/lang/tests/exit_owner.rs
@@ -1,0 +1,153 @@
+//! `exit` must not re-serialize an account whose ownership moved away from the program
+//! mid-instruction (e.g. reassigned via CPI); such a write fails under direct mapping.
+
+#[cfg(feature = "lazy-account")]
+use anchor_lang::accounts::lazy_account::LazyAccount;
+use anchor_lang::{
+    accounts::{account_loader::AccountLoader, migration::Migration},
+    prelude::*,
+};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[account]
+#[derive(Default, Debug)]
+pub struct Data {
+    pub value: u64,
+}
+
+#[account]
+#[derive(Default, Debug)]
+pub struct DataV2 {
+    pub value: u64,
+    pub extra: u64,
+}
+
+#[account(zero_copy)]
+#[derive(Default, Debug)]
+pub struct ZcData {
+    pub value: u64,
+}
+
+/// Deserializes `Data` while owned by this program, mutates it, optionally reassigns the
+/// account to `new_owner` (as a CPI would), then runs `exit` and returns the raw data.
+fn exit_account(new_owner: Option<&Pubkey>) -> Vec<u8> {
+    let key = Pubkey::new_unique();
+    let owner = crate::ID;
+    let mut lamports = 0;
+    let mut data = Data::DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&0u64.to_le_bytes());
+    {
+        let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+        let mut account: Account<Data> = Account::try_from_unchecked(&info).unwrap();
+        account.value = 42;
+        if let Some(new_owner) = new_owner {
+            info.assign(new_owner);
+        }
+        AccountsExit::exit(&account, &crate::ID).unwrap();
+    }
+    data
+}
+
+fn exit_account_loader(new_owner: Option<&Pubkey>) -> Vec<u8> {
+    let key = Pubkey::new_unique();
+    let owner = crate::ID;
+    let mut lamports = 0;
+    let mut data = vec![0u8; 8 + std::mem::size_of::<ZcData>()];
+    {
+        let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+        let loader: AccountLoader<ZcData> =
+            AccountLoader::try_from_unchecked(&crate::ID, &info).unwrap();
+        if let Some(new_owner) = new_owner {
+            info.assign(new_owner);
+        }
+        AccountsExit::exit(&loader, &crate::ID).unwrap();
+    }
+    data
+}
+
+#[test]
+fn account_exit_persists_when_owned() {
+    let data = exit_account(None);
+    assert_eq!(&data[8..], &42u64.to_le_bytes());
+}
+
+#[test]
+fn account_exit_skips_when_owner_changed() {
+    let data = exit_account(Some(&Pubkey::new_unique()));
+    assert_eq!(&data[8..], &0u64.to_le_bytes());
+}
+
+#[test]
+fn account_loader_exit_persists_when_owned() {
+    let data = exit_account_loader(None);
+    assert_eq!(&data[..8], ZcData::DISCRIMINATOR);
+}
+
+#[test]
+fn account_loader_exit_skips_when_owner_changed() {
+    let data = exit_account_loader(Some(&Pubkey::new_unique()));
+    assert_eq!(&data[..8], &[0u8; 8]);
+}
+
+/// Runs `exit` while the account data is immutably borrowed: a write attempt fails with
+/// `AccountBorrowFailed`, a skipped exit succeeds. Returns whether `exit` succeeded.
+fn exit_with_data_borrowed<'info>(
+    info: &AccountInfo<'info>,
+    exit: impl FnOnce() -> Result<()>,
+) -> bool {
+    let _guard = info.try_borrow_data().unwrap();
+    exit().is_ok()
+}
+
+#[cfg(feature = "lazy-account")]
+fn lazy_account_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
+    let key = Pubkey::new_unique();
+    let owner = crate::ID;
+    let mut lamports = 0;
+    let mut data = Data::DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&0u64.to_le_bytes());
+    let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+    let account: LazyAccount<Data> = LazyAccount::try_from_unchecked(&info).unwrap();
+    if let Some(new_owner) = new_owner {
+        info.assign(new_owner);
+    }
+    exit_with_data_borrowed(&info, || account.exit(&crate::ID))
+}
+
+fn migration_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
+    let key = Pubkey::new_unique();
+    let owner = crate::ID;
+    let mut lamports = 0;
+    let mut data = Data::DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&0u64.to_le_bytes());
+    let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+    let mut account: Migration<Data, DataV2> = Migration::try_from_unchecked(&info).unwrap();
+    account.migrate(DataV2::default()).unwrap();
+    if let Some(new_owner) = new_owner {
+        info.assign(new_owner);
+    }
+    exit_with_data_borrowed(&info, || AccountsExit::exit(&account, &crate::ID))
+}
+
+#[cfg(feature = "lazy-account")]
+#[test]
+fn lazy_account_exit_writes_when_owned() {
+    assert!(!lazy_account_exit_succeeds(None));
+}
+
+#[cfg(feature = "lazy-account")]
+#[test]
+fn lazy_account_exit_skips_when_owner_changed() {
+    assert!(lazy_account_exit_succeeds(Some(&Pubkey::new_unique())));
+}
+
+#[test]
+fn migration_exit_writes_when_owned() {
+    assert!(!migration_exit_succeeds(None));
+}
+
+#[test]
+fn migration_exit_skips_when_owner_changed() {
+    assert!(migration_exit_succeeds(Some(&Pubkey::new_unique())));
+}

--- a/lang/tests/exit_owner.rs
+++ b/lang/tests/exit_owner.rs
@@ -1,5 +1,6 @@
-//! `exit` must not re-serialize an account whose ownership moved away from the program
-//! mid-instruction (e.g. reassigned via CPI); such a write fails under direct mapping.
+//! On exit, an account whose ownership moved away from the program during the
+//! instruction (e.g. reassigned via CPI) is not written: unchanged data is
+//! tolerated, an unpersisted modification is an error.
 
 use anchor_lang::{
     accounts::{account_loader::AccountLoader, migration::Migration},
@@ -27,127 +28,204 @@ pub struct ZcData {
     pub value: u64,
 }
 
-/// Deserializes `Data` while owned by this program, mutates it, optionally reassigns the
-/// account to `new_owner` (as a CPI would), then runs `exit` and returns the raw data.
-fn exit_account(new_owner: Option<&Pubkey>) -> Vec<u8> {
+fn wrong_owner() -> Error {
+    ErrorCode::AccountOwnedByWrongProgram.into()
+}
+
+/// Loads `Data` while owned by this program, optionally mutates it in memory,
+/// optionally reassigns the account (as a CPI would), then runs `exit`.
+fn account_exit(mutate: bool, new_owner: Option<&Pubkey>) -> (Result<()>, Vec<u8>) {
     let key = Pubkey::new_unique();
     let owner = crate::ID;
     let mut lamports = 0;
     let mut data = Data::DISCRIMINATOR.to_vec();
     data.extend_from_slice(&0u64.to_le_bytes());
-    {
+    let result = {
         let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
         let mut account: Account<Data> = Account::try_from_unchecked(&info).unwrap();
-        account.value = 42;
+        if mutate {
+            account.value = 42;
+        }
         if let Some(new_owner) = new_owner {
             info.assign(new_owner);
         }
-        AccountsExit::exit(&account, &crate::ID).unwrap();
-    }
-    data
+        AccountsExit::exit(&account, &crate::ID)
+    };
+    (result, data)
 }
 
-fn exit_account_loader(new_owner: Option<&Pubkey>) -> Vec<u8> {
+#[test]
+fn account_exit_persists_when_owned() {
+    let (result, data) = account_exit(true, None);
+    result.unwrap();
+    assert_eq!(&data[8..], &42u64.to_le_bytes());
+}
+
+#[test]
+fn account_exit_tolerates_unchanged_when_owner_changed() {
+    let (result, data) = account_exit(false, Some(&Pubkey::new_unique()));
+    result.unwrap();
+    assert_eq!(&data[8..], &0u64.to_le_bytes());
+}
+
+#[test]
+fn account_exit_rejects_modified_when_owner_changed() {
+    let (result, data) = account_exit(true, Some(&Pubkey::new_unique()));
+    assert_eq!(result.unwrap_err(), wrong_owner());
+    assert_eq!(&data[8..], &0u64.to_le_bytes());
+}
+
+fn account_loader_exit(
+    with_discriminator: bool,
+    new_owner: Option<&Pubkey>,
+) -> (Result<()>, Vec<u8>) {
+    account_loader_exit_sized(
+        8 + std::mem::size_of::<ZcData>(),
+        with_discriminator,
+        new_owner,
+    )
+}
+
+fn account_loader_exit_sized(
+    len: usize,
+    with_discriminator: bool,
+    new_owner: Option<&Pubkey>,
+) -> (Result<()>, Vec<u8>) {
     let key = Pubkey::new_unique();
     let owner = crate::ID;
     let mut lamports = 0;
-    let mut data = vec![0u8; 8 + std::mem::size_of::<ZcData>()];
-    {
+    let mut data = vec![0u8; len];
+    if with_discriminator {
+        data[..8].copy_from_slice(ZcData::DISCRIMINATOR);
+    }
+    let result = {
         let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
         let loader: AccountLoader<ZcData> =
             AccountLoader::try_from_unchecked(&crate::ID, &info).unwrap();
         if let Some(new_owner) = new_owner {
             info.assign(new_owner);
         }
-        AccountsExit::exit(&loader, &crate::ID).unwrap();
-    }
-    data
-}
-
-#[test]
-fn account_exit_persists_when_owned() {
-    let data = exit_account(None);
-    assert_eq!(&data[8..], &42u64.to_le_bytes());
-}
-
-#[test]
-fn account_exit_skips_when_owner_changed() {
-    let data = exit_account(Some(&Pubkey::new_unique()));
-    assert_eq!(&data[8..], &0u64.to_le_bytes());
+        AccountsExit::exit(&loader, &crate::ID)
+    };
+    (result, data)
 }
 
 #[test]
 fn account_loader_exit_persists_when_owned() {
-    let data = exit_account_loader(None);
+    let (result, data) = account_loader_exit(false, None);
+    result.unwrap();
     assert_eq!(&data[..8], ZcData::DISCRIMINATOR);
 }
 
 #[test]
-fn account_loader_exit_skips_when_owner_changed() {
-    let data = exit_account_loader(Some(&Pubkey::new_unique()));
+fn account_loader_exit_tolerates_unchanged_when_owner_changed() {
+    let (result, data) = account_loader_exit(true, Some(&Pubkey::new_unique()));
+    result.unwrap();
+    assert_eq!(&data[..8], ZcData::DISCRIMINATOR);
+}
+
+#[test]
+fn account_loader_exit_rejects_modified_when_owner_changed() {
+    let (result, data) = account_loader_exit(false, Some(&Pubkey::new_unique()));
+    assert_eq!(result.unwrap_err(), wrong_owner());
     assert_eq!(&data[..8], &[0u8; 8]);
 }
 
-/// Runs `exit` while the account data is immutably borrowed: a write attempt fails with
-/// `AccountBorrowFailed`, a skipped exit succeeds. Returns whether `exit` succeeded.
-fn exit_with_data_borrowed<'info>(
-    info: &AccountInfo<'info>,
-    exit: impl FnOnce() -> Result<()>,
-) -> bool {
-    let _guard = info.try_borrow_data().unwrap();
-    exit().is_ok()
+#[test]
+fn account_loader_exit_rejects_truncated_when_owner_changed() {
+    let (result, _) = account_loader_exit_sized(8, true, Some(&Pubkey::new_unique()));
+    assert_eq!(
+        result.unwrap_err(),
+        ErrorCode::AccountDidNotDeserialize.into()
+    );
 }
 
-fn migration_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
+/// Migrates in memory, optionally persists with `exit` while still owned,
+/// optionally reassigns the account, then runs `exit`.
+fn migration_exit(persist_first: bool, new_owner: Option<&Pubkey>) -> (Result<()>, Vec<u8>) {
     let key = Pubkey::new_unique();
     let owner = crate::ID;
     let mut lamports = 0;
     let mut data = Data::DISCRIMINATOR.to_vec();
-    data.extend_from_slice(&0u64.to_le_bytes());
-    let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
-    let mut account: Migration<Data, DataV2> = Migration::try_from_unchecked(&info).unwrap();
-    account.migrate(DataV2::default()).unwrap();
-    if let Some(new_owner) = new_owner {
-        info.assign(new_owner);
-    }
-    exit_with_data_borrowed(&info, || AccountsExit::exit(&account, &crate::ID))
+    data.extend_from_slice(&[0u8; 16]);
+    let result = {
+        let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+        let mut account: Migration<Data, DataV2> = Migration::try_from_unchecked(&info).unwrap();
+        account.migrate(DataV2::default()).unwrap();
+        if persist_first {
+            AccountsExit::exit(&account, &crate::ID).unwrap();
+        }
+        if let Some(new_owner) = new_owner {
+            info.assign(new_owner);
+        }
+        AccountsExit::exit(&account, &crate::ID)
+    };
+    (result, data)
 }
 
 #[test]
-fn migration_exit_writes_when_owned() {
-    assert!(!migration_exit_succeeds(None));
+fn migration_exit_persists_when_owned() {
+    let (result, data) = migration_exit(false, None);
+    result.unwrap();
+    assert_eq!(&data[..8], DataV2::DISCRIMINATOR);
 }
 
 #[test]
-fn migration_exit_skips_when_owner_changed() {
-    assert!(migration_exit_succeeds(Some(&Pubkey::new_unique())));
+fn migration_exit_tolerates_persisted_when_owner_changed() {
+    let (result, data) = migration_exit(true, Some(&Pubkey::new_unique()));
+    result.unwrap();
+    assert_eq!(&data[..8], DataV2::DISCRIMINATOR);
+}
+
+#[test]
+fn migration_exit_rejects_unpersisted_when_owner_changed() {
+    let (result, data) = migration_exit(false, Some(&Pubkey::new_unique()));
+    assert_eq!(result.unwrap_err(), wrong_owner());
+    assert_eq!(&data[..8], Data::DISCRIMINATOR);
 }
 
 #[cfg(feature = "lazy-account")]
 mod lazy_account {
     use {super::*, anchor_lang::accounts::lazy_account::LazyAccount};
 
-    fn lazy_account_exit_succeeds(new_owner: Option<&Pubkey>) -> bool {
+    fn lazy_account_exit(mutate: bool, new_owner: Option<&Pubkey>) -> (Result<()>, Vec<u8>) {
         let key = Pubkey::new_unique();
         let owner = crate::ID;
         let mut lamports = 0;
         let mut data = Data::DISCRIMINATOR.to_vec();
         data.extend_from_slice(&0u64.to_le_bytes());
-        let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
-        let account: LazyAccount<Data> = LazyAccount::try_from_unchecked(&info).unwrap();
-        if let Some(new_owner) = new_owner {
-            info.assign(new_owner);
-        }
-        exit_with_data_borrowed(&info, || account.exit(&crate::ID))
+        let result = {
+            let info = AccountInfo::new(&key, false, true, &mut lamports, &mut data, &owner, false);
+            let account: LazyAccount<Data> = LazyAccount::try_from_unchecked(&info).unwrap();
+            if mutate {
+                account.load_mut().unwrap().value = 42;
+            }
+            if let Some(new_owner) = new_owner {
+                info.assign(new_owner);
+            }
+            account.exit(&crate::ID)
+        };
+        (result, data)
     }
 
     #[test]
-    fn lazy_account_exit_writes_when_owned() {
-        assert!(!lazy_account_exit_succeeds(None));
+    fn lazy_account_exit_persists_when_owned() {
+        let (result, data) = lazy_account_exit(true, None);
+        result.unwrap();
+        assert_eq!(&data[8..], &42u64.to_le_bytes());
     }
 
     #[test]
-    fn lazy_account_exit_skips_when_owner_changed() {
-        assert!(lazy_account_exit_succeeds(Some(&Pubkey::new_unique())));
+    fn lazy_account_exit_tolerates_unchanged_when_owner_changed() {
+        let (result, data) = lazy_account_exit(false, Some(&Pubkey::new_unique()));
+        result.unwrap();
+        assert_eq!(&data[8..], &0u64.to_le_bytes());
+    }
+
+    #[test]
+    fn lazy_account_exit_rejects_modified_when_owner_changed() {
+        let (result, data) = lazy_account_exit(true, Some(&Pubkey::new_unique()));
+        assert_eq!(result.unwrap_err(), wrong_owner());
+        assert_eq!(&data[8..], &0u64.to_le_bytes());
     }
 }


### PR DESCRIPTION
## Summary

`Account`, `AccountLoader`, `LazyAccount` and `Migration` gate their generated `exit` on the compile-time owner (`T::owner() == program_id`), not on the account's current owner. `InterfaceAccount`, `Box` and `Option` delegate to the same paths. If an instruction reassigns the account to another program via CPI and then returns, `exit` still serializes into it.

Today that write is a silent no-op when the bytes are unchanged, because the loader only rejects writes to non-owned accounts if the data differs. Under direct mapping (SIMD-0460, active on devnet, pending mainnet) the account region is remapped read-only after the CPI and the store fails immediately with `ExternalAccountDataModified`. Programs that delegate a PDA to another program in the same instruction hit this in production replay.

## Fix

When the account is no longer owned by the program at exit (`info.owner != program_id`), serialize through a `CompareWriter` against the existing account data instead of writing into it. This mirrors what the runtime does at instruction end: unchanged bytes are a no-op, changed bytes fail with `AccountOwnedByWrongProgram`.

Observable semantics match mainnet today in every case:

| Case | Before | After |
|---|---|---|
| untouched, ownership moved | no-op | no-op |
| mutated, `exit` called, then CPI | ok | ok |
| mutated, no `exit`, then CPI | error | error |
| migrated, no `exit`, then CPI | error | error |
| mutably borrowed, unchanged, then CPI | no-op | no-op |

Affected types: `Account`, `InterfaceAccount` (same `exit_with_expected_owner` path), `AccountLoader` (discriminator only), `LazyAccount`, `Migration`, and their `Box` / `Option` wrappers. `init`, `zero`, `realloc`, `close` and CPI-created accounts are unaffected. The extra cost, one serialization plus a compare, lands only on the path where ownership actually moved.

## Docs

Persistence-on-exit note added to the `account-types` reference page and to the rustdoc of each affected type, including `InterfaceAccount`.

## Tests

`lang/tests/exit_owner.rs` covers `Account`, `AccountLoader`, `LazyAccount` and `Migration`: persisting while owned, tolerating unchanged data after ownership moved, and rejecting an unpersisted change. `InterfaceAccount` is exercised through the `Account` path.

## Branch Target

`master`. Bug fix, no API or behavior change for correctly owned accounts.
