### PR TITLE
ci: enable v0.30 branch tests

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -38,3 +38,7 @@ runs:
       shell: bash
     - run: solana config set --url localhost
       shell: bash
+    # Solana 1.18's SBF toolchain bundles Cargo 1.79. Seed independent
+    # release-owned test workspaces with this release's compatible resolution.
+    - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && [ ! -e "$dir/Cargo.lock" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;
+      shell: bash

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -38,11 +38,6 @@ runs:
       shell: bash
     - run: solana config set --url localhost
       shell: bash
-    # v0.30's IDL builder injects `procmacro2_semver_exempt` through RUSTFLAGS.
-    # Cargo's encoded form takes precedence and keeps that unstable cfg out of
-    # Solana 1.18's older SBF toolchain.
-    - run: echo 'CARGO_ENCODED_RUSTFLAGS=-Awarnings' >> "$GITHUB_ENV"
-      shell: bash
     # Solana 1.18's SBF toolchain bundles Cargo 1.79. Seed independent
     # release-owned test workspaces with this release's compatible resolution.
     - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && [ ! -e "$dir/Cargo.lock" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -38,6 +38,11 @@ runs:
       shell: bash
     - run: solana config set --url localhost
       shell: bash
+    # v0.30's IDL builder injects `procmacro2_semver_exempt` through RUSTFLAGS.
+    # Cargo's encoded form takes precedence and keeps that unstable cfg out of
+    # Solana 1.18's older SBF toolchain.
+    - run: echo 'CARGO_ENCODED_RUSTFLAGS=-Awarnings' >> "$GITHUB_ENV"
+      shell: bash
     # Solana 1.18's SBF toolchain bundles Cargo 1.79. Seed independent
     # release-owned test workspaces with this release's compatible resolution.
     - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && [ ! -e "$dir/Cargo.lock" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -19,7 +19,11 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_CLI_VERSION }}/install)"
+        command: |
+          curl -sSfL -o "$RUNNER_TEMP/solana-install-init" \
+            "https://github.com/solana-labs/solana/releases/download/v${{ env.SOLANA_CLI_VERSION }}/solana-install-init-x86_64-unknown-linux-gnu"
+          chmod +x "$RUNNER_TEMP/solana-install-init"
+          "$RUNNER_TEMP/solana-install-init" "${{ env.SOLANA_CLI_VERSION }}"
     - uses: nick-fields/retry@v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -19,7 +19,7 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install)"
+        command: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_CLI_VERSION }}/install)"
     - uses: nick-fields/retry@v2
       if: steps.cache-solana.outputs.cache-hit != 'true'
       with:

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -46,3 +46,6 @@ runs:
     # release-owned test workspaces with this release's compatible resolution.
     - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && [ ! -e "$dir/Cargo.lock" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;
       shell: bash
+    # The client example is also an independent workspace, but has no Anchor.toml.
+    - run: cp "$GITHUB_WORKSPACE/Cargo.lock" client/example/Cargo.lock
+      shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -3,6 +3,10 @@ description: "Setup"
 runs:
   using: "composite"
   steps:
+    - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0
+      with:
+        toolchain: 1.79.0
+        components: rustfmt, clippy
     - run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev
       shell: bash
     - run: echo "ANCHOR_VERSION=$(cat ./VERSION)" >> $GITHUB_ENV

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -13,6 +13,6 @@ jobs:
       cache: false
       solana_cli_version: 1.18.17
       solang_version: 0.3.2
-      node_version: 18.18.0
+      node_version: 20.18.0
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -492,6 +492,14 @@ jobs:
           path: ${{ matrix.node.path }}/target
           key: cargo-${{ runner.os }}-${{ matrix.node.path }}-${{ env.ANCHOR_VERSION }}-${{ env.SOLANA_CLI_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
+      # Solana 1.14's bundled BPF cargo requires OpenSSL 1.1, which is not
+      # present on current Ubuntu runners.
+      - name: Install OpenSSL 1.1 for swap
+        if: matrix.node.path == 'tests/swap'
+        run: |
+          curl --fail --location --silent --show-error --output /tmp/libssl1.1.deb https://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
+          sudo dpkg --install /tmp/libssl1.1.deb
+
       - run: ${{ matrix.node.cmd }}
         name: ${{ matrix.node.path }} program test
 

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -92,7 +92,7 @@ jobs:
         if: env.CARGO_PROFILE != 'debug'
 
       - run: chmod +x ~/.cargo/bin/anchor
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/anchor
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -183,14 +183,14 @@ jobs:
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-solana/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +rwx ~/.cargo/bin/anchor
 
       - run: cd ${{ matrix.node.path }} && anchor build --skip-lint
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.node.name }}
           path: ${{ matrix.node.path }}target/deploy/${{ matrix.node.name }}
@@ -206,13 +206,13 @@ jobs:
       - uses: ./.github/actions/setup/
       - uses: ./.github/actions/setup-ts/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: optional.so
           path: tests/optional/target/deploy/
@@ -220,15 +220,15 @@ jobs:
         with:
           name: events.so
           path: tests/events/target/deploy/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: basic_4.so
           path: examples/tutorial/basic-4/target/deploy/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: basic_2.so
           path: examples/tutorial/basic-2/target/deploy/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: composite.so
           path: tests/composite/target/deploy/
@@ -262,7 +262,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -356,7 +356,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/
@@ -478,7 +478,7 @@ jobs:
           path: ${{ env.CARGO_CACHE_PATH }}
           key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.ANCHOR_BINARY_NAME }}
           path: ~/.cargo/bin/

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -216,7 +216,7 @@ jobs:
         with:
           name: optional.so
           path: tests/optional/target/deploy/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: events.so
           path: tests/events/target/deploy/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,6 @@ jobs:
       cache: true
       solana_cli_version: 1.18.17
       solang_version: 0.3.2
-      node_version: 18.18.0
+      node_version: 20.18.0
       cargo_profile: debug
       anchor_binary_name: anchor-binary

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v0.30
   pull_request:
     branches:
       - master
+      - v0.30
 
 jobs:
   tests:

--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -61,9 +61,11 @@ pub fn build_idl(
 /// Build IDL.
 fn build(program_path: &Path, resolution: bool, skip_lint: bool, no_docs: bool) -> Result<Idl> {
     // `nightly` toolchain is currently required for building the IDL.
+    // v0.30's lockfile still enables ahash's removed `stdsimd` feature, so use
+    // a compatible pinned nightly for this release's dependency graph by default.
     let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
         .map(|toolchain| format!("+{}", toolchain))
-        .unwrap_or_else(|_| "+nightly".to_string());
+        .unwrap_or_else(|_| "+nightly-2024-01-30".to_string());
 
     install_toolchain_if_needed(&toolchain)?;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.79.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.79.0"
-components = ["clippy", "rustfmt"]

--- a/tests/idl/test.sh
+++ b/tests/idl/test.sh
@@ -9,7 +9,8 @@ tmp_dir=$(mktemp -d)
 pushd $tmp_dir
 cargo new external-ci
 pushd external-ci
-cargo add anchor-lang
+cargo add anchor-lang@0.30.1
+cp "$GITHUB_WORKSPACE/Cargo.lock" Cargo.lock
 cargo b
 popd
 popd


### PR DESCRIPTION
Enables the existing test workflow for pushes and pull requests targeting v0.30. Pins the release-line Rust toolchain and aligns Node with the package engine requirement.