### PR TITLE
Fix/v2: nested float aliases bypass v2’s Borsh-compatibility guard

### DIFF
--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -38,7 +38,11 @@ pub fn derive_accounts(input: TokenStream) -> TokenStream {
 /// Wincode attributes remain supported when required.
 #[proc_macro_derive(AnchorSerialize, attributes(wincode))]
 pub fn anchor_serialize(input: TokenStream) -> TokenStream {
-    derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaWrite))
+    derive_wincode_schema(
+        input,
+        quote!(anchor_lang::wincode::SchemaWrite),
+        quote!(anchor_lang::__private::BorshSerializeCompatible),
+    )
 }
 
 /// Derive Anchor's Wincode-backed deserialization implementation.
@@ -48,18 +52,67 @@ pub fn anchor_serialize(input: TokenStream) -> TokenStream {
 /// dependency is needed.
 #[proc_macro_derive(AnchorDeserialize, attributes(wincode))]
 pub fn anchor_deserialize(input: TokenStream) -> TokenStream {
-    derive_wincode_schema(input, quote!(anchor_lang::wincode::SchemaRead))
+    derive_wincode_schema(
+        input,
+        quote!(anchor_lang::wincode::SchemaRead),
+        quote!(anchor_lang::__private::BorshDeserializeCompatible),
+    )
 }
 
-fn derive_wincode_schema(input: TokenStream, schema_derive: TokenStream2) -> TokenStream {
-    let input = TokenStream2::from(input);
+fn derive_wincode_schema(
+    input: TokenStream,
+    schema_derive: TokenStream2,
+    compatibility_trait: TokenStream2,
+) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let compatibility_impl = borsh_compatibility_impl(&input, &compatibility_trait);
     quote! {
         #[derive(#schema_derive)]
         #[wincode(crate = "anchor_lang::wincode")]
         #[anchor_lang::__erase]
         #input
+
+        #compatibility_impl
     }
     .into()
+}
+
+fn borsh_compatibility_impl(
+    input: &DeriveInput,
+    compatibility_trait: &TokenStream2,
+) -> TokenStream2 {
+    let name = &input.ident;
+    let field_types: Vec<_> = match &input.data {
+        Data::Struct(data) => data.fields.iter().map(|field| &field.ty).collect(),
+        Data::Enum(data) => data
+            .variants
+            .iter()
+            .flat_map(|variant| variant.fields.iter().map(|field| &field.ty))
+            .collect(),
+        Data::Union(_) => Vec::new(),
+    };
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let serialize_field_list = field_types
+        .iter()
+        .rev()
+        .fold(quote!(anchor_lang::__private::BorshSerializeFieldsEnd), |tail, ty| {
+            quote!(anchor_lang::__private::BorshSerializeFields<#ty, #tail>)
+        });
+    let fields_type = if compatibility_trait.to_string().contains("Serialize") {
+        serialize_field_list
+    } else {
+        field_types.iter().rev().fold(
+            quote!(anchor_lang::__private::BorshDeserializeFieldsEnd),
+            |tail, ty| quote!(anchor_lang::__private::BorshDeserializeFields<#ty, #tail>),
+        )
+    };
+
+    quote! {
+        impl #impl_generics #compatibility_trait for #name #ty_generics #where_clause {
+            type Fields = #fields_type;
+        }
+    }
 }
 
 /// Removes the duplicate item emitted by the schema-derive wrappers.
@@ -2222,6 +2275,19 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
             return err.to_compile_error().into();
         }
     }
+    let borsh_compatibility_asserts = if is_borsh {
+        let mut asserts = borsh_compatibility_asserts(
+            fields,
+            quote!(anchor_lang::__private::BorshSerializeCompatible),
+        );
+        asserts.extend(borsh_compatibility_asserts(
+            fields,
+            quote!(anchor_lang::__private::BorshDeserializeCompatible),
+        ));
+        asserts
+    } else {
+        Vec::new()
+    };
     use sha2::Digest;
     let hash = sha2::Sha256::digest(format!("account:{name_str}").as_bytes());
     let disc_bytes = &hash[..8];
@@ -2450,6 +2516,7 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
         #vis struct #name #fields
 
         #(#idl_validation_tokens)*
+        #(#borsh_compatibility_asserts)*
         #pod_impls
 
         impl anchor_lang::Owner for #name {
@@ -4915,6 +4982,46 @@ fn reject_float_fields(surface: &str, fields: &Fields) -> syn::Result<()> {
     Ok(())
 }
 
