### PR TITLE
fix(ts): support parsing Solana v1 transactions - v0.31

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -803,7 +803,7 @@ pub struct _TestValidator {
     pub upgradeable: Option<bool>,
 }
 
-pub const STARTUP_WAIT: i32 = 5000;
+pub const STARTUP_WAIT: i32 = 15000;
 pub const SHUTDOWN_WAIT: i32 = 2000;
 
 impl From<_TestValidator> for TestValidator {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3662,6 +3662,11 @@ fn stream_logs(config: &WithPath<Config>, rpc_url: &str) -> Result<Vec<std::proc
     Ok(handles)
 }
 
+// A validator can answer `getLatestBlockhash` before its forwarding stage is
+// ready to accept transactions. Starting test scripts at that point can drop
+// their first transaction, particularly with Solana 2.x validators.
+const MINIMUM_TEST_VALIDATOR_BLOCK_HEIGHT: u64 = 25;
+
 fn start_test_validator(
     cfg: &Config,
     test_validator: &Option<TestValidator>,
@@ -3726,8 +3731,11 @@ fn start_test_validator(
         .map(|test| test.startup_wait)
         .unwrap_or(STARTUP_WAIT);
     while count < ms_wait {
-        let r = client.get_latest_blockhash();
-        if r.is_ok() {
+        let latest_blockhash = client.get_latest_blockhash();
+        let block_height = client.get_block_height();
+        if latest_blockhash.is_ok()
+            && matches!(block_height, Ok(height) if height >= MINIMUM_TEST_VALIDATOR_BLOCK_HEIGHT)
+        {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(100));

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@coral-xyz/anchor-errors": "^0.31.1",
-    "@coral-xyz/borsh": "^0.31.1",
+    "@coral-xyz/borsh": "^0.32.1",
     "@noble/hashes": "^1.3.1",
-    "@solana/web3.js": "^1.69.0",
+    "@solana/web3.js": "1.99.0-beta.0",
     "bn.js": "^5.1.2",
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.2",

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.18.0"
   },
   "scripts": {
     "build": "rimraf dist/ && yarn build:node && yarn build:browser",

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor-errors": "^0.31.1",
-    "@coral-xyz/borsh": "^0.32.1",
+    "@coral-xyz/borsh": "^0.31.1",
     "@noble/hashes": "^1.3.1",
     "@solana/web3.js": "1.99.0",
     "bn.js": "^5.1.2",

--- a/ts/packages/anchor/package.json
+++ b/ts/packages/anchor/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor-errors": "^0.31.1",
     "@coral-xyz/borsh": "^0.32.1",
     "@noble/hashes": "^1.3.1",
-    "@solana/web3.js": "1.99.0-beta.0",
+    "@solana/web3.js": "1.99.0",
     "bn.js": "^5.1.2",
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.2",

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -178,7 +178,7 @@ export class AnchorProvider implements Provider {
             ? tx.signatures?.[0] || new Uint8Array()
             : tx.signature ?? new Uint8Array()
         );
-        const maxVer = isVersionedTransaction(tx) ? 0 : undefined;
+        const maxVer = isVersionedTransaction(tx) ? 1 : undefined;
         const failedTx = await this.connection.getTransaction(txSig, {
           commitment: "confirmed",
           maxSupportedTransactionVersion: maxVer,
@@ -187,7 +187,14 @@ export class AnchorProvider implements Provider {
           throw err;
         } else {
           const logs = failedTx.meta?.logMessages;
-          throw !logs ? err : new SendTransactionError(err.message, logs);
+          throw !logs
+            ? err
+            : new SendTransactionError({
+                action: "send",
+                signature: txSig,
+                transactionMessage: err.message,
+                logs,
+              });
         }
       } else {
         throw err;
@@ -262,7 +269,7 @@ export class AnchorProvider implements Provider {
               ? tx.signatures?.[0] || new Uint8Array()
               : tx.signature ?? new Uint8Array()
           );
-          const maxVer = isVersionedTransaction(tx) ? 0 : undefined;
+          const maxVer = isVersionedTransaction(tx) ? 1 : undefined;
           const failedTx = await this.connection.getTransaction(txSig, {
             commitment: "confirmed",
             maxSupportedTransactionVersion: maxVer,
@@ -271,7 +278,14 @@ export class AnchorProvider implements Provider {
             throw err;
           } else {
             const logs = failedTx.meta?.logMessages;
-            throw !logs ? err : new SendTransactionError(err.message, logs);
+            throw !logs
+              ? err
+              : new SendTransactionError({
+                  action: "send",
+                  signature: txSig,
+                  transactionMessage: err.message,
+                  logs,
+                });
           }
         } else {
           throw err;

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -178,10 +178,9 @@ export class AnchorProvider implements Provider {
             ? tx.signatures?.[0] || new Uint8Array()
             : tx.signature ?? new Uint8Array()
         );
-        const maxVer = isVersionedTransaction(tx) ? 1 : undefined;
         const failedTx = await this.connection.getTransaction(txSig, {
           commitment: "confirmed",
-          maxSupportedTransactionVersion: maxVer,
+          maxSupportedTransactionVersion: 1,
         });
         if (!failedTx) {
           throw err;
@@ -269,10 +268,9 @@ export class AnchorProvider implements Provider {
               ? tx.signatures?.[0] || new Uint8Array()
               : tx.signature ?? new Uint8Array()
           );
-          const maxVer = isVersionedTransaction(tx) ? 1 : undefined;
           const failedTx = await this.connection.getTransaction(txSig, {
             commitment: "confirmed",
-            maxSupportedTransactionVersion: maxVer,
+            maxSupportedTransactionVersion: 1,
           });
           if (!failedTx) {
             throw err;

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -151,7 +151,9 @@ export class AnchorProvider implements Provider {
     } else {
       tx.feePayer = tx.feePayer ?? this.wallet.publicKey;
       tx.recentBlockhash = (
-        await this.connection.getLatestBlockhash(opts.preflightCommitment)
+        await this.connection.getLatestBlockhash(
+          opts.preflightCommitment ?? opts.commitment
+        )
       ).blockhash;
 
       if (signers) {
@@ -214,7 +216,9 @@ export class AnchorProvider implements Provider {
       opts = this.opts;
     }
     const recentBlockhash = (
-      await this.connection.getLatestBlockhash(opts.preflightCommitment)
+      await this.connection.getLatestBlockhash(
+        opts.preflightCommitment ?? opts.commitment
+      )
     ).blockhash;
 
     let txs = txWithSigners.map((r) => {

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -188,12 +188,7 @@ export class AnchorProvider implements Provider {
           const logs = failedTx.meta?.logMessages;
           throw !logs
             ? err
-            : new SendTransactionError({
-                action: "send",
-                signature: txSig,
-                transactionMessage: err.message,
-                logs,
-              });
+            : createSendTransactionError(txSig, err.message, logs);
         }
       } else {
         throw err;
@@ -278,12 +273,7 @@ export class AnchorProvider implements Provider {
             const logs = failedTx.meta?.logMessages;
             throw !logs
               ? err
-              : new SendTransactionError({
-                  action: "send",
-                  signature: txSig,
-                  transactionMessage: err.message,
-                  logs,
-                });
+              : createSendTransactionError(txSig, err.message, logs);
           }
         } else {
           throw err;
@@ -458,6 +448,21 @@ class ConfirmError extends Error {
   constructor(message?: string) {
     super(message);
   }
+}
+
+function createSendTransactionError(
+  signature: TransactionSignature,
+  transactionMessage: string,
+  logs: string[]
+): SendTransactionError {
+  const error = new SendTransactionError({
+    action: "send",
+    signature,
+    transactionMessage,
+    logs,
+  });
+  error.message = transactionMessage;
+  return error;
 }
 
 /**

--- a/ts/packages/anchor/src/utils/rpc.ts
+++ b/ts/packages/anchor/src/utils/rpc.ts
@@ -202,10 +202,13 @@ export async function simulateTransaction(
         console.error(res.error.message, logTrace);
       }
     }
-    throw new SendTransactionError(
-      "failed to simulate transaction: " + res.error.message,
-      logs
-    );
+    throw new SendTransactionError({
+      action: "simulate",
+      signature: "",
+      transactionMessage:
+        "failed to simulate transaction: " + res.error.message,
+      logs,
+    });
   }
   return res.result;
 }

--- a/ts/packages/anchor/tests/provider.spec.ts
+++ b/ts/packages/anchor/tests/provider.spec.ts
@@ -1,0 +1,59 @@
+import { Connection, PublicKey, VersionedTransaction } from "@solana/web3.js";
+import { AnchorProvider, Wallet } from "../src/provider";
+import { isVersionedTransaction } from "../src/utils/common";
+
+describe("AnchorProvider", () => {
+  it("processes deserialized version 1 transactions", async () => {
+    // A v1 message containing two accounts and one instruction. Version 1
+    // transactions place their signatures after the message.
+    const serializedTransaction = new Uint8Array([
+      0x81,
+      2,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0,
+      ...new Array(32).fill(10),
+      1,
+      2,
+      ...new Array(32).fill(11),
+      ...new Array(32).fill(12),
+      1,
+      1,
+      3,
+      0,
+      0,
+      1,
+      2,
+      3,
+      ...new Array(128).fill(0),
+    ]);
+    const transaction = VersionedTransaction.deserialize(serializedTransaction);
+
+    const connection = {
+      commitment: "processed",
+      getLatestBlockhash: jest.fn().mockResolvedValue({
+        blockhash: PublicKey.default.toBase58(),
+      }),
+      simulateTransaction: jest.fn().mockResolvedValue({
+        context: { slot: 1 },
+        value: { err: null, logs: [] },
+      }),
+    } as unknown as Connection;
+    const wallet = { publicKey: PublicKey.default } as unknown as Wallet;
+    const provider = new AnchorProvider(connection, wallet);
+
+    expect(transaction.version).toBe(1);
+    expect(transaction.signatures).toHaveLength(2);
+    expect(transaction.message.compiledInstructions).toHaveLength(1);
+    expect(isVersionedTransaction(transaction)).toBe(true);
+    await expect(provider.simulate(transaction)).resolves.toMatchObject({
+      err: null,
+    });
+    expect(connection.simulateTransaction).toHaveBeenCalledWith(transaction, {
+      commitment: undefined,
+    });
+  });
+});

--- a/ts/packages/anchor/tests/provider.spec.ts
+++ b/ts/packages/anchor/tests/provider.spec.ts
@@ -1,8 +1,57 @@
-import { Connection, PublicKey, VersionedTransaction } from "@solana/web3.js";
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { AnchorProvider, Wallet } from "../src/provider";
 import { isVersionedTransaction } from "../src/utils/common";
 
 describe("AnchorProvider", () => {
+  it("fetches legacy transaction blockhashes at the preflight commitment", async () => {
+    const transaction = new Transaction();
+    jest.spyOn(transaction, "serialize").mockReturnValue(Buffer.alloc(0));
+    const connection = {
+      commitment: "processed",
+      getLatestBlockhash: jest.fn().mockResolvedValue({
+        blockhash: PublicKey.default.toBase58(),
+      }),
+      sendRawTransaction: jest.fn().mockResolvedValue("mocked-signature"),
+      confirmTransaction: jest.fn().mockResolvedValue({ value: { err: null } }),
+    } as unknown as Connection;
+    const wallet = {
+      publicKey: PublicKey.default,
+      signTransaction: jest.fn().mockImplementation(async (tx) => tx),
+    } as unknown as Wallet;
+    const provider = new AnchorProvider(connection, wallet);
+
+    await provider.sendAndConfirm(transaction, [], { commitment: "confirmed" });
+
+    expect(connection.getLatestBlockhash).toHaveBeenCalledWith("confirmed");
+  });
+
+  it("fetches batched legacy transaction blockhashes at the preflight commitment", async () => {
+    const transaction = new Transaction();
+    jest.spyOn(transaction, "serialize").mockReturnValue(Buffer.alloc(0));
+    const connection = {
+      commitment: "processed",
+      getLatestBlockhash: jest.fn().mockResolvedValue({
+        blockhash: PublicKey.default.toBase58(),
+      }),
+      sendRawTransaction: jest.fn().mockResolvedValue("mocked-signature"),
+      confirmTransaction: jest.fn().mockResolvedValue({ value: { err: null } }),
+    } as unknown as Connection;
+    const wallet = {
+      publicKey: PublicKey.default,
+      signAllTransactions: jest.fn().mockImplementation(async (txs) => txs),
+    } as unknown as Wallet;
+    const provider = new AnchorProvider(connection, wallet);
+
+    await provider.sendAll([{ tx: transaction }], { commitment: "confirmed" });
+
+    expect(connection.getLatestBlockhash).toHaveBeenCalledWith("confirmed");
+  });
+
   it("processes deserialized version 1 transactions", async () => {
     // A v1 message containing two accounts and one instruction. Version 1
     // transactions place their signatures after the message.

--- a/ts/packages/anchor/tests/provider.spec.ts
+++ b/ts/packages/anchor/tests/provider.spec.ts
@@ -56,4 +56,58 @@ describe("AnchorProvider", () => {
       commitment: undefined,
     });
   });
+
+  it("looks up failed version 1 transactions with version 1 support", async () => {
+    const transaction = VersionedTransaction.deserialize(
+      new Uint8Array([
+        0x81,
+        2,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        ...new Array(32).fill(10),
+        1,
+        2,
+        ...new Array(32).fill(11),
+        ...new Array(32).fill(12),
+        1,
+        1,
+        3,
+        0,
+        0,
+        1,
+        2,
+        3,
+        ...new Array(128).fill(0),
+      ])
+    );
+    jest.spyOn(transaction, "serialize").mockReturnValue(new Uint8Array());
+    const signature = "mocked-signature";
+    const connection = {
+      commitment: "processed",
+      sendRawTransaction: jest.fn().mockResolvedValue(signature),
+      confirmTransaction: jest.fn().mockResolvedValue({
+        value: { err: { InstructionError: [0, "Custom"] } },
+      }),
+      getTransaction: jest.fn().mockResolvedValue({
+        meta: { logMessages: ["Program failed"] },
+      }),
+    } as unknown as Connection;
+    const wallet = {
+      publicKey: PublicKey.default,
+      signTransaction: jest.fn().mockImplementation(async (tx) => tx),
+    } as unknown as Wallet;
+    const provider = new AnchorProvider(connection, wallet);
+
+    await expect(provider.sendAndConfirm(transaction)).rejects.toThrow(
+      `Raw transaction ${signature} failed`
+    );
+    expect(connection.getTransaction).toHaveBeenCalledWith(expect.any(String), {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 1,
+    });
+  });
 });

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -24,7 +24,7 @@
     "buffer-layout": "^1.2.0"
   },
   "peerDependencies": {
-    "@solana/web3.js": "^1.69.0"
+    "@solana/web3.js": "^1.69.0 || ^1.99.0-beta.0"
   },
   "files": [
     "dist"

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -24,7 +24,7 @@
     "buffer-layout": "^1.2.0"
   },
   "peerDependencies": {
-    "@solana/web3.js": "^1.69.0"
+    "@solana/web3.js": "^1.99.0"
   },
   "files": [
     "dist"

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -24,7 +24,7 @@
     "buffer-layout": "^1.2.0"
   },
   "peerDependencies": {
-    "@solana/web3.js": "^1.69.0 || ^1.99.0-beta.0"
+    "@solana/web3.js": "^1.69.0"
   },
   "files": [
     "dist"

--- a/ts/packages/borsh/package.json
+++ b/ts/packages/borsh/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=20.18.0"
   },
   "scripts": {
     "build": "tsc",

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -320,6 +320,11 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -512,6 +517,11 @@
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-11.0.0.tgz#719cf05fcc1abb6533610a2e0f5dd1e61eac14fe"
   integrity sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==
+
+"@coral-xyz/anchor-errors@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz#d635cbac2533973ae6bfb5d3ba1de89ce5aece2d"
+  integrity sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -830,10 +840,22 @@
     "@solana/buffer-layout" "=4.0.0"
     "@solana/buffer-layout-utils" "=0.2.0"
 
+"@noble/curves@^1.9.7":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
 "@noble/ed25519@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/hashes@^1.1.2":
   version "1.1.3"
@@ -985,7 +1007,58 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0":
+"@solana/buffer-layout@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz#b996235eaec15b1e0b5092a8ed6028df77fa6c15"
+  integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
+  dependencies:
+    buffer "~6.0.3"
+
+"@solana/codecs-core@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-core/-/codecs-core-5.5.1.tgz#1b2619c697ad04c99f98cc468135d584b7e2b16d"
+  integrity sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==
+  dependencies:
+    "@solana/errors" "5.5.1"
+
+"@solana/codecs-numbers@^5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz#6ebc43250133ceb7836f1ac5780a7767e383efde"
+  integrity sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==
+  dependencies:
+    "@solana/codecs-core" "5.5.1"
+    "@solana/errors" "5.5.1"
+
+"@solana/errors@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@solana/errors/-/errors-5.5.1.tgz#1c17bc822264fd5a6305d8bfb9d597858e4ce17b"
+  integrity sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==
+  dependencies:
+    chalk "5.6.2"
+    commander "14.0.2"
+
+"@solana/web3.js@1.99.0-beta.0":
+  version "1.99.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.99.0-beta.0.tgz#3ba31a978f78a0239b6ee775011f11eb0532c16a"
+  integrity sha512-hvDoGOocYkrg0YXLHmZe8TOtG2ojJYWJRUCaiQWFH9wmRXLdkALqukqhVRfhN/WFhsLi6Yj+7qPhn/iMipN5vw==
+  dependencies:
+    "@babel/runtime" "^7.29.7"
+    "@noble/curves" "^1.9.7"
+    "@noble/hashes" "^1.8.0"
+    "@solana/buffer-layout" "^4.0.1"
+    "@solana/codecs-numbers" "^5.5.1"
+    agentkeepalive "^4.6.0"
+    bn.js "^5.2.5"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.3.0"
+    node-fetch "^2.7.0"
+    rpc-websockets "^9.0.2"
+    superstruct "^2.0.2"
+
+"@solana/web3.js@^1.32.0":
   version "1.69.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.69.0.tgz#1756b1a26087172291c0b5163d3b44d24eef8aa7"
   integrity sha512-iU2Q0IG25RITsxBkY1Vkk74LffRokViEcSblz4CGxyt+/V7xSkC2DNM0n0rB3aY/9+FvMiz4l5wHnD9UC4Ac/w==
@@ -1005,6 +1078,13 @@
     node-fetch "2"
     rpc-websockets "^7.5.0"
     superstruct "^0.14.2"
+
+"@swc/helpers@^0.5.11":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.23.tgz#19287d0d86d962b111376039a50c792902c9a86a"
+  integrity sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==
+  dependencies:
+    tslib "^2.8.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1200,6 +1280,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ws@^8.2.2":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1334,6 +1421,13 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.6.0.tgz#35f73e94b3f40bf65f105219c623ad19c136ea6a"
+  integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1551,6 +1645,11 @@ bn.js@^5.0.0, bn.js@^5.1.2, bn.js@^5.2.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
+bn.js@^5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.5.tgz#e81ce41cf25e6f0cd1e05f20a9db8c18405e375f"
+  integrity sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==
+
 borsh@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.7.0.tgz#6e9560d719d86d90dc589bca60ffc8a6c51fec2a"
@@ -1636,7 +1735,7 @@ buffer@6.0.1:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buffer@~6.0.3:
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -1692,6 +1791,11 @@ chalk@4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
@@ -1813,6 +1917,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.2.tgz#b71fd37fe4069e4c3c7c13925252ada4eba14e8e"
+  integrity sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==
 
 commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -2270,6 +2379,11 @@ eventemitter3@^4.0.7:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
 execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
@@ -2651,6 +2765,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
+
 husky@^4.3.0:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
@@ -2908,6 +3029,24 @@ jayson@^3.4.4:
     lodash "^4.17.20"
     uuid "^8.3.2"
     ws "^7.4.5"
+
+jayson@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-4.3.0.tgz#22eb8f3dcf37a5e893830e5451f32bde6d1bde4d"
+  integrity sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==
+  dependencies:
+    "@types/connect" "^3.4.33"
+    "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
+    commander "^2.20.3"
+    delay "^5.0.0"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
+    json-stringify-safe "^5.0.1"
+    stream-json "^1.9.1"
+    uuid "^8.3.2"
+    ws "^7.5.10"
 
 jest-changed-files@^27.5.1:
   version "27.5.1"
@@ -3711,6 +3850,11 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3720,6 +3864,13 @@ node-fetch@2, node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -4204,6 +4355,20 @@ rpc-websockets@^7.5.0:
     bufferutil "^4.0.1"
     utf-8-validate "^5.0.2"
 
+rpc-websockets@^9.0.2:
+  version "9.3.10"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-9.3.10.tgz#d6f9b08edfac40e873a059b358806f6d58572e80"
+  integrity sha512-QT5PQ6LiWhA5RCS93oWwgxU4XzQltkYm8C3aTmmKEgj0HolGRo3VbdzELw7CEV35l9T7Amha8Vnr4rCfSjVP+w==
+  dependencies:
+    "@swc/helpers" "^0.5.11"
+    "@types/ws" "^8.2.2"
+    buffer "^6.0.3"
+    eventemitter3 "^5.0.1"
+    ws "^8.5.0"
+  optionalDependencies:
+    bufferutil "^4.0.1"
+    utf-8-validate "^6.0.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -4401,6 +4566,18 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stream-chain@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
+  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+
+stream-json@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.9.1.tgz#e3fec03e984a503718946c170db7d74556c2a187"
+  integrity sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==
+  dependencies:
+    stream-chain "^2.2.5"
+
 string-argv@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -4477,6 +4654,11 @@ superstruct@^0.15.4:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.15.5.tgz#0f0a8d3ce31313f0d84c6096cd4fa1bfdedc9dab"
   integrity sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==
+
+superstruct@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-2.0.2.tgz#3f6d32fbdc11c357deff127d591a39b996300c54"
+  integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -4703,6 +4885,11 @@ tslib@^2.1.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
+tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -4824,6 +5011,13 @@ utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
+utf-8-validate@^6.0.0:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-6.0.6.tgz#8a842c9b15af3f6323a3d5ed5eb9e61d208d8c22"
+  integrity sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==
   dependencies:
     node-gyp-build "^4.3.0"
 
@@ -4998,6 +5192,11 @@ ws@^7.4.5, ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^7.5.10:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 ws@^8.5.0:
   version "8.11.0"

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -1037,10 +1037,10 @@
     chalk "5.6.2"
     commander "14.0.2"
 
-"@solana/web3.js@1.99.0-beta.0":
-  version "1.99.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.99.0-beta.0.tgz#3ba31a978f78a0239b6ee775011f11eb0532c16a"
-  integrity sha512-hvDoGOocYkrg0YXLHmZe8TOtG2ojJYWJRUCaiQWFH9wmRXLdkALqukqhVRfhN/WFhsLi6Yj+7qPhn/iMipN5vw==
+"@solana/web3.js@1.99.0":
+  version "1.99.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.99.0.tgz#864ce3fefe03b258c430e31e6672b422426821f7"
+  integrity sha512-QZYQ2T1z6xWisoyALPq25i/QZTsRlM02BABtAsfaQ1p8wX4SdTfxrKTRue/ZZqrhNVh5oL7T/DUFiTS9DRgxow==
   dependencies:
     "@babel/runtime" "^7.29.7"
     "@noble/curves" "^1.9.7"


### PR DESCRIPTION
Ports the web3.js 1.99 transaction-v1 support to Anchor v0.31. Includes provider/RPC parsing support, compatible error handling, and mocked v1 transaction coverage.