### PR TITLE
Fix/v2: Boxed accounts lose CPI borrow handling

### DIFF
--- a/lang-v2/src/accounts/boxed.rs
+++ b/lang-v2/src/accounts/boxed.rs
@@ -13,6 +13,8 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
     type Data = T;
     const IS_SIGNER: bool = T::IS_SIGNER;
     const MIN_DATA_LEN: usize = T::MIN_DATA_LEN;
+    const RELAX_READONLY_CPI_BORROW_FROM_MUT: bool =
+        T::RELAX_READONLY_CPI_BORROW_FROM_MUT;
 
     fn load(view: AccountView) -> Result<Self, ProgramError> {
         T::load(view).map(Box::new)
@@ -36,6 +38,18 @@ impl<T: AnchorAccount> AnchorAccount for Box<T> {
 
     fn account(&self) -> &AccountView {
         (**self).account()
+    }
+
+    #[inline(always)]
+    fn cpi_handle(&self) -> crate::CpiHandle<'_> {
+        <T as AnchorAccount>::cpi_handle(self.as_ref())
+    }
+
+    #[inline(always)]
+    fn try_cpi_handle_mut(
+        &mut self,
+    ) -> Result<crate::CpiHandleMut<'_>, ProgramError> {
+        <T as AnchorAccount>::try_cpi_handle_mut(self.as_mut())
     }
 
     fn exit(&mut self) -> pinocchio::ProgramResult {

--- a/lang-v2/tests/program_invoke.rs
+++ b/lang-v2/tests/program_invoke.rs
@@ -1,6 +1,9 @@
 //! Run: `cargo test -p anchor-lang --features testing --test program_invoke`
 
+extern crate alloc;
+
 use {
+    alloc::boxed::Box,
     anchor_lang::{
         accounts::Account,
         prelude::BorshAccount,
@@ -541,6 +544,42 @@ fn cpi_context_invoke_accepts_readonly_slab_handle_from_mutable_wrapper() {
 }
 
 #[test]
+fn cpi_context_invoke_accepts_mutable_boxed_slab_handle() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe {
+        <Box<Account<PodCounter>> as AnchorAccount>::load_mut(view)
+    }
+    .unwrap();
+    let accounts = WritableCpi {
+        account: acct.cpi_handle_mut(),
+    };
+
+    CpiContext::new(&program, accounts)
+        .invoke(&[1, 2, 3])
+        .unwrap();
+}
+
+#[test]
+fn cpi_context_invoke_accepts_readonly_boxed_slab_handle_from_mutable_wrapper() {
+    let program = ID;
+    let buffer = slab_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let acct = unsafe {
+        <Box<Account<PodCounter>> as AnchorAccount>::load_mut(view)
+    }
+    .unwrap();
+    let accounts = ReadonlyCpi {
+        account: acct.cpi_handle(),
+    };
+
+    CpiContext::new(&program, accounts)
+        .invoke(&[1, 2, 3])
+        .unwrap();
+}
+
+#[test]
 fn invoke_ix_rejects_live_borrow_for_writable_meta() {
     let program = ID;
     let buffer = account_view([1; 32], true);
@@ -620,6 +659,30 @@ fn cpi_context_invoke_accepts_mutable_borsh_handle() {
 
     acct.reacquire_borrow_mut().unwrap();
     acct.value = 11;
+    assert_eq!(acct.value, 11);
+}
+
+#[test]
+fn cpi_context_invoke_accepts_mutable_boxed_borsh_handle() {
+    let program = ID;
+    let buffer = borsh_account_view([1; 32], true, 9);
+    let view = unsafe { buffer.view() };
+    let mut acct = unsafe {
+        <Box<BorshAccount<BorshCounter>> as AnchorAccount>::load_mut(view)
+    }
+    .unwrap();
+    acct.value = 11;
+
+    {
+        let accounts = WritableCpi {
+            account: acct.cpi_handle_mut(),
+        };
+        CpiContext::new(&program, accounts)
+            .invoke(&[1, 2, 3])
+            .unwrap();
+    }
+
+    acct.reacquire_borrow_mut().unwrap();
     assert_eq!(acct.value, 11);
 }
 


### PR DESCRIPTION
### Hackhack finding AI # 014
`Box<T>` forwards account loading but not wrapper-specific `CPI` borrow policies, so boxed mutable `Slab` and `Borsh` accounts fail before `CPI` invocation with `AccountBorrowFailed`. 
This patch forwards the policy and handle methods to the `inner` wrapper, preserving readonly relaxation and `Borsh` write-back, with boxed `CPI` regression coverage.