+fn borsh_compatibility_asserts(
+    fields: &Fields,
+    compatibility_trait: TokenStream2,
+) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let ty = &field.ty;
+            let cfg_attrs = cfg_attrs(&field.attrs);
+            let compatibility_assert =
+                borsh_compatibility_assert_for_type(ty, &compatibility_trait);
+            quote! {
+                #(#cfg_attrs)*
+                #compatibility_assert
+            }
+        })
+        .collect()
+}
+
+fn borsh_compatibility_assert_for_type(
+    ty: &Type,
+    compatibility_trait: &TokenStream2,
+) -> TokenStream2 {
+    let compatibility_proof = if compatibility_trait.to_string().contains("Serialize") {
+        quote!(anchor_lang::__private::BorshSerializeCompatibilityProof)
+    } else {
+        quote!(anchor_lang::__private::BorshDeserializeCompatibilityProof)
+    };
+    quote! {
+        const _: fn() = || {
+            fn assert_compatible<T>()
+            where
+                T: #compatibility_trait,
+                <T as #compatibility_trait>::Fields: #compatibility_proof,
+            {}
+            assert_compatible::<#ty>();
+        };
+    }
+}
+
 fn process_handler(
     handler: &syn::ItemFn,
     mod_name: &Ident,
@@ -5015,6 +5122,21 @@ fn process_handler(
             None
         })
         .collect();
