### PR TITLE
Fix/v2: enforce duplicate mutable-account checks in direct parsing

### DIFF
--- a/lang-v2/Cargo.toml
+++ b/lang-v2/Cargo.toml
@@ -184,3 +184,7 @@ required-features = ["testing"]
 [[test]]
 name = "init_if_needed_reuse_validation"
 required-features = ["testing"]
+
+[[test]]
+name = "direct_try_accounts_duplicate"
+required-features = ["testing"]

--- a/lang-v2/derive/src/lib.rs
+++ b/lang-v2/derive/src/lib.rs
@@ -2108,6 +2108,18 @@ fn impl_accounts(input: &DeriveInput) -> TokenStream2 {
                 __base_offset: usize,
                 __ix_data: &'ix [u8],
             ) -> anchor_lang::Result<(Self, #bumps_name, Self::IxArgs<'ix>)> {
+                if let Some(__dups) = __duplicates {
+                    let __shifted_mut_mask = anchor_lang::mut_mask_or_shifted(
+                        [0u64; 4],
+                        <Self as anchor_lang::TryAccounts>::MUT_MASK,
+                        __base_offset,
+                    );
+                    if __dups.intersects(&__shifted_mut_mask) {
+                        return Err(
+                            anchor_lang::ErrorCode::ConstraintDuplicateMutableAccount.into(),
+                        );
+                    }
+                }
                 let (mut __accounts, __bumps, __ix_args) =
                     <Self as anchor_lang::TryAccounts>::validate_accounts(
                         __program_id,
@@ -2598,10 +2610,7 @@ pub fn derive_idl_type(input: TokenStream) -> TokenStream {
                     &input.generics,
                 ),
                 cfg_variant_dep_walkers(&data.variants),
-                wincode_idl_override_tokens_for_variants(
-                    "`#[derive(IdlType)]`",
-                    &data.variants,
-                ),
+                wincode_idl_override_tokens_for_variants("`#[derive(IdlType)]`", &data.variants),
             )
         }
         Data::Union(_) => {

--- a/lang-v2/src/dispatch.rs
+++ b/lang-v2/src/dispatch.rs
@@ -48,7 +48,9 @@ pub trait TryAccounts: Bumps + Sized {
     /// `base_offset` is the index of the first view in the global bitvec.
     /// Top-level callers pass 0; `Nested<T>` passes its field's offset so
     /// the inner struct's duplicate-mutable-account checks hit the correct
-    /// global bits.
+    /// global bits. Implementations reject duplicates in the static mutable
+    /// mask before constructing any account wrappers; optional mutable
+    /// fields retain their own check after resolving to `Some`.
     fn try_accounts<'ix>(
         program_id: &Address,
         views: &[AccountView],

--- a/lang-v2/tests/direct_try_accounts_duplicate.rs
+++ b/lang-v2/tests/direct_try_accounts_duplicate.rs
@@ -1,0 +1,122 @@
+use {
+    anchor_lang::{
+        accounts::{Account, UncheckedAccount},
+        testing::{AccountRecord, SbfInputBuffer},
+        AccountCursor, Accounts, Discriminator, ErrorCode, Nested, Owner, TryAccounts,
+    },
+    bytemuck::{Pod, Zeroable},
+    core::mem::{size_of, MaybeUninit},
+    pinocchio::{account::AccountView, address::Address},
+    solana_program_error::ProgramError,
+};
+
+const PROGRAM_ID: [u8; 32] = [0xAA; 32];
+anchor_lang::declare_id!("11111111111111111111111111111111");
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct Counter {
+    value: u64,
+    _pad: [u8; 8],
+}
+impl Owner for Counter {
+    const OWNER: Address = Address::new_from_array(PROGRAM_ID);
+}
+impl Discriminator for Counter {
+    const DISCRIMINATOR: &'static [u8] = &[1; 8];
+}
+
+#[derive(Accounts)]
+struct TwoMutable {
+    #[account(mut)]
+    first: Account<Counter>,
+    #[account(mut)]
+    second: Account<Counter>,
+}
+#[derive(Accounts)]
+struct InnerMutable {
+    #[account(mut)]
+    first: Account<Counter>,
+    #[account(mut)]
+    second: Account<Counter>,
+}
+#[derive(Accounts)]
+#[allow(dead_code)]
+struct OuterNested {
+    prefix: UncheckedAccount,
+    inner: Nested<InnerMutable>,
+}
+
+fn account(address: [u8; 32], writable: bool) -> AccountRecord {
+    AccountRecord::NonDup {
+        address,
+        owner: PROGRAM_ID,
+        lamports: 100,
+        is_signer: false,
+        is_writable: writable,
+        executable: false,
+        data_len: 8 + size_of::<Counter>(),
+    }
+}
+fn duplicate_input() -> SbfInputBuffer {
+    SbfInputBuffer::build(&[account([1; 32], true), AccountRecord::Dup { index: 0 }])
+}
+fn nested_input() -> SbfInputBuffer {
+    SbfInputBuffer::build(&[
+        AccountRecord::NonDup {
+            address: [9; 32],
+            owner: [0xBB; 32],
+            lamports: 100,
+            is_signer: false,
+            is_writable: false,
+            executable: false,
+            data_len: 0,
+        },
+        account([1; 32], true),
+        AccountRecord::Dup { index: 1 },
+    ])
+}
+
+fn parse_at<T: TryAccounts>(
+    input: &mut SbfInputBuffer,
+    walk: usize,
+    start: usize,
+    base: usize,
+) -> Result<(), ProgramError> {
+    let mut lookup = [const { MaybeUninit::<AccountView>::uninit() }; 256];
+    let mut cursor = unsafe { AccountCursor::new(input.as_mut_ptr(), lookup.as_mut_ptr().cast()) };
+    let (views, duplicates) = unsafe { cursor.walk_n(walk) };
+    T::try_accounts(
+        &Address::new_from_array(PROGRAM_ID),
+        &views[start..start + T::HEADER_SIZE],
+        duplicates,
+        base,
+        &[],
+    )
+    .map(|_| ())
+}
+fn duplicate_error() -> ProgramError {
+    ErrorCode::ConstraintDuplicateMutableAccount.into()
+}
+
+#[test]
+fn direct_try_accounts_rejects_duplicate_mutables_before_loading() {
+    // The input has zeroed data, while Counter requires a nonzero discriminator;
+    // duplicate rejection winning proves it precedes unsafe `load_mut`.
+    assert_eq!(
+        parse_at::<TwoMutable>(&mut duplicate_input(), 2, 0, 0),
+        Err(duplicate_error())
+    );
+}
+
+#[test]
+fn direct_nested_try_accounts_shifts_the_global_duplicate_mask() {
+    assert_eq!(
+        parse_at::<OuterNested>(&mut nested_input(), 3, 0, 0),
+        Err(duplicate_error())
+    );
+    assert_eq!(
+        parse_at::<InnerMutable>(&mut nested_input(), 3, 1, 1),
+        Err(duplicate_error())
+    );
+}


### PR DESCRIPTION
### HackHack Findings AI # 018
`TryAccounts::try_accounts` skipped the duplicate-mutable mask, allowing aliased non-optional mutable roles to reach `load_mut`; generated dispatch remained protected. 

The fix checks the global duplicate `bitvec` against a base-offset-shifted `MUT_MASK` before validation, preserving optional sentinels, nested parsing, and explicit `unsafe(dup)` opt-outs without constructing wrappers or invoking hooks.