### PR TITLE
ci: enable v0.31 branch tests

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -28,5 +28,5 @@ runs:
       shell: bash
     # The SBF toolchain bundled with Solana 2.1 uses Cargo 1.79. Pin each
     # independent test workspace to this release's compatible resolution.
-    - run: find . -name Anchor.toml -exec sh -c 'cp "$GITHUB_WORKSPACE/Cargo.lock" "$(dirname "$1")/Cargo.lock"' _ {} \;
+    - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;
       shell: bash

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -30,3 +30,5 @@ runs:
     # independent test workspace to this release's compatible resolution.
     - run: find . -name Anchor.toml -exec sh -c 'dir="$(dirname "$1")"; [ "$(git -C "$dir" rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE" ] && cp "$GITHUB_WORKSPACE/Cargo.lock" "$dir/Cargo.lock"' _ {} \;
       shell: bash
+    - run: cp "$GITHUB_WORKSPACE/Cargo.lock" client/example/Cargo.lock
+      shell: bash

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -26,3 +26,7 @@ runs:
       shell: bash
     - run: solana config set --url localhost
       shell: bash
+    # The SBF toolchain bundled with Solana 2.1 uses Cargo 1.79. Pin each
+    # independent test workspace to this release's compatible resolution.
+    - run: find . -name Anchor.toml -exec sh -c 'cp "$GITHUB_WORKSPACE/Cargo.lock" "$(dirname "$1")/Cargo.lock"' _ {} \;
+      shell: bash

--- a/.github/workflows/no-caching-tests.yaml
+++ b/.github/workflows/no-caching-tests.yaml
@@ -12,6 +12,6 @@ jobs:
     with:
       cache: false
       solana_cli_version: 2.1.0
-      node_version: 20.16.0
+      node_version: 20.18.0
       cargo_profile: release
       anchor_binary_name: anchor-binary-no-caching

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -361,7 +361,16 @@ jobs:
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/anchor
 
-      - run: cd "$(mktemp -d)" && anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }} && cd hello-anchor-${{ matrix.template }} && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
+      - run: |
+          test_dir="$(mktemp -d)"
+          cd "$test_dir"
+          anchor init --test-template ${{ matrix.template }} hello-anchor-${{ matrix.template }}
+          cd hello-anchor-${{ matrix.template }}
+          cp "$GITHUB_WORKSPACE/Cargo.lock" Cargo.lock
+          yarn link @coral-xyz/anchor
+          yarn
+          anchor test
+          yarn lint:fix
       - uses: ./.github/actions/git-diff/
 
   test-programs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,6 @@ jobs:
     with:
       cache: true
       solana_cli_version: 2.1.0
-      node_version: 20.16.0
+      node_version: 20.18.0
       cargo_profile: debug
       anchor_binary_name: anchor-binary

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v0.31
   pull_request:
     branches:
       - master
+      - v0.31
 
 jobs:
   tests:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.1"
+components = ["clippy", "rustfmt"]

--- a/tests/bench/Anchor.toml
+++ b/tests/bench/Anchor.toml
@@ -8,6 +8,9 @@ bench = "Bench11111111111111111111111111111111111111"
 [workspace]
 members = ["programs/bench"]
 
+[test]
+startup_wait = 20000
+
 [scripts]
 test = "yarn run ts-mocha -t 1000000 -p ./tsconfig.json tests/**/*.ts"
 sync = "yarn run ts-node scripts/sync.ts"


### PR DESCRIPTION
Enables the existing test workflow for pushes and pull requests targeting v0.31. Pins the release-line Rust toolchain and aligns Node with the package engine requirement.