+    let extra_arg_compatibility_asserts: Vec<_> = extra_args
+        .iter()
+        .map(|(_, ty)| {
+            borsh_compatibility_assert_for_type(
+                ty,
+                &quote!(anchor_lang::__private::BorshDeserializeCompatible),
+            )
+        })
+        .collect();
+    let return_compatibility_assert = return_type.as_ref().map(|ty| {
+        borsh_compatibility_assert_for_type(
+            ty,
+            &quote!(anchor_lang::__private::BorshSerializeCompatible),
+        )
+    });
     if let Some((_, ty)) = extra_args.iter().find(|(_, ty)| type_contains_float(ty)) {
         return HandlerCodegen::error(
             handler,
@@ -5095,6 +5217,9 @@ fn process_handler(
                 #[cfg(not(feature = "no-log-ix-name"))]
                 anchor_lang::msg!(#fn_name_log);
 
+                #(#extra_arg_compatibility_asserts)*
+                #return_compatibility_assert
+
                 #[inline(always)]
                 fn __anchor_assert_no_ix_args(_: ()) {}
 
@@ -5131,6 +5256,9 @@ fn process_handler(
             ) -> u64 {
                 #[cfg(not(feature = "no-log-ix-name"))]
                 anchor_lang::msg!(#fn_name_log);
+
+                #(#extra_arg_compatibility_asserts)*
+                #return_compatibility_assert
 
                 trait __AnchorIxArgCoerce<'ix> {
                     fn __coerce(self, __ix_data: &'ix [u8]) -> anchor_lang::Result<#tuple_ty>;
@@ -5956,6 +6084,14 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         Vec::new()
     };
+    let borsh_compatibility_asserts = if matches!(mode, EventMode::Wincode) {
+        borsh_compatibility_asserts(
+            fields,
+            quote!(anchor_lang::__private::BorshSerializeCompatible),
+        )
+    } else {
+        Vec::new()
+    };
     let event_type_def = idl::build_struct_type_def_emission(
         &name_str,
         &struct_docs,
@@ -6051,6 +6187,7 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
             #vis struct #name #fields
 
             #(#idl_validation_tokens)*
+            #(#borsh_compatibility_asserts)*
             #discriminator_impl
 
             impl anchor_lang::Event for #name {

--- a/lang-v2/src/lib.rs
+++ b/lang-v2/src/lib.rs
@@ -288,6 +288,109 @@ pub mod __private {
     use crate::CpiHandle;
     use pinocchio::account::AccountView;
 
+    /// Compile-time markers used by the derive macros to keep the
+    /// Borsh-shaped Wincode surfaces free of floating-point fields
+    /// transitively. Floats intentionally have no implementation.
+    pub trait BorshSerializeCompatible {
+        type Fields;
+    }
+    pub trait BorshDeserializeCompatible {
+        type Fields;
+    }
+
+    pub trait BorshSerializeCompatibilityProof {}
+    pub trait BorshDeserializeCompatibilityProof {}
+    pub struct BorshSerializeFields<H: ?Sized, T: ?Sized>(core::marker::PhantomData<fn(H) -> T>);
+    pub struct BorshDeserializeFields<H: ?Sized, T: ?Sized>(core::marker::PhantomData<fn(H) -> T>);
+    pub struct BorshSerializeFieldsEnd;
+    pub struct BorshDeserializeFieldsEnd;
+
+    impl BorshSerializeCompatibilityProof for BorshSerializeFieldsEnd {}
+    impl BorshDeserializeCompatibilityProof for BorshDeserializeFieldsEnd {}
+
+    macro_rules! impl_compatibility_proof {
+        ($fields:ident, $marker:path, $proof:path) => {
+            impl<H: $marker + ?Sized, T: $proof + ?Sized> $proof for $fields<H, T>
+            where
+                <H as $marker>::Fields: $proof,
+            {}
+        };
+    }
+
+    impl_compatibility_proof!(
+        BorshSerializeFields,
+        BorshSerializeCompatible,
+        BorshSerializeCompatibilityProof
+    );
+    impl_compatibility_proof!(
+        BorshDeserializeFields,
+        BorshDeserializeCompatible,
+        BorshDeserializeCompatibilityProof
+    );
+
+    macro_rules! impl_primitive {
+        ($($ty:ty),* $(,)?) => {
+            $(
+                impl BorshSerializeCompatible for $ty {
+                    type Fields = BorshSerializeFieldsEnd;
+                }
+                impl BorshDeserializeCompatible for $ty {
+                    type Fields = BorshDeserializeFieldsEnd;
+                }
+            )*
+        };
+    }
+
+    impl_primitive!(
+        bool, u8, u16, u32, u64, u128, usize,
+        i8, i16, i32, i64, i128, isize,
+        char,
+        crate::Address,
+    );
+
+    impl<'a, T: BorshSerializeCompatible + ?Sized> BorshSerializeCompatible for &'a T {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<'a, T: BorshDeserializeCompatible + ?Sized> BorshDeserializeCompatible for &'a T {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl<'a, T: BorshSerializeCompatible + ?Sized> BorshSerializeCompatible for &'a mut T {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<'a, T: BorshDeserializeCompatible + ?Sized> BorshDeserializeCompatible for &'a mut T {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl<T: BorshSerializeCompatible> BorshSerializeCompatible for Option<T> {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<T: BorshDeserializeCompatible> BorshDeserializeCompatible for Option<T> {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl<T: BorshSerializeCompatible> BorshSerializeCompatible for alloc::vec::Vec<T> {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<T: BorshDeserializeCompatible> BorshDeserializeCompatible for alloc::vec::Vec<T> {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl<T: BorshSerializeCompatible> BorshSerializeCompatible for [T] {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<T: BorshDeserializeCompatible> BorshDeserializeCompatible for [T] {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl<T: BorshSerializeCompatible, const N: usize> BorshSerializeCompatible for [T; N] {
+        type Fields = <T as BorshSerializeCompatible>::Fields;
+    }
+    impl<T: BorshDeserializeCompatible, const N: usize> BorshDeserializeCompatible for [T; N] {
+        type Fields = <T as BorshDeserializeCompatible>::Fields;
+    }
+    impl BorshSerializeCompatible for alloc::string::String {
+        type Fields = BorshSerializeFieldsEnd;
+    }
+    impl BorshDeserializeCompatible for alloc::string::String {
+        type Fields = BorshDeserializeFieldsEnd;
+    }
+
     /// Used by `#[derive(InitSpace)]` on enums to pick the largest variant size.
     pub const fn max(a: usize, b: usize) -> usize {
         [a, b][(a < b) as usize]

--- a/lang-v2/tests/macro_diagnostics.rs
+++ b/lang-v2/tests/macro_diagnostics.rs
@@ -694,6 +694,54 @@ pub struct Price {
     miri,
     ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
 )]
+fn nested_float_aliases_are_rejected_on_borsh_accounts() {
+    compile_pass_case(
+        "nested_safe_borsh_account",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct SafeInner {
+    pub value: u64,
+}
+
+#[account(borsh)]
+pub struct SafeAccount {
+    pub value: SafeInner,
+}
+"#,
+    );
+
+    compile_fail_case(
+        "nested_float_alias_borsh_account",
+        r#"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+type FloatAlias = f64;
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct HiddenFloat {
+    pub value: FloatAlias,
+}
+
+#[account(borsh)]
+pub struct Price {
+    pub value: HiddenFloat,
+}
+"#,
+        &["BorshSerializeCompatible", "BorshDeserializeCompatible"],
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "spawns cargo and writes temporary workspaces; covered by normal cargo test"
+)]
 fn cfg_gated_public_handlers_do_not_emit_missing_wrappers() {
     compile_pass_case(
         "cfg_gated_handler",


### PR DESCRIPTION
### Hackhack Findings AI # 016

Anchor v2’s Borsh-compatible float ban checks only visible `type` syntax, allowing named structs or aliases containing `f32/f64` to deserialize `NaN` through `Wincode`. 

The fix adds recursive compatibility markers with no `float` implementations, requiring nested `Borsh` surfaces to prove safe field types before generated serialization or deserialization code.